### PR TITLE
#239886: removed unecessary is-selected style for large pivots 

### DIFF
--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -130,10 +130,6 @@
   .ms-Pivot-link {
     font-size: $ms-font-size-l;
 
-    &.is-selected {
-      font-weight: $ms-font-weight-semilight;
-    }
-
     .ms-Pivot-count {
       @include margin-left(4px);
     }


### PR DESCRIPTION
For some reason the large pivots is-selected was using semi-light. Just removed it so it uses the same base is-selected style.

Before:
![before](https://cloud.githubusercontent.com/assets/13757784/18022100/f303c126-6ba0-11e6-9150-a7a48f3907a1.png)

After:
![after](https://cloud.githubusercontent.com/assets/13757784/18022101/f73b8b48-6ba0-11e6-8c7e-585e5a2d16c5.png)
