### PR TITLE
Adds example of primary button with icon

### DIFF
--- a/src/demo/pages/ButtonPage/examples/Button.Basic.Example.scss
+++ b/src/demo/pages/ButtonPage/examples/Button.Basic.Example.scss
@@ -1,8 +1,11 @@
+@import '~office-ui-fabric/src/sass/Fabric.Common';
+
 .ms-BasicButtonsExample .ms-Button {
   margin: 10px 0;
+
+  .ms-Icon {
+    @include margin-right(5px);
+    @include margin-left(-10px);
+  }
 }
 
-.ms-Icon {
-  margin-right: 5px;
-  margin-left: -10px;
-}

--- a/src/demo/pages/ButtonPage/examples/Button.Basic.Example.scss
+++ b/src/demo/pages/ButtonPage/examples/Button.Basic.Example.scss
@@ -1,3 +1,8 @@
 .ms-BasicButtonsExample .ms-Button {
   margin: 10px 0;
 }
+
+.ms-Icon {
+  margin-right: 5px;
+  margin-left: -10px;
+}

--- a/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
@@ -44,6 +44,12 @@ export class ButtonBasicExample extends React.Component<any, IBasicButtonsExampl
         <Label>Command button</Label>
         <Button disabled={ disabled } buttonType={ ButtonType.command } icon='personAdd' description='Description of the action this button takes'>Create account</Button>
 
+        <Label>Primary Button with Icon</Label>
+        <Button disabled={ disabled } buttonType={ ButtonType.primary } title='Star' description='Description of the action this button takes'>
+          <i className='ms-Icon ms-Icon--star' />
+          <span>I am a button.</span>
+        </Button>
+
         <Label>Icon button</Label>
         <Button disabled={ disabled } buttonType={ ButtonType.icon } icon='star' title='Star' ariaLabel='Take a star' />
 


### PR DESCRIPTION
Adds @dzearing example for adding an inline button.  I think once the styles are enhanced to take an icon universally, we should leave this example up to show the flexibility of the button.

Side note: @dzearing Can you tell I was hitting the refresh button nonstop waiting for you to open this project up?  :+1:   Great work to you and team.  Can't wait to dig in more!