### PR TITLE
Allow for null children to Dialog

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -113,7 +113,7 @@ export class Dialog extends React.Component<IDialogProps, any> {
     };
 
     React.Children.map(this.props.children, child => {
-      if (typeof child === 'object' && child.type === DialogFooter) {
+      if (typeof child === 'object' && child !== null && child.type === DialogFooter) {
         groupings.footers.push(child);
       } else {
         groupings.contents.push(child);

--- a/src/demo/pages/DialogPage/examples/Dialog.Basic.Example.tsx
+++ b/src/demo/pages/DialogPage/examples/Dialog.Basic.Example.tsx
@@ -50,6 +50,7 @@ export class DialogBasicExample extends React.Component<any, any> {
             ] }
             onChanged={ this._onChoiceChanged }
           />
+          { null /** You can also include null values as the result of conditionals */ }
           <DialogFooter>
             <Button buttonType={ ButtonType.primary } onClick={this._closeDialog.bind(this)}>Save</Button>
             <Button onClick={this._closeDialog.bind(this)}>Cancel</Button>


### PR DESCRIPTION
This PR addresses Issue #412, which was encountered by OWA during development.

It's not unreasonable to have null or undefined children of a control, depending on the state of the component. Previously, Dialog._groupChildren() would map the children, then dereference all objects. However, map converts all 'undefined' values to 'null', and 'typeof null' evaluates to 'object'. This meant any undefined or null children would result in TypeErrors.