### PR TITLE
Allow 0 to be a valid key for Dropdown options

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -147,7 +147,7 @@ export class Dropdown extends BaseComponent<IDropdownProps, any> {
   }
 
   private _getSelectedIndex(options: IDropdownOption[], selectedKey: string | number) {
-    return findIndex(options, (option => (option.isSelected || selectedKey && option.key === selectedKey)));
+    return findIndex(options, (option => (option.isSelected || (selectedKey != null) && option.key === selectedKey)));
   }
 
   @autobind


### PR DESCRIPTION
SelectedKey was being null checked using a falsy comparison, meaning that 0 could not be used as a valid key. Changed the null check to be explicit