### PR TITLE
#196749: updated checkbox per redlines and added keyboard focus rect.

### DIFF
--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -200,4 +200,49 @@
 // TODO: overrides that need to be removed.
 .ms-ChoiceField {
   user-select: none;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.is-focusVisible .ms-ChoiceField .ms-ChoiceField-input[type="checkbox"] {
+  &:focus {
+    + .ms-ChoiceField-field {
+      outline: 1px solid $ms-color-neutralSecondaryAlt;
+    }
+  }
+}
+
+// The choicefield radio button or checkbox
+.ms-ChoiceField .ms-ChoiceField-input[type="checkbox"] {
+  // The actual styled choicefield element - radio button by default
+  + .ms-ChoiceField-field {
+    @include margin-left(-8px);
+    padding: 8px;
+
+    &:after {
+      top: 7px;
+      left: 7px;
+    }
+
+    .ms-Label {
+      padding: 0 0 0 34px;
+    }
+  }
+
+  &:focus {
+    + .ms-ChoiceField-field {
+      outline: none;
+    }
+  }
+
+  &:checked {
+    + .ms-ChoiceField-field {
+      &:before {
+        top: 11px;
+        left: 11px;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Updated the padding for the checkbox to match the redlines and get the keyboard focus rect positioned properly. After adding the padding I also added a negative margin-left so the focus rect is positioned properly while still maintaining the default component positioning. 

Design wanted the focus rext to surround the check and label. Since the :before is already being used by the label.ms-ChoiceField-field this conflicted with the focus-border mixin so I had to use the outline for the focus rect. Open to suggestions if there is a better way to approach this. 

![checkbox_focus_rect](https://cloud.githubusercontent.com/assets/13757784/17227564/c927c666-54c3-11e6-9b56-c7380059c9cb.png)