### PR TITLE
Fix component example code styles

### DIFF
--- a/src/demo/components/ExampleCard/ExampleCard.scss
+++ b/src/demo/components/ExampleCard/ExampleCard.scss
@@ -6,7 +6,6 @@
 
 .ExampleCard-header {
   border-bottom: 1px solid $ms-color-neutralTertiary;
-  min-height: 50px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -14,13 +13,13 @@
 }
 
 .ExampleCard-title {
-  line-height: 50px;
+  margin-bottom: 10px;
+  display: inline-block;
 }
 
 .ExampleCard-toggleButtons {
-  position: absolute;
-  bottom: 0;
-  right: 0;
+  display: block;
+  float: right;
 
   .ms-Button.ExampleCard-codeButton {
     @include margin-right(0);

--- a/src/demo/components/ExampleCard/ExampleCard.tsx
+++ b/src/demo/components/ExampleCard/ExampleCard.tsx
@@ -40,14 +40,14 @@ export class ExampleCard extends React.Component<IExampleCardProps, IExampleCard
       <div className={ rootClass }>
         <div className='ExampleCard-header'>
           <span className='ExampleCard-title ms-font-l'>{ title }</span>
-          <span className='ExampleCard-toggleButtons ms-font-l'>
+          <div className='ExampleCard-toggleButtons ms-font-l'>
             { code ? (
             <Button buttonType={ ButtonType.icon } icon='Embed'
               onClick={ this._onToggleCodeClick } className={ css('ExampleCard-codeButton', { 'is-active': isCodeVisible }) }>
               { this.state.isCodeVisible ? 'Hide code' : 'Show code' }
             </Button>
             ) : ( null ) }
-          </span>
+          </div>
         </div>
 
         <div className='ExampleCard-code'>


### PR DESCRIPTION
Fixes component example styles so code titles doesn't go over show code button.
Before
![screen shot 2016-10-10 at 10 28 58 am](https://cloud.githubusercontent.com/assets/1291968/19245145/65590726-8ed4-11e6-8edb-0d36e6f9044b.png)


After
![screen shot 2016-10-10 at 10 24 39 am](https://cloud.githubusercontent.com/assets/1291968/19245081/23f98a80-8ed4-11e6-9a6e-6173a9f073d9.png)
