### PR TITLE
DetailsList: [Breaking] onColumnClick ev should be first, then column

### DIFF
--- a/src/components/DetailsList/DetailsHeader.tsx
+++ b/src/components/DetailsList/DetailsHeader.tsx
@@ -21,7 +21,7 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
   onColumnIsSizingChanged?: (column: IColumn, isSizing: boolean) => void;
   onColumnResized?: (column: IColumn, newWidth: number) => void;
   onColumnAutoResized?: (column: IColumn, columnIndex: number) => void;
-  onColumnClick?: (column: IColumn, ev: Event) => void;
+  onColumnClick?: (ev: React.MouseEvent, column: IColumn) => void;
   onColumnContextMenu?: (column: IColumn, ev: Event) => void;
   groupNestingDepth?: number;
   isAllCollapsed?: boolean;
@@ -363,11 +363,11 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
     let { onColumnClick } = this.props;
 
     if (column.onColumnClick) {
-      column.onColumnClick(column, ev);
+      column.onColumnClick(ev, column);
     }
 
     if (onColumnClick) {
-      onColumnClick(column, ev);
+      onColumnClick(ev, column);
     }
   }
 

--- a/src/components/DetailsList/DetailsList.Props.ts
+++ b/src/components/DetailsList/DetailsList.Props.ts
@@ -85,7 +85,7 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
   onRowWillUnmount?: (item?: any, index?: number) => void;
 
   /** Callback for when the user clicks on the column header. */
-  onColumnHeaderClick?: (column?: IColumn, ev?: Event) => void;
+  onColumnHeaderClick?: (ev?: React.MouseEvent, column?: IColumn) => void;
 
   /** Callback for when the user asks for a contextual menu (usually via right click) from a column header. */
   onColumnHeaderContextMenu?: (column?: IColumn, ev?: Event) => void;
