### PR TITLE
Add list styles to component page's overview section

### DIFF
--- a/src/demo/components/ComponentPage/ComponentPage.scss
+++ b/src/demo/components/ComponentPage/ComponentPage.scss
@@ -64,6 +64,17 @@ $dontColor: #A61E22;
     margin-top: 1em;
     margin-bottom: 1em;
   }
+
+  ul {
+    padding-left: 18px;
+  }
+
+  li {
+    @include ms-font-m;
+    line-height: $ms-font-size-xl;
+    list-style: disc;
+    margin-bottom: 16px;
+  }
 }
 
 .ComponentPage-related {


### PR DESCRIPTION
![screen shot 2016-09-22 at 2 37 51 pm](https://cloud.githubusercontent.com/assets/1291968/18767102/28f52810-80d2-11e6-9b32-fab5307446d6.png)

Copy styles from do's and donts section and apply them to overview section lists
This is for react bug 252164:Fabric Site 2.0 Bug: Add bullet points to Panel Overview examples