### PR TITLE
DetailsList: initialFocusIndex added to allow focus to be initially set to an item when it is mounted.

### DIFF
--- a/src/components/DetailsList/DetailsHeader.tsx
+++ b/src/components/DetailsList/DetailsHeader.tsx
@@ -13,7 +13,7 @@ const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.butt
 const MOUSEMOVE_PRIMARY_BUTTON = 1; // for mouse move event we are using ev.buttons property, 1 means left button
 const INNER_PADDING = 16;
 
-export interface IDetailsHeaderProps {
+export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
   columns: IColumn[];
   selection: ISelection;
   selectionMode: SelectionMode;
@@ -30,7 +30,6 @@ export interface IDetailsHeaderProps {
   ariaLabel?: string;
   /** ariaLabel for the header checkbox that selects or deselects everything */
   ariaLabelForSelectAllCheckbox?: string;
-  ref?: string;
   selectAllVisibility?: SelectAllVisibility;
 }
 

--- a/src/components/DetailsList/DetailsList.Props.ts
+++ b/src/components/DetailsList/DetailsList.Props.ts
@@ -30,6 +30,11 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
   /** The items to render. */
   items: any[];
 
+  /**
+   * Optional default focused index to set focus to once the items have rendered and the index exists.
+   */
+  initialFocusedIndex?: number;
+
   /** Optional class name to add to the root element. */
   className?: string;
 

--- a/src/components/DetailsList/DetailsList.tsx
+++ b/src/components/DetailsList/DetailsList.tsx
@@ -58,15 +58,13 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
     isHeaderVisible: true
   };
 
-  public refs: {
-    [key: string]: React.ReactInstance,
-    header: DetailsHeader,
-    root: HTMLElement,
-    groups: GroupedList,
-    list: List,
-    focusZone: FocusZone,
-    selectionZone: SelectionZone
-  };
+  // Refs
+  private _header: DetailsHeader;
+  private _root: HTMLElement;
+  private _groupedList: GroupedList;
+  private _list: List;
+  private _focusZone: FocusZone;
+  private _selectionZone: SelectionZone;
 
   private _events: EventGroup;
   private _selection: ISelection;
@@ -223,7 +221,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
       // If shouldApplyApplicationRole is true, role application will be applied to make arrow keys work
       // with JAWS.
       <div
