### PR TITLE
#218302: updated keyboard focus styles for pivot links and pivot tab …

### DIFF
--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -13,6 +13,9 @@
   @include ms-u-normalize;
   font-size: $ms-font-size-m;
   font-weight: $ms-font-weight-regular;
+  position: relative;
+  color: $ms-color-themePrimary;
+  white-space: nowrap;
 }
 
 .ms-Pivot-links {
@@ -35,6 +38,10 @@
 
   &:hover {
     cursor: pointer;
+  }
+
+  &:focus {
+    outline: none;
   }
 
   // Underline, not yet visible
@@ -77,11 +84,13 @@
   }
 }
 
-
-
+.ms-Fabric.is-focusVisible .ms-Pivot-link {
+  &:focus {
+    outline: 1px solid $ms-color-neutralSecondaryAlt;
+  }
+}
 
 // @TODO: Determine if any of the styles below this are necessary anymore.
-
 
 // Overflow (ellipsis)
 .ms-Pivot-link.ms-Pivot-link--overflow {
@@ -133,16 +142,16 @@
   }
 }
 
-
 //== Modifier: Tabs
 //
 .ms-Pivot.ms-Pivot--tabs {
 
   .ms-Pivot-link {
+    @include focus-border();
     height: 40px;
     background-color: $ms-color-neutralLighter;
     line-height: 40px;
-    margin-right: -2px; // Remove space next to inline-block element
+    margin-right: 0px; // Remove space next to inline-block element
     padding: 0 10px;
 
     &:hover:not(.is-selected):not(.ms-Pivot-link--overflow),
@@ -175,6 +184,14 @@
   }
 }
 
+.ms-Fabric.is-focusVisible .ms-Pivot.ms-Pivot--tabs .ms-Pivot-link:focus {
+  &:before {
+    height: auto;
+    background: transparent;
+    transition: none;
+  }
+}
+
 // @TODO: Confirm that this component is not responsive.
 //
 // @media (min-width: $ms-screen-lg-min) {
@@ -198,12 +215,4 @@
       }
     }
   }
-}
-
-// TODO: Remove override below.
-
-.ms-Pivot {
-  position: relative;
-  color: $ms-color-themePrimary;
-  white-space: nowrap;
 }

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -148,10 +148,10 @@
 
   .ms-Pivot-link {
     @include focus-border();
+    @include margin-right(0px);
     height: 40px;
     background-color: $ms-color-neutralLighter;
     line-height: 40px;
-    margin-right: 0px; // Remove space next to inline-block element
     padding: 0 10px;
 
     &:hover:not(.is-selected):not(.ms-Pivot-link--overflow),


### PR DESCRIPTION
Updated keyboard focus styles for pivot links and pivot tabs. Since the pivot links already use the :before for the selected underline I could not use the focus-border mixin and had to use the outline.

Focus-border does work on the pivot-tabs with a little bit of overriding.

![pivot-focused](https://cloud.githubusercontent.com/assets/13757784/17346048/e164c258-58bd-11e6-8d57-5ad2c514dd80.png)
![pivot-selected-focused](https://cloud.githubusercontent.com/assets/13757784/17346046/e162f860-58bd-11e6-8b89-5e3ff3b1de86.png)
![pivot-tab-focused](https://cloud.githubusercontent.com/assets/13757784/17346047/e163950e-58bd-11e6-89fb-19029f6f8769.png)
