### PR TITLE
#239194: fixed styles that were causing the out transition to not pos…

### DIFF
--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -35,6 +35,7 @@
   margin-right: 8px;
   padding: 0 8px;
   text-align: center;
+  position: relative;
 
   &:hover {
     cursor: pointer;
@@ -70,7 +71,6 @@
   //== State: Selected
   &.is-selected {
     font-weight: $ms-font-weight-semibold;
-    position: relative;
 
     // Show the underline
     &::before {
@@ -173,6 +173,11 @@
       background-color: $ms-color-themePrimary;
       color: $ms-color-white;
       font-weight: $ms-font-weight-semilight;
+
+      &::before {
+        background-color: transparent;
+        transition: none;
+      }
     }
   }
 


### PR DESCRIPTION
The problem was that when selecting a new pivot there would be a long flashing blue line underneath:

![blueline](https://cloud.githubusercontent.com/assets/13757784/17821755/25f559f8-6608-11e6-838f-75027a416b9a.jpg)

The problem was with the out transition for the is-selected underline. That underline is on the ::before with a position of absolute. Position relative was only on the is-selected version of the pivot link so the out transition would then stretch to the far left and right of the un-selected/position initial pivot link. 

Also put in an override for the tab version because the selected underline was getting applied to tab style pivots as well. 