### PR TITLE
Add an example of a required TextField

### DIFF
--- a/src/demo/pages/TextFieldPage/examples/TextField.Basic.Example.tsx
+++ b/src/demo/pages/TextFieldPage/examples/TextField.Basic.Example.tsx
@@ -9,6 +9,7 @@ export class TextFieldBasicExample extends React.Component<any, any> {
       <div>
         <TextField label='Default TextField' />
         <TextField label='Disabled TextField' disabled={ true } />
+        <TextField label='Required TextField' required={ true } />
         <TextField label='TextField with a placeholder' placeholder='Now I am a Placeholder' ariaLabel='Please enter text here' />
         <TextField label='Multiline TextField' multiline />
         <TextField label='Multiline TextField Unresizable' multiline resizable={ false } />


### PR DESCRIPTION
This PR adds an example of a TextField with the `required` attribute set to `true`.

The result looks like:

![screen shot 2016-10-05 at 12 51 08 pm](https://cloud.githubusercontent.com/assets/1382445/19128980/6a16d212-8afa-11e6-8729-d6c7d8a45cbd.png)
