### PR TITLE
Slider: Prevent thumb from being positioned outside of Slider container

### DIFF
--- a/src/components/Slider/Slider.scss
+++ b/src/components/Slider/Slider.scss
@@ -61,6 +61,7 @@
 }
 
 .ms-Slider-container {
+  @include padding-left(8px); // Make room for thumb
   display: flex;
 
   .ms-Slider-slideBox {

--- a/src/components/Slider/Slider.scss
+++ b/src/components/Slider/Slider.scss
@@ -59,7 +59,6 @@
 }
 
 .ms-Slider-container {
-  @include padding-left(8px); // Make room for thumb
   display: flex;
 
   .ms-Slider-slideBox {
@@ -67,13 +66,13 @@
     height: 28px;
     line-height: 28px;
     @include focus-border();
-
+    padding: 0 8px; // Make room for thumb at ends of line
   }
 
   .ms-Label {
     flex-shrink: 1;
     width: 30px;
-    @include margin-left(12px);
+    @include margin-left(8px);
   }
 }
 


### PR DESCRIPTION
This PR adds padding to the Slider's container so that when the thumb is all the way at the left (0%), it is still within the Slider and not cut off.

Before:
![screen shot 2016-10-03 at 12 08 25 pm](https://cloud.githubusercontent.com/assets/1382445/19050132/1c651af4-8962-11e6-9bbe-41e43a0a5f23.png)

After:
![screen shot 2016-10-03 at 12 07 59 pm](https://cloud.githubusercontent.com/assets/1382445/19050114/0c557104-8962-11e6-9e80-715c689d64b0.png)

