### PR TITLE
Add small margin to right side of small teaching bubble header

### DIFF
--- a/src/components/TeachingBubble/TeachingBubble.scss
+++ b/src/components/TeachingBubble/TeachingBubble.scss
@@ -30,6 +30,7 @@
   }
   .ms-TeachingBubble-header--small & {
     @include ms-font-m;
+    @include margin-right(10px);
     font-weight: $ms-font-weight-semibold;
   }
 }


### PR DESCRIPTION
Removed additional specificity from ms-Button--icon, could not reproduce original issue, and change caused regression in teaching bubble. 