### PR TITLE
Fixing high contrast for Link

### DIFF
--- a/src/common/_fabricExtraColors.scss
+++ b/src/common/_fabricExtraColors.scss
@@ -1,5 +1,2 @@
 $ms-color-neutralQuaternary: #d0d0d0;
 $ms-color-neutralQuaternaryAlt: #dadada;
-// Overriding link colors that are incorrect in fabric core while
-// waiting on https://github.com/OfficeDev/office-ui-fabric-core/pull/793/files
-$ms-color-contrastBlackLink:     #FFFF00

--- a/src/common/_fabricExtraColors.scss
+++ b/src/common/_fabricExtraColors.scss
@@ -1,2 +1,5 @@
 $ms-color-neutralQuaternary: #d0d0d0;
 $ms-color-neutralQuaternaryAlt: #dadada;
+// Overriding link colors that are incorrect in fabric core while
+// waiting on https://github.com/OfficeDev/office-ui-fabric-core/pull/793/files
+$ms-color-contrastBlackLink:     #FFFF00

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -23,11 +23,17 @@
   }
 
   @media screen and (-ms-high-contrast: active) {
-    color: $ms-color-contrastBlackLink;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   @media screen and (-ms-high-contrast: black-on-white) {
     color: $ms-color-contrastWhiteLink;
+  }
+
+  @media screen and (-ms-high-contrast: white-on-black) {
+    color: $ms-color-contrastBlackLink;
   }
 }
 

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -21,20 +21,6 @@
   &:active {
     color: $ms-color-themePrimary;
   }
-
-  @media screen and (-ms-high-contrast: active) {
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    color: $ms-color-contrastWhiteLink;
-  }
-
-  @media screen and (-ms-high-contrast: white-on-black) {
-    color: $ms-color-contrastBlackLink;
-  }
 }
 
 .ms-Link {


### PR DESCRIPTION
After a discussion with designers, removing all the overrides to ensure the defaults are met AND the end user can customize as with the rest of the links.

I've played with all the high contrast settings and confirmed they match the expectations and pass WebAIM.