@@ -237,7 +237,7 @@ export interface IColumn {
   /**
    * If provided, will be executed when the user clicks on the column header.
    */
-  onColumnClick?: (column?: IColumn, ev?: React.MouseEvent) => any;
+  onColumnClick?: (ev?: React.MouseEvent, column?: IColumn) => any;
 
   /**
    * If provided, will be executed when the user accesses the contextmenu on a column header.

--- a/src/components/DetailsList/DetailsList.tsx
+++ b/src/components/DetailsList/DetailsList.tsx
@@ -638,7 +638,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
 export function buildColumns(
   items: any[],
   canResizeColumns?: boolean,
-  onColumnClick?: (column: IColumn, ev: React.MouseEvent) => any,
+  onColumnClick?: (ev: React.MouseEvent, column: IColumn) => any,
   sortedColumnKey?: string,
   isSortedDescending?: boolean,
   groupedColumnKey?: string,
@@ -664,7 +664,7 @@ export function buildColumns(
           isRowHeader: false,
           columnActionsMode: ColumnActionsMode.clickable,
           isResizable: canResizeColumns,
-          onColumnClick: onColumnClick,
+          onColumnClick,
           isGrouped: groupedColumnKey === propName
         });
 

--- a/src/demo/pages/DetailsListPage/examples/DetailsList.Advanced.Example.tsx
+++ b/src/demo/pages/DetailsListPage/examples/DetailsList.Advanced.Example.tsx
@@ -14,6 +14,7 @@ import {
   Link,
   Selection,
   TextField,
+  autobind,
   buildColumns
 } from '../../../../index';
 import { SelectionMode } from '../../../../utilities/selection/interfaces';
@@ -61,17 +62,6 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
 
     this._selection = new Selection();
     this._selection.setItems(_items, false);
-
-    this._onToggleResizing = this._onToggleResizing.bind(this);
-    this._onToggleLazyLoad = this._onToggleLazyLoad.bind(this);
-    this._onLayoutChanged = this._onLayoutChanged.bind(this);
-    this._onConstrainModeChanged = this._onConstrainModeChanged.bind(this);
-    this._onSelectionChanged = this._onSelectionChanged.bind(this);
-    this._onColumnClick = this._onColumnClick.bind(this);
-    this._onContextualMenuDismissed = this._onContextualMenuDismissed.bind(this);
-    this._onItemLimitChanged = this._onItemLimitChanged.bind(this);
-    this._onAddRow = this._onAddRow.bind(this);
-    this._onDeleteRow = this._onDeleteRow.bind(this);
 
     this.state = {
       items: _items,
@@ -174,6 +164,7 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     }
   }
 
+  @autobind
   private _onToggleLazyLoad() {
     let { isLazyLoaded } = this.state;
 
@@ -185,6 +176,7 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     });
   }
 
+  @autobind
   private _onToggleResizing() {
     let { items, canResizeColumns, sortedColumnKey, isSortedDescending } = this.state;
 
@@ -196,24 +188,28 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     });
   }
 
-  private _onLayoutChanged(menuItem: IContextualMenuItem) {
+  @autobind
+  private _onLayoutChanged(ev: React.MouseEvent, menuItem: IContextualMenuItem) {
     this.setState({
       layoutMode: menuItem.data
     });
   }
 
-  private _onConstrainModeChanged(menuItem: IContextualMenuItem) {
+  @autobind
+  private _onConstrainModeChanged(ev: React.MouseEvent, menuItem: IContextualMenuItem) {
     this.setState({
       constrainMode: menuItem.data
     });
   }
 
-  private _onSelectionChanged(menuItem: IContextualMenuItem) {
+  @autobind
+  private _onSelectionChanged(ev: React.MouseEvent, menuItem: IContextualMenuItem) {
     this.setState({
       selectionMode: menuItem.data
     });
   }
 
+  @autobind
   private _onItemLimitChanged(value: string) {
     let newValue = parseInt(value, 10);
     if (isNaN(newValue)) {
@@ -350,7 +346,7 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     ];
   }
 
-  private _getContextualMenuProps(column: IColumn, ev: React.MouseEvent): IContextualMenuProps {
+  private _getContextualMenuProps(ev: React.MouseEvent, column: IColumn): IContextualMenuProps {
     let items = [
       {
         key: 'aToZ',
@@ -389,22 +385,26 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     };
   }
 
+  @autobind
   private _onItemInvoked(item: any, index: number) {
     console.log('Item invoked', item, index);
   }
 
-  private _onColumnClick(column: IColumn, ev: React.MouseEvent) {
+  @autobind
+  private _onColumnClick(ev: React.MouseEvent, column: IColumn) {
     this.setState({
-      contextualMenuProps: this._getContextualMenuProps(column, ev)
+      contextualMenuProps: this._getContextualMenuProps(ev, column)
     });
   }
 
+  @autobind
   private _onContextualMenuDismissed() {
     this.setState({
       contextualMenuProps: null
     });
   }
 
+  @autobind
   private _onSortColumn(key: string, isSortedDescending: boolean) {
     let sortedItems = _items.slice(0).sort((a, b) => (isSortedDescending ? a[key] < b[key] : a[key] > b[key]) ? 1 : -1);
 
@@ -417,6 +417,7 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     });
   }
 
+  @autobind
   private _onGroupByColumn(column: IColumn) {
     let { key, isGrouped } = column;
     let { sortedColumnKey, isSortedDescending, groups, items, columns } = this.state;
@@ -499,12 +500,14 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     return leafKey;
   }
 
+  @autobind
   private _onAddRow() {
     this.setState({
       items: createListItems(1).concat(this.state.items)
     });
   }
 
+  @autobind
   private _onDeleteRow() {
     this.setState({
       items: this.state.items.slice(1)
@@ -514,7 +517,7 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
   private _buildColumns(
     items: any[],
     canResizeColumns?: boolean,
-    onColumnClick?: (column: IColumn, ev: React.MouseEvent) => any,
+    onColumnClick?: (ev: React.MouseEvent, column: IColumn) => any,
     sortedColumnKey?: string,
     isSortedDescending?: boolean,
     groupedColumnKey?: string) {


### PR DESCRIPTION
Updating DetailsList props and advanced example. I've only modified and tested the one single callback. This may break some scenarios downstream. 

Before:
```jsx
<DetailsList onColumnClick={ (column, ev) => console.log(column.name); } />
```

After:
```jsx
<DetailsList onColumnClick={ (ev, column) => console.log(column.name); } />
