### PR TITLE
Scope the Image's demo border

### DIFF
--- a/src/demo/pages/ImagePage/ImagePage.scss
+++ b/src/demo/pages/ImagePage/ImagePage.scss
@@ -1,5 +1,5 @@
 @import '../../../common/common';
 
-.ms-Image {
+.ImageExample .ms-Image {
   border: 1px solid $ms-color-neutralLight;
 }

--- a/src/demo/pages/ImagePage/ImagePage.tsx
+++ b/src/demo/pages/ImagePage/ImagePage.tsx
@@ -20,7 +20,7 @@ const ImageNoneExampleCode = require('./examples/Image.None.Example.tsx');
 export class ImagePage extends React.Component<any, any> {
   public render() {
     return (
-      <div className='ms-ImageExample'>
+      <div className='ImageExample'>
         <h1 className='ms-font-xxl'>Image</h1>
         <div>
           <span>


### PR DESCRIPTION
Scopes the demonstration class added to the Image component, so that the border doesn't show up when Image is used in other components.