### PR TITLE
Call onChange() on SearchBox when field cleared

### DIFF
--- a/src/components/SearchBox/SearchBox.Props.ts
+++ b/src/components/SearchBox/SearchBox.Props.ts
@@ -12,6 +12,12 @@ export interface ISearchBoxProps extends React.Props<SearchBox> {
   /**
   * Callback function for when the typed input for the SearchBox has changed.
   */
+  onChange?: (newValue: any) => void;
+
+  /**
+   * Deprecated at v0.52.2, to be removed at >= v1.0.0. Use 'onChange' instead.
+   * @deprecated
+   */
   onChanged?: (newValue: any) => void;
 
   /**

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -23,6 +23,11 @@ export class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState>
   public constructor(props: ISearchBoxProps) {
     super(props);
 
+    // Handle deprecated prop
+    if (this.props.onChanged) {
+      this.props.onChange = this.props.onChanged;
+    }
+
     this.state = {
       value: props.value,
       hasFocus: false,
@@ -85,14 +90,14 @@ export class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState>
     this.setState({
       value: this.refs.inputText.value
     });
-    this._onChanged(this.refs.inputText.value);
+    this._onChange(this.refs.inputText.value);
   }
 
-  private _onChanged(newValue: string): void {
-    let { onChanged } = this.props;
+  private _onChange(newValue: string): void {
+    let { onChange } = this.props;
 
-    if (onChanged) {
-      onChanged(newValue);
+    if (onChange) {
+      onChange(newValue);
     }
   }
 }

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -70,6 +70,7 @@ export class SearchBox extends React.Component<ISearchBoxProps, ISearchBoxState>
     this.setState({
       value: ''
     });
+    this._onChange('');
     ev.stopPropagation();
     ev.preventDefault();
   }

--- a/src/demo/pages/SearchBoxPage/examples/SearchBox.Small.Example.tsx
+++ b/src/demo/pages/SearchBoxPage/examples/SearchBox.Small.Example.tsx
@@ -8,7 +8,11 @@ export class SearchBoxSmallExample extends React.Component<any, any> {
   public render() {
     return (
       <div className='ms-SearchBoxSmallExample'>
-        <SearchBox />
+        <SearchBox onChange={
+          function(newValue) {
+            console.log('Search box value changed to: ' + newValue);
+          }
+        } />
       </div>
     );
   }

--- a/src/demo/pages/SearchBoxPage/examples/SearchBox.Small.Example.tsx
+++ b/src/demo/pages/SearchBoxPage/examples/SearchBox.Small.Example.tsx
@@ -9,7 +9,7 @@ export class SearchBoxSmallExample extends React.Component<any, any> {
     return (
       <div className='ms-SearchBoxSmallExample'>
         <SearchBox onChange={
-          function(newValue) {
+          (newValue) => {
             console.log('Search box value changed to: ' + newValue);
           }
         } />


### PR DESCRIPTION
Fixes #276 

This PR deprecates `onChanged` in favor of `onChange` to match our naming conventions. This callback is now fired whenever the field is cleared. Also added a simple `console.log()` function in the example to demonstrate the functionality.