### PR TITLE
DetailsList: Fixing scroll utilities to handle body scroll better.

### DIFF
--- a/src/components/DetailsList/DetailsList.tsx
+++ b/src/components/DetailsList/DetailsList.tsx
@@ -368,7 +368,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
 
   private _onHeaderKeyDown(ev: React.KeyboardEvent) {
     if (ev.which === KeyCodes.down) {
-      if (this.refs.focusZone.focus()) {
+      if (this.refs.focusZone && this.refs.focusZone.focus()) {
         ev.preventDefault();
         ev.stopPropagation();
       }
@@ -377,7 +377,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
 
   private _onContentKeyDown(ev: React.KeyboardEvent) {
     if (ev.which === KeyCodes.up) {
-      if (this.refs.header.focus()) {
+      if (this.refs.header && this.refs.header.focus()) {
         ev.preventDefault();
         ev.stopPropagation();
       }

--- a/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -59,7 +59,7 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
 
   public componentDidMount() {
     this._scrollableParent = findScrollableParent(this.refs.root);
-    this._scrollableSurface = this._scrollableParent == window as any ? document.body : this._scrollableParent;
+    this._scrollableSurface = this._scrollableParent === window as any ? document.body : this._scrollableParent;
     // When scroll events come from window, we need to read scrollTop values from the body.
 
     this._events.on(
@@ -67,7 +67,6 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
       'mousedown',
       this._onMouseDown);
   }
-
 
   public componentWillUnmount() {
     if (this._autoScroll) {

--- a/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -46,6 +46,7 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
   private _selectedIndicies: { [key: string]: boolean };
   private _itemRectCache: { [key: string]: IRectangle };
   private _scrollableParent: HTMLElement;
+  private _scrollableSurface: HTMLElement;
   private _scrollTop: number;
 
   constructor(props: IMarqueeSelectionProps) {
@@ -58,14 +59,15 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
 
   public componentDidMount() {
     this._scrollableParent = findScrollableParent(this.refs.root);
+    this._scrollableSurface = this._scrollableParent == window as any ? document.body : this._scrollableParent;
+    // When scroll events come from window, we need to read scrollTop values from the body.
 
-    if (this._scrollableParent) {
-      this._events.on(
-        this.props.isDraggingConstrainedToRoot ? this.refs.root : this._scrollableParent,
-        'mousedown',
-        this._onMouseDown);
-    }
+    this._events.on(
+      this.props.isDraggingConstrainedToRoot ? this.refs.root : this._scrollableSurface,
+      'mousedown',
+      this._onMouseDown);
   }
+
 
   public componentWillUnmount() {
     if (this._autoScroll) {
@@ -132,16 +134,13 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
     }
 
     if (isEnabled && (!onShouldStartSelection || onShouldStartSelection(ev))) {
-      let scrollableParent = findScrollableParent(this.refs.root);
-
-      if (scrollableParent && ev.button === 0) {
+      if (this._scrollableSurface && ev.button === 0) {
         this._selectedIndicies = {};
         this._events.on(window, 'mousemove', this._onMouseMove);
-        this._events.on(scrollableParent, 'scroll', this._onMouseMove);
+        this._events.on(this._scrollableParent, 'scroll', this._onMouseMove);
         this._events.on(window, 'mouseup', this._onMouseUp, true);
         this._autoScroll = new AutoScroll(this.refs.root);
-        this._scrollableParent = scrollableParent;
-        this._scrollTop = scrollableParent.scrollTop;
+        this._scrollTop = this._scrollableSurface.scrollTop;
         this._rootRect = this.refs.root.getBoundingClientRect();
       }
     }
@@ -150,7 +149,7 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
   private _getRootRect(): IRectangle {
     return {
       left: this._rootRect.left,
-      top: this._rootRect.top + (this._scrollTop - this._scrollableParent.scrollTop),
+      top: this._rootRect.top + (this._scrollTop - this._scrollableSurface.scrollTop),
       width: this._rootRect.width,
       height: this._rootRect.height
     };
@@ -177,9 +176,9 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
           x: Math.max(0, Math.min(rootRect.width, this._lastMouseEvent.clientX - rootRect.left)),
           y: Math.max(0, Math.min(rootRect.height, this._lastMouseEvent.clientY - rootRect.top))
         } : {
-          x: this._lastMouseEvent.clientX - rootRect.left,
-          y: this._lastMouseEvent.clientY - rootRect.top
-        };
+            x: this._lastMouseEvent.clientX - rootRect.left,
+            y: this._lastMouseEvent.clientY - rootRect.top
+          };
 
         let dragRect = {
           left: Math.min(this._dragOrigin.x, constrainedPoint.x),
@@ -200,10 +199,9 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
   }
 
   private _onMouseUp(ev: MouseEvent) {
-    let scrollableParent = findScrollableParent(this.refs.root);
 
     this._events.off(window);
-    this._events.off(scrollableParent, 'scroll');
+    this._events.off(this._scrollableParent, 'scroll');
 
     this._autoScroll.dispose();
     this._autoScroll = this._dragOrigin = this._lastMouseEvent = this._selectedIndicies = this._itemRectCache = undefined;

--- a/src/demo/app.tsx
+++ b/src/demo/app.tsx
@@ -58,7 +58,7 @@ function _getRoutes() {
       .filter(link => link.hasOwnProperty('component'))
       .forEach((link, linkIndex) => {
         let { component } = link;
-        appRoutes.push(<Route key={ linkIndex } path={ link.url } component={ component } />);
+        appRoutes.push(<Route key={ link.key } path={ link.url } component={ component } />);
       });
   });
 
@@ -68,7 +68,7 @@ function _getRoutes() {
   );
 
   routes.push(
-    <Route component={ App }>
+    <Route key='app' component={ App }>
       { appRoutes }
     </Route>
   );

--- a/src/demo/app.tsx
+++ b/src/demo/app.tsx
@@ -7,6 +7,7 @@ import { AppState } from './components/App/AppState';
 import { Router, Route } from '../utilities/router/index';
 import { GettingStartedPage } from './pages/GettingStartedPage/GettingStartedPage';
 import { setBaseUrl } from '../utilities/resources';
+import { Fabric } from '../Fabric';
 import * as Debugging from './utilities/debugging';
 
 import './app.scss';
@@ -40,29 +41,36 @@ function _onLoad() {
   rootElement = rootElement || document.getElementById('content');
 
   ReactDOM.render(
-    <Router onNewRouteLoaded = { _scrollAnchorLink }>
-      <Route component={ App }>
-        { _getAppRoutes() }
-      </Route>
-    </Router>,
+    <Fabric>
+      <Router onNewRouteLoaded = { _scrollAnchorLink }>
+        { _getRoutes() }
+      </Router>
+    </Fabric>,
     rootElement);
 }
 
-function _getAppRoutes() {
-  let routes = [];
+function _getRoutes() {
+  let routes = AppState.testPages.map(page => <Route key={ page.key } path={ page.url } component={ page.component } />);
+  let appRoutes = [];
 
   AppState.examplePages.forEach(group => {
     group.links
       .filter(link => link.hasOwnProperty('component'))
       .forEach((link, linkIndex) => {
         let { component } = link;
-        routes.push(<Route key={ linkIndex } path={ link.url } component={ component } />);
+        appRoutes.push(<Route key={ linkIndex } path={ link.url } component={ component } />);
       });
   });
 
   // Default route.
-  routes.push(
+  appRoutes.push(
     <Route key='gettingstarted' component={ GettingStartedPage } />
+  );
+
+  routes.push(
+    <Route component={ App }>
+      { appRoutes }
+    </Route>
   );
 
   return routes;

--- a/src/demo/components/App/App.scss
+++ b/src/demo/components/App/App.scss
@@ -4,11 +4,10 @@ body {
   padding: 0;
   margin: 0;
   position: absolute;
-  overflow: hidden;
   left: 0;
   top: 0;
-  width: 100%;
-  height: 100%;
+  min-width: 100%;
+  min-height: 100%;
 }
 
 .ms-App-header {

--- a/src/demo/components/App/AppState.ts
+++ b/src/demo/components/App/AppState.ts
@@ -246,6 +246,7 @@ export const AppState: IAppState = {
         },
         {
           component: TeachingBubblePage,
+          key: 'TeachingBubble',
           name: 'TeachingBubble',
           status: ExampleStatus.beta,
           url: '#/examples/teachingbubble'

--- a/src/demo/components/App/AppState.ts
+++ b/src/demo/components/App/AppState.ts
@@ -38,6 +38,7 @@ import { TeachingBubblePage } from '../../pages/TeachingBubblePage/TeachingBubbl
 import { TextFieldPage } from '../../pages/TextFieldPage/TextFieldPage';
 import { TogglePage } from '../../pages/TogglePage/TogglePage';
 import { ThemePage } from '../../pages/ThemePage/ThemePage';
+import { DetailsListBasicExample } from '../../pages/DetailsListPage/examples/DetailsList.Basic.Example';
 
 export enum ExampleStatus {
   placeholder,
@@ -48,12 +49,22 @@ export enum ExampleStatus {
 
 export interface IAppState {
   appTitle: string;
+  testPages: any[];
   examplePages: INavLinkGroup[];
   headerLinks: INavLink[];
 }
 
 export const AppState: IAppState = {
   appTitle: 'Fabric - React',
+
+  testPages: [
+    {
+      component: DetailsListBasicExample,
+      key: 'DetailsListBasicExample',
+      name: 'DetailsListBasicExample',
+      url: '#/tests/detailslistbasicexample'
+    }
+  ],
 
   examplePages: [
     {

--- a/src/utilities/AutoScroll/AutoScroll.ts
+++ b/src/utilities/AutoScroll/AutoScroll.ts
@@ -1,5 +1,7 @@
 import { EventGroup } from '../eventGroup/EventGroup';
 import { findScrollableParent } from '../scroll';
+import { getRect } from '../dom';
+import { IRectangle } from '../../common/IRectangle';
 
 const SCROLL_ITERATION_DELAY = 16;
 const SCROLL_GUTTER_HEIGHT = 100;
@@ -14,15 +16,21 @@ const MAX_SCROLL_VELOCITY = 15;
 export class AutoScroll {
   private _events: EventGroup;
   private _scrollableParent: HTMLElement;
-  private _scrollRect: ClientRect;
+  private _scrollableSurface: HTMLElement;
+  private _scrollRect: IRectangle;
   private _scrollVelocity: number;
   private _timeoutId: number;
 
   constructor(element: HTMLElement) {
     this._events = new EventGroup(this);
     this._scrollableParent = findScrollableParent(element);
+
     this._incrementScroll = this._incrementScroll.bind(this);
-    this._scrollRect = this._scrollableParent.getBoundingClientRect();
+    this._scrollRect = getRect(this._scrollableParent);
+
+    if (this._scrollableParent === window as any) {
+      this._scrollableParent = document.body;
+    }
 
     if (this._scrollableParent) {
       this._events.on(window, 'mousemove', this._onMouseMove, true);

--- a/src/utilities/AutoScroll/AutoScroll.ts
+++ b/src/utilities/AutoScroll/AutoScroll.ts
@@ -16,7 +16,6 @@ const MAX_SCROLL_VELOCITY = 15;
 export class AutoScroll {
   private _events: EventGroup;
   private _scrollableParent: HTMLElement;
-  private _scrollableSurface: HTMLElement;
   private _scrollRect: IRectangle;
   private _scrollVelocity: number;
   private _timeoutId: number;

--- a/src/utilities/decorators/withViewport.tsx
+++ b/src/utilities/decorators/withViewport.tsx
@@ -73,6 +73,12 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
       let { viewport } = this.state;
       let viewportElement = (this.refs as any).root;
       let scrollElement = findScrollableParent(viewportElement);
+
+      // If we are window scrolling, use body to measure.
+      if (scrollElement === window as any) {
+        scrollElement = document.body;
+      }
+
       let clientRect = viewportElement.getBoundingClientRect();
       let scrollRect = scrollElement.getBoundingClientRect();
       let updateComponent = () => {

--- a/src/utilities/decorators/withViewport.tsx
+++ b/src/utilities/decorators/withViewport.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { BaseDecorator } from './BaseDecorator';
 import { findScrollableParent } from '../../utilities/scroll';
+import { getRect } from '../../utilities/dom';
 
 export interface IViewport {
   width: number;
@@ -73,23 +74,8 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
       let { viewport } = this.state;
       let viewportElement = (this.refs as any).root;
       let scrollElement = findScrollableParent(viewportElement);
-      let scrollRect;
-
-      // If we are window scrolling, measure the window rather than the container element.
-      if (scrollElement === window as any) {
-        scrollRect = {
-          left: 0,
-          top: 0,
-          width: window.innerWidth,
-          height: window.innerHeight,
-          right: window.innerWidth,
-          bottom: window.innerHeight
-        };
-      } else {
-        scrollRect = scrollElement.getBoundingClientRect();
-      }
-
-      let clientRect = viewportElement.getBoundingClientRect();
+      let scrollRect = getRect(scrollElement);
+      let clientRect = getRect(viewportElement);
       let updateComponent = () => {
         if (withForceUpdate && this._composedComponentInstance) {
           this._composedComponentInstance.forceUpdate();

--- a/src/utilities/decorators/withViewport.tsx
+++ b/src/utilities/decorators/withViewport.tsx
@@ -73,14 +73,23 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
       let { viewport } = this.state;
       let viewportElement = (this.refs as any).root;
       let scrollElement = findScrollableParent(viewportElement);
+      let scrollRect;
 
-      // If we are window scrolling, use body to measure.
+      // If we are window scrolling, measure the window rather than the container element.
       if (scrollElement === window as any) {
-        scrollElement = document.body;
+        scrollRect = {
+          left: 0,
+          top: 0,
+          width: window.innerWidth,
+          height: window.innerHeight,
+          right: window.innerWidth,
+          bottom: window.innerHeight
+        };
+      } else {
+        scrollRect = scrollElement.getBoundingClientRect();
       }
 
       let clientRect = viewportElement.getBoundingClientRect();
-      let scrollRect = scrollElement.getBoundingClientRect();
       let updateComponent = () => {
         if (withForceUpdate && this._composedComponentInstance) {
           this._composedComponentInstance.forceUpdate();

--- a/src/utilities/dom.ts
+++ b/src/utilities/dom.ts
@@ -1,3 +1,5 @@
+import { IRectangle } from '../common/IRectangle';
+
 /**
  * Attached interface for elements which support virtual references.
  * Used internally by the virtual hierarchy methods.
@@ -115,6 +117,28 @@ export function elementContains(parent: HTMLElement, child: HTMLElement, allowVi
   }
 
   return isContained;
+}
+
+/** Helper to get bounding client rect, works with window. */
+export function getRect(element: HTMLElement | Window): IRectangle {
+  let rect: IRectangle;
+
+  if (element) {
+    if (element === window) {
+      rect = {
+        left: 0,
+        top: 0,
+        width: window.innerWidth,
+        height: window.innerHeight,
+        right: window.innerWidth,
+        bottom: window.innerHeight
+      };
+    } else if ((element as HTMLElement).getBoundingClientRect) {
+      rect = (element as HTMLElement).getBoundingClientRect();
+    }
+  }
+
+  return rect;
 }
 
 /**

--- a/src/utilities/scroll.ts
+++ b/src/utilities/scroll.ts
@@ -53,9 +53,9 @@ export function findScrollableParent(startingElement: HTMLElement): HTMLElement 
     el = el.parentElement;
   }
 
-  // Fall back to body scroll.
-  if (!el) {
-    el = document.body;
+  // Fall back to window scroll.
+  if (!el || el === document.body) {
+    el = window as any;
   }
 
   return el;


### PR DESCRIPTION
MileIQ uses DetailsList in a body scroll scenario which is different than our typical scrollable div scenarios, so I hooked up DetailsList to a body scroll and found a bug in the scroll utility which returns the "scrollable element" as body, which actually should be "window" in the default case, since window raises scroll events and not body.

Once this was fixed, I also realized that withViewport, which measures the scroll rect, needs to handle this and fall back to measuring body in the case we're using window as the scroll element.