### PR TITLE
add empty alt attribute to the image with presentation role in DocumentCard. 

### DIFF
--- a/src/components/DocumentCard/DocumentCardActivity.tsx
+++ b/src/components/DocumentCard/DocumentCardActivity.tsx
@@ -40,7 +40,7 @@ export class DocumentCardActivity extends React.Component<IDocumentCardActivityP
               </div>
           ) }
           { person.profileImageSrc && (
-            <Image src={ person.profileImageSrc } role='presentation'/>
+            <Image src={ person.profileImageSrc } role='presentation' alt=''/>
           ) }
         </div>
       );

--- a/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -45,7 +45,7 @@ export class DocumentCardPreview extends React.Component<IDocumentCardPreviewPro
 
     let icon;
     if (previewImage.iconSrc) {
-      icon = <Image className='ms-DocumentCardPreview-icon' src={ previewImage.iconSrc } role='presentation'/>;
+      icon = <Image className='ms-DocumentCardPreview-icon' src={ previewImage.iconSrc } role='presentation' alt=''/>;
     }
 
     return (
@@ -56,7 +56,7 @@ export class DocumentCardPreview extends React.Component<IDocumentCardPreviewPro
           imageFit={ imageFit }
           src={ previewImage.previewImageSrc }
           errorSrc={ previewImage.errorImageSrc }
-          role='presentation'/>
+          role='presentation' alt=''/>
         { icon }
       </div>
     );


### PR DESCRIPTION
add empty alt attribute to the image with presentation role in DocumentCard. Otherwise the accessibility checker will show warning. These images only for presentation and they don't really need alt text but accessibility checker doesn't check the role, it will always complain for image without alt attribution. To workaround it, just add empty alt text.