### PR TITLE
Apply high contrast styles to Dropdown's :hover, :focus, :active

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -39,6 +39,14 @@
     .ms-Dropdown-title,
     .ms-Dropdown-caretDown {
       color: $ms-color-black;
+
+      @media screen and (-ms-high-contrast: active) {
+        color: $ms-color-contrastBlackSelected;
+      }
+
+      @media screen and (-ms-high-contrast: black-on-white) {
+        color: $ms-color-contrastWhiteSelected;
+      }
     }
   }
 
@@ -46,12 +54,28 @@
   &:active {
     .ms-Dropdown-title {
       border-color: $ms-color-neutralSecondaryAlt;
+
+      @media screen and (-ms-high-contrast: active) {
+        border-color: $ms-color-contrastBlackSelected;
+      }
+
+      @media screen and (-ms-high-contrast: black-on-white) {
+        border-color: $ms-color-contrastWhiteSelected;
+      }
     }
   }
 
   &:focus {
     .ms-Dropdown-title {
       border-color: $ms-color-themePrimary;
+
+      @media screen and (-ms-high-contrast: active) {
+        border-color: $ms-color-contrastBlackSelected;
+      }
+
+      @media screen and (-ms-high-contrast: black-on-white) {
+        border-color: $ms-color-contrastWhiteSelected;
+      }
     }
   }
 


### PR DESCRIPTION
In high contrast:
before: [view link](https://microsoft-my.sharepoint.com/personal/cmalonzo_microsoft_com/_layouts/15/guestaccess.aspx?guestaccesstoken=oHmF3f8GUrmmLrjRmn2t9I04hl6CHyhzFqhsFwPTyJA%3d&docid=2_0c812cde9efb34410a26286671279d892&rev=1)
after: [view link](https://microsoft-my.sharepoint.com/personal/cmalonzo_microsoft_com/_layouts/15/guestaccess.aspx?guestaccesstoken=44zSwqyu6taG7Tj1gA%2fxFF1t%2ffFZNLVhC%2fEVDzE1FlY%3d&docid=2_0bf12bf5f14bc492aad006ca6c079255a&rev=1)

In black and white:
before: [view link](https://microsoft-my.sharepoint.com/personal/cmalonzo_microsoft_com/_layouts/15/guestaccess.aspx?guestaccesstoken=7GvjY3cbLnNyg%2b%2fwu7O%2btD%2fRrfOjbk%2fowOKTHzeKvRA%3d&docid=2_0724147ae22064fe28b1943439a69fdbb&rev=1)
after: [view link](https://microsoft-my.sharepoint.com/personal/cmalonzo_microsoft_com/_layouts/15/guestaccess.aspx?guestaccesstoken=LJH0RUSSo4NK%2bE3lOru4OuJ0vRR%2f6O2AGrto%2bRw8GNU%3d&docid=2_0f360f79a4b324a29a933c548eb98ec11&rev=1)