### PR TITLE
Change text input validation to only call onSelectDate when text input is allowed

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -358,26 +358,25 @@ export class DatePicker extends React.Component<IDatePickerProps, IDatePickerSta
 
     if (allowTextInput) {
       let date = null;
-
-        if (inputValue) {
-          date = parseDateFromString(inputValue);
-          if (!date) {
-            this.setState({
-              errorMessage: strings.invalidInputErrorMessage || '*'
-            });
-          } else {
-            this.setState({
-              selectedDate: date,
-              formattedDate: formatDate && date ? formatDate(date) : null,
-              errorMessage: ''
-            });
-          }
-        } else {
-          // No input date string shouldn't be an error if field is not required
+      if (inputValue) {
+        date = parseDateFromString(inputValue);
+        if (!date) {
           this.setState({
+            errorMessage: strings.invalidInputErrorMessage || '*'
+          });
+        } else {
+          this.setState({
+            selectedDate: date,
+            formattedDate: formatDate && date ? formatDate(date) : null,
             errorMessage: ''
           });
         }
+      } else {
+        // No input date string shouldn't be an error if field is not required
+        this.setState({
+          errorMessage: ''
+        });
+      }
 
       // Execute onSelectDate callback
       if (onSelectDate) {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -356,34 +356,35 @@ export class DatePicker extends React.Component<IDatePickerProps, IDatePickerSta
       return;
     }
 
-    let date = null;
     if (allowTextInput) {
-      if (inputValue) {
-        date = parseDateFromString(inputValue);
-        if (!date) {
-          this.setState({
-            errorMessage: strings.invalidInputErrorMessage || '*'
-          });
+      let date = null;
+
+        if (inputValue) {
+          date = parseDateFromString(inputValue);
+          if (!date) {
+            this.setState({
+              errorMessage: strings.invalidInputErrorMessage || '*'
+            });
+          } else {
+            this.setState({
+              selectedDate: date,
+              formattedDate: formatDate && date ? formatDate(date) : null,
+              errorMessage: ''
+            });
+          }
         } else {
+          // No input date string shouldn't be an error if field is not required
           this.setState({
-            selectedDate: date,
-            formattedDate: formatDate && date ? formatDate(date) : null,
             errorMessage: ''
           });
         }
-      } else {
-        // No input date string shouldn't be an error if field is not required
-        this.setState({
-          errorMessage: ''
-        });
-      }
-    }
 
-    // Execute onSelectDate callback
-    if (onSelectDate) {
-      // If no input date string or input date string is invalid
-      // date variable will be null, callback should expect null value for this case
-      onSelectDate(date);
+      // Execute onSelectDate callback
+      if (onSelectDate) {
+        // If no input date string or input date string is invalid
+        // date variable will be null, callback should expect null value for this case
+        onSelectDate(date);
+      }
     }
   }
 }


### PR DESCRIPTION
Change text input validation to only call onSelectDate when text input is allowed
Previously, when text input was not allowed, clicking outside the DatePicker would fire onBlur(), which would then call _validateTextInput().

When _validateTextInput() was called when allowTextInput was false, it would call onSelectDate with null, even if the date was never changed. This change ensures that this only happens when allowTextInput is true.