### PR TITLE
FocusZone up/down element detection now more correct, Selection fires less change events

### DIFF
--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -7,6 +7,7 @@ import { EventGroup } from '../../utilities/eventGroup/EventGroup';
 import { getRelativePositions, IPositionInfo } from '../../utilities/positioning';
 import { focusFirstChild } from '../../utilities/focus';
 import { Popup } from '../Popup/index';
+import { getRTL } from '../../utilities/rtl';
 import './Callout.scss';
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
@@ -25,7 +26,7 @@ export class Callout extends React.Component<ICalloutProps, ICalloutState> {
     beakStyle: 'ms-Callout-beak',
     beakWidth: 28,
     gapSpace: 16,
-    directionalHint: DirectionalHint.rightCenter
+    directionalHint: getRTL() ? DirectionalHint.bottomRightEdge : DirectionalHint.bottomLeftEdge
   };
 
   private _hostElement: HTMLDivElement;

--- a/src/components/FocusZone/FocusZone.tsx
+++ b/src/components/FocusZone/FocusZone.tsx
@@ -408,7 +408,11 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> implements I
         (targetRect.top === targetTop)) {
 
         targetTop = targetRect.top;
-        distance = Math.abs((targetRect.left + (targetRect.width / 2)) - leftAlignment);
+        if (leftAlignment >= targetRect.left && leftAlignment <= (targetRect.left + targetRect.width)) {
+          distance = 0;
+        } else {
+          distance = Math.abs((targetRect.left + (targetRect.width / 2)) - leftAlignment);
+        }
       }
 
       return distance;
@@ -430,7 +434,11 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> implements I
       if ((targetTop === -1 && targetRect.bottom <= activeRect.top) ||
       (targetRect.top === targetTop)) {
         targetTop = targetRect.top;
-        distance = Math.abs((targetRect.left + (targetRect.width / 2)) - leftAlignment);
+        if (leftAlignment >= targetRect.left && leftAlignment <= (targetRect.left + targetRect.width)) {
+          distance = 0;
+        } else {
+          distance = Math.abs((targetRect.left + (targetRect.width / 2)) - leftAlignment);
+        }
       }
 
       return distance;

--- a/src/utilities/selection/Selection.test.ts
+++ b/src/utilities/selection/Selection.test.ts
@@ -1,0 +1,56 @@
+let { expect } = chai;
+
+import { Selection } from './index';
+
+let setA = [ { key: 'a' }, { key: 'b' }, { key: 'c' } ];
+let setB = [ { key: 'a' }, { key: 'd' }, { key: 'b' } ];
+
+describe('Selection', () => {
+
+  it('fires change events only when selection changes occur', () => {
+    let changeCount = 0;
+    let selection = new Selection({ onSelectionChanged: () => changeCount++ });
+
+    selection.setItems(setA, false);
+    expect(changeCount).equals(0, 'after setting set a');
+
+    selection.setKeySelected('a', true, true);
+    selection.setKeySelected('a', true, true);
+    selection.setIndexSelected(0, true, true);
+    expect(changeCount).equals(1, 'after selecting item a');
+
+    // Switch to set b, which also contains item a, in the same position. No change event should occur.
+    selection.setItems(setB, false);
+    expect(changeCount).equals(1, 'after switching to set b');
+
+    // Select b
+    selection.setKeySelected('b', true, true);
+    expect(changeCount).equals(2, 'after selecting b');
+
+    // Change back to set a, which has item b in a different index.
+    selection.setItems(setA, false);
+    expect(changeCount).equals(3, 'after changing back to set a');
+
+    // Change to set b, but clear it.
+    selection.setItems(setB, true);
+    expect(changeCount).equals(4, 'after switching to set b and clearing');
+
+    // Select an item in set b that doesn't exist in set a, then switch to set a.
+    selection.setKeySelected('d', true, true);
+    selection.setItems(setA, false);
+    expect(changeCount).equals(6, 'after selecting c and switching to set a');
+
+    // Select an item, clear, clear again.
+    selection.setAllSelected(true);
+    selection.setAllSelected(true);
+    selection.setAllSelected(false);
+    selection.setAllSelected(false);
+    expect(changeCount).equals(8, 'after selecting all 2 times and clearing 2 times');
+
+    selection.setIndexSelected(0, true, true);
+    selection.selectToIndex(2, true);
+    expect(changeCount).equals(10, 'after range selecting from 0 to 2');
+  });
+
+
+});

--- a/src/utilities/selection/Selection.test.ts
+++ b/src/utilities/selection/Selection.test.ts
@@ -52,5 +52,4 @@ describe('Selection', () => {
     expect(changeCount).equals(10, 'after range selecting from 0 to 2');
   });
 
