### PR TITLE
Fix Commandbar showing ms-icon-more even if icons are toggled to hidden

### DIFF
--- a/src/components/CommandBar/CommandBar.scss
+++ b/src/components/CommandBar/CommandBar.scss
@@ -88,6 +88,10 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
     height: 38px;
     outline: none;
   }
+
+  &.is-hidden {
+    display: none;
+  }
 }
 
 .ms-CommandBarItem-chevronDown,

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -97,13 +97,6 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
       );
     }
 
-    let visibleOverflow = false;
-    if (renderedOverflowItems) {
-      visibleOverflow = renderedOverflowItems.some(function(item) {
-        return (item.icon !== '' || item.name !== '');
-      });
-    }
-
     return (
       <div className={ css('ms-CommandBar', className) } ref='commandBarRegion'>
         { searchBox }
@@ -111,7 +104,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
           <div className='ms-CommandBar-primaryCommands' ref='commandSurface'>
             { renderedItems.map((item, index) => (
               this._renderItemInCommandBar(item, index, expandedMenuItemKey)
-            )).concat((renderedOverflowItems && renderedOverflowItems.length && visibleOverflow) ? [
+            )).concat((renderedOverflowItems && renderedOverflowItems.length) ? [
               <div className='ms-CommandBarItem' key={ OVERFLOW_KEY } ref={ OVERFLOW_KEY }>
                 <button
                   id={ this._id + OVERFLOW_KEY }
@@ -155,8 +148,9 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
     const itemKey = item.key || index;
     const className = css(item.onClick ? 'ms-CommandBarItem-link' : 'ms-CommandBarItem-text', !item.name && 'ms-CommandBarItem--noName');
     const classNameValue = css(className, { 'is-expanded': (expandedMenuItemKey === item.key) });
+    const showItem = (!(item.items && item.items.length) && item.name === '' && item.icon === '') ? 'is-hidden' : '';
 
-    return <div className={ css('ms-CommandBarItem', item.className) } key={ itemKey } ref={ itemKey }>
+    return <div className={ css('ms-CommandBarItem', item.className, showItem) } key={ itemKey } ref={ itemKey }>
              {(() => {
                if (item.onClick || item.items) {
                  return <button

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -97,6 +97,13 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
       );
     }
 
+    let visibleOverflow = false;
+    if (renderedOverflowItems) {
+      visibleOverflow = renderedOverflowItems.some(function(item) {
+        return (item.icon !== '' || item.name !== '');
+      });
+    }
+
     return (
       <div className={ css('ms-CommandBar', className) } ref='commandBarRegion'>
         { searchBox }
@@ -104,19 +111,19 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
           <div className='ms-CommandBar-primaryCommands' ref='commandSurface'>
             { renderedItems.map((item, index) => (
               this._renderItemInCommandBar(item, index, expandedMenuItemKey)
-            )).concat((renderedOverflowItems && renderedOverflowItems.length) ? [
-            <div className='ms-CommandBarItem' key={ OVERFLOW_KEY } ref={ OVERFLOW_KEY }>
-              <button
-                id={ this._id + OVERFLOW_KEY }
-                className={ css('ms-CommandBarItem-link', { 'is-expanded': (expandedMenuItemKey === OVERFLOW_KEY) }) }
-                onClick={ this._onOverflowClick }
-                role='menuitem'
-                aria-label={ this.props.elipisisAriaLabel || '' }
-                aria-haspopup={ true }
-              >
-                <i className='ms-CommandBarItem-overflow ms-Icon ms-Icon--More' />
-              </button>
-            </div>
+            )).concat((renderedOverflowItems && renderedOverflowItems.length && visibleOverflow) ? [
+              <div className='ms-CommandBarItem' key={ OVERFLOW_KEY } ref={ OVERFLOW_KEY }>
+                <button
+                  id={ this._id + OVERFLOW_KEY }
+                  className={ css('ms-CommandBarItem-link', { 'is-expanded': (expandedMenuItemKey === OVERFLOW_KEY) }) }
+                  onClick={ this._onOverflowClick }
+                  role='menuitem'
+                  aria-label={ this.props.elipisisAriaLabel || '' }
+                  aria-haspopup={ true }
+                >
+                  <i className='ms-CommandBarItem-overflow ms-Icon ms-Icon--More' />
+                </button>
+              </div>
             ] : []) }
           </div>
           <div className='ms-CommandBar-sideCommands' ref='farCommandSurface'>


### PR DESCRIPTION
Fix commandbar so ms-Icon-More is hidden if Show Names and Show Icons is toggled off.

![screen shot 2016-09-01 at 12 55 19 pm](https://cloud.githubusercontent.com/assets/1291968/18182128/6726c9e4-7043-11e6-9055-5c896d77c4f6.png)