### PR TITLE
Make documentCardTitle inherit from BaseComponent and optimize it only listen to resize event when necessary

### DIFF
--- a/src/components/DocumentCard/DocumentCardTitle.tsx
+++ b/src/components/DocumentCard/DocumentCardTitle.tsx
@@ -44,10 +44,10 @@ export class DocumentCardTitle extends BaseComponent<IDocumentCardTitleProps, ID
   }
 
   public componentWillReceiveProps(newProps: IDocumentCardTitleProps) {
-    if (!newProps.shouldTruncate || !newProps.title || newProps.title.length <= TRUNCATION_MINIMUM_LENGTH) {
-      this._events.off(window, 'resize');
-      this._isTruncated = false;
-    } else {
+    this._events.off(window, 'resize');
+    this._isTruncated = false;
+
+    if (newProps.shouldTruncate && newProps.title && newProps.title.length > TRUNCATION_MINIMUM_LENGTH) {
       this._startTruncation(newProps);
       this._events.on(window, 'resize', this._updateTruncation);
     }

--- a/src/components/DocumentCard/DocumentCardTitle.tsx
+++ b/src/components/DocumentCard/DocumentCardTitle.tsx
@@ -1,6 +1,8 @@
+/* tslint:disable:no-unused-variable */
 import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
 import { IDocumentCardTitleProps } from './DocumentCard.Props';
-import { EventGroup } from '../../utilities/eventGroup/EventGroup';
 import { BaseComponent } from '../../common/BaseComponent';
 import { autobind } from '../../utilities/autobind';
 import './DocumentCardTitle.scss';

--- a/src/components/DocumentCard/DocumentCardTitle.tsx
+++ b/src/components/DocumentCard/DocumentCardTitle.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { IDocumentCardTitleProps } from './DocumentCard.Props';
 import { EventGroup } from '../../utilities/eventGroup/EventGroup';
+import { BaseComponent } from '../../common/BaseComponent';
+import { autobind } from '../../utilities/autobind';
 import './DocumentCardTitle.scss';
 
 export interface IDocumentCardTitleState {
@@ -9,20 +11,16 @@ export interface IDocumentCardTitleState {
 }
 
 const TRUNCATION_SEPARATOR = '&hellip;';
-const TRUNCATION_MINIMUM_LENGTH = 40;
+const TRUNCATION_MINIMUM_LENGTH = 40; // This is the length we know can fit into the min width of DocumentCard.
 const TRUNCATION_MAXIMUM_LENGTH = 90 - TRUNCATION_SEPARATOR.length;
 const TRUNCATION_FIRST_PIECE_LONGER_BY = 10;
 const TRUNCATION_VERTICAL_OVERFLOW_THRESHOLD = 5;
 
-export class DocumentCardTitle extends React.Component<IDocumentCardTitleProps, IDocumentCardTitleState> {
-  public refs: {
-    [key: string]: React.ReactInstance;
-    titleElement: HTMLElement;
-  };
-
-  private _events: EventGroup;
+export class DocumentCardTitle extends BaseComponent<IDocumentCardTitleProps, IDocumentCardTitleState> {
+  private _titleElement: HTMLDivElement;
   private _scrollTimerId: number;
   private _truncatedTitleAtWidth: number;
+  private _isTruncated: boolean;
 
   constructor(props: IDocumentCardTitleProps) {
     super(props);
@@ -31,26 +29,25 @@ export class DocumentCardTitle extends React.Component<IDocumentCardTitleProps, 
       truncatedTitleFirstPiece : '',
       truncatedTitleSecondPiece: ''
     };
-
-    this._events = new EventGroup(this);
-
-    this._startTruncation = this._startTruncation.bind(this);
   }
 
   public componentDidMount() {
-    if (this.props.shouldTruncate) {
-      this._startTruncation();
+    let { title, shouldTruncate } = this.props;
+    if (shouldTruncate && title && title.length > TRUNCATION_MINIMUM_LENGTH) {
+      if (this._doesTitleOverflow()) {
+        this._startTruncation(this.props);
+      }
       this._events.on(window, 'resize', this._updateTruncation);
     }
   }
 
-  public componentWillUnmount() {
-    this._events.dispose();
-  }
-
   public componentWillReceiveProps(newProps: IDocumentCardTitleProps) {
-    if ((newProps.title !== this.props.title) && this.props.shouldTruncate) {
-      this._startTruncation();
+    if (!newProps.shouldTruncate || !newProps.title || newProps.title.length <= TRUNCATION_MINIMUM_LENGTH) {
+      this._events.off(window, 'resize');
+      this._isTruncated = false;
+    } else {
+      this._startTruncation(newProps);
+      this._events.on(window, 'resize', this._updateTruncation);
     }
   }
 
@@ -66,13 +63,13 @@ export class DocumentCardTitle extends React.Component<IDocumentCardTitleProps, 
     let { truncatedTitleFirstPiece, truncatedTitleSecondPiece } = this.state;
 
     let documentCardTitle;
-    if (shouldTruncate && (truncatedTitleFirstPiece || truncatedTitleSecondPiece)) {
+    if (shouldTruncate && this._isTruncated) {
       documentCardTitle = (
-        <div className='ms-DocumentCardTitle' ref='titleElement' title={ title }>{ truncatedTitleFirstPiece }&hellip;{ truncatedTitleSecondPiece }</div>
+        <div className='ms-DocumentCardTitle' ref={ this._resolveRef('_titleElement') } title={ title }>{ truncatedTitleFirstPiece }&hellip;{ truncatedTitleSecondPiece }</div>
       );
     } else {
       documentCardTitle = (
-        <div className='ms-DocumentCardTitle' ref='titleElement' title={ title }>{ title }</div>
+        <div className='ms-DocumentCardTitle' ref={ this._resolveRef('_titleElement') } title={ title }>{ title }</div>
       );
     }
 
@@ -83,8 +80,10 @@ export class DocumentCardTitle extends React.Component<IDocumentCardTitleProps, 
     );
   }
 
-  private _startTruncation() {
-    let originalTitle = this.props.title;
+  @autobind
+  private _startTruncation(props: IDocumentCardTitleProps) {
+    let originalTitle = props.title;
+    this._isTruncated = false;
 
     // If the title is really short, there's no need to truncate it
     if (originalTitle && originalTitle.length >= TRUNCATION_MINIMUM_LENGTH) {
@@ -92,6 +91,7 @@ export class DocumentCardTitle extends React.Component<IDocumentCardTitleProps, 
       // Break the text into two pieces for assembly later
       if (originalTitle.length > TRUNCATION_MAXIMUM_LENGTH) {
         // The text is really long, so we can take a chunk out of the middle so the two pieces combine for the maximum length
+        this._isTruncated = true;
         this.setState({
           truncatedTitleFirstPiece : originalTitle.slice(0, TRUNCATION_MAXIMUM_LENGTH / 2 + TRUNCATION_FIRST_PIECE_LONGER_BY),
           truncatedTitleSecondPiece : originalTitle.slice(originalTitle.length - (TRUNCATION_MAXIMUM_LENGTH / 2 - TRUNCATION_FIRST_PIECE_LONGER_BY))
@@ -106,13 +106,19 @@ export class DocumentCardTitle extends React.Component<IDocumentCardTitleProps, 
     }
 
     // Save the width we just started truncation at, so that later we will only update truncation if necessary
-    this._truncatedTitleAtWidth = this.refs.titleElement.clientWidth;
+    this._truncatedTitleAtWidth = this._titleElement.clientWidth;
 
   }
 
   private _shrinkTitle() {
     if (this._doesTitleOverflow()) {
       let { truncatedTitleFirstPiece, truncatedTitleSecondPiece } = this.state;
+      this._isTruncated = true;
+
+      if (!truncatedTitleFirstPiece && !truncatedTitleSecondPiece) {
+        this._startTruncation(this.props);
+      }
+
       this.setState({
         truncatedTitleFirstPiece : truncatedTitleFirstPiece.slice(0, truncatedTitleFirstPiece.length - 1),
         truncatedTitleSecondPiece : truncatedTitleSecondPiece.slice(1)
@@ -121,16 +127,16 @@ export class DocumentCardTitle extends React.Component<IDocumentCardTitleProps, 
   }
 
   private _doesTitleOverflow(): boolean {
-    let titleElement = this.refs.titleElement;
+    let titleElement = this._titleElement;
     return titleElement.scrollHeight > titleElement.clientHeight + TRUNCATION_VERTICAL_OVERFLOW_THRESHOLD || titleElement.scrollWidth > titleElement.clientWidth;
   }
 
   private _updateTruncation() {
     // Only update truncation if the title's size has changed since the last time we truncated
-    if (this.refs.titleElement.clientWidth !== this._truncatedTitleAtWidth) {
+    if (this._titleElement.clientWidth !== this._truncatedTitleAtWidth) {
       // Throttle truncation so that it doesn't happen during a window resize
       clearTimeout(this._scrollTimerId);
-      this._scrollTimerId = setTimeout(this._startTruncation, 250);
+      this._scrollTimerId = this._async.setTimeout(this._startTruncation.bind(this, this.props), 250);
     }
   }
 


### PR DESCRIPTION
Make documentCardTitle inherit from BaseComponent and optimize it only listen to resize event when necessary. And fix bug that it always show "..." even when the title is not overflow.