### PR TITLE
Panels should lock focus

### DIFF
--- a/src/components/Panel/Panel.Props.ts
+++ b/src/components/Panel/Panel.Props.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Panel } from './Panel';
+import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
 
-export interface IPanelProps extends React.Props<Panel> {
+export interface IPanelProps extends React.Props<Panel>, IAccessiblePopupProps {
   /**
   * Whether the panel is displayed.
   * @default false

--- a/src/components/Panel/Panel.Props.ts
+++ b/src/components/Panel/Panel.Props.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Panel } from './Panel';
-import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
 
-export interface IPanelProps extends React.Props<Panel>, IAccessiblePopupProps {
+export interface IPanelProps extends React.Props<Panel> {
   /**
   * Whether the panel is displayed.
   * @default false
@@ -52,6 +51,29 @@ export interface IPanelProps extends React.Props<Panel>, IAccessiblePopupProps {
    * Optional parameter to provider the class name for header text
    */
   headerClassName?: string;
+
+  /**
+   * Sets the HTMLElement to focus on when exiting the FocusTrapZone.
+   * @default The element.target that triggered the Panel.
+   */
+  elementToFocusOnDismiss?: HTMLElement;
+
+  /**
+   * Indicates if this Panel will ignore keeping track of HTMLElement that activated the Zone.
+   * @default false
+   */
+  ignoreExternalFocusing?: boolean;
+
+   /**
+   * Indicates whether Panel should force focus inside the focus trap zone
+   * @default true
+   */
+  forceFocusInsideTrap?: boolean;
+
+   /**
+   * Indicates the selector for first focusable item
+   */
+  firstFocusableSelector?: string;
 }
 
 export enum PanelType {

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 
 import { BaseComponent } from '../../common/BaseComponent';
+import { FocusTrapZone } from '../FocusTrapZone/index';
 import { IPanelProps, PanelType } from './Panel.Props';
 import { Layer } from '../Layer/Layer';
 import { Overlay } from '../../Overlay';
@@ -62,7 +63,20 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
   }
 
   public render() {
-    let { children, className = '', type, hasCloseButton, isLightDismiss, headerText, closeButtonAriaLabel, headerClassName = ''  } = this.props;
+    let {
+      children,
+      className = '',
+      type,
+      hasCloseButton,
+      isLightDismiss,
+      headerText,
+      closeButtonAriaLabel,
+      headerClassName = '',
+      elementToFocusOnDismiss,
+      ignoreExternalFocusing,
+      forceFocusInsideTrap,
+      firstFocusableSelector
+    } = this.props;
     let { isOpen, isAnimatingOpen, isAnimatingClose, id } = this.state;
     let isLeft = type === PanelType.smallFixedNear ? true : false;
     let isRTL = getRTL();
@@ -70,6 +84,10 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
     const headerTextId = id + '-headerText';
 
     let pendingCommandBarContent = '';
+
+    if (!isOpen) {
+      return null;
+    }
 
     let header;
     if (headerText) {
@@ -112,7 +130,14 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
               isDarkThemed={ false }
               onClick={ isLightDismiss ? this._onPanelClick : null }
               />
-            <div className='ms-Panel-main'>
+            <FocusTrapZone
+              className='ms-Panel-main'
+              elementToFocusOnDismiss={ elementToFocusOnDismiss }
+              isClickableOutsideFocusTrap = { isLightDismiss }
+              ignoreExternalFocusing={ ignoreExternalFocusing }
+              forceFocusInsideTrap={ forceFocusInsideTrap }
+              firstFocusableSelector={ firstFocusableSelector }
+            >
               <div className='ms-Panel-commands' data-is-visible={ true } >
                 { pendingCommandBarContent }
                 { closeButton }
@@ -123,7 +148,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
                   { children }
                 </div>
               </div>
-            </div>
+            </FocusTrapZone>
           </div>
         </Popup>
       </Layer>


### PR DESCRIPTION
Panels are always modal UI like dialogs with an overlay and should trap keyboard focus.