### PR TITLE
Added null check to root search for withViewport

### DIFF
--- a/src/utilities/decorators/withViewport.tsx
+++ b/src/utilities/decorators/withViewport.tsx
@@ -91,6 +91,9 @@ export function withViewport<P, S>(ComposedComponent: any): any {
         (computedOverflow !== 'auto') &&
         (computedOverflow !== 'scroll')
       ) {
+        if (rootElement.parentElement === null) {
+          break;
+        }
         rootElement = rootElement.parentElement;
         computedOverflow = getComputedStyle(rootElement)['overflow-y'];
       }


### PR DESCRIPTION
Stops unit tests on components with the @withViewport decorator from failing instantly.