### PR TITLE
Fix FacePile example onclick for RK.  Remove stray commas from Layer/Button pages

### DIFF
--- a/src/demo/pages/ButtonPage/ButtonPage.tsx
+++ b/src/demo/pages/ButtonPage/ButtonPage.tsx
@@ -77,7 +77,7 @@ export class ButtonPage extends React.Component<IComponentDemoPageProps, IButton
         }
         propertiesTables={
           <div>
-            <PropertiesTableSet componentName='Button' />,
+            <PropertiesTableSet componentName='Button' />
             <p>Besides the above properties, the <code>Button</code> component accepts all properties that the React <code>button</code> and <code>a</code> components accept.</p>
           </div>
         }

--- a/src/demo/pages/Facepile/examples/Facepile.Basic.Example.tsx
+++ b/src/demo/pages/Facepile/examples/Facepile.Basic.Example.tsx
@@ -22,7 +22,7 @@ const facepileProps: IFacepileProps = {
       imageInitials: 'RK',
       initialsColor: PersonaInitialsColor.purple,
       data: 'Emp1234',
-      onClick: (persona: IFacepilePersona, ev: React.MouseEvent) =>
+      onClick: (ev: React.MouseEvent, persona: IFacepilePersona) =>
         alert('You clicked on ' + persona.personaName + '. Extra data: ' + persona.data)
     }
   ]

--- a/src/demo/pages/LayerPage/LayerPage.tsx
+++ b/src/demo/pages/LayerPage/LayerPage.tsx
@@ -32,7 +32,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, any> {
           <div>
             <ExampleCard title='Basic layered content' code={ LayerBasicExampleCode }>
               <LayerBasicExample />
-            </ExampleCard>,
+            </ExampleCard>
             <ExampleCard title='Using LayerHost to control projection' code={ LayerHostedExampleCode }>
               <LayerHostedExample />
             </ExampleCard>


### PR DESCRIPTION
FacePile props for onclick was in the wrong order.  Removed stray commas from Layer and Button pages also.