### PR TITLE
Antonla/button aria instance

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -15,7 +15,8 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
     elementType: ElementType.button,
     buttonType: ButtonType.normal
   };
-  private static _instance: number = 0;
+  // Start at random value in case consumer bundles react multiple times
+  private static _instance: number = Math.round(Math.random() * 1000);
   private _buttonElement: HTMLButtonElement;
 
   constructor(props: IButtonProps) {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,22 +10,21 @@ export interface IButtonState {
   ariaDescriptionId?: string;
 }
 
-let _instance = 0;
-
 export class Button extends React.Component<IButtonProps, IButtonState> {
   public static defaultProps: IButtonProps = {
     elementType: ElementType.button,
     buttonType: ButtonType.normal
   };
+  private static _instance: number = 0;
   private _buttonElement: HTMLButtonElement;
 
   constructor(props: IButtonProps) {
     super(props);
 
     this.state = {
-      labelId: `Button-${_instance++}`,
-      descriptionId: `Button-${_instance++}`,
-      ariaDescriptionId: `Button-${_instance++}`,
+      labelId: `Button-${Button._instance++}`,
+      descriptionId: `Button-${Button._instance++}`,
+      ariaDescriptionId: `Button-${Button._instance++}`,
     };
   }
 


### PR DESCRIPTION
We found that currently within our app component and page buttons have some repeating IDs. It's most likely due to Fabric being overbundled and being included multiple times, so making the starting value be static and starting at random. 