### PR TITLE
Add 'npm start' and 'npm test' scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "url": "https://github.com/OfficeDev/office-ui-fabric-react"
   },
   "license": "MIT",
+  "scripts": {
+    "start": "gulp serve",
+    "test": "gulp test"
+  },
   "devDependencies": {
     "es6-promise": "3.2.1",
     "git-rev": "0.2.1",


### PR DESCRIPTION
For people who don't like to search for gulp task names or don't have a
global gulp installation.