### PR TITLE
recover preventDefault for popup window.

### DIFF
--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -51,6 +51,7 @@ export class Link extends React.Component<ILinkProps, any> {
 
     if (popupWindowProps) {
       this._popupWindow(popupWindowProps);
+      ev.preventDefault();
     }
 
     if (onClick) {


### PR DESCRIPTION
recover preventDefault for popup window ( https://github.com/OfficeDev/office-ui-fabric-react/commit/accb3ecf8458ada563dc65b12e54c678665f7cdb ), otherwise it will redirect to link page beside poping up a popUpWindow, and content embed web part help doc it's a bug.