### PR TITLE
#225536: added support for item count on link style pivots. Added Piv…

### DIFF
--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -69,6 +69,10 @@
     &::before {
       background-color: $ms-color-themePrimary;
     }
+
+    .ms-Pivot-count {
+      font-weight: $ms-font-weight-regular;
+    }
   }
 
   //== State: Disabled
@@ -123,6 +127,10 @@
 
     &.is-selected {
       font-weight: $ms-font-weight-semilight;
+    }
+
+    .ms-Pivot-count {
+      @include margin-left(5px);
     }
   }
 

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -69,10 +69,6 @@
     &::before {
       background-color: $ms-color-themePrimary;
     }
-
-    .ms-Pivot-count {
-      font-weight: $ms-font-weight-regular;
-    }
   }
 
   //== State: Disabled

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -127,18 +127,10 @@
 
     &.is-selected {
       font-weight: $ms-font-weight-semilight;
-
-      .ms-Pivot-count {
-        font-weight: $ms-font-weight-regular;
-      }
     }
 
     .ms-Pivot-count {
-      @include margin-left(5px);
-    }
-
-    .ms-Pivot-count {
-      @include margin-left(5px);
+      @include margin-left(4px);
     }
   }
 

--- a/src/components/Pivot/Pivot.tsx
+++ b/src/components/Pivot/Pivot.tsx
@@ -102,7 +102,13 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
    */
   private _renderLink(link: IPivotItemProps) {
     const itemKey = link.itemKey;
+    const itemCount = link.itemCount;
     let { id } = this.state;
+    let countText;
+    if (itemCount !== undefined && this.props.linkFormat !== PivotLinkFormat.tabs) {
+      countText = <span className={ css('ms-Pivot-count') }>({ itemCount })</span>;
+    }
+
     return (
       <a
         id={ id + '-tab' }
@@ -115,6 +121,7 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
         aria-controls={ id + '-panel' }
         aria-selected={ this.state.selectedKey === itemKey }>
         { link.linkText }
+        { countText }
       </a>
     );
   }
@@ -153,7 +160,8 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
         links.push({
           linkText: pivotItem.props.linkText,
           ariaLabel: pivotItem.props.ariaLabel,
-          itemKey: itemKey
+          itemKey: itemKey,
+          itemCount: pivotItem.props.itemCount
         });
         this._keyToIndexMapping[itemKey] = index;
       }

--- a/src/components/Pivot/Pivot.tsx
+++ b/src/components/Pivot/Pivot.tsx
@@ -101,12 +101,11 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
    * Renders a pivot link
    */
   private _renderLink(link: IPivotItemProps) {
-    const itemKey = link.itemKey;
-    const itemCount = link.itemCount;
+    const { itemKey, itemCount } = link;
     let { id } = this.state;
     let countText;
     if (itemCount !== undefined && this.props.linkFormat !== PivotLinkFormat.tabs) {
-      countText = <span className={ css('ms-Pivot-count') }>({ itemCount })</span>;
+      countText = <span className='ms-Pivot-count'>({ itemCount })</span>;
     }
 
     return (

--- a/src/components/Pivot/PivotItem.Props.ts
+++ b/src/components/Pivot/PivotItem.Props.ts
@@ -19,4 +19,12 @@ export interface IPivotItemProps extends React.HTMLProps<HTMLDivElement> {
    * Note that unless you have compelling requirements you should not override aria-label.
    */
   ariaLabel?: string;
+
+  /**
+   * An optional item count that gets displayed just after the linkText(itemCount)
+   *
+   * Example: completed(4)
+   */
+  itemCount?: number;
+
 }

--- a/src/demo/pages/PivotPage/PivotPage.tsx
+++ b/src/demo/pages/PivotPage/PivotPage.tsx
@@ -9,6 +9,7 @@ import {
 
 import { PivotBasicExample } from './examples/Pivot.Basic.Example';
 import { PivotLargeExample } from './examples/Pivot.Large.Example';
+import { PivotItemCountExample } from './examples/Pivot.ItemCount.Example';
 import { PivotTabsExample } from './examples/Pivot.Tabs.Example';
 import { PivotTabsLargeExample } from './examples/Pivot.TabsLarge.Example';
 import { PivotFabricExample } from './examples/Pivot.Fabric.Example';
@@ -18,6 +19,7 @@ import { PivotRemoveExample } from './examples/Pivot.Remove.Example';
 const PivotRemoveExampleCode = require('./examples/Pivot.Remove.Example.tsx');
 const PivotBasicExampleCode = require('./examples/Pivot.Basic.Example.tsx');
 const PivotLargeExampleCode = require('./examples/Pivot.Large.Example.tsx');
+const PivotItemCountExampleCode = require('./examples/Pivot.ItemCount.Example.tsx');
 const PivotTabsExampleCode = require('./examples/Pivot.Tabs.Example.tsx');
 const PivotTabsLargesExampleCode = require('./examples/Pivot.TabsLarge.Example.tsx');
 const PivotFabricExampleCode = require('./examples/Pivot.Fabric.Example.tsx');
@@ -38,6 +40,9 @@ export class PivotPage extends React.Component<any, any> {
         </ExampleCard>
         <ExampleCard title='Large link size' code={ PivotLargeExampleCode }>
           <PivotLargeExample />
+        </ExampleCard>
+        <ExampleCard title='Item Count' code={ PivotItemCountExampleCode }>
+          <PivotItemCountExample />
         </ExampleCard>
         <ExampleCard title='Links of tab style' code={ PivotTabsExampleCode }>
           <PivotTabsExample />

--- a/src/demo/pages/PivotPage/PivotPage.tsx
+++ b/src/demo/pages/PivotPage/PivotPage.tsx
@@ -41,7 +41,7 @@ export class PivotPage extends React.Component<any, any> {
         <ExampleCard title='Large link size' code={ PivotLargeExampleCode }>
           <PivotLargeExample />
         </ExampleCard>
-        <ExampleCard title='Item Count' code={ PivotItemCountExampleCode }>
+        <ExampleCard title='Item count' code={ PivotItemCountExampleCode }>
           <PivotItemCountExample />
         </ExampleCard>
         <ExampleCard title='Links of tab style' code={ PivotTabsExampleCode }>

--- a/src/demo/pages/PivotPage/examples/Pivot.ItemCount.Example.tsx
+++ b/src/demo/pages/PivotPage/examples/Pivot.ItemCount.Example.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {
+  Label,
+  Pivot,
+  PivotItem,
+  PivotLinkSize
+} from '../../../../index';
+
+export class PivotItemCountExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <div>
+        <Pivot linkSize={ PivotLinkSize.large }>
+            <PivotItem linkText='My Files' itemCount={ 5 }>
+              <Label>Pivot #1</Label>
+            </PivotItem>
+            <PivotItem linkText='Recent' itemCount={ 0 }>
+              <Label>Pivot #2</Label>
+            </PivotItem>
+            <PivotItem linkText='Shared with me' itemCount={ 22 }>
+              <Label>Pivot #3</Label>
+            </PivotItem>
+        </Pivot>
+      </div>
+    );
+  }
+
+}


### PR DESCRIPTION
Added support for an itemCount to be added to link style pivot items. Also created a Pivot.ItemCount.Example for the Pivot demo page. 

![pivot-item-count-example](https://cloud.githubusercontent.com/assets/13757784/17350219/7ff6d242-58d9-11e6-8660-872481c63ae7.png)
