### PR TITLE
Add hoisting to all decorators

### DIFF
--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -1,3 +1,4 @@
 export * from './common/BaseComponent';
 export * from './utilities/css';
 export * from './utilities/rtl';
+export * from './utilities/hoist';

--- a/src/utilities/decorators/BaseDecorator.ts
+++ b/src/utilities/decorators/BaseDecorator.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { hoistMethods, unhoistMethods } from '../hoist';
+import { BaseComponent } from '../../common/BaseComponent';
+
+export class BaseDecorator<P, S> extends BaseComponent<P, S> {
+  protected _composedComponentInstance: React.Component<P, S>;
+  private _hoisted: string[];
+
+  constructor() {
+    super();
+    this._updateChildRef = this._updateChildRef.bind(this);
+  }
+
+  protected _updateChildRef(composedComponentInstance: React.Component<P, S>) {
+    this._composedComponentInstance = composedComponentInstance;
+    if (composedComponentInstance) {
+      this._hoisted = hoistMethods(this, composedComponentInstance);
+    } else if (this._hoisted) {
+      unhoistMethods(this, this._hoisted);
+    }
+  }
+}

--- a/src/utilities/decorators/BaseDecorator.ts
+++ b/src/utilities/decorators/BaseDecorator.ts
@@ -8,10 +8,16 @@ export class BaseDecorator<P, S> extends BaseComponent<P, S> {
 
   constructor() {
     super();
-    this._updateChildRef = this._updateChildRef.bind(this);
+    this._updateComposedComponentRef = this._updateComposedComponentRef.bind(this);
   }
 
-  protected _updateChildRef(composedComponentInstance: React.Component<P, S>) {
+  /**
+   * Updates the ref to the component composed by the decorator, which will also take care of hoisting
+   * (and unhoisting as appropriate) methods from said component.
+   *
+   * Pass this method as the argument to the 'ref' property of the composed component.
+   */
+  protected _updateComposedComponentRef(composedComponentInstance: React.Component<P, S>) {
     this._composedComponentInstance = composedComponentInstance;
     if (composedComponentInstance) {
       this._hoisted = hoistMethods(this, composedComponentInstance);

--- a/src/utilities/decorators/withContainsFocus.tsx
+++ b/src/utilities/decorators/withContainsFocus.tsx
@@ -1,27 +1,21 @@
 import * as React from 'react';
-import { Async } from '../Async/Async';
-import { hoistMethods, unhoistMethods } from '../hoist';
+import { BaseDecorator } from './BaseDecorator';
 
-export function withContainsFocus<P, S>(ComposedComponent: any): any {
+export function withContainsFocus<P extends { containsFocus?: boolean }, S>(ComposedComponent: (new (props: P, ...args: any[]) => (React.Component<P, S>))): any {
 
-  return class WithContainsFocusComponent extends React.Component<P, any> {
+  return class WithContainsFocusComponent extends BaseDecorator<P & { containsFocus? }, { containsFocus?: boolean }> {
     public refs: {
       [key: string]: React.ReactInstance,
       /** @deprecated */
       composed: any
     };
 
-    private _async: Async;
-    private _composedComponentInstance: any;
-    private _hoisted: string[];
     private _newContainsFocus: boolean;
-
     private _delayedSetContainsFocus: () => void;
 
     constructor() {
       super();
 
-      this._async = new Async(this);
       this.state = {
         containsFocus: false
       };
@@ -46,17 +40,6 @@ export function withContainsFocus<P, S>(ComposedComponent: any): any {
 
     public forceUpdate() {
       this._composedComponentInstance.forceUpdate();
-    }
-
-    private _updateChildRef(composedComponentInstance: any) {
-      this.refs.composed = composedComponentInstance;
-      this._composedComponentInstance = composedComponentInstance;
-      if (composedComponentInstance) {
-        this._hoisted = hoistMethods(this, composedComponentInstance);
-      } else if (this._hoisted) {
-        this.refs.composed = null;
-        unhoistMethods(this, this._hoisted);
-      }
     }
 
     private _handleFocus(ev) {

--- a/src/utilities/decorators/withContainsFocus.tsx
+++ b/src/utilities/decorators/withContainsFocus.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
 import { Async } from '../Async/Async';
+import { hoistMethods, unhoistMethods } from '../hoist';
 
 export function withContainsFocus<P, S>(ComposedComponent: any): any {
 
   return class WithContainsFocusComponent extends React.Component<P, any> {
     public refs: {
       [key: string]: React.ReactInstance,
+      /** @deprecated */
       composed: any
     };
 
     private _async: Async;
+    private _composedComponentInstance: any;
+    private _hoisted: string[];
     private _newContainsFocus: boolean;
 
     private _delayedSetContainsFocus: () => void;
@@ -23,6 +27,7 @@ export function withContainsFocus<P, S>(ComposedComponent: any): any {
       };
 
       this._delayedSetContainsFocus = this._async.debounce(this._setContainsFocus, 20);
+      this._updateChildRef = this._updateChildRef.bind(this);
     }
 
     public componentWillUnmount() {
@@ -34,20 +39,24 @@ export function withContainsFocus<P, S>(ComposedComponent: any): any {
 
       return (
         <div ref='root' onFocus={ this._handleFocus.bind(this) } onBlur={ this._handleBlur.bind(this) }>
-          <ComposedComponent ref='composed' containsFocus={ containsFocus } {...this.props} />
+          <ComposedComponent ref={ this._updateChildRef } containsFocus={ containsFocus } {...this.props} />
         </div>
       );
     }
 
-    /**
-     * Accessor for the instance of the component being wrapped by withContainsFocus.
-     */
-    public get composedComponentInstance() {
-      return this.refs.composed;
+    public forceUpdate() {
+      this._composedComponentInstance.forceUpdate();
     }
 
-    public forceUpdate() {
-      this.refs.composed.forceUpdate();
+    private _updateChildRef(composedComponentInstance: any) {
+      this.refs.composed = composedComponentInstance;
+      this._composedComponentInstance = composedComponentInstance;
+      if (composedComponentInstance) {
+        this._hoisted = hoistMethods(this, composedComponentInstance);
+      } else if (this._hoisted) {
+        this.refs.composed = null;
+        unhoistMethods(this, this._hoisted);
+      }
     }
 
     private _handleFocus(ev) {
@@ -65,7 +74,5 @@ export function withContainsFocus<P, S>(ComposedComponent: any): any {
         this.setState({ containsFocus: this._newContainsFocus });
       }
     }
-
   };
-
 }

--- a/src/utilities/decorators/withContainsFocus.tsx
+++ b/src/utilities/decorators/withContainsFocus.tsx
@@ -21,7 +21,7 @@ export function withContainsFocus<P extends { containsFocus?: boolean }, S>(Comp
       };
 
       this._delayedSetContainsFocus = this._async.debounce(this._setContainsFocus, 20);
-      this._updateChildRef = this._updateChildRef.bind(this);
+      this._updateComposedComponentRef = this._updateComposedComponentRef.bind(this);
     }
 
     public componentWillUnmount() {
@@ -33,7 +33,7 @@ export function withContainsFocus<P extends { containsFocus?: boolean }, S>(Comp
 
       return (
         <div ref='root' onFocus={ this._handleFocus.bind(this) } onBlur={ this._handleBlur.bind(this) }>
-          <ComposedComponent ref={ this._updateChildRef } containsFocus={ containsFocus } {...this.props} />
+          <ComposedComponent ref={ this._updateComposedComponentRef } containsFocus={ containsFocus } {...this.props} />
         </div>
       );
     }

--- a/src/utilities/decorators/withContainsFocus.tsx
+++ b/src/utilities/decorators/withContainsFocus.tsx
@@ -6,8 +6,6 @@ export function withContainsFocus<P extends { containsFocus?: boolean }, S>(Comp
   return class WithContainsFocusComponent extends BaseDecorator<P & { containsFocus? }, { containsFocus?: boolean }> {
     public refs: {
       [key: string]: React.ReactInstance,
-      /** @deprecated */
-      composed: any
     };
 
     private _newContainsFocus: boolean;

--- a/src/utilities/decorators/withContainsFocus.tsx
+++ b/src/utilities/decorators/withContainsFocus.tsx
@@ -39,6 +39,13 @@ export function withContainsFocus<P, S>(ComposedComponent: any): any {
       );
     }
 
+    /**
+     * Accessor for the instance of the component being wrapped by withContainsFocus.
+     */
+    public get composedComponentInstance() {
+      return this.refs.composed;
+    }
+
     public forceUpdate() {
       this.refs.composed.forceUpdate();
     }

--- a/src/utilities/decorators/withResponsiveMode.tsx
+++ b/src/utilities/decorators/withResponsiveMode.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { EventGroup } from '../eventGroup/EventGroup';
+import { hoistMethods, unhoistMethods } from '../hoist';
 
 export interface IWithResponsiveModeState {
   responsiveMode?: ResponsiveMode;
@@ -26,8 +27,9 @@ const RESPONSIVE_MAX_CONSTRAINT = [
 export function withResponsiveMode<P, S>(ComposedComponent: any): any {
 
   return class WithResponsiveMode extends React.Component<P, IWithResponsiveModeState> {
-    private _events: EventGroup;
     private _composedComponentInstance: any;
+    private _events: EventGroup;
+    private _hoisted: string[];
 
     constructor() {
       super();
@@ -64,15 +66,13 @@ export function withResponsiveMode<P, S>(ComposedComponent: any): any {
       );
     }
 
-    /**
-     * Accessor for the instance of the component being wrapped by WithResponsiveMode.
-     */
-    public get composedComponentInstance() {
-      return this._composedComponentInstance;
-    }
-
     private _updateChildRef(composedComponentInstance: any) {
       this._composedComponentInstance = composedComponentInstance;
+      if (composedComponentInstance) {
+        this._hoisted = hoistMethods(this, composedComponentInstance);
+      } else if (this._hoisted) {
+        unhoistMethods(this, this._hoisted);
+      }
     }
 
     private _getResponsiveMode(): ResponsiveMode {

--- a/src/utilities/decorators/withResponsiveMode.tsx
+++ b/src/utilities/decorators/withResponsiveMode.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { EventGroup } from '../eventGroup/EventGroup';
-import { hoistMethods, unhoistMethods } from '../hoist';
+import { BaseDecorator } from './BaseDecorator';
 
 export interface IWithResponsiveModeState {
   responsiveMode?: ResponsiveMode;
@@ -24,17 +23,11 @@ const RESPONSIVE_MAX_CONSTRAINT = [
   99999999
 ];
 
-export function withResponsiveMode<P, S>(ComposedComponent: any): any {
+export function withResponsiveMode<P extends { responsiveMode?: ResponsiveMode }, S>(ComposedComponent: (new (props: P, ...args: any[]) => React.Component<P, S>)): any {
 
-  return class WithResponsiveMode extends React.Component<P, IWithResponsiveModeState> {
-    private _composedComponentInstance: any;
-    private _events: EventGroup;
-    private _hoisted: string[];
-
+  return class WithResponsiveMode extends BaseDecorator<P, IWithResponsiveModeState> {
     constructor() {
       super();
-
-      this._events = new EventGroup(this);
       this._updateChildRef = this._updateChildRef.bind(this);
 
       this.state = {
@@ -64,15 +57,6 @@ export function withResponsiveMode<P, S>(ComposedComponent: any): any {
       return (
         <ComposedComponent ref={ this._updateChildRef } responsiveMode={ responsiveMode } { ...this.props } />
       );
-    }
-
-    private _updateChildRef(composedComponentInstance: any) {
-      this._composedComponentInstance = composedComponentInstance;
-      if (composedComponentInstance) {
-        this._hoisted = hoistMethods(this, composedComponentInstance);
-      } else if (this._hoisted) {
-        unhoistMethods(this, this._hoisted);
-      }
     }
 
     private _getResponsiveMode(): ResponsiveMode {

--- a/src/utilities/decorators/withResponsiveMode.tsx
+++ b/src/utilities/decorators/withResponsiveMode.tsx
@@ -28,7 +28,7 @@ export function withResponsiveMode<P extends { responsiveMode?: ResponsiveMode }
   return class WithResponsiveMode extends BaseDecorator<P, IWithResponsiveModeState> {
     constructor() {
       super();
-      this._updateChildRef = this._updateChildRef.bind(this);
+      this._updateComposedComponentRef = this._updateComposedComponentRef.bind(this);
 
       this.state = {
         responsiveMode: this._getResponsiveMode()
@@ -55,7 +55,7 @@ export function withResponsiveMode<P extends { responsiveMode?: ResponsiveMode }
       let { responsiveMode } = this.state;
 
       return (
-        <ComposedComponent ref={ this._updateChildRef } responsiveMode={ responsiveMode } { ...this.props } />
+        <ComposedComponent ref={ this._updateComposedComponentRef } responsiveMode={ responsiveMode } { ...this.props } />
       );
     }
 

--- a/src/utilities/decorators/withResponsiveMode.tsx
+++ b/src/utilities/decorators/withResponsiveMode.tsx
@@ -27,11 +27,13 @@ export function withResponsiveMode<P, S>(ComposedComponent: any): any {
 
   return class WithResponsiveMode extends React.Component<P, IWithResponsiveModeState> {
     private _events: EventGroup;
+    private _composedComponentInstance: any;
 
     constructor() {
       super();
 
       this._events = new EventGroup(this);
+      this._updateChildRef = this._updateChildRef.bind(this);
 
       this.state = {
         responsiveMode: this._getResponsiveMode()
@@ -58,8 +60,19 @@ export function withResponsiveMode<P, S>(ComposedComponent: any): any {
       let { responsiveMode } = this.state;
 
       return (
-        <ComposedComponent responsiveMode={ responsiveMode } { ...this.props } />
+        <ComposedComponent ref={ this._updateChildRef } responsiveMode={ responsiveMode } { ...this.props } />
       );
+    }
+
+    /**
+     * Accessor for the instance of the component being wrapped by WithResponsiveMode.
+     */
+    public get composedComponentInstance() {
+      return this._composedComponentInstance;
+    }
+
+    private _updateChildRef(composedComponentInstance: any) {
+      this._composedComponentInstance = composedComponentInstance;
     }
 
     private _getResponsiveMode(): ResponsiveMode {
@@ -71,7 +84,5 @@ export function withResponsiveMode<P, S>(ComposedComponent: any): any {
 
       return responsiveMode;
     }
-
   };
-
 }

--- a/src/utilities/decorators/withViewport.tsx
+++ b/src/utilities/decorators/withViewport.tsx
@@ -61,6 +61,13 @@ export function withViewport<P, S>(ComposedComponent: any): any {
       );
     }
 
+    /**
+     * Accessor for the instance of the component being wrapped by withViewport.
+     */
+    public get composedComponentInstance() {
+      return this.refs.component;
+    }
+
     public forceUpdate() {
       this._updateViewport(true);
     }

--- a/src/utilities/decorators/withViewport.tsx
+++ b/src/utilities/decorators/withViewport.tsx
@@ -54,7 +54,7 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
       return (
         <div className='ms-Viewport' ref='root' style={ { minWidth: 1, minHeight: 1 } }>
           { isViewportVisible && (
-            <ComposedComponent ref={ this._updateChildRef } viewport={ viewport } { ...this.props } />
+            <ComposedComponent ref={ this._updateComposedComponentRef } viewport={ viewport } { ...this.props } />
           ) }
         </div>
       );

--- a/src/utilities/hoist.ts
+++ b/src/utilities/hoist.ts
@@ -40,9 +40,7 @@ export function hoistMethods(destination, source, exclusions = REACT_LIFECYCLE_E
  * @param {string[]} methodNames An array of method names to unhoist.
  */
 export function unhoistMethods(source: Object, methodNames: string[]): void {
-  for (let methodName of methodNames) {
-    if (source.hasOwnProperty(methodName) && typeof source[methodName] === 'function') {
-      delete source[methodName];
-    }
-  }
+  methodNames
+    .filter((methodName) => source.hasOwnProperty(methodName) && typeof source[methodName] === 'function')
+    .forEach((methodName) => delete source[methodName]);
 }

--- a/src/utilities/hoist.ts
+++ b/src/utilities/hoist.ts
@@ -1,6 +1,5 @@
 const REACT_LIFECYCLE_EXCLUSIONS = [
   'setState',
-  'forceUpdate',
   'render',
   'componentWillMount',
   'componentDidMount',

--- a/src/utilities/hoist.ts
+++ b/src/utilities/hoist.ts
@@ -21,6 +21,7 @@ export function hoistMethods(destination, source, exclusions = REACT_LIFECYCLE_E
     if (
       typeof source[methodName] === 'function' &&
       destination[methodName] === undefined &&
+      exclusions &&
       exclusions.indexOf(methodName) === -1
     ) {
       hoisted.push(methodName);

--- a/src/utilities/hoist.ts
+++ b/src/utilities/hoist.ts
@@ -1,0 +1,47 @@
+const REACT_LIFECYCLE_EXCLUSIONS = [
+  'setState',
+  'forceUpdate',
+  'render',
+  'componentWillMount',
+  'componentDidMount',
+  'componentWillReceiveProps',
+  'shouldComponentUpdate',
+  'componentWillUpdate',
+  'componentDidUpdate',
+  'componentWillUnmount'
+];
+
+/**
+ * Allows you to hoist methods, except those in an exclusion set from a source object into a destination object.
+ * @returns {string[]} An array of names of methods that were hoisted.
+ */
+export function hoistMethods(destination, source, exclusions = REACT_LIFECYCLE_EXCLUSIONS): string[] {
+  let hoisted: string[] = [];
+  for (let methodName in source) {
+    if (
+      typeof source[methodName] === 'function' &&
+      destination[methodName] === undefined &&
+      exclusions.indexOf(methodName) === -1
+    ) {
+      hoisted.push(methodName);
+      /* tslint:disable:no-function-expression */
+      destination[methodName] = function () { source[methodName].apply(source, arguments); };
+      /* tslint:enable */
+    }
+  }
+
+  return hoisted;
+}
+
+/**
+ * Provides a method for convenience to unhoist hoisted methods.
+ * @param {Object} source The source object upon which methods were hoisted.
+ * @param {string[]} methodNames An array of method names to unhoist.
+ */
+export function unhoistMethods(source: Object, methodNames: string[]): void {
+  for (let methodName of methodNames) {
+    if (source.hasOwnProperty(methodName) && typeof source[methodName] === 'function') {
+      source[methodName] = null; // or should this be undefined?
+    }
+  }
+}

--- a/src/utilities/hoist.ts
+++ b/src/utilities/hoist.ts
@@ -39,6 +39,5 @@ export function hoistMethods(destination, source, exclusions = REACT_LIFECYCLE_E
  */
 export function unhoistMethods(source: Object, methodNames: string[]): void {
   methodNames
-    .filter((methodName) => source.hasOwnProperty(methodName) && typeof source[methodName] === 'function')
     .forEach((methodName) => delete source[methodName]);
 }

--- a/src/utilities/hoist.ts
+++ b/src/utilities/hoist.ts
@@ -21,8 +21,7 @@ export function hoistMethods(destination, source, exclusions = REACT_LIFECYCLE_E
     if (
       typeof source[methodName] === 'function' &&
       destination[methodName] === undefined &&
-      exclusions &&
-      exclusions.indexOf(methodName) === -1
+      (!exclusions || exclusions.indexOf(methodName) === -1)
     ) {
       hoisted.push(methodName);
       /* tslint:disable:no-function-expression */

--- a/src/utilities/hoist.ts
+++ b/src/utilities/hoist.ts
@@ -42,7 +42,7 @@ export function hoistMethods(destination, source, exclusions = REACT_LIFECYCLE_E
 export function unhoistMethods(source: Object, methodNames: string[]): void {
   for (let methodName of methodNames) {
     if (source.hasOwnProperty(methodName) && typeof source[methodName] === 'function') {
-      source[methodName] = null; // or should this be undefined?
+      delete source[methodName];
     }
   }
 }


### PR DESCRIPTION
Adds hoisting support to all decorators in office-ui-fabric-react, now making it possible to access the composed components in each of these decorators.