### PR TITLE
Increase padding around ColorPicker

### DIFF
--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -6,7 +6,7 @@
 }
 
 .ms-ColorPicker-panel {
-  padding: 10px;
+  padding: 16px;
 }
 
 .ms-ColorPicker-colorRect {


### PR DESCRIPTION
Increases the padding around the ColorPicker, ensuring that the shadow on the 'thumb' element is not cut off.

Before:
![image](https://cloud.githubusercontent.com/assets/1382445/18811106/88fe8f50-825b-11e6-827a-372d1f4c3687.png)


After:
![image](https://cloud.githubusercontent.com/assets/1382445/18811101/7dcc4f14-825b-11e6-8886-727fdeb51481.png)