-
 });

--- a/src/utilities/selection/Selection.ts
+++ b/src/utilities/selection/Selection.ts
@@ -64,6 +64,9 @@ export class Selection implements ISelection {
   public setItems(items: IObjectWithKey[], shouldClear = true) {
     let newKeyToIndexMap: { [key: string]: number } = {};
     let newUnselectableIndices: { [key: string]: boolean } = {};
+    let hasSelectionChanged = false;
+
+    this.setChangeEvents(false);
 
     // Build lookup table for quick selection evaluation.
     for (let i = 0; i < items.length; i++) {
@@ -86,8 +89,9 @@ export class Selection implements ISelection {
     // Check the exemption list for discrepencies.
     let newExemptedIndicies: { [key: string]: boolean } = {};
 
-    for (let index in this._exemptedIndices) {
-      if (this._exemptedIndices.hasOwnProperty(index)) {
+    for (let indexProperty in this._exemptedIndices) {
+      if (this._exemptedIndices.hasOwnProperty(indexProperty)) {
+        let index = Number(indexProperty);
         let item = this._items[index];
         let exemptKey = item ? this.getKey(item, Number(index)) : undefined;
         let newIndex = exemptKey ? newKeyToIndexMap[exemptKey] : index;
@@ -95,13 +99,12 @@ export class Selection implements ISelection {
         if (newIndex === undefined) {
           // We don't know the index of the item any more so it's either moved or removed.
           // In this case we reset the entire selection.
-          newExemptedIndicies = {};
-          this._isAllSelected = false;
-          this._exemptedCount = 0;
+          this.setAllSelected(false);
           break;
         } else {
           // We know the new index of the item. update the existing exemption table.
           newExemptedIndicies[newIndex] = true;
+          hasSelectionChanged = hasSelectionChanged || (newIndex !== index);
         }
       }
     }
@@ -111,7 +114,11 @@ export class Selection implements ISelection {
     this._unselectableIndices = newUnselectableIndices;
     this._items = items || [];
 
-    this._change();
+    if (hasSelectionChanged) {
+      this._change();
+    }
+
+    this.setChangeEvents(true);
   }
 
   public getItems(): IObjectWithKey[] {

--- a/src/utilities/selection/Selection.ts
+++ b/src/utilities/selection/Selection.ts
@@ -157,10 +157,12 @@ export class Selection implements ISelection {
   }
 
   public setAllSelected(isAllSelected: boolean) {
-    this._exemptedIndices = {};
-    this._exemptedCount = 0;
-    this._isAllSelected = isAllSelected;
-    this._updateCount();
+    if (this._exemptedCount > 0 || isAllSelected !== this._isAllSelected) {
+      this._exemptedIndices = {};
+      this._exemptedCount = 0;
+      this._isAllSelected = isAllSelected;
+      this._updateCount();
+    }
   }
 
   public setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean) {

--- a/src/utilities/selection/SelectionZone.test.tsx
+++ b/src/utilities/selection/SelectionZone.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-addons-test-utils';
-let { assert, expect } = chai;
+let { expect } = chai;
 
 import { SelectionZone, Selection, SelectionMode } from './index';
 import { KeyCodes } from '../KeyCodes';
@@ -77,22 +77,22 @@ describe('SelectionZone', () => {
 
   it('toggles an item on click of toggle element', () => {
     _simulateClick(_toggle0);
-    assert(_selection.isIndexSelected(0) === true, 'Index 0 not selected');
+    expect(_selection.isIndexSelected(0)).equals(true, 'Index 0 not selected');
     _simulateClick(_toggle0);
-    assert(_selection.isIndexSelected(0) === false, 'Index 0 selected');
-    assert(_onItemInvokeCalled === 0, 'onItemInvoked was called');
+    expect(_selection.isIndexSelected(0)).equals(false, 'Index 0 selected');
+    expect(_onItemInvokeCalled).equals(0, 'onItemInvoked was called');
   });
 
   it('toggles an item on dblclick of toggle element', () => {
     ReactTestUtils.Simulate.doubleClick(_toggle0);
-    assert(_selection.isIndexSelected(0) === false, 'Index 0 selected');
-    assert(_onItemInvokeCalled === 0, 'onItemInvoked was called');
+    expect(_selection.isIndexSelected(0)).equals(false, 'Index 0 selected');
+    expect(_onItemInvokeCalled).equals(0, 'onItemInvoked was called');
   });
 
   it('does not toggle an item on mousedown of toggle element', () => {
     ReactTestUtils.Simulate.mouseDown(_toggle0);
-    assert(_selection.isIndexSelected(0) === false, 'Index 0 selected');
-    assert(_onItemInvokeCalled === 0, 'onItemInvoked was called');
+    expect(_selection.isIndexSelected(0) === false, 'Index 0 selected');
+    expect(_onItemInvokeCalled === 0, 'onItemInvoked was called');
   });
 
   it('selects an unselected item on mousedown of invoke without modifiers pressed', () => {
@@ -114,31 +114,31 @@ describe('SelectionZone', () => {
 
   it('calls the invoke callback on click of invoke area', () => {
     _simulateClick(_invoke0);
-    assert(_onItemInvokeCalled === 1, 'onItemInvoked was not called 1 time after normal click');
+    expect(_onItemInvokeCalled === 1, 'onItemInvoked was not called 1 time after normal click');
   });
 
   it('selects an unselected item on click of item surface element', () => {
     _simulateClick(_surface0);
-    assert(_selection.isIndexSelected(0) === true, 'Index 0 not selected');
-    assert(_onItemInvokeCalled === 0, 'onItemInvoked was called');
+    expect(_selection.isIndexSelected(0)).equals(true, 'Index 0 not selected');
+    expect(_onItemInvokeCalled).equals(0, 'onItemInvoked was called');
   });
 
   it('does not unselect a selected item on click of item surface element', () => {
     _selection.setIndexSelected(0, true, true);
     _simulateClick(_surface0);
-    assert(_selection.isIndexSelected(0) === true, 'Index 0 not selected');
-    assert(_onItemInvokeCalled === 0, 'onItemInvoked was called');
+    expect(_selection.isIndexSelected(0)).equals(true, 'Index 0 not selected');
+    expect(_onItemInvokeCalled).equals(0, 'onItemInvoked was called');
   });
 
   it('does not select an unselected item on mousedown of item surface element', () => {
     ReactTestUtils.Simulate.mouseDown(_surface0);
-    assert(_selection.isIndexSelected(0) === false, 'Index 0 selected');
+    expect(_selection.isIndexSelected(0)).equals(false, 'Index 0 selected');
   });
 
   it('invokes an item on double clicking the surface element', () => {
     ReactTestUtils.Simulate.doubleClick(_surface0);
-    assert(_onItemInvokeCalled === 1, 'Item was invoked');
-    assert(_lastItemInvoked.key === 'a', 'Item invoked was not expected item');
+    expect(_onItemInvokeCalled).equals(1, 'Item was invoked');
+    expect(_lastItemInvoked.key).equals('a', 'Item invoked was not expected item');
   });
 
   it('toggles all on toggle-all clicks', () => {
@@ -168,12 +168,12 @@ describe('SelectionZone', () => {
 
   it('toggles by ctrl clicking a surface', () => {
     _simulateClick(_toggleAll);
-    assert(_selection.getSelectedCount() === 4, 'There were not 4 selected items');
+    expect(_selection.getSelectedCount()).equals(4, 'There were not 4 selected items');
 
     _simulateClick(_surface1, {
       ctrlKey: true
     });
-    assert(_selection.getSelectedCount() === 3, 'There were not 3 selected items');
+    expect(_selection.getSelectedCount()).equals(3, 'There were not 3 selected items');
   });
 
   it ('selects all on ctrl-a', () => {

--- a/src/utilities/selection/SelectionZone.tsx
+++ b/src/utilities/selection/SelectionZone.tsx
@@ -32,7 +32,7 @@ const SELECTALL_TOGGLE_ALL_ATTRIBUTE_NAME = 'data-selection-all-toggle';
 export interface ISelectionZoneProps extends React.Props<SelectionZone> {
   selection: ISelection;
   layout?: ISelectionLayout;
-  selectionMode: SelectionMode;
+  selectionMode?: SelectionMode;
   isSelectedOnFocus?: boolean;
   onItemInvoked?: (item?: any, index?: number, ev?: Event) => void;
 }
@@ -41,7 +41,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   public static defaultProps = {
     layout: new SelectionLayout(SelectionDirection.vertical),
     isMultiSelectEnabled: true,
-    isSelectedOnFocus: true
+    isSelectedOnFocus: true,
+    selectionMode: SelectionMode.multiple
   };
 
   public refs: {


### PR DESCRIPTION
1. FocusZone fix: Previously if you would press up and down, it would select the element whose CENTER is closest to the centerpoint. That meant that even if an item is covering up the centerpoint, its center may not be closest if for example it's a very wide element next to a short element. Now if an element covers the centerpoint, it will have a horizontal distance of 0, meaning that it will become the selected item in the row.

2. Callout positioning default: Making callout default position belowleft or belowright depending on initial getrtl value.

3. Selection now no-ops on setAllSelected operations that make no changes to current state and avoids unnecessary change events.