### PR TITLE
Update the getParent method to return parentNode if parentElement is not defined

### DIFF
--- a/src/components/Slider/Slider.scss
+++ b/src/components/Slider/Slider.scss
@@ -11,8 +11,6 @@
 }
 
 .ms-Slider-line {
-  top: 50%;
-  margin-top: -2px;
   position: relative;
   width: 100%;
 }
@@ -42,7 +40,7 @@
   }
 }
 .ms-Slider-slideBox {
-  background: inherit;
+  background: transparent;
   border: none;
   padding: 0;
   margin: 0;
@@ -66,6 +64,7 @@
   .ms-Slider-slideBox {
     flex-grow: 1;
     height: 28px;
+    line-height: 28px;
     @include focus-border();
 
   }

--- a/src/utilities/dom.test.ts
+++ b/src/utilities/dom.test.ts
@@ -1,5 +1,5 @@
 import {
-  elementContains
+  elementContains, getParent
 } from './dom';
 
 const { expect } = chai;
@@ -28,7 +28,19 @@ describe('elementContains', () => {
     expect(elementContains(null, null)).equals(false);
   });
 
-  it ('can return false when parent is an svg', () => {
+  it('can return false when parent is an svg', () => {
     expect(elementContains(unattachedSvg, unattachedDiv)).equals(false);
+  });
+});
+
+describe('getParent', () => {
+  it('returns correct parent for inner SVG elements', () => {
+    let childSvg = document.createElement('svg');
+    let svgRectangle = document.createElement('rect');
+    childSvg.appendChild(svgRectangle);
+    parentDiv.appendChild(childSvg);
+
+    expect(getParent(svgRectangle)).equals(childSvg);
+    expect(getParent(childSvg)).equals(parentDiv);
   });
 });

--- a/src/utilities/dom.ts
+++ b/src/utilities/dom.ts
@@ -75,7 +75,8 @@ export function getVirtualParent(child: HTMLElement): HTMLElement {
  * @returns {HTMLElement}
  */
 export function getParent(child: HTMLElement, allowVirtualParents: boolean = true): HTMLElement {
-  return child && (allowVirtualParents && getVirtualParent(child) || child.parentElement);
+  return child && (allowVirtualParents && getVirtualParent(child) || child.parentElement ||
+    (child.parentNode && child.parentNode.nodeType === Node.ELEMENT_NODE ? child.parentNode as HTMLElement : null));
 }
 
 /**

--- a/src/utilities/dom.ts
+++ b/src/utilities/dom.ts
@@ -75,8 +75,10 @@ export function getVirtualParent(child: HTMLElement): HTMLElement {
  * @returns {HTMLElement}
  */
 export function getParent(child: HTMLElement, allowVirtualParents: boolean = true): HTMLElement {
-  return child && (allowVirtualParents && getVirtualParent(child) || child.parentElement ||
-    (child.parentNode && child.parentNode.nodeType === Node.ELEMENT_NODE ? child.parentNode as HTMLElement : null));
+  return child && (
+    allowVirtualParents && getVirtualParent(child) ||
+    child.parentNode && child.parentNode as HTMLElement
+  );
 }
 
 /**


### PR DESCRIPTION
This works for SVG inner nodes which do not have parentElement but parentNode.