### PR TITLE
Add support for aria- and data- in React.HTMLAttributes typings 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-ui-fabric-react",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "description": "Reusable React components for building experiences for Office 365.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/typings/react/react.d.ts
+++ b/typings/react/react.d.ts
@@ -1845,6 +1845,9 @@ declare namespace __React {
         results?: number;
         security?: string;
         unselectable?: boolean;
+
+        // Allows aria- and data- Attributes
+        [key: string]: any;
     }
 
     interface SVGAttributes extends HTMLAttributes {


### PR DESCRIPTION
This is also what the latest react typings file supports: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cc3d223a946f661eff871787edeb0fcb8f0db156/react/react.d.ts