### PR TITLE
[major] Change Button and FocusZone to rootProps model

### DIFF
--- a/src/components/Button/Button.Props.ts
+++ b/src/components/Button/Button.Props.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { Button } from './Button';
 
-export interface IButtonProps extends React.HTMLProps<HTMLElement> {
+export interface IButtonProps extends React.Props<Button> {
   /**
    * The type of the element to render.
    * @default ElementType.anchor
@@ -30,6 +31,16 @@ export interface IButtonProps extends React.HTMLProps<HTMLElement> {
   disabled?: boolean;
 
   /**
+   * If provided, additional class name to provide on the root element.
+   */
+  className?: string;
+
+  /**
+   * Event handler for click event.
+   */
+  onClick?: React.MouseEventHandler;
+
+  /**
    * The aria label of the button for the benefit of screen readers.
    */
   ariaLabel?: string;
@@ -40,12 +51,22 @@ export interface IButtonProps extends React.HTMLProps<HTMLElement> {
    * Besides the compound button, other button types will need more information provided to screen reader.
    */
   ariaDescription?: string;
+
+  /**
+   * If provided, HTMLProps which will be mixed in onto the root element emitted by this component, before
+   * other props are applied. This allows you to extend the root element with additional attributes, such as
+   * data-automation-id needed for automation.
+   *
+   * The root element will either be a button or an anchor, depending on what value is specified for
+   * the elementType prop.
+   */
+  rootProps?: React.HTMLProps<HTMLButtonElement> | React.HTMLProps<HTMLAnchorElement>;
 }
 
 export enum ElementType {
-  /** <button> element */
+  /** <button> element. */
   button,
-  /** <a> element */
+  /** <a> element. */
   anchor
 }
 

--- a/src/components/Button/Button.Props.ts
+++ b/src/components/Button/Button.Props.ts
@@ -3,10 +3,10 @@ import { Button } from './Button';
 
 export interface IButtonProps extends React.Props<Button> {
   /**
-   * The type of the element to render.
+   * If provided, this component will be rendered as an anchor.
    * @default ElementType.anchor
    */
-  elementType?: ElementType;
+  href?: string;
 
   /**
    * The type of button to render.

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import './Button.scss';
 import { css } from '../../utilities/css';
 import { assign } from '../../utilities/object';
-import { IButtonProps, ButtonType, ElementType } from './Button.Props';
+import { IButtonProps, ButtonType } from './Button.Props';
 
 export interface IButtonState {
   labelId?: string;
@@ -14,7 +14,6 @@ let _instance = 0;
 
 export class Button extends React.Component<IButtonProps, IButtonState> {
   public static defaultProps: IButtonProps = {
-    elementType: ElementType.button,
     buttonType: ButtonType.normal
   };
   private _buttonElement: HTMLButtonElement;
@@ -30,10 +29,11 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
   }
 
   public render(): JSX.Element {
-    let { buttonType, children, icon, description, ariaLabel, ariaDescription, elementType, disabled } = this.props;
+    let { buttonType, children, icon, description, ariaLabel, ariaDescription, href, disabled } = this.props;
     let { labelId, descriptionId, ariaDescriptionId } = this.state;
 
-    const tag = elementType === ElementType.button ? 'button' : 'a';
+    const renderAsAnchor: boolean = !!href;
+    const tag = !renderAsAnchor ? 'button' : 'a';
 
     const className = css((this.props.className), 'ms-Button', {
       'ms-Button--primary': buttonType === ButtonType.primary,
@@ -41,7 +41,7 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
       'ms-Button--compound': buttonType === ButtonType.compound,
       'ms-Button--command': buttonType === ButtonType.command,
       'ms-Button--icon': buttonType === ButtonType.icon,
-      'disabled': (elementType === ElementType.anchor && disabled)
+      'disabled': (!renderAsAnchor && disabled)
     });
 
     const iconSpan = icon && (buttonType === ButtonType.command || buttonType === ButtonType.hero || buttonType === ButtonType.icon)
@@ -69,7 +69,8 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
           'aria-label': ariaLabel,
           'aria-labelledby': ariaLabel ? null : labelId,
           'aria-describedby': ariaDescription ? ariaDescriptionId : description ? descriptionId : null,
-          'ref': (c: HTMLButtonElement): HTMLButtonElement => this._buttonElement = c
+          'ref': (c: HTMLButtonElement): HTMLButtonElement => this._buttonElement = c,
+          'onClick': this.props.onClick
         },
         { className }),
       iconSpan,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,14 +3,13 @@ import './Button.scss';
 import { css } from '../../utilities/css';
 import { assign } from '../../utilities/object';
 import { IButtonProps, ButtonType } from './Button.Props';
+import { getId } from '../../utilities/object';
 
 export interface IButtonState {
   labelId?: string;
   descriptionId?: string;
   ariaDescriptionId?: string;
 }
-
-let _instance = 0;
 
 export class Button extends React.Component<IButtonProps, IButtonState> {
   public static defaultProps: IButtonProps = {
@@ -22,14 +21,14 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
     super(props);
 
     this.state = {
-      labelId: `Button-${_instance++}`,
-      descriptionId: `Button-${_instance++}`,
-      ariaDescriptionId: `Button-${_instance++}`,
+      labelId: getId('Button-'),
+      descriptionId: getId('Button-'),
+      ariaDescriptionId: getId('Button-'),
     };
   }
 
   public render(): JSX.Element {
-    let { buttonType, children, icon, description, ariaLabel, ariaDescription, href, disabled } = this.props;
+    let { buttonType, children, icon, description, ariaLabel, ariaDescription, href, disabled, onClick } = this.props;
     let { labelId, descriptionId, ariaDescriptionId } = this.state;
 
     const renderAsAnchor: boolean = !!href;
@@ -41,7 +40,8 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
       'ms-Button--compound': buttonType === ButtonType.compound,
       'ms-Button--command': buttonType === ButtonType.command,
       'ms-Button--icon': buttonType === ButtonType.icon,
-      'disabled': (!renderAsAnchor && disabled)
+      'disabled': (renderAsAnchor && disabled) // add disable styling if it is an anchor
+                                               // if not utilize default button disabled behavior.
     });
 
     const iconSpan = icon && (buttonType === ButtonType.command || buttonType === ButtonType.hero || buttonType === ButtonType.icon)
@@ -69,9 +69,10 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
           'aria-label': ariaLabel,
           'aria-labelledby': ariaLabel ? null : labelId,
           'aria-describedby': ariaDescription ? ariaDescriptionId : description ? descriptionId : null,
-          'ref': (c: HTMLButtonElement): HTMLButtonElement => this._buttonElement = c,
-          'onClick': this.props.onClick
+          'ref': (c: HTMLButtonElement): HTMLButtonElement => this._buttonElement = c
         },
+        onClick && { 'onClick': onClick },
+        disabled && { 'disabled': disabled },
         { className }),
       iconSpan,
       <span className='ms-Button-label' id={ labelId } >{ children }</span>,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -63,6 +63,7 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
     return React.createElement(
       tag,
       assign(
+        {},
         this.props.rootProps,
         {
           'aria-label': ariaLabel,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -33,7 +33,7 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
     let { labelId, descriptionId, ariaDescriptionId } = this.state;
 
     const renderAsAnchor: boolean = !!href;
-    const tag = !renderAsAnchor ? 'button' : 'a';
+    const tag = renderAsAnchor ? 'a' : 'button';
 
     const className = css((this.props.className), 'ms-Button', {
       'ms-Button--primary': buttonType === ButtonType.primary,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -33,9 +33,9 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
     let { buttonType, children, icon, description, ariaLabel, ariaDescription, elementType, disabled } = this.props;
     let { labelId, descriptionId, ariaDescriptionId } = this.state;
 
-    const tag = this.props.elementType === ElementType.button ? 'button' : 'a';
+    const tag = elementType === ElementType.button ? 'button' : 'a';
 
-    const className = css(this.props.className, 'ms-Button', {
+    const className = css((this.props.className), 'ms-Button', {
       'ms-Button--primary': buttonType === ButtonType.primary,
       'ms-Button--hero': buttonType === ButtonType.hero,
       'ms-Button--compound': buttonType === ButtonType.compound,
@@ -62,13 +62,14 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
 
     return React.createElement(
       tag,
-      assign({
-        'aria-label': ariaLabel,
-        'aria-labelledby': ariaLabel ? null : labelId,
-        'aria-describedby': ariaDescription ? ariaDescriptionId : description ? descriptionId : null,
-        'ref': (c: HTMLButtonElement): HTMLButtonElement => this._buttonElement = c
-      },
-        this.props,
+      assign(
+        this.props.rootProps,
+        {
+          'aria-label': ariaLabel,
+          'aria-labelledby': ariaLabel ? null : labelId,
+          'aria-describedby': ariaDescription ? ariaDescriptionId : description ? descriptionId : null,
+          'ref': (c: HTMLButtonElement): HTMLButtonElement => this._buttonElement = c
+        },
         { className }),
       iconSpan,
       <span className='ms-Button-label' id={ labelId } >{ children }</span>,

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -101,7 +101,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
     return (
       <div className={ css('ms-CommandBar', className) } ref='commandBarRegion'>
         { searchBox }
-        <FocusZone direction={ FocusZoneDirection.horizontal } role='menubar'>
+        <FocusZone direction={ FocusZoneDirection.horizontal } rootProps={ { role:'menubar' } }>
           <div className='ms-CommandBar-primaryCommands' ref='commandSurface'>
             { renderedItems.map((item, index) => (
               this._renderItemInCommandBar(item, index, expandedMenuItemKey)

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -188,11 +188,13 @@ export class ContextualMenu extends React.Component<IContextualMenuProps, IConte
         <div ref={ (host: HTMLDivElement) => this._host = host} id={ id } className={ css('ms-ContextualMenu-container', className) }>
           { (items && items.length) ? (
             <FocusZone
-              className={ 'ms-ContextualMenu is-open'}
               direction={ FocusZoneDirection.vertical }
-              role='menu'
               ariaLabelledBy={ labelElementId }
               ref={ (focusZone) => this._focusZone = focusZone }
+              rootProps= { {
+                className: 'ms-ContextualMenu is-open',
+                role: 'menu'
+              } }
               >
               <ul className='ms-ContextualMenu-list is-open' onKeyDown={ this._onKeyDown }>
                 { items.map((item, index) => (

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -191,7 +191,7 @@ export class ContextualMenu extends React.Component<IContextualMenuProps, IConte
               direction={ FocusZoneDirection.vertical }
               ariaLabelledBy={ labelElementId }
               ref={ (focusZone) => this._focusZone = focusZone }
-              rootProps= { {
+              rootProps={ {
                 className: 'ms-ContextualMenu is-open',
                 role: 'menu'
               } }

--- a/src/components/DocumentCard/DocumentCardActions.tsx
+++ b/src/components/DocumentCard/DocumentCardActions.tsx
@@ -15,9 +15,9 @@ export class DocumentCardActions extends React.Component<IDocumentCardActionsPro
           <Button
             buttonType={ ButtonType.icon }
             icon={ action.icon }
-            title=''
-            description=''
-            onClick={ action.onClick } />
+            onClick={ action.onClick }
+            rootProps={ { title:'' } }
+            description='' />
         </div>
         )) }
 

--- a/src/components/FocusZone/FocusZone.Props.ts
+++ b/src/components/FocusZone/FocusZone.Props.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { FocusZone } from './FocusZone';
 
-export interface IFocusZoneProps extends React.HTMLProps<HTMLDivElement> {
+export interface IFocusZoneProps extends React.Props<FocusZone> {
   /**
    * Defines which arrows to react to.
    * @default FocusZoneDirection.bidriectional
@@ -36,6 +37,18 @@ export interface IFocusZoneProps extends React.HTMLProps<HTMLDivElement> {
    * or by having one of its respective children elements focused.
    */
   onActiveElementChanged?: (element?: HTMLElement, ev?: React.FocusEvent) => void;
+
+  /**
+   * If provided, additional class name to provide on the root element.
+   */
+  className?: string;
+
+  /**
+   * If provided, HTMLProps which will be mixed in onto the root element emitted by the FocusZone, before
+   * other props are applied. This allows you to extend the root element with additional attributes, such as
+   * data-automation-id needed for automation.
+   */
+  rootProps?: React.HTMLProps<HTMLDivElement>;
 }
 
 export enum FocusZoneDirection {

--- a/src/components/FocusZone/FocusZone.tsx
+++ b/src/components/FocusZone/FocusZone.tsx
@@ -85,12 +85,12 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> {
   }
 
   public render() {
-    let { className, ariaLabelledBy } = this.props;
+    let { rootProps, ariaLabelledBy } = this.props;
 
     return (
       <div
-        { ...this.props as any }
-        className={ css('ms-FocusZone', className) }
+        { ...this.props.rootProps as any }
+        className={ css('ms-FocusZone', rootProps && rootProps.className ) }
         ref='root'
         data-focuszone-id={ this._id }
         aria-labelledby={ ariaLabelledBy }

--- a/src/components/FocusZone/FocusZone.tsx
+++ b/src/components/FocusZone/FocusZone.tsx
@@ -85,12 +85,12 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> {
   }
 
   public render() {
-    let { rootProps, ariaLabelledBy } = this.props;
+    let { rootProps, ariaLabelledBy, className } = this.props;
 
     return (
       <div
-        { ...this.props.rootProps as any }
-        className={ css('ms-FocusZone', rootProps && rootProps.className ) }
+        { ...rootProps }
+        className={ css('ms-FocusZone', className ) }
         ref='root'
         data-focuszone-id={ this._id }
         aria-labelledby={ ariaLabelledBy }

--- a/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
@@ -57,12 +57,12 @@ export class ButtonBasicExample extends React.Component<any, IBasicButtonsExampl
         <Label>Button with aria description for screen reader</Label>
         <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.primary } ariaDescription='This is aria description used for screen reader.'>Aria Description</Button>
 
-        <Checkbox text='Disable buttons' isChecked={ areButtonsDisabled } onChanged={ this._onDisabledChanged } />
+        <Checkbox label='Disable buttons' checked={ areButtonsDisabled } onChange={ this._onDisabledChanged.bind(this) } />
       </div>
     );
   }
 
-  private _onDisabledChanged(isDisabled: boolean) {
+  private _onDisabledChanged(ev: React.MouseEvent, isDisabled: boolean) {
     this.setState({
       areButtonsDisabled: isDisabled
     });

--- a/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
@@ -45,10 +45,17 @@ export class ButtonBasicExample extends React.Component<any, IBasicButtonsExampl
         <Button disabled={ disabled } buttonType={ ButtonType.command } icon='personAdd' description='Description of the action this button takes'>Create account</Button>
 
         <Label>Icon button</Label>
-        <Button disabled={ disabled } buttonType={ ButtonType.icon } icon='star' title='Star' ariaLabel='Take a star' />
+        <Button disabled={ disabled } buttonType={ ButtonType.icon } icon='star' rootProps={ { title: 'Star' } } ariaLabel='Take a star' />
 
-        <Label>Button like anchor</Label>
-        <Button disabled={ disabled } elementType={ ElementType.anchor } buttonType={ ButtonType.primary } href='http://bing.com' target='_blank' title='Let us bing!' description='Navigate to Bing home page.'>Bing</Button>
+        <Label>Button like anchor (cannot be disabled)</Label>
+        <Button
+          disabled={ disabled }
+          elementType={ ElementType.anchor }
+          buttonType={ ButtonType.primary }
+          rootProps={ { href: 'http://bing.com', target: '_blank', title: 'Let us bing!' } }
+          description='Navigate to Bing home page.'>
+          Bing
+        </Button>
 
         <Label>Button with aria description for screen reader</Label>
         <Button disabled={ disabled } buttonType={ ButtonType.primary } ariaDescription='This is aria description used for screen reader.'>Aria Description</Button>

--- a/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
@@ -39,12 +39,18 @@ export class ButtonBasicExample extends React.Component<any, IBasicButtonsExampl
         <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.compound } description='You can create a new account here.'>Create account</Button>
 
         <Label>Command button</Label>
-        <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.command } icon='personAdd' description='Description of the action this button takes'>Create account</Button>
+        <Button
+          buttonType={ ButtonType.command }
+          icon='personAdd'
+          description='Description of the action this button takes'
+          rootProps={ { disabled: areButtonsDisabled } }>
+          Create account
+        </Button>
 
         <Label>Icon button</Label>
         <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.icon } icon='star' rootProps={ { title: 'Star' } } ariaLabel='Take a star' />
 
-        <Label>Button like anchor (cannot be disabled)</Label>
+        <Label>Button like anchor</Label>
         <Button
           disabled={ areButtonsDisabled }
           buttonType={ ButtonType.primary }

--- a/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Basic.Example.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 import {
   Button,
   ButtonType,
-  ElementType,
   Label,
   Checkbox
 } from '../../../../index';
 import './Button.Basic.Example.scss';
 
 export interface IBasicButtonsExampleState {
-  disabled: boolean;
+  areButtonsDisabled: boolean;
 }
 
 export class ButtonBasicExample extends React.Component<any, IBasicButtonsExampleState> {
@@ -20,54 +19,54 @@ export class ButtonBasicExample extends React.Component<any, IBasicButtonsExampl
     this._onDisabledChanged = this._onDisabledChanged.bind(this);
 
     this.state = {
-      disabled: false
+      areButtonsDisabled: false
     };
   }
 
   public render() {
-    let { disabled } = this.state;
+    let { areButtonsDisabled } = this.state;
 
     return (
       <div className='ms-BasicButtonsExample'>
         <Label>Normal button</Label>
-        <Button disabled={ disabled }>Create account</Button>
+        <Button disabled={ areButtonsDisabled }>Create account</Button>
 
         <Label>Primary button</Label>
-        <Button disabled={ disabled } buttonType={ ButtonType.primary }>Create account</Button>
+        <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.primary }>Create account</Button>
 
         <Label>Hero button</Label>
-        <Button disabled={ disabled } buttonType={ ButtonType.hero }>Create account</Button>
+        <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.hero }>Create account</Button>
 
         <Label>Compound button</Label>
-        <Button disabled={ disabled } buttonType={ ButtonType.compound } description='You can create a new account here.'>Create account</Button>
+        <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.compound } description='You can create a new account here.'>Create account</Button>
 
         <Label>Command button</Label>
-        <Button disabled={ disabled } buttonType={ ButtonType.command } icon='personAdd' description='Description of the action this button takes'>Create account</Button>
+        <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.command } icon='personAdd' description='Description of the action this button takes'>Create account</Button>
 
         <Label>Icon button</Label>
-        <Button disabled={ disabled } buttonType={ ButtonType.icon } icon='star' rootProps={ { title: 'Star' } } ariaLabel='Take a star' />
+        <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.icon } icon='star' rootProps={ { title: 'Star' } } ariaLabel='Take a star' />
 
         <Label>Button like anchor (cannot be disabled)</Label>
         <Button
