### PR TITLE
Fixing IsElementVisible to return value according to data-is-visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-ui-fabric-react",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "Reusable React components for building experiences for Office 365.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/utilities/focus.test.tsx
+++ b/src/utilities/focus.test.tsx
@@ -1,0 +1,55 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
+import * as ReactDOM from 'react-dom';
+import * as ReactTestUtils from 'react-addons-test-utils';
+let { expect } = chai;
+
+import { isElementVisible } from './focus';
+
+let _hiddenElement;
+let _visibleElement;
+let _element;
+
+function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
+  const component: React.Component<any, any> = ReactTestUtils.renderIntoDocument(element);
+  const renderedDOM: Element = ReactDOM.findDOMNode(component);
+  return renderedDOM as HTMLElement;
+}
+
+function _initialize() {
+  _hiddenElement = renderIntoDocument(
+    <div data-is-visible={ false }>
+      <button></button>
+    </div>
+  ) as HTMLElement;
+  _visibleElement = renderIntoDocument(
+    <div data-is-visible={ true }>
+      <button></button>
+    </div>
+  ) as HTMLElement;
+  _element = renderIntoDocument(
+    <div>
+      <button></button>
+    </div>
+  ) as HTMLElement;
+  (_element as any).isVisible = true;
+}
+
+describe('isElementVisible', () => {
+  beforeEach(() => _initialize());
+  it('returns false if data-is-visible is false', () => {
+    expect(isElementVisible(_hiddenElement)).equals(false, 'Element is not visible');
+  });
+
+  it('returns true if data-is-visible is true', () => {
+    expect(isElementVisible(_visibleElement)).equals(true, 'Element is visible');
+  });
+
+  it('returns true if data-is-visible is undefined but element is visible', () => {
+    expect(isElementVisible(_element)).equals(true, 'Element is visible but data-is-visible is undefined');
+  });
+
+});
+

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -133,10 +133,11 @@ export function getNextElement(
 export function isElementVisible(element: HTMLElement): boolean {
   return (
     !!element &&
-    (element.offsetHeight !== 0 ||
-      element.offsetParent !== null ||
-      (element as any).isVisible === true || // used as a workaround for testing.
-      (element.getAttribute && element.getAttribute(IS_VISIBLE_ATTRIBUTE) === 'true'))
+      element.getAttribute && isVisibleAttribute(element) ?
+      element.getAttribute(IS_VISIBLE_ATTRIBUTE) === 'true' :
+      (element.offsetHeight !== 0 ||
+        element.offsetParent !== null ||
+        (element as any).isVisible === true) // used as a workaround for testing.
   );
 }
 
@@ -151,4 +152,8 @@ export function isElementTabbable(element: HTMLElement): boolean {
 
 export function isElementFocusZone(element?: HTMLElement): boolean {
   return element && !!element.getAttribute(FOCUSZONE_ID_ATTRIBUTE);
+}
+
+export function isVisibleAttribute(element?: HTMLElement): boolean {
+  return element && !!element.getAttribute(IS_VISIBLE_ATTRIBUTE);
 }

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -136,7 +136,7 @@ export function isElementVisible(element: HTMLElement): boolean {
     return false;
   }
 
-  let visibilityAttribute = element.getAttribute(IS_VISIBLE_ATTRIBUTE);
+  const visibilityAttribute = element.getAttribute(IS_VISIBLE_ATTRIBUTE);
 
   // If the element is explicitly marked with the visibility attribute, return that value as boolean.
   if (visibilityAttribute !== null) {

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -139,7 +139,7 @@ export function isElementVisible(element: HTMLElement): boolean {
   const visibilityAttribute = element.getAttribute(IS_VISIBLE_ATTRIBUTE);
 
   // If the element is explicitly marked with the visibility attribute, return that value as boolean.
-  if (visibilityAttribute !== null) {
+  if (visibilityAttribute !== null && visibilityAttribute !== undefined) {
     return visibilityAttribute === 'true';
   }
 

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -131,14 +131,22 @@ export function getNextElement(
 }
 
 export function isElementVisible(element: HTMLElement): boolean {
-  return (
-    !!element &&
-      element.getAttribute && isVisibleAttribute(element) ?
-      element.getAttribute(IS_VISIBLE_ATTRIBUTE) === 'true' :
-      (element.offsetHeight !== 0 ||
-        element.offsetParent !== null ||
-        (element as any).isVisible === true) // used as a workaround for testing.
-  );
+  // If the element is not valid, return false.
+  if (!element || !element.getAttribute) {
+    return false;
+  }
+
+  let visibilityAttribute = element.getAttribute(IS_VISIBLE_ATTRIBUTE);
+
+  // If the element is explicitly marked with the visibility attribute, return that value as boolean.
+  if (visibilityAttribute !== null) {
+    return visibilityAttribute === 'true';
+  }
+
+  // Fallback to other methods of determining actual visibility.
+  return (element.offsetHeight !== 0 ||
+    element.offsetParent !== null ||
+    (element as any).isVisible === true); // used as a workaround for testing.
 }
 
 export function isElementTabbable(element: HTMLElement): boolean {
@@ -152,8 +160,4 @@ export function isElementTabbable(element: HTMLElement): boolean {
 
 export function isElementFocusZone(element?: HTMLElement): boolean {
   return element && !!element.getAttribute(FOCUSZONE_ID_ATTRIBUTE);
-}
-
-export function isVisibleAttribute(element?: HTMLElement): boolean {
-  return element && !!element.getAttribute(IS_VISIBLE_ATTRIBUTE);
 }


### PR DESCRIPTION
The issue was that even if the data-is-visible was set to false, isElementVisible was returning true. Changing the method such that if the attribute is set, ignore other conditions.