### PR TITLE
Nav item background should fill entire row

### DIFF
--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -19,10 +19,6 @@
   padding: 0;
 }
 
-.ms-Nav li > ul {
-  margin: 0 14px;
-}
-
 .ms-Nav-groupContent {
   display: none;
   margin-bottom: 20px;
@@ -127,6 +123,21 @@
       right: 0;
       bottom: 0;
       left: 0;
+    }
+  }
+}
+
+// ms-Nav-link-level-0 through .ms-Nav-link-level-9
+// If more nesting levels are needed, update this loop.
+@for $nestingLevel from 0 through 9 {
+  .ms-Nav-level-#{$nestingLevel} {
+    .ms-Nav-link {
+      padding: 0 14px * $nestingLevel + 20px;
+
+      // If there is a group header, add another 20px.
+      .ms-Nav-groupButton + .ms-Nav-groupContent & {
+        padding: 0 14px * $nestingLevel + 40px;
+      }
     }
   }
 }

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -89,7 +89,7 @@
   height: 40px;
   line-height: 40px;
   text-decoration: none;
-  padding: 0 40px;
+  padding: 0 20px;
   cursor: pointer;
   text-overflow: ellipsis;
   text-decoration: none;

--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -127,21 +127,6 @@
   }
 }
 
-// ms-Nav-link-level-0 through .ms-Nav-link-level-9
-// If more nesting levels are needed, update this loop.
-@for $nestingLevel from 0 through 9 {
-  .ms-Nav-level-#{$nestingLevel} {
-    .ms-Nav-link {
-      padding: 0 14px * $nestingLevel + 20px;
-
-      // If there is a group header, add another 20px.
-      .ms-Nav-groupButton + .ms-Nav-groupContent & {
-        padding: 0 14px * $nestingLevel + 40px;
-      }
-    }
-  }
-}
-
 .ms-Nav-groupButton, .ms-Nav-link {
   @include focus-border();
 }

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -55,7 +55,7 @@ export class Nav extends React.Component<INavProps, INavState> implements INav {
     return this._selectedKey;
   }
 
-  private _renderLink(link: INavLink, linkIndex: number): React.ReactElement<{}> {
+  private _renderLink(link: INavLink, linkIndex: number, nestingLevel: number): React.ReactElement<{}> {
     let { onLinkClick } = this.props;
 
     const isLinkSelected: boolean = _isLinkSelected(link, this._selectedKey);
@@ -77,21 +77,22 @@ export class Nav extends React.Component<INavProps, INavState> implements INav {
           <i className={ css('ms-Icon', 'ms-Nav-IconLink', link.iconClassName) }></i>
           : '') }
          { this.props.onRenderLink(link)}
-        </a> { this._renderLinks(link.links) }
+        </a>
+        { this._renderLinks(link.links, nestingLevel + 1) }
     </li>
     );
   }
 
-  private _renderLinks(links: INavLink[]): React.ReactElement<{}> {
+  private _renderLinks(links: INavLink[], nestingLevel: number): React.ReactElement<{}> {
     if (!links || !links.length) {
       return null;
     }
 
     const linkElements: React.ReactElement<{}>[] = links.map(
-      (link: INavLink, linkIndex: number) => this._renderLink(link, linkIndex));
+      (link: INavLink, linkIndex: number) => this._renderLink(link, linkIndex, nestingLevel));
 
     return (
-      <ul>
+      <ul className={'ms-Nav-level-' + nestingLevel.toString(10)}>
         { linkElements }
       </ul>
     );
@@ -113,7 +114,7 @@ export class Nav extends React.Component<INavProps, INavState> implements INav {
         }
 
         <div className={ css('ms-Nav-groupContent', 'ms-u-slideDownIn20') }>
-        { this._renderLinks(group.links) }
+          { this._renderLinks(group.links, 0 /* nestingLevel */) }
         </div>
       </div>
     );

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -63,10 +63,7 @@ export class Nav extends React.Component<INavProps, INavState> implements INav {
     let { onLinkClick } = this.props;
 
     const isRtl: boolean = getRTL();
-    const paddingAfter: string = '0';
     const paddingBefore: string = (_indentationSize * nestingLevel + (hasGroupButton ? 40 : 20)).toString(10) + 'px';
-    const leftPadding: string = isRtl ? paddingAfter : paddingBefore;
-    const rightPadding: string = isRtl ? paddingBefore : paddingAfter;
 
     const isLinkSelected: boolean = _isLinkSelected(link, this._selectedKey);
     if (isLinkSelected) {
@@ -77,7 +74,7 @@ export class Nav extends React.Component<INavProps, INavState> implements INav {
       <li key={ linkIndex }>
         <a
           className={ css('ms-Nav-link', { 'is-selected' : isLinkSelected }) }
-          style={ { padding: '0 ' + rightPadding + ' 0 ' + leftPadding } }
+          style={ { [isRtl ? 'paddingRight' : 'paddingLeft'] : paddingBefore } }
           href={ link.url || 'javascript:' }
           onClick={ onLinkClick }
           aria-label={ link.ariaLabel }

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -62,6 +62,8 @@ export class Nav extends React.Component<INavProps, INavState> implements INav {
   private _renderLink(link: INavLink, linkIndex: number, nestingLevel: number, hasGroupButton: boolean): React.ReactElement<{}> {
     let { onLinkClick } = this.props;
 
+    // Determine the appropriate padding to add before this link.
+    // In RTL, the "before" padding will go on the right instead of the left.
     const isRtl: boolean = getRTL();
     const paddingBefore: string = (_indentationSize * nestingLevel + (hasGroupButton ? 40 : 20)).toString(10) + 'px';
 


### PR DESCRIPTION
When a Nav item is selected or hovered, the background color should extend all the way to the initial edge of the control.
If a "group header" is present, the items in the group should be indented further, but the background should still extend to the sides of the control.