### PR TITLE
add onClick prop to Link.

### DIFF
--- a/src/components/Link/Link.Props.ts
+++ b/src/components/Link/Link.Props.ts
@@ -12,6 +12,11 @@ export interface ILinkProps extends React.HTMLProps<HTMLLabelElement> {
    *  The props of pop up window.
    */
   popupWindowProps?: IPopupWindowProps;
+
+  /**
+   * Function to call when the card is clicked.
+   */
+  onClick?: (ev?: React.MouseEvent) => void;
 }
 
 export interface IPopupWindowProps {


### PR DESCRIPTION
this PR is about the problem "remove popUpWindow logic from Link" (as we discussed in email).
i plan have 3 steps for this issue:
1. add onClick to Link.props.ts (this PR for this)
2. when sp-client use the fabric-react's version including this PR, i will move popUpWindow logic to content embed web part.
3. remove popUpWindow logic out of Link.