### PR TITLE
Fix scrollbar and mobile view on PeoplePicker

### DIFF
--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -180,7 +180,6 @@ $personaItemHeight: 42px;
 // List of results
 .ms-PeoplePicker-resultList {
   @include ms-u-normalize;
-  margin-bottom: -1px;
   list-style-type: none; // Browser default override.
 }
 
@@ -216,16 +215,12 @@ $personaItemHeight: 42px;
   @include button-reset();
   position: relative;
   box-sizing: border-box;
-  height: $personaItemHeight;
+  height: $peoplePicker-rowHeight;
   width: 100%;
   background: none;
   border: 0;
   @include text-align(left);
   @include padding(4px, 0, 4px, 16px);
-
-  @media (min-width: $ms-screen-md-min) {
-    height: $peoplePicker-rowHeight;
-  }
 
   &:hover {
     background-color: $ms-color-neutralLight;
@@ -269,7 +264,7 @@ $personaItemHeight: 42px;
 .ms-PeoplePicker-resultAction {
   @include button-reset();
   display: block;
-  height: 34px;
+  height: $peoplePicker-rowHeight;
   transition: background-color 0.367s $ms-ease1;
   position: absolute;
   @include right(0);


### PR DESCRIPTION
Fix bug 239894 and 239885.  Remove scroll bar when dropdown shows 1-3 people, fix item height under 480px breakpoint.

Removed 480px breakpoint, so item height is 56px, changed actionbutton height to match accordingly.

Screenshots attached
**fixed scrollbar**
![screen shot 2016-08-30 at 11 17 23 am](https://cloud.githubusercontent.com/assets/1291968/18101416/7ed94d10-6ea3-11e6-8e8a-4a733c37945b.png)

**fixed mobile view**
![screen shot 2016-08-30 at 11 17 39 am](https://cloud.githubusercontent.com/assets/1291968/18101417/7f9e5b28-6ea3-11e6-9a12-ec520cc2001f.png)
