### PR TITLE
Publicly expose the currently selected link and allow setting initially selected link

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -39,6 +39,14 @@
     .ms-Dropdown-title,
     .ms-Dropdown-caretDown {
       color: $ms-color-black;
+
+      @media screen and (-ms-high-contrast: active) {
+        color: $ms-color-contrastBlackSelected;
+      }
+
+      @media screen and (-ms-high-contrast: black-on-white) {
+        color: $ms-color-contrastWhiteSelected;
+      }
     }
   }
 
@@ -46,12 +54,28 @@
   &:active {
     .ms-Dropdown-title {
       border-color: $ms-color-neutralSecondaryAlt;
+
+      @media screen and (-ms-high-contrast: active) {
+        border-color: $ms-color-contrastBlackSelected;
+      }
+
+      @media screen and (-ms-high-contrast: black-on-white) {
+        border-color: $ms-color-contrastWhiteSelected;
+      }
     }
   }
 
   &:focus {
     .ms-Dropdown-title {
       border-color: $ms-color-themePrimary;
+
+      @media screen and (-ms-high-contrast: active) {
+        border-color: $ms-color-contrastBlackSelected;
+      }
+
+      @media screen and (-ms-high-contrast: black-on-white) {
+        border-color: $ms-color-contrastWhiteSelected;
+      }
     }
   }
 

--- a/src/components/Nav/Nav.Props.ts
+++ b/src/components/Nav/Nav.Props.ts
@@ -1,5 +1,15 @@
 import * as React from 'react';
 