-          disabled={ disabled }
-          elementType={ ElementType.anchor }
+          disabled={ areButtonsDisabled }
           buttonType={ ButtonType.primary }
-          rootProps={ { href: 'http://bing.com', target: '_blank', title: 'Let us bing!' } }
+          href='http://bing.com'
+          rootProps={ { target: '_blank', title: 'Let us bing!' } }
           description='Navigate to Bing home page.'>
           Bing
         </Button>
 
         <Label>Button with aria description for screen reader</Label>
-        <Button disabled={ disabled } buttonType={ ButtonType.primary } ariaDescription='This is aria description used for screen reader.'>Aria Description</Button>
+        <Button disabled={ areButtonsDisabled } buttonType={ ButtonType.primary } ariaDescription='This is aria description used for screen reader.'>Aria Description</Button>
 
-        <Checkbox text='Disable buttons' isChecked={ disabled } onChanged={ this._onDisabledChanged } />
+        <Checkbox text='Disable buttons' isChecked={ areButtonsDisabled } onChanged={ this._onDisabledChanged } />
       </div>
     );
   }
 
   private _onDisabledChanged(isDisabled: boolean) {
     this.setState({
-      disabled: isDisabled
+      areButtonsDisabled: isDisabled
     });
   }
 }


### PR DESCRIPTION
From @dzearing:

