### PR TITLE
only trigger onChange callback of Slider when the value of slider is changed

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -180,13 +180,14 @@ export class Slider extends BaseComponent<ISliderProps, ISliderState> implements
       currentValue = min + step * Math.round(currentSteps);
     }
 
+    if (onChange && currentValue !== this.state.value) {
+      onChange(currentValue);
+    }
+
     this.setState({
       value: currentValue,
       renderedValue: renderedValue
     });
-    if (onChange) {
-      onChange(currentValue);
-    }
 
     if (!suppressEventCancelation) {
       event.preventDefault();


### PR DESCRIPTION
Now when we drag the slider button, the onChange callback will be triggered on every MouseMove or TouchMove event. We could only trigger the onChange if the value of the slider is really changed.