### PR TITLE
Fix: Have callout correctly manage max-height and overflow.

### DIFF
--- a/src/components/Callout/Callout.scss
+++ b/src/components/Callout/Callout.scss
@@ -25,6 +25,8 @@ $Callout-smallbeak-slant-width: 16px;
   @include ms-baseFont;
   @include drop-shadow(0,0, 15px, -5px);
   position: absolute;
+  max-height: 100vh;
+  overflow-y: auto;
   display: inline-block;
   border: 1px solid $ms-color-neutralLight;
 
@@ -44,7 +46,6 @@ $Callout-smallbeak-slant-width: 16px;
 .ms-Callout-main {
   position: relative;
   background-color: $ms-color-white;
-  box-sizing: border-box;
 }
 
 .ms-Callout-beak {

--- a/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -81,6 +81,10 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IPosi
    * If none specified no aria label will be applied to the ContextualMenu.
    */
   ariaLabel?: string;
+  /**
+   * If true do not render on a new layer. If false render on a new layer.
+   */
+  doNotLayer?: boolean;
 
 }
 
@@ -172,7 +176,6 @@ export interface IContextualMenuItem {
    * the commands. This should only be used in special cases when react and non-react are mixed.
    */
   onMouseDown?: (item: IContextualMenuItem, event: any) => void;
-
   /**
    * Any additional properties to use when custom rendering menu items.
    */

--- a/src/components/ContextualMenu/ContextualMenu.scss
+++ b/src/components/ContextualMenu/ContextualMenu.scss
@@ -15,8 +15,6 @@ $ContextualMenu-iconWidth: 14px;
   list-style-type: none;
   margin: 0;
   padding: 0;
-  max-height: 100vh;
-  overflow-y: auto;
   line-height: 0;
 }
 

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -161,9 +161,9 @@ export class ContextualMenu extends React.Component<IContextualMenuProps, IConte
       beakWidth,
       directionalHint,
       gapSpace,
-      isSubMenu,
       coverTarget,
-      ariaLabel } = this.props;
+      ariaLabel,
+      doNotLayer } = this.props;
 
     let { submenuProps } = this.state;
 
@@ -179,8 +179,8 @@ export class ContextualMenu extends React.Component<IContextualMenuProps, IConte
         beakWidth={ beakWidth }
         directionalHint={ directionalHint }
         gapSpace={ gapSpace }
-        doNotLayer={ isSubMenu }
         coverTarget={ coverTarget }
+        doNotLayer={ doNotLayer }
         className='ms-ContextualMenu-Callout'
         setInitialFocus={ true }
         onDismiss={ this.props.onDismiss }>


### PR DESCRIPTION
This may be a breaking change as submenu's no longer appear as children of the contextualmenu.