### PR TITLE
Making header optional for component demo pages and fixing various style bugs

### DIFF
--- a/src/demo/components/ComponentPage/ComponentPage.scss
+++ b/src/demo/components/ComponentPage/ComponentPage.scss
@@ -48,13 +48,17 @@ $dontColor: #A61E22;
 .ComponentPage-navLink {
   display: inline-block;
   margin-right: 40px;
-  @include ms-font-l;
-  color: $ms-color-white;
 }
 
-.ComponentPage-navLink a {
+.ComponentPage-navLink .ms-Link {
   color: $ms-color-white;
   text-decoration: none;
+  @include ms-font-l;
+  color: $ms-color-white;
+
+  &:hover {
+    color: $ms-color-neutralLight;
+  }
 }
 
 .ComponentPage-bestPracticesSection {

--- a/src/demo/components/ComponentPage/ComponentPage.tsx
+++ b/src/demo/components/ComponentPage/ComponentPage.tsx
@@ -18,13 +18,12 @@ export interface IComponentPageProps {
 }
 
 export class ComponentPage extends React.Component<IComponentPageProps, {}> {
+  public static defaultProps = {
+    showHeader: true
+  };
 
   constructor(props: IComponentPageProps) {
     super(props);
-  }
-
-  public static defaultProps = {
-    showHeader: true
   }
 
   public render() {

--- a/src/demo/components/ComponentPage/ComponentPage.tsx
+++ b/src/demo/components/ComponentPage/ComponentPage.tsx
@@ -14,6 +14,7 @@ export interface IComponentPageProps {
   donts?: JSX.Element;
   overview: JSX.Element;
   route: string;
+  showHeader?: boolean;
 }
 
 export class ComponentPage extends React.Component<IComponentPageProps, {}> {
@@ -22,9 +23,12 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
     super(props);
   }
 
+  public static defaultProps = {
+    showHeader: true
+  }
+
   public render() {
     let {
-      title,
       componentName,
       exampleCards,
       overview
@@ -33,10 +37,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
     return (
       <div className='ComponentPage'>
         <div className={ componentName }>
-          <div className='ComponentPage-header'>
-            <h1 className='ComponentPage-title'>{ title }</h1>
-            { this._navigationLinks() }
-          </div>
+          { this._pageHeader() }
           <div className='ComponentPage-body'>
             <div className='ComponentPage-overviewSection'>
                 <h2 className='ComponentPage-subHeading' id='Overview'>Overview</h2>
@@ -56,6 +57,17 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
     );
   }
 
+  private _pageHeader(): JSX.Element {
+    if (this.props.showHeader) {
+      return (
+        <div className='ComponentPage-header'>
+          <h1 className='ComponentPage-title'>{ this.props.title }</h1>
+          { this._navigationLinks() }
+        </div>
+      );
+    }
+  }
+
   private _navigationLinks(): JSX.Element {
     let links: Array<JSX.Element> = [];
     let {
@@ -68,7 +80,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
     if (bestPractices && dos && donts) {
       links.push(
         <div className='ComponentPage-navLink'>
-          <a href={ route + '#Best Practices' }>Best Practices</a>
+          <Link href={ route + '#Best Practices' }>Best Practices</Link>
         </div>
       );
     }

--- a/src/demo/components/ComponentPage/ComponentPage.tsx
+++ b/src/demo/components/ComponentPage/ComponentPage.tsx
@@ -14,12 +14,12 @@ export interface IComponentPageProps {
   donts?: JSX.Element;
   overview: JSX.Element;
   route: string;
-  showHeader?: boolean;
+  isHeaderVisible?: boolean;
 }
 
 export class ComponentPage extends React.Component<IComponentPageProps, {}> {
   public static defaultProps = {
-    showHeader: true
+    isHeaderVisible: true
   };
 
   constructor(props: IComponentPageProps) {
@@ -57,7 +57,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
   }
 
   private _pageHeader(): JSX.Element {
-    if (this.props.showHeader) {
+    if (this.props.isHeaderVisible) {
       return (
         <div className='ComponentPage-header'>
           <h1 className='ComponentPage-title'>{ this.props.title }</h1>

--- a/src/demo/components/ComponentPage/IComponentDemoPageProps.tsx
+++ b/src/demo/components/ComponentPage/IComponentDemoPageProps.tsx
@@ -1,0 +1,3 @@
+export interface IComponentDemoPageProps {
+  showHeader?: boolean;
+}

--- a/src/demo/components/ComponentPage/IComponentDemoPageProps.tsx
+++ b/src/demo/components/ComponentPage/IComponentDemoPageProps.tsx
@@ -1,3 +1,3 @@
 export interface IComponentDemoPageProps {
-  showHeader?: boolean;
+  isHeaderVisible?: boolean;
 }

--- a/src/demo/components/Header/Header.scss
+++ b/src/demo/components/Header/Header.scss
@@ -1,10 +1,12 @@
 @import '../../../common/common';
 
+$Header-fabricWebsiteHeaderColor: #272630;
+
 .Header {
   height: 50px;
   line-height: 50px;
   padding: 0 20px;
-  background: $ms-color-themeDark;
+  background: $Header-fabricWebsiteHeaderColor;
   overflow: hidden;
   white-space: no-wrap;
   user-select: none;

--- a/src/demo/pages/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/demo/pages/BreadcrumbPage/BreadcrumbPage.tsx
@@ -5,8 +5,7 @@ import {
 import {
   ExampleCard,
   PropertiesTableSet,
-  ComponentPage,
-  IComponentPageProps
+  ComponentPage
 } from '../../components/index';
 import { BreadcrumbBasicExample } from './examples/Breadcrumb.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';

--- a/src/demo/pages/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/demo/pages/BreadcrumbPage/BreadcrumbPage.tsx
@@ -5,15 +5,17 @@ import {
 import {
   ExampleCard,
   PropertiesTableSet,
-  ComponentPage
+  ComponentPage,
+  IComponentPageProps
 } from '../../components/index';
 import { BreadcrumbBasicExample } from './examples/Breadcrumb.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const BreadcrumbBasicExampleCode = require('./examples/Breadcrumb.Basic.Example.tsx');
 
-export class BreadcrumbPage extends React.Component<any, any> {
+export class BreadcrumbPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -62,7 +64,8 @@ export class BreadcrumbPage extends React.Component<any, any> {
             </ul>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/demo/pages/BreadcrumbPage/BreadcrumbPage.tsx
@@ -64,7 +64,7 @@ export class BreadcrumbPage extends React.Component<IComponentDemoPageProps, any
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ButtonPage/ButtonPage.tsx
+++ b/src/demo/pages/ButtonPage/ButtonPage.tsx
@@ -11,9 +11,11 @@ import {
 import { ButtonBasicExample } from './examples/Button.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
+
 const ButtonBasicExampleCode = require('./examples/Button.Basic.Example.tsx');
 
-export class ButtonPage extends React.Component<any, any> {
+export class ButtonPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -77,7 +79,8 @@ export class ButtonPage extends React.Component<any, any> {
             </ul>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ButtonPage/ButtonPage.tsx
+++ b/src/demo/pages/ButtonPage/ButtonPage.tsx
@@ -80,7 +80,7 @@ export class ButtonPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/CalloutPage/CalloutPage.tsx
+++ b/src/demo/pages/CalloutPage/CalloutPage.tsx
@@ -15,13 +15,14 @@ import { CalloutDirectionalExample } from './examples/Callout.Directional.Exampl
 import { CalloutCoverExample } from './examples/Callout.Cover.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const CalloutBasicExampleCode = require('./examples/Callout.Basic.Example.tsx');
 const CalloutNestedExampleCode = require('./examples/Callout.Nested.Example.tsx');
 const CalloutDirectionalExampleCode = require('./examples/Callout.Directional.Example.tsx');
 const CalloutCoverExampleCode = require('./examples/Callout.Cover.Example.tsx');
 
-export class CalloutPage extends React.Component<any, any> {
+export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -96,7 +97,8 @@ export class CalloutPage extends React.Component<any, any> {
             </ul>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/CalloutPage/CalloutPage.tsx
+++ b/src/demo/pages/CalloutPage/CalloutPage.tsx
@@ -98,7 +98,7 @@ export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/CheckboxPage/CheckboxPage.tsx
+++ b/src/demo/pages/CheckboxPage/CheckboxPage.tsx
@@ -47,7 +47,7 @@ export class CheckboxPage extends React.Component<IComponentDemoPageProps, any> 
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/CheckboxPage/CheckboxPage.tsx
+++ b/src/demo/pages/CheckboxPage/CheckboxPage.tsx
@@ -11,10 +11,11 @@ import {
 import { CheckboxBasicExample } from './examples/Checkbox.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const CheckboxBasicExampleCode = require('./examples/Checkbox.Basic.Example.tsx');
 
-export class CheckboxPage extends React.Component<any, any> {
+export class CheckboxPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -45,7 +46,8 @@ export class CheckboxPage extends React.Component<any, any> {
             <span> allow the user to enable or disable a setting.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ChoiceGroupPage/ChoiceGroupPage.tsx
+++ b/src/demo/pages/ChoiceGroupPage/ChoiceGroupPage.tsx
@@ -11,10 +11,11 @@ import {
 import { ChoiceGroupBasicExample } from './examples/ChoiceGroup.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const ChoiceGroupBasicExampleCode = require('./examples/ChoiceGroup.Basic.Example.tsx');
 
-export class ChoiceGroupPage extends React.Component<any, any> {
+export class ChoiceGroupPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -45,7 +46,8 @@ export class ChoiceGroupPage extends React.Component<any, any> {
             <span> allow the user to choose one of many options.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ChoiceGroupPage/ChoiceGroupPage.tsx
+++ b/src/demo/pages/ChoiceGroupPage/ChoiceGroupPage.tsx
@@ -47,7 +47,7 @@ export class ChoiceGroupPage extends React.Component<IComponentDemoPageProps, an
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ColorPickerPage/ColorPickerPage.tsx
+++ b/src/demo/pages/ColorPickerPage/ColorPickerPage.tsx
@@ -43,7 +43,7 @@ export class ColorPickerPage extends React.Component<IComponentDemoPageProps, an
           <div>ColorPicker is used to allow a user to select a color</div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ColorPickerPage/ColorPickerPage.tsx
+++ b/src/demo/pages/ColorPickerPage/ColorPickerPage.tsx
@@ -8,10 +8,11 @@ import {
 import { ColorPickerBasicExample } from './examples/ColorPicker.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const ColorPickerBasicExampleCode = require('./examples/ColorPicker.Basic.Example.tsx');
 
-export class ColorPickerPage extends React.Component<any, any> {
+export class ColorPickerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -41,7 +42,8 @@ export class ColorPickerPage extends React.Component<any, any> {
         overview={
           <div>ColorPicker is used to allow a user to select a color</div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/CommandBarPage/CommandBarPage.tsx
+++ b/src/demo/pages/CommandBarPage/CommandBarPage.tsx
@@ -13,11 +13,12 @@ import { CommandBarBasicExample } from './examples/CommandBar.Basic.Example';
 import { CommandBarNonFocusableItemsExample } from './examples/CommandBar.NonFocusable.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const CommandBarBasicExampleCode = require('./examples/CommandBar.Basic.Example.tsx');
 const CommandBarNoFocusableItemsExampleCode = require('./examples/CommandBar.NonFocusable.Example.tsx');
 
-export class CommandBarPage extends React.Component<any, any> {
+export class CommandBarPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -54,7 +55,8 @@ export class CommandBarPage extends React.Component<any, any> {
           <span> provide a menu control to expose application commands. Command bars typically are rendered just below the header.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/CommandBarPage/CommandBarPage.tsx
+++ b/src/demo/pages/CommandBarPage/CommandBarPage.tsx
@@ -56,7 +56,7 @@ export class CommandBarPage extends React.Component<IComponentDemoPageProps, any
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ContextualMenuPage/ContextualMenuPage.tsx
+++ b/src/demo/pages/ContextualMenuPage/ContextualMenuPage.tsx
@@ -15,13 +15,14 @@ import { ContextualMenuCustomizationExample } from './examples/ContextualMenu.Cu
 
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const ContextualMenuBasicExampleCode = require('./examples/ContextualMenu.Basic.Example.tsx');
 const ContextualMenuCheckmarksExampleCode = require('./examples/ContextualMenu.Checkmarks.Example.tsx');
 const ContextualMenuDirectionalExampleCode = require('./examples/ContextualMenu.Directional.Example.tsx');
 const ContextualMenuCustomizationExampleCode = require('./examples/ContextualMenu.Customization.Example.tsx');
 
-export class ContextualMenuPage extends React.Component<any, any> {
+export class ContextualMenuPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -62,7 +63,8 @@ export class ContextualMenuPage extends React.Component<any, any> {
             <span> provide a menu for use in context menus and dropdowns.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ContextualMenuPage/ContextualMenuPage.tsx
+++ b/src/demo/pages/ContextualMenuPage/ContextualMenuPage.tsx
@@ -64,7 +64,7 @@ export class ContextualMenuPage extends React.Component<IComponentDemoPageProps,
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DatePickerPage/DatePickerPage.tsx
+++ b/src/demo/pages/DatePickerPage/DatePickerPage.tsx
@@ -13,12 +13,13 @@ import { DatePickerRequiredExample } from './examples/DatePicker.Required.Exampl
 import { DatePickerInputExample } from './examples/DatePicker.Input.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const DatePickerBasicExampleCode = require('./examples/DatePicker.Basic.Example.tsx');
 const DatePickerRequiredExampleCode = require('./examples/DatePicker.Required.Example.tsx');
 const DatePickerInputExampleCode = require('./examples/DatePicker.Input.Example.tsx');
 
-export class DatePickerPage extends React.Component<any, any> {
+export class DatePickerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -54,7 +55,8 @@ export class DatePickerPage extends React.Component<any, any> {
             <span> provide a menu for use in context menus and dropdowns.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DatePickerPage/DatePickerPage.tsx
+++ b/src/demo/pages/DatePickerPage/DatePickerPage.tsx
@@ -56,7 +56,7 @@ export class DatePickerPage extends React.Component<IComponentDemoPageProps, any
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DetailsListPage/DetailsListPage.tsx
+++ b/src/demo/pages/DetailsListPage/DetailsListPage.tsx
@@ -67,7 +67,7 @@ export class DetailsListPage extends React.Component<IComponentDemoPageProps, an
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DetailsListPage/DetailsListPage.tsx
+++ b/src/demo/pages/DetailsListPage/DetailsListPage.tsx
@@ -10,6 +10,7 @@ import {
 
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 import { DetailsListBasicExample } from './examples/DetailsList.Basic.Example';
 const DetailsListBasicExampleCode = require('./examples/DetailsList.Basic.Example.tsx');
@@ -23,7 +24,7 @@ const DetailsListCustomRowsExampleCode = require('./examples/DetailsList.CustomR
 import { DetailsListAdvancedExample } from './examples/DetailsList.Advanced.Example';
 const DetailsListAdvancedExampleCode = require('./examples/DetailsList.Advanced.Example.tsx');
 
-export class DetailsListPage extends React.Component<any, any> {
+export class DetailsListPage extends React.Component<IComponentDemoPageProps, any> {
  private _url: string;
 
   constructor() {
@@ -65,7 +66,8 @@ export class DetailsListPage extends React.Component<any, any> {
             <span> and provides a sortable, filterable, justified table for rendering large sets of items. This component replaces the Table Component.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DialogPage/DialogPage.tsx
+++ b/src/demo/pages/DialogPage/DialogPage.tsx
@@ -62,7 +62,7 @@ export class DialogPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DialogPage/DialogPage.tsx
+++ b/src/demo/pages/DialogPage/DialogPage.tsx
@@ -14,13 +14,14 @@ import { DialogCloseExample } from './examples/Dialog.Close.Example';
 import { DialogBlockingExample } from './examples/Dialog.Blocking.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const DialogBasicExampleCode = require('./examples/Dialog.Basic.Example.tsx');
 const DialogLargeHeaderExampleCode = require('./examples/Dialog.LargeHeader.Example.tsx');
 const DialogCloseExampleCode = require('./examples/Dialog.Close.Example.tsx');
 const DialogBlockingExampleCode = require('./examples/Dialog.Blocking.Example.tsx');
 
-export class DialogPage extends React.Component<any, any> {
+export class DialogPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -60,7 +61,8 @@ export class DialogPage extends React.Component<any, any> {
             <span> are used to render a modal window.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DocumentCardPage/DocumentCardPage.tsx
+++ b/src/demo/pages/DocumentCardPage/DocumentCardPage.tsx
@@ -53,7 +53,7 @@ export class DocumentCardPage extends React.Component<IComponentDemoPageProps, a
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DocumentCardPage/DocumentCardPage.tsx
+++ b/src/demo/pages/DocumentCardPage/DocumentCardPage.tsx
@@ -10,12 +10,13 @@ import { DocumentCardCompleteExample } from './examples/DocumentCard.Complete.Ex
 import { DocumentCardCompactExample } from './examples/DocumentCard.Compact.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const DocumentCardBasicExampleCode = require('./examples/DocumentCard.Basic.Example.tsx');
 const DocumentCardCompleteExampleCode = require('./examples/DocumentCard.Complete.Example.tsx');
 const DocumentCardCompactExampleCode = require('./examples/DocumentCard.Compact.Example.tsx');
 
-export class DocumentCardPage extends React.Component<any, any> {
+export class DocumentCardPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -51,7 +52,8 @@ export class DocumentCardPage extends React.Component<any, any> {
              A card representation of a document. Can be configured with various card parts, including a preview, title, and location.
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DropdownPage/DropdownPage.tsx
+++ b/src/demo/pages/DropdownPage/DropdownPage.tsx
@@ -47,7 +47,7 @@ export class DropdownPage extends React.Component<IComponentDemoPageProps, any> 
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/DropdownPage/DropdownPage.tsx
+++ b/src/demo/pages/DropdownPage/DropdownPage.tsx
@@ -11,10 +11,11 @@ import {
 import { DropdownBasicExample } from './examples/Dropdown.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const DropdownBasicExampleCode = require('./examples/Dropdown.Basic.Example.tsx');
 
-export class DropdownPage extends React.Component<any, any> {
+export class DropdownPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -45,7 +46,8 @@ export class DropdownPage extends React.Component<any, any> {
             <span> provide a way for users to choose an option.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/Facepile/FacepilePage.tsx
+++ b/src/demo/pages/Facepile/FacepilePage.tsx
@@ -8,10 +8,11 @@ import {
 import { FacepileBasicExample } from './examples/Facepile.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const FacepileBasicExampleCode = require('./examples/Facepile.Basic.Example.tsx');
 
-export class FacepilePage extends React.Component<any, any> {
+export class FacepilePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -39,7 +40,8 @@ export class FacepilePage extends React.Component<any, any> {
         overview={
           <div>A control for managing people through a panel.</div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/Facepile/FacepilePage.tsx
+++ b/src/demo/pages/Facepile/FacepilePage.tsx
@@ -41,7 +41,7 @@ export class FacepilePage extends React.Component<IComponentDemoPageProps, any> 
           <div>A control for managing people through a panel.</div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/FocusTrapZonePage/FocusTrapZonePage.tsx
+++ b/src/demo/pages/FocusTrapZonePage/FocusTrapZonePage.tsx
@@ -16,10 +16,11 @@ let FocusTrapZoneBoxExampleWithFocusableItemCode =
     require('./examples/FocusTrapZone.Box.FocusOnCustomElement.Example');
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 import FocusTrapZoneBoxClickExample from './examples/FocusTrapZone.Box.Click.Example';
 let FocusTrapZoneBoxClickExampleCode = require('./examples/FocusTrapZone.Box.Click.Example');
 
-export class FocusTrapZonePage extends React.Component<any, any> {
+export class FocusTrapZonePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -56,7 +57,8 @@ export class FocusTrapZonePage extends React.Component<any, any> {
             <span> is used to trap the focus in any html element. Pressing tab will circle focus within the inner focusable elements of the FocusTrapZone.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/FocusTrapZonePage/FocusTrapZonePage.tsx
+++ b/src/demo/pages/FocusTrapZonePage/FocusTrapZonePage.tsx
@@ -58,7 +58,7 @@ export class FocusTrapZonePage extends React.Component<IComponentDemoPageProps, 
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/FocusZonePage/FocusZonePage.tsx
+++ b/src/demo/pages/FocusZonePage/FocusZonePage.tsx
@@ -55,7 +55,7 @@ export class FocusZonePage extends React.Component<IComponentDemoPageProps, any>
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/FocusZonePage/FocusZonePage.tsx
+++ b/src/demo/pages/FocusZonePage/FocusZonePage.tsx
@@ -10,12 +10,13 @@ import { FocusZoneListExample } from './examples/FocusZone.List.Example';
 import { FocusZoneDisabledExample } from './examples/FocusZone.Disabled.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const FocusZonePhotosExampleCode = require('./examples/FocusZone.Photos.Example.tsx');
 const FocusZoneListExampleCode = require('./examples/FocusZone.List.Example.tsx');
 const FocusZoneDisabledExampleCode = require('./examples/FocusZone.Disabled.Example.tsx');
 
-export class FocusZonePage extends React.Component<any, any> {
+export class FocusZonePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -53,7 +54,8 @@ export class FocusZonePage extends React.Component<any, any> {
             <p>Using a FocusZone is simple. Just wrap a bunch of content inside of a FocusZone, and arrows and tabbling will be handled for you! See examples below.</p>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/GettingStartedPage/GettingStartedPage.scss
+++ b/src/demo/pages/GettingStartedPage/GettingStartedPage.scss
@@ -2,6 +2,7 @@
 
 .ms-GettingStartedPage {
   margin-top: -20px;
+  padding: 40px;
 
   h1 {
     @include ms-font-xxl;
@@ -18,7 +19,6 @@
 }
 
 .ms-GettingStartedPage-banner {
-  background: $ms-color-neutralLight;
   padding: 1px 20px;
   margin: -20px;
   margin-bottom: 20px;

--- a/src/demo/pages/GroupedListPage/GroupedListPage.tsx
+++ b/src/demo/pages/GroupedListPage/GroupedListPage.tsx
@@ -46,7 +46,7 @@ export class GroupedListPage extends React.Component<IComponentDemoPageProps, an
           <p>Allows you to render a set of items as multiple lists with various grouping properties.</p>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/GroupedListPage/GroupedListPage.tsx
+++ b/src/demo/pages/GroupedListPage/GroupedListPage.tsx
@@ -9,11 +9,12 @@ import { GroupedListBasicExample } from './examples/GroupedList.Basic.Example';
 import { GroupedListCustomExample } from './examples/GroupedList.Custom.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const GroupedListBasicExampleCode = require('./examples/GroupedList.Basic.Example.tsx');
 const GroupedListCustomExampleCode = require('./examples/GroupedList.Custom.Example.tsx');
 
-export class GroupedListPage extends React.Component<any, any> {
+export class GroupedListPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -44,7 +45,8 @@ export class GroupedListPage extends React.Component<any, any> {
         overview={
           <p>Allows you to render a set of items as multiple lists with various grouping properties.</p>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ImagePage/ImagePage.tsx
+++ b/src/demo/pages/ImagePage/ImagePage.tsx
@@ -13,6 +13,7 @@ import { ImageCoverExample } from './examples/Image.Cover.Example';
 import { ImageNoneExample } from './examples/Image.None.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const ImageDefaultExampleCode = require('./examples/Image.Default.Example.tsx');
 const ImageCenterExampleCode = require('./examples/Image.Center.Example.tsx');
@@ -20,7 +21,7 @@ const ImageContainExampleCode = require('./examples/Image.Contain.Example.tsx');
 const ImageCoverExampleCode = require('./examples/Image.Cover.Example.tsx');
 const ImageNoneExampleCode = require('./examples/Image.None.Example.tsx');
 
-export class ImagePage extends React.Component<any, any> {
+export class ImagePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -62,7 +63,8 @@ export class ImagePage extends React.Component<any, any> {
             Images render an image. The borders have been added to these examples in order to help visualize empty space in the image frame.
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ImagePage/ImagePage.tsx
+++ b/src/demo/pages/ImagePage/ImagePage.tsx
@@ -64,7 +64,7 @@ export class ImagePage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/LabelPage/LabelPage.tsx
+++ b/src/demo/pages/LabelPage/LabelPage.tsx
@@ -11,6 +11,7 @@ import {
 import { LabelBasicExample } from './examples/Label.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const LabelBasicExampleCode = require('./examples/Label.Basic.Example.tsx');
 
@@ -45,7 +46,8 @@ export class LabelPage extends React.Component<any, any> {
             <span> render a text string, styled as a label.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/LabelPage/LabelPage.tsx
+++ b/src/demo/pages/LabelPage/LabelPage.tsx
@@ -47,7 +47,7 @@ export class LabelPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/LabelPage/LabelPage.tsx
+++ b/src/demo/pages/LabelPage/LabelPage.tsx
@@ -15,7 +15,7 @@ import { IComponentDemoPageProps } from '../../components/ComponentPage/ICompone
 
 const LabelBasicExampleCode = require('./examples/Label.Basic.Example.tsx');
 
-export class LabelPage extends React.Component<any, any> {
+export class LabelPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {

--- a/src/demo/pages/LayerPage/LayerPage.tsx
+++ b/src/demo/pages/LayerPage/LayerPage.tsx
@@ -54,7 +54,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/LayerPage/LayerPage.tsx
+++ b/src/demo/pages/LayerPage/LayerPage.tsx
@@ -10,11 +10,12 @@ import { LayerBasicExample } from './examples/Layer.Basic.Example';
 import { LayerInteractiveExample } from './examples/Layer.Interactive.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const LayerBasicExampleCode = require('./examples/Layer.Basic.Example.tsx');
 const LayerInteractiveExampleCode = require('./examples/Layer.Interactive.Example.tsx');
 
-export class LayerPage extends React.Component<any, any> {
+export class LayerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -52,7 +53,8 @@ export class LayerPage extends React.Component<any, any> {
             }</p>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/LinkPage/LinkPage.tsx
+++ b/src/demo/pages/LinkPage/LinkPage.tsx
@@ -10,10 +10,11 @@ import {
 import { LinkBasicExample } from './examples/Link.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 let LinkBasicExampleCode = require('./examples/Link.Basic.Example.tsx');
 
-export class LinkPage extends React.Component<any, any> {
+export class LinkPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -39,7 +40,8 @@ export class LinkPage extends React.Component<any, any> {
             <span> are used as a styled replacement for A tags. All attributes valid on A tags will be passed through.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/LinkPage/LinkPage.tsx
+++ b/src/demo/pages/LinkPage/LinkPage.tsx
@@ -41,7 +41,7 @@ export class LinkPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ListPage/ListPage.tsx
+++ b/src/demo/pages/ListPage/ListPage.tsx
@@ -19,10 +19,11 @@ const ListGridExampleCode = require('./examples/List.Grid.Example.tsx');
 
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 let _cachedItems;
 
-export class ListPage extends React.Component<any, any> {
+export class ListPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -71,7 +72,8 @@ export class ListPage extends React.Component<any, any> {
             </p>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ListPage/ListPage.tsx
+++ b/src/demo/pages/ListPage/ListPage.tsx
@@ -73,7 +73,7 @@ export class ListPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/MarqueeSelectionPage/MarqueeSelectionPage.tsx
+++ b/src/demo/pages/MarqueeSelectionPage/MarqueeSelectionPage.tsx
@@ -7,10 +7,11 @@ import {
 import { MarqueeSelectionBasicExample } from './examples/MarqueeSelection.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const MarqueeSelectionBasicExampleCode = require('./examples/MarqueeSelection.Basic.Example.tsx');
 
-export class MarqueeSelectionPage extends React.Component<any, any> {
+export class MarqueeSelectionPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -48,7 +49,8 @@ export class MarqueeSelectionPage extends React.Component<any, any> {
             </p>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/MarqueeSelectionPage/MarqueeSelectionPage.tsx
+++ b/src/demo/pages/MarqueeSelectionPage/MarqueeSelectionPage.tsx
@@ -50,7 +50,7 @@ export class MarqueeSelectionPage extends React.Component<IComponentDemoPageProp
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/MessageBarPage/MessageBarPage.tsx
+++ b/src/demo/pages/MessageBarPage/MessageBarPage.tsx
@@ -11,10 +11,11 @@ import {
 import { MessageBarBasicExample } from './examples/MessageBar.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const MessageBarBasicExampleCode = require('./examples/MessageBar.Basic.Example.tsx');
 
-export class MessageBarPage extends React.Component<any, any> {
+export class MessageBarPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -48,7 +49,8 @@ export class MessageBarPage extends React.Component<any, any> {
             <span> are used typically to inform the user like a notification.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/MessageBarPage/MessageBarPage.tsx
+++ b/src/demo/pages/MessageBarPage/MessageBarPage.tsx
@@ -50,7 +50,7 @@ export class MessageBarPage extends React.Component<IComponentDemoPageProps, any
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/NavPage/NavPage.tsx
+++ b/src/demo/pages/NavPage/NavPage.tsx
@@ -57,7 +57,7 @@ export class NavPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/NavPage/NavPage.tsx
+++ b/src/demo/pages/NavPage/NavPage.tsx
@@ -13,12 +13,13 @@ import { NavFabricDemoAppExample } from './examples/Nav.FabricDemoApp.Example';
 import { NavNestedExample } from './examples/Nav.Nested.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const NavBasicExampleCode = require('./examples/Nav.Basic.Example.tsx');
 const NavFabricDemoAppExampleCode = require('./examples/Nav.FabricDemoApp.Example.tsx');
 const NavNestedExampleCode = require('./examples/Nav.Nested.Example.tsx');
 
-export class NavPage extends React.Component<any, any> {
+export class NavPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -55,7 +56,8 @@ export class NavPage extends React.Component<any, any> {
             <span> provide a navigation control to expose internal and external links. Navigation bars typically are rendered vertically to the side of the page content.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/OrgChartPage/OrgChartPage.tsx
+++ b/src/demo/pages/OrgChartPage/OrgChartPage.tsx
@@ -10,10 +10,11 @@ import {
 import { OrgChartBasicExample } from './examples/OrgChart.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const OrgChartBasicExampleCode = require('./examples/OrgChart.Basic.Example.tsx');
 
-export class OrgChartPage extends React.Component<any, any> {
+export class OrgChartPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -39,7 +40,8 @@ export class OrgChartPage extends React.Component<any, any> {
             <span> are used to render an org chart.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/OrgChartPage/OrgChartPage.tsx
+++ b/src/demo/pages/OrgChartPage/OrgChartPage.tsx
@@ -41,7 +41,7 @@ export class OrgChartPage extends React.Component<IComponentDemoPageProps, any> 
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/OverlayPage/OverlayPage.tsx
+++ b/src/demo/pages/OverlayPage/OverlayPage.tsx
@@ -47,7 +47,7 @@ export class OverlayPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/OverlayPage/OverlayPage.tsx
+++ b/src/demo/pages/OverlayPage/OverlayPage.tsx
@@ -11,10 +11,11 @@ import {
 import { OverlayBasicExample } from './examples/Overlay.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const OverlayBasicExampleCode = require('./examples/Overlay.Basic.Example.tsx');
 
-export class OverlayPage extends React.Component<any, any> {
+export class OverlayPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -45,7 +46,8 @@ export class OverlayPage extends React.Component<any, any> {
             <span> are used to render a semi transparent overlaying div on top of content. This can be used in modal situations, such as Dialogs, which render on top of existing content.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PanelPage/PanelPage.tsx
+++ b/src/demo/pages/PanelPage/PanelPage.tsx
@@ -82,7 +82,7 @@ export class PanelPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PanelPage/PanelPage.tsx
+++ b/src/demo/pages/PanelPage/PanelPage.tsx
@@ -18,6 +18,7 @@ import { PanelExtraLargeExample } from './examples/Panel.ExtraLarge.Example';
 import { PanelLightDismissExample } from './examples/Panel.LightDismiss.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const PanelSmallRightExampleCode = require('./examples/Panel.SmallRight.Example.tsx');
 const PanelSmallLeftExampleCode = require('./examples/Panel.SmallLeft.Example.tsx');
@@ -28,7 +29,7 @@ const PanelLargeFixedExampleCode = require('./examples/Panel.LargeFixed.Example.
 const PanelExtraLargeExampleCode = require('./examples/Panel.ExtraLarge.Example.tsx');
 const PanelLightDismissExampleCode = require('./examples/Panel.LightDismiss.Example.tsx');
 
-export class PanelPage extends React.Component<any, any> {
+export class PanelPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -80,7 +81,8 @@ export class PanelPage extends React.Component<any, any> {
             <span> are used to render an org chart, and other components.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PeoplePickerPage/PeoplePickerPage.tsx
+++ b/src/demo/pages/PeoplePickerPage/PeoplePickerPage.tsx
@@ -16,6 +16,7 @@ import { PeoplePickerEditModeExample } from './/examples/PeoplePicker.EditMode.E
 
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const PeoplePickerBasicExampleCode = require('./examples/PeoplePicker.Basic.Example.tsx');
 const PeoplePickerCompactExampleCode = require('./examples/PeoplePicker.Compact.Example.tsx');
@@ -23,7 +24,7 @@ const PeoplePickerDisconnectedExampleCode = require('./examples/PeoplePicker.Dis
 const PeoplePickerMemberListExampleCode = require('./examples/PeoplePicker.MemberList.Example.tsx');
 const PeoplePickerEditModeExampleCode = require('./examples/PeoplePicker.EditMode.Example.tsx');
 
-export class PeoplePickerPage extends React.Component<any, any> {
+export class PeoplePickerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -66,7 +67,8 @@ export class PeoplePickerPage extends React.Component<any, any> {
             <span> are used to pick recipients.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PeoplePickerPage/PeoplePickerPage.tsx
+++ b/src/demo/pages/PeoplePickerPage/PeoplePickerPage.tsx
@@ -68,7 +68,7 @@ export class PeoplePickerPage extends React.Component<IComponentDemoPageProps, a
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PersonaCardPage/PersonaCardPage.tsx
+++ b/src/demo/pages/PersonaCardPage/PersonaCardPage.tsx
@@ -41,7 +41,7 @@ export class PersonaCardPage extends React.Component<IComponentDemoPageProps, an
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PersonaCardPage/PersonaCardPage.tsx
+++ b/src/demo/pages/PersonaCardPage/PersonaCardPage.tsx
@@ -10,9 +10,11 @@ import {
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { PersonaCardBasicExample } from './examples/PersonaCard.Basic.Example';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
+
 const PersonaCardBasicExampleCode = require('./examples/PersonaCard.Basic.Example.tsx');
 
-export class PersonaCardPage extends React.Component<any, any> {
+export class PersonaCardPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -38,7 +40,8 @@ export class PersonaCardPage extends React.Component<any, any> {
             <span> render a details for an individual.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PersonaPage/PersonaPage.tsx
+++ b/src/demo/pages/PersonaPage/PersonaPage.tsx
@@ -52,7 +52,7 @@ export class PersonaPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PersonaPage/PersonaPage.tsx
+++ b/src/demo/pages/PersonaPage/PersonaPage.tsx
@@ -12,11 +12,12 @@ import { PersonaInitialsExample } from './examples/Persona.Initials.Example';
 import { PersonaBasicExample } from './examples/Persona.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const PersonaInitialsExampleCode = require('./examples/Persona.Initials.Example.tsx');
 const PersonaBasicExampleCode = require('./examples/Persona.Basic.Example.tsx');
 
-export class PersonaPage extends React.Component<any, any> {
+export class PersonaPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -50,7 +51,8 @@ export class PersonaPage extends React.Component<any, any> {
             <span> are used for rendering an individual's avatar and presence. They are used within the PersonaCard and PeoplePicker.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PivotPage/PivotPage.tsx
+++ b/src/demo/pages/PivotPage/PivotPage.tsx
@@ -78,7 +78,7 @@ export class PivotPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/PivotPage/PivotPage.tsx
+++ b/src/demo/pages/PivotPage/PivotPage.tsx
@@ -17,6 +17,7 @@ import { PivotOnChangeExample } from './examples/Pivot.OnChange.Example';
 import { PivotRemoveExample } from './examples/Pivot.Remove.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const PivotRemoveExampleCode = require('./examples/Pivot.Remove.Example.tsx');
 const PivotBasicExampleCode = require('./examples/Pivot.Basic.Example.tsx');
@@ -26,7 +27,7 @@ const PivotTabsLargesExampleCode = require('./examples/Pivot.TabsLarge.Example.t
 const PivotFabricExampleCode = require('./examples/Pivot.Fabric.Example.tsx');
 const PivotOnChangeExampleCode = require('./examples/Pivot.OnChange.Example.tsx');
 
-export class PivotPage extends React.Component<any, any> {
+export class PivotPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -76,7 +77,8 @@ export class PivotPage extends React.Component<any, any> {
             <span> are used for grouping components under a set of Links or Tabs</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ProgressIndicatorPage/ProgressIndicatorPage.tsx
+++ b/src/demo/pages/ProgressIndicatorPage/ProgressIndicatorPage.tsx
@@ -14,7 +14,7 @@ import { IComponentDemoPageProps } from '../../components/ComponentPage/ICompone
 import { ProgressIndicatorBasicExample } from './examples/ProgressIndicator.Basic.Example';
 const ProgressIndicatorBasicExampleCode = require('./examples/ProgressIndicator.Basic.Example.tsx');
 
-export class ProgressIndicatorPage extends React.Component<any, any> {
+export class ProgressIndicatorPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {

--- a/src/demo/pages/ProgressIndicatorPage/ProgressIndicatorPage.tsx
+++ b/src/demo/pages/ProgressIndicatorPage/ProgressIndicatorPage.tsx
@@ -10,6 +10,7 @@ import {
 
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 import { ProgressIndicatorBasicExample } from './examples/ProgressIndicator.Basic.Example';
 const ProgressIndicatorBasicExampleCode = require('./examples/ProgressIndicator.Basic.Example.tsx');
 
@@ -44,7 +45,8 @@ export class ProgressIndicatorPage extends React.Component<any, any> {
             <span> allow the user to see the status of activities. Unlike the Spinner, ProgressIndicator should accurately display the progress of the activity while the Spinner is used when the time is indeterminate.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+         showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/ProgressIndicatorPage/ProgressIndicatorPage.tsx
+++ b/src/demo/pages/ProgressIndicatorPage/ProgressIndicatorPage.tsx
@@ -46,7 +46,7 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
           </div>
         }
         route={ this._url }
-         showHeader={ this.props.showHeader }>
+         isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/SearchBoxPage/SearchBoxPage.tsx
+++ b/src/demo/pages/SearchBoxPage/SearchBoxPage.tsx
@@ -52,7 +52,7 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, any>
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/SearchBoxPage/SearchBoxPage.tsx
+++ b/src/demo/pages/SearchBoxPage/SearchBoxPage.tsx
@@ -12,11 +12,12 @@ import { SearchBoxSmallExample } from './examples/SearchBox.Small.Example';
 import { SearchBoxFullSizeExample } from './examples/SearchBox.FullSize.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const SearchBoxSmallExampleCode = require('./examples/SearchBox.Small.Example.tsx');
 const SearchBoxFullSizeExampleCode = require('./examples/SearchBox.FullSize.Example.tsx');
 
-export class SearchBoxPage extends React.Component<any, any> {
+export class SearchBoxPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -50,7 +51,8 @@ export class SearchBoxPage extends React.Component<any, any> {
             <span> provide a box for searching, complete with auto complete callbacks and suggestions.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/SelectionPage/SelectionPage.tsx
+++ b/src/demo/pages/SelectionPage/SelectionPage.tsx
@@ -62,7 +62,7 @@ export class SelectionPage extends React.Component<IComponentDemoPageProps, any>
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/SelectionPage/SelectionPage.tsx
+++ b/src/demo/pages/SelectionPage/SelectionPage.tsx
@@ -7,10 +7,11 @@ import {
 import { SelectionBasicExample } from './examples/Selection.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const SelectionBasicExampleCode = require('./examples/Selection.Basic.Example.tsx');
 
-export class SelectionPage extends React.Component<any, any> {
+export class SelectionPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -60,7 +61,8 @@ export class SelectionPage extends React.Component<any, any> {
             </ul>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/SliderPage/SliderPage.tsx
+++ b/src/demo/pages/SliderPage/SliderPage.tsx
@@ -8,10 +8,11 @@ import {
 import { SliderBasicExample } from './examples/Slider.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const SliderBasicExampleCode = require('./examples/Slider.Basic.Example.tsx');
 
-export class SliderPage extends React.Component<any, any> {
+export class SliderPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -41,7 +42,8 @@ export class SliderPage extends React.Component<any, any> {
             <span>Sliders provide a way for users to choose a value or an option.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/SliderPage/SliderPage.tsx
+++ b/src/demo/pages/SliderPage/SliderPage.tsx
@@ -43,7 +43,7 @@ export class SliderPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/SpinnerPage/SpinnerPage.tsx
+++ b/src/demo/pages/SpinnerPage/SpinnerPage.tsx
@@ -49,7 +49,7 @@ export class SpinnerPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/SpinnerPage/SpinnerPage.tsx
+++ b/src/demo/pages/SpinnerPage/SpinnerPage.tsx
@@ -11,10 +11,11 @@ import {
 import { SpinnerBasicExample } from './examples/Spinner.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const SpinnerBasicExampleCode = require('./examples/Spinner.Basic.Example.tsx');
 
-export class SpinnerPage extends React.Component<any, any> {
+export class SpinnerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -47,7 +48,8 @@ export class SpinnerPage extends React.Component<any, any> {
             <span> provide a ui indicator for progress.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/TextFieldPage/TextFieldPage.tsx
+++ b/src/demo/pages/TextFieldPage/TextFieldPage.tsx
@@ -52,7 +52,7 @@ export class TextFieldPage extends React.Component<IComponentDemoPageProps, any>
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/TextFieldPage/TextFieldPage.tsx
+++ b/src/demo/pages/TextFieldPage/TextFieldPage.tsx
@@ -12,11 +12,12 @@ import { TextFieldBasicExample } from './examples/TextField.Basic.Example';
 import { TextFieldErrorMessageExample } from './examples/TextField.ErrorMessage.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const TextFieldBasicExampleCode = require('./examples/TextField.Basic.Example.tsx');
 const TextFieldErrorMessageExampleCode = require('./examples/TextField.ErrorMessage.Example.tsx');
 
-export class TextFieldPage extends React.Component<any, any> {
+export class TextFieldPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -50,7 +51,8 @@ export class TextFieldPage extends React.Component<any, any> {
             <span> allow the user to enter text.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/TogglePage/TogglePage.tsx
+++ b/src/demo/pages/TogglePage/TogglePage.tsx
@@ -11,10 +11,11 @@ import {
 import { ToggleBasicExample } from './examples/Toggle.Basic.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
+import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 const ToggleBasicExampleCode = require('./examples/Toggle.Basic.Example.tsx');
 
-export class TogglePage extends React.Component<any, any> {
+export class TogglePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
 
   constructor() {
@@ -45,7 +46,8 @@ export class TogglePage extends React.Component<any, any> {
             <span> allow the user to turn an option on/off.</span>
           </div>
         }
-        route={ this._url }>
+        route={ this._url }
+        showHeader={ this.props.showHeader }>
       </ComponentPage>
     );
   }

--- a/src/demo/pages/TogglePage/TogglePage.tsx
+++ b/src/demo/pages/TogglePage/TogglePage.tsx
@@ -47,7 +47,7 @@ export class TogglePage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         route={ this._url }
-        showHeader={ this.props.showHeader }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }


### PR DESCRIPTION
Added a new interface for component demo pages
Made the header for the demo page optional - Useful when we integrate them into the Fabric website.
Changed the header color to match the primary bg color on the fabric website
Fixed link hover colors and header link size issue.

