### PR TITLE
Dialog: Add optional class name to the root element

### DIFF
--- a/src/components/Dialog/Dialog.Props.ts
+++ b/src/components/Dialog/Dialog.Props.ts
@@ -44,6 +44,11 @@ export interface IDialogProps extends React.Props<Dialog>, IWithResponsiveModeSt
   isBlocking?: boolean;
 
   /**
+   * Optional class name to be added to the root class
+   */
+  className?: string;
+
+  /**
   * Optional override for container class
   */
   containerClassName?: string;

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -21,6 +21,7 @@ export class Dialog extends React.Component<IDialogProps, any> {
     type: DialogType.normal,
     isDarkOverlay: true,
     isBlocking: false,
+    className: '',
     containerClassName: '',
     contentClassName: ''
   };
@@ -42,7 +43,7 @@ export class Dialog extends React.Component<IDialogProps, any> {
     }
 
     let subTextContent;
-    const dialogClassName = css('ms-Dialog', {
+    const dialogClassName = css('ms-Dialog', this.props.className, {
       'ms-Dialog--lgHeader': type === DialogType.largeHeader,
       'ms-Dialog--close': type === DialogType.close
     });


### PR DESCRIPTION
This PR adds a new optional prop to the Dialog component, which allows for specifying an additional CSS class to add to the root `.ms-Dialog` element. This is necessary for targeting CSS overrides at the Overlay.