### PR TITLE
Fix issue where NavLinks were not being selected if NavLinks had empty urls but all had keys

### DIFF
--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -217,8 +217,8 @@ function _isLinkSelected(link: INavLink, selectedKey: string): boolean {
     _urlResolver.href = link.url || '';
     const target: string = _urlResolver.href;
 
-    if (selectedKey && link.key === selectedKey) {
-      return true;
+    if (selectedKey) {
+      return link.key === selectedKey;
     }
 
     if (location.protocol + '//' + location.host + location.pathname === target) {

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -211,15 +211,15 @@ export class Nav extends React.Component<INavProps, INavState> implements INav {
 const _urlResolver = document.createElement('a');
 
 function _isLinkSelected(link: INavLink, selectedKey: string): boolean {
+    if (selectedKey && link.key === selectedKey) {
+      return true;
+    }
+
     if (!link.url) {
       return false;
     }
     _urlResolver.href = link.url || '';
     const target: string = _urlResolver.href;
-
-    if (selectedKey) {
-      return link.key === selectedKey;
-    }
 
     if (location.protocol + '//' + location.host + location.pathname === target) {
       return true;

--- a/src/demo/pages/NavPage/NavPage.tsx
+++ b/src/demo/pages/NavPage/NavPage.tsx
@@ -8,6 +8,7 @@ import {
 import { NavBasicExample } from './examples/Nav.Basic.Example';
 import { NavFabricDemoAppExample } from './examples/Nav.FabricDemoApp.Example';
 import { NavNestedExample } from './examples/Nav.Nested.Example';
+import { NavByKeysExample } from './examples/Nav.ByKeys.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
@@ -15,6 +16,7 @@ import { IComponentDemoPageProps } from '../../components/ComponentPage/ICompone
 const NavBasicExampleCode = require('./examples/Nav.Basic.Example.tsx');
 const NavFabricDemoAppExampleCode = require('./examples/Nav.FabricDemoApp.Example.tsx');
 const NavNestedExampleCode = require('./examples/Nav.Nested.Example.tsx');
+const NavByKeysExampleCode = require('./examples/Nav.ByKeys.Example.tsx');
 
 export class NavPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -39,6 +41,9 @@ export class NavPage extends React.Component<IComponentDemoPageProps, any> {
             </ExampleCard>
             <ExampleCard title='Nested navigation menu (without group header)' code={ NavNestedExampleCode }>
               <NavNestedExample />
+            </ExampleCard>
+            <ExampleCard title='Nav bar of links each with unique keys and empty urls' code={ NavByKeysExampleCode }>
+              <NavByKeysExample />
             </ExampleCard>
           </div>
         }

--- a/src/demo/pages/NavPage/examples/Nav.ByKeys.Example.tsx
+++ b/src/demo/pages/NavPage/examples/Nav.ByKeys.Example.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import {
+  Nav
+} from '../../../../index';
+
+export class NavByKeysExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <Nav
+        groups={ [ { links: [
+          { name: 'Home', key: 'Home', url: '' },
+          { name: 'Activity', key: 'Activity', url: '' },
+          { name: 'News', key: 'News', url: '' },
+          { name: 'Documents', key: 'Documents', url: '' },
+        ] } ] }
+      />
+    );
+  }
+}


### PR DESCRIPTION
In the scenario that INavLinks in the Nav have no urls (i.e. empty strings) but selection of NavLinks are done through keys of INavLinks (i.e. each compositeLink's isLinkSelected boolean is determined through checking if that Link's key is the same as the Nav's currently selectedKey), the problem was that the _isLinkSelected method was always returning false precisely because urls were empty/ undefined. 

This moves up the check for selectedKey before that check and fixes the problem that NavLinks with no urls but all with keys are properly being deemed as 'selected'.

Now with added example.