### PR TITLE
Panel: Place close button on the left for RTL

### DIFF
--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -270,7 +270,7 @@ $CommandBarHeight: 40px;
 .ms-Panel-closeButton {
   @include button-reset();
   position: absolute;
-  right: 8px;
+  @include right(8px);
   top: 0;
   height: $CommandBarHeight;
   width: $CommandBarHeight;


### PR DESCRIPTION
Uses the mixin to place the close button on the left side of Panel when viewed in RTL.