+export interface INav {
+  /**
+   * The meta 'key' property of the currently selected NavItem of the Nav. Can return
+   * undefined if the currently selected nav item has no populated key property. Be aware
+   * that in order for Nav to properly understand which key is selected all NavItems in
+   * all groups of the Nav must have populated key properties.
+   */
+  selectedKey: string;
+}
+
 export interface INavProps {
   /**
    * A collection of link groups to display in the navigation bar

--- a/src/components/Nav/Nav.Props.ts
+++ b/src/components/Nav/Nav.Props.ts
@@ -21,6 +21,11 @@ export interface INavProps {
    * Indicates whether the navigation component renders on top of other content in the UI
    */
   isOnTop?: boolean;
+
+  /**
+   * (Optional) The key of the nav item initially selected.
+   */
+  initialSelectedKey?: string;
 }
 
 export interface INavLinkGroup {

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -9,10 +9,10 @@ import {
 
 export interface INavState {
   isGroupExpanded: boolean[];
-  selectedKey?: string;
 }
 
 export class Nav extends React.Component<INavProps, INavState> {
+  private _selectedKey: string;
 
   public static defaultProps: INavProps = {
     groups: null,
@@ -44,12 +44,22 @@ export class Nav extends React.Component<INavProps, INavState> {
     );
   }
 
+  public get selectedKey(): string {
+    return this._selectedKey;
+  }
+
   private _renderLink(link: INavLink, linkIndex: number): React.ReactElement<{}> {
     let { onLinkClick } = this.props;
+
+    const ifLinkSelected: boolean = _isLinkSelected(link);
+    if (ifLinkSelected) {
+      this._selectedKey = link.key;
+    }
+
     return (
       <li key={ linkIndex }>
         <a
-          className={'ms-Nav-link' + (_isLinkSelected(link) ? ' is-selected' : '')}
+          className={'ms-Nav-link' + (ifLinkSelected ? ' is-selected' : '')}
           href={ link.url || 'javascript:' }
           onClick={ onLinkClick }
           aria-label={ link.ariaLabel }

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -9,6 +9,7 @@ import {
 
 export interface INavState {
   isGroupExpanded: boolean[];
+  selectedKey?: string;
 }
 
 export class Nav extends React.Component<INavProps, INavState> {

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
+import { css } from '../../utilities/css';
 import './Nav.scss';
 
 import {
@@ -56,15 +57,15 @@ export class Nav extends React.Component<INavProps, INavState> {
   private _renderLink(link: INavLink, linkIndex: number): React.ReactElement<{}> {
     let { onLinkClick } = this.props;
 
-    const ifLinkSelected: boolean = _isLinkSelected(link, this._selectedKey);
-    if (ifLinkSelected) {
+    const isLinkSelected: boolean = _isLinkSelected(link, this._selectedKey);
+    if (isLinkSelected) {
       this._selectedKey = link.key ? link.key : undefined;
     }
 
     return (
       <li key={ linkIndex }>
         <a
-          className={'ms-Nav-link' + (ifLinkSelected ? ' is-selected' : '')}
+          className={ css('ms-Nav-link', { 'is-selected' : isLinkSelected }) }
           href={ link.url || 'javascript:' }
           onClick={ onLinkClick }
           aria-label={ link.ariaLabel }
@@ -138,7 +139,7 @@ function _isLinkSelected(link: INavLink, selectedKey: string): boolean {
     _urlResolver.href = link.url || '';
     const target: string = _urlResolver.href;
 
-    if (selectedKey && link.key && link.key === selectedKey) {
+    if (selectedKey && link.key === selectedKey) {
       return true;
     }
 

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -58,7 +58,7 @@ export class Nav extends React.Component<INavProps, INavState> {
 
     const ifLinkSelected: boolean = _isLinkSelected(link, this._selectedKey);
     if (ifLinkSelected) {
-      this._selectedKey = link.key;
+      this._selectedKey = link.key ? link.key : undefined;
     }
 
     return (

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -4,6 +4,7 @@ import { css } from '../../utilities/css';
 import './Nav.scss';
 
 import {
+  INav,
   INavProps,
   INavLinkGroup,
   INavLink } from './Nav.Props';
@@ -12,7 +13,7 @@ export interface INavState {
   isGroupExpanded: boolean[];
 }
 
-export class Nav extends React.Component<INavProps, INavState> {
+export class Nav extends React.Component<INavProps, INavState> implements INav {
 
   public static defaultProps: INavProps = {
     groups: null,
@@ -43,7 +44,7 @@ export class Nav extends React.Component<INavProps, INavState> {
 
     return (
       <FocusZone direction={ FocusZoneDirection.vertical }>
-        <nav role='navigation' className={'ms-Nav' + (this.props.isOnTop ? ' is-onTop ms-u-slideRightIn40' : '')}>
+        <nav role='navigation' className={ css('ms-Nav', { 'is-onTop ms-u-slideRightIn40' : this.props.isOnTop }) }>
           { groupElements }
         </nav>
       </FocusZone>
@@ -73,7 +74,7 @@ export class Nav extends React.Component<INavProps, INavState> {
           target={ link.target || '' }
         >
           { (link.iconClassName ?
-          <i className={'ms-Icon ms-Nav-IconLink ' + link.iconClassName}></i>
+          <i className={ css('ms-Icon', 'ms-Nav-IconLink', link.iconClassName) }></i>
           : '') }
          { this.props.onRenderLink(link)}
         </a> { this._renderLinks(link.links) }
@@ -100,18 +101,18 @@ export class Nav extends React.Component<INavProps, INavState> {
     const isGroupExpanded: boolean = this.state.isGroupExpanded[groupIndex] !== false;
 
     return (
-      <div key={ groupIndex } className={ 'ms-Nav-group' + (isGroupExpanded ? ' is-expanded' : '') }>
+      <div key={ groupIndex } className={ css('ms-Nav-group', { 'is-expanded' : isGroupExpanded }) }>
         { (group.name ?
         <button
           className='ms-Nav-groupButton'
           onClick={ this._onGroupHeaderClicked.bind(this, groupIndex) }
         >
-          <i className='ms-Nav-groupChevron ms-Icon ms-Icon--chevronDown'></i>
+          <i className={ css('ms-Nav-groupChevron', 'ms-Icon', 'ms-Icon--chevronDown') }></i>
           { group.name }
         </button> : null)
         }
 
-        <div className='ms-Nav-groupContent ms-u-slideDownIn20'>
+        <div className={ css('ms-Nav-groupContent', 'ms-u-slideDownIn20') }>
         { this._renderLinks(group.links) }
         </div>
       </div>

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -12,12 +12,13 @@ export interface INavState {
 }
 
 export class Nav extends React.Component<INavProps, INavState> {
-  private _selectedKey: string;
 
   public static defaultProps: INavProps = {
     groups: null,
     onRenderLink: (link: INavLink) => (<span className='ms-Nav-linkText'>{ link.name }</span>)
   };
+
+  private _selectedKey: string;
 
   constructor() {
     super();
@@ -30,6 +31,10 @@ export class Nav extends React.Component<INavProps, INavState> {
   public render(): React.ReactElement<{}> {
     if (!this.props.groups) {
       return null;
+    }
+
+    if (this.props.initialSelectedKey) {
+      this._selectedKey = this.props.initialSelectedKey;
     }
 
     const groupElements: React.ReactElement<{}>[] = this.props.groups.map(
@@ -51,7 +56,7 @@ export class Nav extends React.Component<INavProps, INavState> {
   private _renderLink(link: INavLink, linkIndex: number): React.ReactElement<{}> {
     let { onLinkClick } = this.props;
 
-    const ifLinkSelected: boolean = _isLinkSelected(link);
+    const ifLinkSelected: boolean = _isLinkSelected(link, this._selectedKey);
     if (ifLinkSelected) {
       this._selectedKey = link.key;
     }
@@ -126,12 +131,16 @@ export class Nav extends React.Component<INavProps, INavState> {
 // A tag used for resolving links.
 const _urlResolver = document.createElement('a');
 
-function _isLinkSelected(link: INavLink): boolean {
+function _isLinkSelected(link: INavLink, selectedKey: string): boolean {
     if (!link.url) {
       return false;
     }
     _urlResolver.href = link.url || '';
     const target: string = _urlResolver.href;
+
+    if (selectedKey && link.key && link.key === selectedKey) {
+      return true;
+    }
 
     if (location.protocol + '//' + location.host + location.pathname === target) {
       return true;


### PR DESCRIPTION
**Scenario solving for:** In the FilePicker component, we have an instance of a Nav component on the left part and on the right are views of different sources from which a user can select a file. In this way, we're using the Nav to "navigate" between the different views on the right and this requires the FilePicker to know which Nav item has been clicked. Right now, we're traversing the DOM to find which child in the FilePicker's Nav component has the class "is-selected" and this isn't the ideal solution for various reasons, one glaring one: this logic in the filepicker tightly couples it to and is necessarily vulnerable to classname changes in fabric-react. 

**Proposed solution:** publicly expose the key of currently selected nav item. This would only work if all links in the group(s) of links passed to a Nav instance have populated and individually unique 'key' property.

If this is the approved solution, I can write up documentation in the demo pages to accompany this change.