> The root problem is this:
>  
> `<div { …this.props }>`
>  
> We want to support scenarios where the caller can provide any default HTML attributes for the root element. A use case might be that they want to provide a data-automation-id or a style attribute. Things like Button or FocusZone are just simple wrappers around simple components and there are many default attributes that could be pushed into the root. But clearly, this is not great if properties that default `div`s don’t support are getting things like “buttonType” and React is warning on it.
>  
> Cliff and I worked out a separate, better solution that will be documented a lot more clearly; for props that you wish to “mix in” to the root, we will expose those as a separate “rootProps” property.
>  
> Something like instead of:
>  
> ```typescript
> <Button style={ { background: ‘red’ } } />
>  ```
>  
> You would say:
>  
> ```typescript
>  <Button rootProps={ { style: ‘background: red’ } } />
>   ```
>  
> While it’s a bit less ergonomic, it means that it is entirely more clear about what things get mixed into the `div`. the `rootProps` property will be of type `HTMLProps<…>` and will have its own description, so that we can be very explicit to say “you can mix any valid div property in here”. That enables the consumer to do things like mix in data-automation-id attributes in a predictable way.
>  
> Every component would get this, we could be really consistent here. We could also support mixing in props into sub elements. For example, perhaps `<TextField>` should have props that get mixed into the input element. You could have `inputProps` and document it appropriately, allowing for more optional flexibility.
>  
> This would definitely be a breaking change but I feel like it’s a flexible but more explicit approach towards extensibility.
> 

Also fixes issue #44.
