### PR TITLE
MessageBar: Added support for deprecated remove value

### DIFF
--- a/src/components/MessageBar/MessageBar.Props.ts
+++ b/src/components/MessageBar/MessageBar.Props.ts
@@ -50,5 +50,10 @@ export enum MessageBarType {
   /** Success styled MessageBar */
   success,
   /** Warning styled MessageBar */
-  warning
+  warning,
+  /**
+   * Deprecated at v0.48.0, to be removed at >= v1.0.0. Use 'blocked' instead.
+   * @deprecated
+   */
+  remove
 }

--- a/src/components/MessageBar/MessageBar.tsx
+++ b/src/components/MessageBar/MessageBar.tsx
@@ -17,12 +17,12 @@ export class MessageBar extends React.Component<IMessageBarProps, IMessageBarSta
     isMultiline: true,
   };
 
-  // TODO bug 230228: Success icon not circled.
   private ICON_MAP = {
     [MessageBarType.info]:    'Info',
     [MessageBarType.warning]: 'Info',
     [MessageBarType.error]: 'ErrorBadge',
     [MessageBarType.blocked]: 'Blocked',
+    [MessageBarType.remove]: 'Blocked', // TODO remove deprecated value at >= 1.0.0
     [MessageBarType.severeWarning]: 'Warning',
     [MessageBarType.success]: 'Completed'
   };
@@ -54,7 +54,7 @@ export class MessageBar extends React.Component<IMessageBarProps, IMessageBarSta
     return css(this.props.className, 'ms-MessageBar', {
       'ms-MessageBar': this.props.messageBarType === MessageBarType.info,
       'ms-MessageBar--error': this.props.messageBarType === MessageBarType.error,
-      'ms-MessageBar--blocked': this.props.messageBarType === MessageBarType.blocked,
+      'ms-MessageBar--blocked': (this.props.messageBarType === MessageBarType.blocked) || (this.props.messageBarType === MessageBarType.remove), // TODO remove deprecated value at >= 1.0.0
       'ms-MessageBar--severeWarning': this.props.messageBarType === MessageBarType.severeWarning,
       'ms-MessageBar--success' : this.props.messageBarType === MessageBarType.success,
       'ms-MessageBar--warning' : this.props.messageBarType === MessageBarType.warning


### PR DESCRIPTION
@dzearing this PR deprecates a value that's an enum. The value has a deprecated comment, but since it's not a prop the build does not create a deprecated section for it. Just wanted to know if the docs output is acceptable.

![image](https://cloud.githubusercontent.com/assets/12520428/18113104/fb884cb0-6ee1-11e6-91f8-c4fea45c718f.png)
