### PR TITLE
Enabling native props on contextual menu items

### DIFF
--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -7,6 +7,7 @@ import { DirectionalHint } from '../../common/DirectionalHint';
 import { autobind } from '../../utilities/autobind';
 import { css } from '../../utilities/css';
 import { getId } from '../../utilities/object';
+import { buttonProperties, divProperties, getNativeProps } from '../../utilities'
 import './CommandBar.scss';
 
 const OVERFLOW_KEY = 'overflow';
@@ -110,6 +111,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
                 role='menuitem'
                 aria-label={ this.props.elipisisAriaLabel || '' }
                 aria-haspopup={ true }
+                data-automation-id='commandBarOverflow'
               >
                 <i className='ms-CommandBarItem-overflow ms-Icon ms-Icon--More' />
               </button>
@@ -141,7 +143,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
     this.refs.focusZone.focus();
   }
 
-  private _renderItemInCommandBar(item, index, expandedMenuItemKey, isFarItem?: boolean) {
+  private _renderItemInCommandBar(item: IContextualMenuItem, index: number, expandedMenuItemKey: string, isFarItem?: boolean) {
     const itemKey = item.key || index;
     const className = css(item.onClick ? 'ms-CommandBarItem-link' : 'ms-CommandBarItem-text', !item.name && 'ms-CommandBarItem--noName');
     const classNameValue = css(className, { 'is-expanded': (expandedMenuItemKey === item.key) });
@@ -150,6 +152,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
              {(() => {
                if (item.onClick || item.items) {
                  return <button
+                         { ...getNativeProps(item, buttonProperties) }
                          id={ this._id + item.key }
                          className={ classNameValue }
                          onClick={ this._onItemClick.bind(this, item) }
@@ -166,6 +169,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
                        </button>;
                } else {
                  return <div
+                         { ...getNativeProps(item, divProperties) }
                          id={ this._id + item.key }
                          className={ classNameValue }
                          data-command-key={ index }

--- a/src/components/CommandBar/CommandBar.tsx
+++ b/src/components/CommandBar/CommandBar.tsx
@@ -7,7 +7,7 @@ import { DirectionalHint } from '../../common/DirectionalHint';
 import { autobind } from '../../utilities/autobind';
 import { css } from '../../utilities/css';
 import { getId } from '../../utilities/object';
-import { buttonProperties, divProperties, getNativeProps } from '../../utilities'
+import { buttonProperties, divProperties, getNativeProps } from '../../utilities/properties';
 import './CommandBar.scss';
 
 const OVERFLOW_KEY = 'overflow';

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -9,6 +9,7 @@ import { css } from '../../utilities/css';
 import { getRTL } from '../../utilities/rtl';
 import { getId } from '../../utilities/object';
 import { Async } from '../../utilities/Async/Async';
+import { assign, anchorProperties, buttonProperties, getNativeProps } from '../../utilities'
 import { Callout } from '../../Callout';
 import './ContextualMenu.scss';
 
@@ -239,6 +240,7 @@ export class ContextualMenu extends React.Component<IContextualMenuProps, IConte
     }
     return React.createElement(
       'button',
+      assign(
       {
         className: css('ms-ContextualMenu-link', { 'is-expanded': (expandedMenuItemKey === item.key) }),
         onClick: this._onItemClick.bind(this, item),
@@ -253,14 +255,16 @@ export class ContextualMenu extends React.Component<IContextualMenuProps, IConte
         'aria-label': ariaLabel,
         'aria-haspopup': item.items && item.items.length ? true : null,
         'aria-owns': item.key === expandedMenuItemKey ? subMenuId : null
-      },
+      }, getNativeProps(item, buttonProperties)),
       this._renderMenuItemChildren(item, index, hasCheckmarks, hasIcons));
   }
 
   private _renderAnchorMenuItem(item: IContextualMenuItem, index: number, hasCheckmarks: boolean, hasIcons: boolean): JSX.Element {
     return (
       <div>
-        <a href={ item.href }
+        <a
+          { ...getNativeProps(item, anchorProperties) }
+          href={ item.href }
           className={ css('ms-ContextualMenu-link', item.isDisabled ? 'is-disabled' : '' ) }
           role='menuitem'
           onClick={ this._onAnchorClick.bind(this, item) }>

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -7,9 +7,9 @@ import { EventGroup } from '../../utilities/eventGroup/EventGroup';
 import { autobind } from '../../utilities/autobind';
 import { css } from '../../utilities/css';
 import { getRTL } from '../../utilities/rtl';
-import { getId } from '../../utilities/object';
+import { assign, getId } from '../../utilities/object';
 import { Async } from '../../utilities/Async/Async';
-import { assign, anchorProperties, buttonProperties, getNativeProps } from '../../utilities'
+import { anchorProperties, buttonProperties, getNativeProps } from '../../utilities/properties';
 import { Callout } from '../../Callout';
 import './ContextualMenu.scss';
 

--- a/src/demo/pages/CommandBarPage/examples/data-nonFocusable.ts
+++ b/src/demo/pages/CommandBarPage/examples/data-nonFocusable.ts
@@ -22,7 +22,8 @@ export const itemsNonFocusable = [
     key: 'upload',
     name: 'Upload',
     icon: 'Upload',
-    onClick: () => { return; }
+    onClick: () => { return; },
+    ['data-automation-id']: 'uploadNonFocusButton'
   }
 ];
 
@@ -30,7 +31,8 @@ export const farItemsNonFocusable = [
   {
     key: 'saveStatus',
     name: 'Your page has been saved',
-    icon: 'CheckMark'
+    icon: 'CheckMark',
+    ['data-automation-id']: 'saveStatusCheckMark'
   },
   {
     key: 'publish',

--- a/src/demo/pages/CommandBarPage/examples/data.ts
+++ b/src/demo/pages/CommandBarPage/examples/data.ts
@@ -5,11 +5,13 @@ export const items = [
     icon: 'Add',
     ariaLabel: 'New. Use left and right arrow keys to navigate',
     onClick: () => { return; },
+    ['data-automation-id']: 'newItemMenu',
     items: [
       {
         key: 'emailMessage',
         name: 'Email message',
-        icon: 'Mail'
+        icon: 'Mail',
+        ['data-automation-id']: 'newEmailButton'
       },
       {
         key: 'calendarEvent',
@@ -22,7 +24,8 @@ export const items = [
     key: 'upload',
     name: 'Upload',
     icon: 'Upload',
-    onClick: () => { return; }
+    onClick: () => { return; },
+    ['data-automation-id']: 'uploadButton'
   },
   {
     key: 'share',


### PR DESCRIPTION
Using the patter for getNativeProps fix the issue to actually let native properties to be rendered for contextual menu items, include command bar items. This is based on feedback from:
https://github.com/OfficeDev/office-ui-fabric-react/pull/334/files