### PR TITLE
Issue 285: Remove textfields min-width css props as it limits how small it can get

### DIFF
--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -31,10 +31,6 @@ $Dialog-default-max-width: 340px;
   line-height: 100vh;
   text-align: center;
 
-  // Flexbox for Modern Browsers
-  @include flexBox();
-  @include alignItems(center);
-
   &::before {
     @include dialogPositioningIE9Fallback();
     content: "";
@@ -66,6 +62,8 @@ $Dialog-default-max-width: 340px;
   position: relative;
   @include text-align(left);
   outline: 3px solid transparent;
+  max-height: 100%;
+  overflow-y: auto;
 }
 
 // Close button, hidden by default

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -66,8 +66,6 @@ $Dialog-default-max-width: 340px;
   position: relative;
   @include text-align(left);
   outline: 3px solid transparent;
-  max-height: 100%;
-  overflow-y: auto;
 }
 
 // Close button, hidden by default

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -31,6 +31,10 @@ $Dialog-default-max-width: 340px;
   line-height: 100vh;
   text-align: center;
 
+  // Flexbox for Modern Browsers
+  @include flexBox();
+  @include alignItems(center);
+
   &::before {
     @include dialogPositioningIE9Fallback();
     content: "";

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -64,7 +64,6 @@
   height: 32px;
   @include padding(6px, 12px, 7px, 12px);
   width: 100%;
-  min-width: 180px;
   outline: 0;
   text-overflow: ellipsis;
 
@@ -111,7 +110,6 @@
   border-bottom: 1px solid $ms-color-neutralTertiaryAlt;
   display: table;
   width: 100%;
-  min-width: 180px;
 
   &:hover {
     border-color: $ms-color-neutralSecondaryAlt;
@@ -195,7 +193,6 @@
     font-weight: $ms-font-weight-regular;
     line-height: 17px;
     min-height: 60px;
-    min-width: 260px;
     padding-top: 6px;
     overflow: auto;
   }

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -64,6 +64,7 @@
   height: 32px;
   @include padding(6px, 12px, 7px, 12px);
   width: 100%;
+  min-width: 180px;
   outline: 0;
   text-overflow: ellipsis;
 
@@ -110,6 +111,7 @@
   border-bottom: 1px solid $ms-color-neutralTertiaryAlt;
   display: table;
   width: 100%;
+  min-width: 180px;
 
   &:hover {
     border-color: $ms-color-neutralSecondaryAlt;
@@ -193,6 +195,7 @@
     font-weight: $ms-font-weight-regular;
     line-height: 17px;
     min-height: 60px;
+    min-width: 260px;
     padding-top: 6px;
     overflow: auto;
   }


### PR DESCRIPTION
Basically for numbers of which are only two digits, 180px is way to much space.