### PR TITLE
let users set focus to the Link.

### DIFF
--- a/src/components/Link/Link.Props.ts
+++ b/src/components/Link/Link.Props.ts
@@ -2,6 +2,11 @@
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 
+export interface ILink {
+  /** Sets focus to the link. */
+  focus(): void;
+}
+
 export interface ILinkProps extends React.HTMLProps<HTMLAnchorElement | HTMLButtonElement> {
   /**
    * Whether the link is disabled

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { BaseComponent } from '../../common/BaseComponent';
 import {
   anchorProperties,
   autobind,
@@ -6,7 +7,7 @@ import {
   css,
   getNativeProps
 } from '../../Utilities';
-import { ILinkProps } from './Link.Props';
+import { ILink, ILinkProps } from './Link.Props';
 import './Link.scss';
 
 interface IMyScreen extends Screen {
@@ -16,7 +17,8 @@ interface IMyScreen extends Screen {
 
 declare var screen: IMyScreen;
 
-export class Link extends React.Component<ILinkProps, any> {
+export class Link extends BaseComponent<ILinkProps, any> implements ILink {
+  private _link: HTMLElement;
 
   public render() {
     let { disabled, children, className, href } = this.props;
@@ -29,7 +31,9 @@ export class Link extends React.Component<ILinkProps, any> {
           className={ css('ms-Link', className, {
             'is-disabled': disabled
           }) }
-          onClick={ this._onClick }>
+          onClick={ this._onClick }
+          ref={ this._resolveRef('_link') }
+        >
           { children }
         </a>
       ) : (
@@ -39,10 +43,18 @@ export class Link extends React.Component<ILinkProps, any> {
             className={ css('ms-Link', className, {
               'is-disabled': disabled
             }) }
-            onClick={ this._onClick } >
+            onClick={ this._onClick }
+            ref={ this._resolveRef('_link') }
+          >
             { children }
           </button>
         ));
+  }
+
+  public focus() {
+    if (this._link) {
+      this._link.focus();
+    }
   }
 
   @autobind


### PR DESCRIPTION
When developing Link Preview web part, we need to set the focus to the link, so we'd like to add focus method to the Link control.