### PR TITLE
BaseComponent: Adding a _resolveRef helper to create memoized helpers to resolve refs.

### DIFF
--- a/src/common/BaseComponent.test.tsx
+++ b/src/common/BaseComponent.test.tsx
@@ -1,3 +1,12 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
+import * as ReactDOM from 'react-dom';
+import * as ReactTestUtils from 'react-addons-test-utils';
+
+let { expect } = chai;
+
 import { BaseComponent } from './BaseComponent';
 
 let { assert } = chai;
@@ -54,6 +63,22 @@ describe('BaseComponent', () => {
   _buildTestFor('render');
   _buildTestFor('componentDidUpdate');
   _buildTestFor('componentWillUnmount');
+
+  it('can resolve refs', () => {
+    class Foo extends BaseComponent<{}, {}> {
+      public root: HTMLElement;
+
+      public render() {
+        return <div ref={ this._resolveRef('root') } />;
+      }
+    }
+
+    let component = ReactTestUtils.renderIntoDocument(
+      <Foo />
+    ) as any;
+
+    expect(component.root).to.exist;
+  });
 });
 
 function _buildTestFor(methodName) {

--- a/src/common/BaseComponent.test.tsx
+++ b/src/common/BaseComponent.test.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 
-import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-addons-test-utils';
 
 let { expect } = chai;

--- a/src/common/BaseComponent.ts
+++ b/src/common/BaseComponent.ts
@@ -18,6 +18,7 @@ export class BaseComponent<P, S> extends React.Component<P, S> {
   private __async: Async;
   private __events: EventGroup;
   private __disposables: IDisposable[];
+  private __resolves: { [ name: string ]: (ref: any) => any };
 
   /**
    * BaseComponent constructor
@@ -102,6 +103,29 @@ export class BaseComponent<P, S> extends React.Component<P, S> {
     }
 
     return this.__events;
+  }
+
+  /**
+   * Helper to return a memoized ref resolver function.
+   * @params refName Name of the member to assign the ref to.
+   *
+   * @examples
+   * class Foo extends BaseComponent<...> {
+   *   private _root: HTMLElement;
+   *
+   *   public render() {
+   *     return <div ref={ this._resolveRef('_root') } />
+   *   }
+   * }
+   */
+  protected _resolveRef(refName: string) {
+    if (!this.__resolves) {
+      this.__resolves = {};
+    }
+    if (!this.__resolves[refName]) {
+      this.__resolves[refName] = (ref) => this[refName] = ref;
+    }
+    return this.__resolves[refName];
   }
 }
 


### PR DESCRIPTION
We've realized that with using refs, strings are deprecated. Inline functions are terrible because they regen every time. So, here's a helper to BaseComponent that makes it a snap to resolve them the right way.

BAD:
```typescript
render() {
  return <div ref=’root’ />
}
```

BAD:
```typescript
render() {
  return <div ref={ (el) => this._root = el } />
}
```

GOOD but verbose:
```typescript
MyComponent extends React.Component {
  private _root: HTMLElement;
  private _resolveRoot: (el: HTMLElement) => HTMLElement;

  constructor() {
     this._resolveRoot = (el) => this._root = el;
  }

  render() {
    return <div ref={ this._resolveRoot } />;
  }
}
```

BEST, use _resolveRef in BaseComponent, short and sweet:
```
MyComponent extends BaseComponent {
  private _root: HTMLElement;

  render() {
    return <div ref={ this._resolveRef(‘_root’) } />
  }
}
```
