### PR TITLE
Use ECMA Date Localization API in DatePicker

### DIFF
--- a/src/components/DatePicker/DatePicker.Props.ts
+++ b/src/components/DatePicker/DatePicker.Props.ts
@@ -88,26 +88,26 @@ export enum DayOfWeek {
 
 export interface IDatePickerStrings {
   /**
-   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
    * @deprecated
+   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
    */
   months?: string[];
 
   /**
-   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
    * @deprecated
+   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
    */
   shortMonths?: string[];
 
   /**
-   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
    * @deprecated
+   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
    */
   days?: string[];
 
   /**
-   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
    * @deprecated
+   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
    */
   shortDays?: string[];
 

--- a/src/components/DatePicker/DatePicker.Props.ts
+++ b/src/components/DatePicker/DatePicker.Props.ts
@@ -69,7 +69,9 @@ export interface IDatePickerProps extends React.Props<DatePicker> {
   strings: IDatePickerStrings;
 
   /**
-  * Locales to use for rendering date strings, in descending order of priority
+  * Locales to use for rendering date strings, in descending order of priority.
+  * Use BCP 47 language tags (eg., 'en-us')
+  * @defaultvalue navigator.language
   */
   locales?: string[];
 }
@@ -85,6 +87,30 @@ export enum DayOfWeek {
 }
 
 export interface IDatePickerStrings {
+  /**
+   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
+   * @deprecated
+   */
+  months?: string[];
+
+  /**
+   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
+   * @deprecated
+   */
+  shortMonths?: string[];
+
+  /**
+   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
+   * @deprecated
+   */
+  days?: string[];
+
+  /**
+   * Deprecated at v0.57.0, to be removed at >= v1.0.0. Provide the appropriate locale instead.
+   * @deprecated
+   */
+  shortDays?: string[];
+
   /**
    * String to render for button to direct the user to today's date.
    */

--- a/src/components/DatePicker/DatePicker.Props.ts
+++ b/src/components/DatePicker/DatePicker.Props.ts
@@ -25,7 +25,7 @@ export interface IDatePickerProps extends React.Props<DatePicker> {
 
   /**
    * Whether the month picker is shown beside the day picker or hidden.
-   * @defaultvalue true 
+   * @defaultvalue true
    */
   isMonthPickerVisible?: boolean;
 
@@ -67,6 +67,11 @@ export interface IDatePickerProps extends React.Props<DatePicker> {
    * Localized strings to use in the DatePicker
    */
   strings: IDatePickerStrings;
+
+  /**
+  * Locales to use for rendering date strings, in descending order of priority
+  */
+  locales?: string[];
 }
 
 export enum DayOfWeek {
@@ -80,30 +85,6 @@ export enum DayOfWeek {
 }
 
 export interface IDatePickerStrings {
-  /**
-   * An array of strings for the full names of months.
-   * The array is 0-based, so months[0] should be the full name of January.
-   */
-  months: string[];
-
-  /**
-   * An array of strings for the short names of months.
-   * The array is 0-based, so shortMonths[0] should be the short name of January.
-   */
-  shortMonths: string[];
-
-  /**
-   * An array of strings for the full names of days of the week.
-   * The array is 0-based, so days[0] should be the full name of Sunday.
-   */
-  days: string[];
-
-  /**
-   * An array of strings for the initials of the days of the week.
-   * The array is 0-based, so days[0] should be the initial of Sunday.
-   */
-  shortDays: string[];
-
   /**
    * String to render for button to direct the user to today's date.
    */

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -40,7 +40,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     isRequired: false,
     isMonthPickerVisible: true,
     strings: null,
-    locales: ['en']
+    locales: [ navigator.language ]
   };
 
   public refs: {
@@ -61,7 +61,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
 
     this.state = {
       selectedDate: value || new Date(),
-      formattedDate: value ? this.formatDate(value) : null,
+      formattedDate: value ? this._formatDate(value) : null,
       isDatePickerShown: false,
       errorMessage: ''
     };
@@ -75,7 +75,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
 
     this.setState({
       selectedDate: value || new Date(),
-      formattedDate: value ? this.formatDate(value) : null,
+      formattedDate: value ? this._formatDate(value) : null,
       errorMessage: errorMessage
     });
   }
@@ -182,7 +182,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     this.setState({
       selectedDate: date,
       isDatePickerShown: false,
-      formattedDate: date ? this.formatDate(date) : null,
+      formattedDate: date ? this._formatDate(date) : null,
     });
 
     this._restoreFocusToTextField();
@@ -382,13 +382,13 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   }
 
   @autobind
-  private formatDate(date: Date) {
+  private _formatDate(date: Date) {
     let { formatDate } = this.props;
 
-    return formatDate ? formatDate(date) : this.defaultFormatDate(date);
+    return formatDate ? formatDate(date) : this._defaultFormatDate(date);
   }
 
-  private defaultFormatDate(date: Date) {
+  private _defaultFormatDate(date: Date) {
     let { locales } = this.props;
 
     if (date) {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -45,7 +45,8 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     firstDayOfWeek: DayOfWeek.Sunday,
     isRequired: false,
     isMonthPickerVisible: true,
-    strings: null
+    strings: null,
+    locales: ['en']
   };
 
   public refs: {
@@ -102,7 +103,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
 
   public render() {
     let rootClass = 'ms-DatePicker';
-    let { firstDayOfWeek, strings, label, isRequired, ariaLabel, placeholder, allowTextInput } = this.props;
+    let { firstDayOfWeek, strings, label, isRequired, ariaLabel, placeholder, allowTextInput, locales } = this.props;
     let { isDatePickerShown, formattedDate, selectedDate, navigatedDate, errorMessage } = this.state;
 
     return (
@@ -141,11 +142,12 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
                     onNavigateDate={ this._onNavigateDate }
                     firstDayOfWeek={ firstDayOfWeek }
                     strings={ strings }
+                    locales={ locales }
                     ref='dayPicker' />
                   <DatePickerMonth
                     navigatedDate={ navigatedDate }
-                    strings={ strings }
-                    onNavigateDate={ this._onNavigateDate } />
+                    onNavigateDate={ this._onNavigateDate }
+                    locales={ locales } />
                   <span
                     className='ms-DatePicker-goToday js-goToday'
                     onClick={ this._onGotoToday }

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -381,7 +381,6 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     }
   }
 
-  @autobind
   private _formatDate(date: Date) {
     let { formatDate } = this.props;
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -27,13 +27,7 @@ export interface IDatePickerState {
 export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState> {
   public static defaultProps: IDatePickerProps = {
     allowTextInput: false,
-    formatDate: (date: Date) => {
-      if (date) {
-        return date.toDateString();
-      }
-
-      return null;
-    },
+    formatDate: null,
     parseDateFromString: (dateStr: string) => {
       const date = Date.parse(dateStr);
       if (date) {
@@ -61,13 +55,13 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   private _focusOnSelectedDateOnUpdate: boolean;
 
   constructor(props: IDatePickerProps) {
-    super();
+    super(props);
 
-    let { formatDate, value } = props;
+    let { value } = props;
 
     this.state = {
       selectedDate: value || new Date(),
-      formattedDate: formatDate && value ? formatDate(value) : null,
+      formattedDate: value ? this.formatDate(value) : null,
       isDatePickerShown: false,
       errorMessage: ''
     };
@@ -76,12 +70,12 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   }
 
   public componentWillReceiveProps(nextProps: IDatePickerProps) {
-    let { formatDate, isRequired, strings, value } = nextProps;
+    let { isRequired, strings, value } = nextProps;
     const errorMessage = isRequired && !value ? (strings.isRequiredErrorMessage || '*') : '';
 
     this.setState({
       selectedDate: value || new Date(),
-      formattedDate: formatDate && value ? formatDate(value) : null,
+      formattedDate: value ? this.formatDate(value) : null,
       errorMessage: errorMessage
     });
   }
@@ -183,12 +177,12 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
 
   @autobind
   private _onSelectDate(date: Date) {
-    let { formatDate, onSelectDate } = this.props;
+    let { onSelectDate } = this.props;
 
     this.setState({
       selectedDate: date,
       isDatePickerShown: false,
-      formattedDate: formatDate && date ? formatDate(date) : null,
+      formattedDate: date ? this.formatDate(date) : null,
     });
 
     this._restoreFocusToTextField();
@@ -385,5 +379,22 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
         onSelectDate(date);
       }
     }
+  }
+
+  @autobind
+  private formatDate(date: Date) {
+    let { formatDate } = this.props;
+
+    return formatDate ? formatDate(date) : this.defaultFormatDate(date);
+  }
+
+  private defaultFormatDate(date: Date) {
+    let { locales } = this.props;
+
+    if (date) {
+      return date.toLocaleDateString(locales);
+    }
+
+    return null;
   }
 }

--- a/src/components/DatePicker/DatePickerMonth.tsx
+++ b/src/components/DatePicker/DatePickerMonth.tsx
@@ -1,36 +1,52 @@
 import * as React from 'react';
-import { IDatePickerStrings } from './DatePicker.Props';
 import { FocusZone } from '../../FocusZone';
 import { KeyCodes } from '../../utilities/KeyCodes';
 import { addYears, setMonth } from '../../utilities/dateMath/DateMath';
 import { getRTL } from '../../utilities/rtl';
 import { css } from '../../utilities/css';
 
+const MONTHS_IN_YEAR = 12;
+
 export interface IDatePickerMonthProps {
    navigatedDate: Date;
-   strings: IDatePickerStrings;
    onNavigateDate: (date: Date, focusOnNavigatedDay: boolean) => void;
+   locales: string[];
 }
 
-export class DatePickerMonth extends React.Component<IDatePickerMonthProps, {}> {
+export interface IDatePickerMonthState {
+  monthStrings: string[];
+}
+
+export class DatePickerMonth extends React.Component<IDatePickerMonthProps, IDatePickerMonthState> {
   private _selectMonthCallbacks: (() => void)[];
 
   public constructor(props: IDatePickerMonthProps) {
     super(props);
 
     this._selectMonthCallbacks = [];
-    props.strings.shortMonths.map((month, index) => {
-      this._selectMonthCallbacks[index] = this._onSelectMonth.bind(this, index);
-    });
+    for (let i = 0; i < MONTHS_IN_YEAR; i++) {
+      this._selectMonthCallbacks[i] = this._onSelectMonth.bind(this, i);
+    }
 
     this._onSelectNextYear = this._onSelectNextYear.bind(this);
     this._onSelectPrevYear = this._onSelectPrevYear.bind(this);
     this._onSelectMonth = this._onSelectMonth.bind(this);
+
+    this.state = {
+      monthStrings: this._getMonthStrings(props.locales),
+    };
+  }
+
+  public componentWillReceiveProps (nextProps: IDatePickerMonthProps) {
+    this.setState({
+      monthStrings: this._getMonthStrings(nextProps.locales),
+    });
   }
 
   public render() {
 
-    let { navigatedDate, strings } = this.props;
+    let { monthStrings } = this.state;
+    let { navigatedDate } = this.props;
 
     return (
       <div className='ms-DatePicker-monthPicker'>
@@ -55,7 +71,7 @@ export class DatePickerMonth extends React.Component<IDatePickerMonthProps, {}> 
         </div>
         <FocusZone>
           <div className='ms-DatePicker-optionGrid'>
-            { strings.shortMonths.map((month, index) => {
+            { monthStrings.map((month, index) => {
               return (<span className='ms-DatePicker-monthOption' key={index} onClick={ this._selectMonthCallbacks[index] } data-is-focusable={true}>{month}</span>);
             }) }
           </div>
@@ -83,5 +99,16 @@ export class DatePickerMonth extends React.Component<IDatePickerMonthProps, {}> 
   private _onSelectMonth(newMonth: number) {
     let { navigatedDate, onNavigateDate } = this.props;
     onNavigateDate(setMonth(navigatedDate, newMonth), true);
+  }
+
+  private _getMonthStrings(locales: string[]) {
+    let strings = new Array(MONTHS_IN_YEAR);
+    let date: Date = new Date();
+
+    for (let i = 0; i < MONTHS_IN_YEAR; i++) {
+      strings[i] = setMonth(date, i).toLocaleString(locales, { month: 'short' });
+    }
+
+    return strings;
   }
 }

--- a/src/demo/pages/DatePickerPage/examples/DatePicker.Basic.Example.tsx
+++ b/src/demo/pages/DatePickerPage/examples/DatePicker.Basic.Example.tsx
@@ -7,56 +7,6 @@ import {
 } from '../../../../index';
 
 const DayPickerStrings = {
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
-  ],
-
-  shortMonths: [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec'
-  ],
-
-  days: [
-    'Sunday',
-    'Monday',
-    'Tuesday',
-    'Wednesday',
-    'Thursday',
-    'Friday',
-    'Saturday'
-  ],
-
-  shortDays: [
-    'S',
-    'M',
-    'T',
-    'W',
-    'T',
-    'F',
-    'S'
-  ],
-
   goToToday: 'Go to today'
 };
 

--- a/src/demo/pages/DatePickerPage/examples/DatePicker.Basic.Example.tsx
+++ b/src/demo/pages/DatePickerPage/examples/DatePicker.Basic.Example.tsx
@@ -12,6 +12,7 @@ const DayPickerStrings = {
 
 export interface IDatePickerBasicExampleState {
   firstDayOfWeek?: DayOfWeek;
+  locale?: string[];
 }
 
 export class DatePickerBasicExample extends React.Component<any, IDatePickerBasicExampleState> {
@@ -24,11 +25,11 @@ export class DatePickerBasicExample extends React.Component<any, IDatePickerBasi
   }
 
   public render() {
-    let { firstDayOfWeek } = this.state;
+    let { firstDayOfWeek, locale } = this.state;
 
     return (
       <div>
-        <DatePicker firstDayOfWeek={ firstDayOfWeek } strings={ DayPickerStrings } placeholder='Select a date...' />
+        <DatePicker firstDayOfWeek={ firstDayOfWeek } strings={ DayPickerStrings } locales={ locale } placeholder='Select a date...' />
         <Dropdown
           label='Select the first day of the week'
           options={ [
@@ -62,15 +63,56 @@ export class DatePickerBasicExample extends React.Component<any, IDatePickerBasi
             }
           ] }
           selectedKey={ DayOfWeek[firstDayOfWeek] }
-          onChanged={ this._onDropdownChanged.bind(this) }
+          onChanged={ this._onStartOfWeekDropdownChanged.bind(this) }
+          />
+        <Dropdown
+          label='Select the locale'
+          options={ [
+            {
+              text: 'English',
+              key: 'en-us'
+            },
+            {
+              text: 'Spanish',
+              key: 'es-es'
+            },
+            {
+              text: 'German',
+              key: 'de-de'
+            },
+            {
+              text: 'Arabic',
+              key: 'ar'
+            },
+            {
+              text: 'Chinese',
+              key: 'zh'
+            },
+            {
+              text: 'Russian',
+              key: 'ru-ru'
+            },
+            {
+              text: 'Telugu',
+              key: 'te'
+            }
+          ] }
+          selectedKey={ DayOfWeek[firstDayOfWeek] }
+          onChanged={ this._onLocaleDropdownChanged.bind(this) }
           />
       </div>
     );
   }
 
-  private _onDropdownChanged(option: IDropdownOption) {
+  private _onStartOfWeekDropdownChanged(option: IDropdownOption) {
     this.setState({
       firstDayOfWeek: DayOfWeek[option.key]
+    });
+  }
+
+  private _onLocaleDropdownChanged(option: IDropdownOption) {
+    this.setState({
+      locale: [option.key.toString()]
     });
   }
 }

--- a/src/demo/pages/DatePickerPage/examples/DatePicker.Input.Example.tsx
+++ b/src/demo/pages/DatePickerPage/examples/DatePicker.Input.Example.tsx
@@ -5,56 +5,6 @@ import {
 } from '../../../../index';
 
 const DayPickerStrings = {
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
-  ],
-
-  shortMonths: [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec'
-  ],
-
-  days: [
-    'Sunday',
-    'Monday',
-    'Tuesday',
-    'Wednesday',
-    'Thursday',
-    'Friday',
-    'Saturday'
-  ],
-
-  shortDays: [
-    'S',
-    'M',
-    'T',
-    'W',
-    'T',
-    'F',
-    'S'
-  ],
-
   goToToday: 'Go to today',
 
   isRequiredErrorMessage: 'Start date is required.',

--- a/src/demo/pages/DatePickerPage/examples/DatePicker.Required.Example.tsx
+++ b/src/demo/pages/DatePickerPage/examples/DatePicker.Required.Example.tsx
@@ -5,56 +5,6 @@ import {
 } from '../../../../index';
 
 const DayPickerStrings = {
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
-  ],
-
-  shortMonths: [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec'
-  ],
-
-  days: [
-    'Sunday',
-    'Monday',
-    'Tuesday',
-    'Wednesday',
-    'Thursday',
-    'Friday',
-    'Saturday'
-  ],
-
-  shortDays: [
-    'S',
-    'M',
-    'T',
-    'W',
-    'T',
-    'F',
-    'S'
-  ],
-
   goToToday: 'Go to today',
 
   isRequiredErrorMessage: 'Field is required.',


### PR DESCRIPTION
Rather than require the consumer to specify a host of localized strings to use for month and weekday names, this change now uses the ECMA Date Localization API. The consumer now merely specifies an array of locales (in decreasing priority), and the browser handles the rest.

As a bonus, we can use the locale for the default formatting of the date string.