### PR TITLE
Preventing circular dependency between references of Tooltip component

### DIFF
--- a/src/components/Tooltip/TooltipHost.tsx
+++ b/src/components/Tooltip/TooltipHost.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { BaseComponent } from '../../common/BaseComponent';
 import { ITooltipHostProps } from './TooltipHost.Props';
 import { autobind } from '../../utilities/autobind';
-import { Tooltip } from './index';
+import { Tooltip } from './Tooltip';
 
 export class TooltipHost extends BaseComponent<ITooltipHostProps, any> {
 


### PR DESCRIPTION
Problematic references: 
components/Tooltip/index => components/Tooltip/TooltipHost => components/Tooltip/index