### PR TITLE
Contextual Menu Link should inherit color

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.scss
+++ b/src/components/ContextualMenu/ContextualMenu.scss
@@ -32,6 +32,7 @@ $ContextualMenu-iconWidth: 24px;
   @include focus-border();
 
   font: inherit;
+  color: inherit;
   background: none;
   border: none;
   margin: 0;


### PR DESCRIPTION
This will allow menu items to theme properly.
Otherwise, they pick up the user-agent styles.