-        ref='root'
+        ref={ root => this._root = root }
         className={css('ms-DetailsList', className, {
           'is-fixed': layoutMode === DetailsListLayoutMode.fixedColumns,
           'is-horizontalConstrained': constrainMode === ConstrainMode.horizontalConstrained
@@ -233,10 +231,10 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
         aria-label={ ariaLabel }
         role={ shouldApplyApplicationRole ? 'application' : '' }>
         <div role='grid' aria-label={ ariaLabelForGrid }>
-          <div ref='headerContainer' onKeyDown={ this._onHeaderKeyDown }>
+          <div onKeyDown={ this._onHeaderKeyDown }>
             { isHeaderVisible && (
               <DetailsHeader
-                ref='header'
+                ref={ header => this._header = header }
                 selectionMode={ selectionMode }
                 layoutMode={ layoutMode }
                 selection={ selection }
@@ -256,15 +254,15 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
             ) }
           </div>
         </div>
-        <div ref='contentContainer' onKeyDown={ this._onContentKeyDown }>
+        <div onKeyDown={ this._onContentKeyDown }>
           <FocusZone
-            ref='focusZone'
+            ref={ focusZone => this._focusZone = focusZone }
             direction={ FocusZoneDirection.vertical }
             isInnerZoneKeystroke={ (ev) => (ev.which === getRTLSafeKeyCode(KeyCodes.right)) }
             onActiveElementChanged={ this._onActiveRowChanged }
             >
             <SelectionZone
-              ref='selectionZone'
+              ref={ selectionZone => this._selectionZone = selectionZone }
               selection={ selection }
               selectionMode={ selectionMode }
               onItemInvoked={ onItemInvoked }>
@@ -281,14 +279,14 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
                   eventsToRegister={ rowElementEventMap }
                   listProps={ additionalListProps }
                   onGroupExpandStateChanged={ this._onGroupExpandStateChanged }
-                  ref='groups'
+                  ref={ groupedList => this._groupedList = groupedList }
                   />
               ) : (
                   <List
                     items={ items }
                     onRenderCell={ (item, itemIndex) => this._onRenderCell(0, item, itemIndex) }
                     { ...additionalListProps }
-                    ref='list'
+                    ref={ list => this._list = list }
                     />
                 )
               }
@@ -362,7 +360,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
 
   private _onHeaderKeyDown(ev: React.KeyboardEvent) {
     if (ev.which === KeyCodes.down) {
-      if (this.refs.focusZone.focus()) {
+      if (this._focusZone.focus()) {
         ev.preventDefault();
         ev.stopPropagation();
       }
@@ -371,7 +369,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
 
   private _onContentKeyDown(ev: React.KeyboardEvent) {
     if (ev.which === KeyCodes.up) {
-      if (this.refs.header.focus()) {
+      if (this._header.focus()) {
         ev.preventDefault();
         ev.stopPropagation();
       }
@@ -399,9 +397,9 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
 
     // Set focus to the row if it should receive focus.
     if (this._initialFocusedIndex !== undefined && index === this._initialFocusedIndex) {
-      this.refs.selectionZone.setEnabled(false);
+      this._selectionZone.setEnabled(false);
       row.focus();
-      this.refs.selectionZone.setEnabled(true);
+      this._selectionZone.setEnabled(true);
       delete this._initialFocusedIndex;
     }
 
@@ -425,17 +423,17 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
     this.setState({
       isCollapsed: collapsed
     });
-    if (this.refs.groups) {
-      this.refs.groups.toggleCollapseAll(collapsed);
+    if (this._groupedList) {
+      this._groupedList.toggleCollapseAll(collapsed);
     }
   }
 
   private _forceListUpdates() {
-    if (this.refs.groups) {
-      this.refs.groups.forceUpdate();
+    if (this._groupedList) {
+      this._groupedList.forceUpdate();
     }
-    if (this.refs.list) {
-      this.refs.list.forceUpdate();
+    if (this._list) {
+      this._list.forceUpdate();
     }
   }
 

--- a/src/components/DetailsList/DetailsRow.tsx
+++ b/src/components/DetailsList/DetailsRow.tsx
@@ -243,6 +243,13 @@ export class DetailsRow extends React.Component<IDetailsRowProps, IDetailsRowSta
     });
   }
 
+  public focus() {
+    if (this.refs && this.refs.root) {
+      this.refs.root.tabIndex = 0;
+      this.refs.root.focus();
+    }
+  }
+
   private _getSelectionState(props: IDetailsRowProps): IDetailsRowSelectionState {
     let { itemIndex, selection } = props;
 

--- a/src/components/Fabric/Fabric.tsx
+++ b/src/components/Fabric/Fabric.tsx
@@ -19,6 +19,10 @@ export interface IFabricState {
   isFocusVisible?: boolean;
 }
 
+// We will track the last focus visibility state so that if we tear down and recreate
+// the Fabric component, we will use the last known value as the default.
+let _lastIsFocusVisible: boolean = false;
+
 export class Fabric extends React.Component<React.HTMLProps<Fabric>, IFabricState> {
   public refs: {
     [key: string]: React.ReactInstance;
@@ -31,7 +35,7 @@ export class Fabric extends React.Component<React.HTMLProps<Fabric>, IFabricStat
     super();
 
     this.state = {
-      isFocusVisible: false
+      isFocusVisible: _lastIsFocusVisible
     };
 
     this._events = new EventGroup(this);
@@ -62,6 +66,8 @@ export class Fabric extends React.Component<React.HTMLProps<Fabric>, IFabricStat
       this.setState({
         isFocusVisible: false
       });
+
+      _lastIsFocusVisible = false;
     }
   }
 
@@ -70,6 +76,8 @@ export class Fabric extends React.Component<React.HTMLProps<Fabric>, IFabricStat
       this.setState({
         isFocusVisible: true
       });
+
+      _lastIsFocusVisible = true;
     }
   }
 }

--- a/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -109,8 +109,6 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
         this._scrollableParent = scrollableParent;
         this._scrollTop = scrollableParent.scrollTop;
         this._rootRect = this.refs.root.getBoundingClientRect();
-
-        this._onMouseMove(ev);
       }
     }
   }

--- a/src/demo/pages/DetailsListPage/examples/DetailsList.Basic.Example.tsx
+++ b/src/demo/pages/DetailsListPage/examples/DetailsList.Basic.Example.tsx
@@ -34,7 +34,7 @@ export class DetailsListBasicExample extends React.Component<any, any> {
           onChanged={ text => this.setState({ filterText: text }) }
         />
         <MarqueeSelection selection={ this._selection }>
-          <DetailsList items={ items } shouldApplyApplicationRole={ true } setKey='set' selection={ this._selection } />
+          <DetailsList items={ items } initialFocusedIndex={ 0 } shouldApplyApplicationRole={ true } setKey='set' selection={ this._selection } />
         </MarqueeSelection>
       </div>
     );

--- a/src/utilities/selection/SelectionZone.tsx
+++ b/src/utilities/selection/SelectionZone.tsx
@@ -54,10 +54,12 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, any> {
   private _isShiftPressed: boolean;
   private _isMetaPressed: boolean;
   private _hasClickedOnItem: boolean;
+  private _isEnabled: boolean;
 
   constructor() {
     super();
 
+    this._isEnabled = true;
     this._events = new EventGroup(this);
   }
 
@@ -92,7 +94,20 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, any> {
     );
   }
 
+  /**
+   * In some cases, the consuming scenario requires to disable the behaviors of selection zone. For
+   * example, the caller wants to set focus onto an item without selecting it. They can use this
+   * method to temporarily disable the selection changes.
+   */
+  public setEnabled(isEnabled: boolean) {
+    this._isEnabled = isEnabled;
+  }
+
   private _onFocus(ev: FocusEvent) {
+    if (!this._isEnabled) {
+      return;
+    }
+
     let { selection, selectionMode } = this.props;
     let index = this._getIndexFromElement(ev.target as HTMLElement);
 
@@ -116,6 +131,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, any> {
   }
 
   private _onMouseDown(ev: MouseEvent) {
+    if (!this._isEnabled) {
+      return;
+    }
+
     // We need to reset the key states for ctrl/meta/etc.
     this._onKeyChangeCapture(ev as any);
 
@@ -129,6 +148,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, any> {
   }
 
   private _onClick(ev: MouseEvent) {
+    if (!this._isEnabled) {
+      return;
+    }
+
     let target = ev.target as HTMLElement;
     let { selection, selectionMode, onItemInvoked } = this.props;
     let isToggleElement = this._isToggleElement(target, SELECTION_TOGGLE_ATTRIBUTE_NAME) || ev.ctrlKey || ev.metaKey;
@@ -161,6 +184,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, any> {
   }
 
   private _onDoubleClick(ev: MouseEvent) {
+    if (!this._isEnabled) {
+      return;
+    }
+
     let { onItemInvoked, selection } = this.props;
     let index = this._getIndexFromElement(ev.target as HTMLElement, true);
 
@@ -176,6 +203,10 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, any> {
   }
 
   private _onKeyDown(ev: KeyboardEvent) {
+    if (!this._isEnabled) {
+      return;
+    }
+
     let target = ev.target as HTMLElement;
     let { selection, selectionMode, onItemInvoked } = this.props;
     let isToggleElement = this._isToggleElement(target, SELECTION_TOGGLE_ATTRIBUTE_NAME);
@@ -217,7 +248,11 @@ export class SelectionZone extends React.Component<ISelectionZoneProps, any> {
       } else if (ev.which === KeyCodes.a && (ev.ctrlKey || ev.metaKey) && selectionMode === SelectionMode.multiple) {
         selection.setAllSelected(true);
       } else if (ev.which === KeyCodes.escape) {
-        selection.setAllSelected(false);
+        if (selection.getSelectedCount() > 0) {
+          selection.setAllSelected(false);
+        } else {
+          return;
+        }
       } else {
         return;
       }


### PR DESCRIPTION
Also in the cleanup:
* MarqueeSelection no longer cancels mouse down, which was causing focus to not be set on an item when clicking.
* SelectionZone setEnabled added to temporarily disable the selectionzone from responding while moving focus to the initial index.
* Fabric now remembers the last "isFocusVisible" setting, so tearing it down and rerendering later will preserve the last known value. Not perfect, but a reasonable solution for keeping focus rect visibility.