### PR TITLE
Fix focuszone throw exception when input element type is checkbox

### DIFF
--- a/src/components/FocusZone/FocusZone.tsx
+++ b/src/components/FocusZone/FocusZone.tsx
@@ -74,7 +74,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
       parentElement &&
       parentElement !== document.body &&
       parentElement.nodeType === 1
-      ) {
+    ) {
       if (isElementFocusZone(parentElement)) {
         this._isInnerZone = true;
         break;
@@ -605,7 +605,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   }
 
   private _shouldInputLoseFocus(element: HTMLInputElement, isForward?: boolean) {
-    if (element) {
+    if (element && element.hasAttribute('selectionStart')) {
       let selectionStart = element.selectionStart;
       let selectionEnd = element.selectionEnd;
       // This means that the input has text selected and we shouldn't lose focus.
@@ -623,7 +623,8 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         }
       }
     }
-    return false;
+
+    return true;
   }
 
 }

--- a/src/components/FocusZone/FocusZone.tsx
+++ b/src/components/FocusZone/FocusZone.tsx
@@ -608,19 +608,17 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
     if (element && element.hasAttribute('selectionStart')) {
       let selectionStart = element.selectionStart;
       let selectionEnd = element.selectionEnd;
-      // This means that the input has text selected and we shouldn't lose focus.
-      if (selectionStart !== selectionEnd) {
-        return false;
-      } else {
-        let inputValue = element.value;
+      let isRangeSelected = selectionStart !== selectionEnd;
+      let inputValue = element.value;
 
-        if (selectionStart === 0 && !isForward) {
-          return true;
-        } else if (selectionStart === inputValue.length && isForward) {
-          return true;
-        } else {
-          return false;
-        }
+      // We shouldn't lose focus in the following cases:
+      // 1. There is range selected.
+      // 2. When selection start is larger than 0 and it is backward.
+      // 3. when selection start is not the end of lenght and it is forward.
+      if (isRangeSelected ||
+        (selectionStart > 0 && !isForward) ||
+        (selectionStart !== inputValue.length && isForward)) {
+        return false;
       }
     }
 


### PR DESCRIPTION
Fix focuszone throw exception when input element type is checkbox, which doesn't have attribute selectionStart.
