### PR TITLE
Fixing a minor bug in selection where isAllSelected is returning true incorrectly

### DIFF
--- a/src/utilities/selection/Selection.test.ts
+++ b/src/utilities/selection/Selection.test.ts
@@ -1,6 +1,6 @@
 let { expect } = chai;
 
-import { Selection } from './index';
+import { Selection, IObjectWithKey } from './index';
 
 let setA = [ { key: 'a' }, { key: 'b' }, { key: 'c' } ];
 let setB = [ { key: 'a' }, { key: 'd' }, { key: 'b' } ];
@@ -50,6 +50,24 @@ describe('Selection', () => {
     selection.setIndexSelected(0, true, true);
     selection.selectToIndex(2, true);
     expect(changeCount).equals(10, 'after range selecting from 0 to 2');
+  });
+
+  it('returns false on isAllSelected when no items are selectable', () => {
+    let changeEvents = 0;
+    let selection = new Selection({
+      canSelectItem: (item: IObjectWithKey) => false,
+      onSelectionChanged: () => changeEvents++
+    });
+
+    selection.setItems(setA);
+
+    expect(selection.isAllSelected()).to.equal(false, 'isAllSelected was not false after initialization');
+
+    selection.setAllSelected(true);
+
+    expect(selection.isAllSelected()).to.equal(false, 'isAllSelected was not false after trying to select all the unselectables');
+
+    expect(changeEvents).to.equal(0, 'changeEvents were not 0');
   });
 
 });

--- a/src/utilities/selection/Selection.ts
+++ b/src/utilities/selection/Selection.ts
@@ -156,10 +156,12 @@ export class Selection implements ISelection {
   }
 
   public isAllSelected(): boolean {
+    let selectableCount = this._items.length - this._unselectableCount;
+
     return (
       (this.count > 0) &&
       (this._isAllSelected && this._exemptedCount === 0) ||
-      (!this._isAllSelected && (this._exemptedCount === this._items.length - this._unselectableCount) && this._items.length > 0));
+      (!this._isAllSelected && (this._exemptedCount === selectableCount) && selectableCount > 0));
   }
 
   public isKeySelected(key: string): boolean {
@@ -176,7 +178,9 @@ export class Selection implements ISelection {
   }
 
   public setAllSelected(isAllSelected: boolean) {
-    if (this._exemptedCount > 0 || isAllSelected !== this._isAllSelected) {
+    let selectableCount = this._items ? (this._items.length - this._unselectableCount) : 0;
+
+    if (selectableCount > 0 && (this._exemptedCount > 0 || isAllSelected !== this._isAllSelected)) {
       this._exemptedIndices = {};
       this._exemptedCount = 0;
       this._isAllSelected = isAllSelected;


### PR DESCRIPTION
When all items are unselectable, we should never toggle isAllSelected to true. Added test, validated the fix works.