### PR TITLE
bump up webpack-split-by-path up 0.0.10 to correctly split

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tslint-microsoft-contrib": "^2.0.9",
     "vinyl-ftp": "0.4.5",
     "@microsoft/web-library-build": "~0.2.7",
-    "webpack-split-by-path": "0.0.8",
+    "webpack-split-by-path": "0.0.10",
     "webpack-visualizer-plugin": "0.1.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/15144072/18081522/40f591aa-6ecd-11e6-83f5-00dfbc6e1aeb.png)

Currently the SplitByPathPlugin in webpack.demo.config.js is not working as expected to generate demo-vendor and demo-components. Bumping it up to 0.0.10 moderate the issue:

![image](https://cloud.githubusercontent.com/assets/15144072/18091769/5d00c6b0-6efc-11e6-8890-573a187f1c37.png)