### PR TITLE
Revert back the aria role grid back.

### DIFF
--- a/src/components/DetailsList/DetailsList.tsx
+++ b/src/components/DetailsList/DetailsList.tsx
@@ -236,6 +236,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
                 />
             ) }
           </div>
+        </div>
           <div ref='contentContainer' onKeyDown={ this._onContentKeyDown }>
             <FocusZone
               ref='focusZone'
@@ -274,7 +275,6 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
             </FocusZone>
           </div>
         </div>
-      </div>
     );
   }
 

--- a/src/components/DetailsList/DetailsList.tsx
+++ b/src/components/DetailsList/DetailsList.tsx
@@ -237,44 +237,44 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
             ) }
           </div>
         </div>
-          <div ref='contentContainer' onKeyDown={ this._onContentKeyDown }>
-            <FocusZone
-              ref='focusZone'
-              direction={ FocusZoneDirection.vertical }
-              isInnerZoneKeystroke={ (ev) => (ev.which === getRTLSafeKeyCode(KeyCodes.right)) }
-              onActiveElementChanged={ this._onActiveRowChanged }
-              >
-              <SelectionZone
-                selection={ selection }
-                selectionMode={ selectionMode }
-                onItemInvoked={ onItemInvoked }>
-                { groups ? (
-                  <GroupedList
-                    groups={ groups }
-                    groupProps={ groupProps }
+        <div ref='contentContainer' onKeyDown={ this._onContentKeyDown }>
+          <FocusZone
+            ref='focusZone'
+            direction={ FocusZoneDirection.vertical }
+            isInnerZoneKeystroke={ (ev) => (ev.which === getRTLSafeKeyCode(KeyCodes.right)) }
+            onActiveElementChanged={ this._onActiveRowChanged }
+            >
+            <SelectionZone
+              selection={ selection }
+              selectionMode={ selectionMode }
+              onItemInvoked={ onItemInvoked }>
+              { groups ? (
+                <GroupedList
+                  groups={ groups }
+                  groupProps={ groupProps }
+                  items={ items }
+                  onRenderCell={ this._onRenderCell }
+                  selection={ selection }
+                  selectionMode={ selectionMode }
+                  dragDropEvents={ dragDropEvents }
+                  dragDropHelper={ dragDropHelper }
+                  eventsToRegister={ rowElementEventMap }
+                  listProps={ additionalListProps }
+                  ref='groups'
+                  />
+              ) : (
+                  <List
                     items={ items }
-                    onRenderCell={ this._onRenderCell }
-                    selection={ selection }
-                    selectionMode={ selectionMode }
-                    dragDropEvents={ dragDropEvents }
-                    dragDropHelper={ dragDropHelper }
-                    eventsToRegister={ rowElementEventMap }
-                    listProps={ additionalListProps }
-                    ref='groups'
+                    onRenderCell={ (item, itemIndex) => this._onRenderCell(0, item, itemIndex) }
+                    { ...additionalListProps }
+                    ref='list'
                     />
-                ) : (
-                    <List
-                      items={ items }
-                      onRenderCell={ (item, itemIndex) => this._onRenderCell(0, item, itemIndex) }
-                      { ...additionalListProps }
-                      ref='list'
-                      />
-                  )
-                }
-              </SelectionZone>
-            </FocusZone>
-          </div>
+                )
+              }
+            </SelectionZone>
+          </FocusZone>
         </div>
+      </div>
     );
   }
 


### PR DESCRIPTION
Reverting the aria role grid to its previous state because JAWS has stopped reading the row aria label with this.