### PR TITLE
SearchBox: Fixing the clear button accessibility.

### DIFF
--- a/src/components/SearchBox/SearchBox.Props.ts
+++ b/src/components/SearchBox/SearchBox.Props.ts
@@ -15,6 +15,11 @@ export interface ISearchBoxProps extends React.Props<SearchBox> {
   onChange?: (newValue: any) => void;
 
   /**
+   * Callback executed when the user presses enter in the search box.
+   */
+  onSearch?: (newValue: any) => void;
+
+  /**
    * @deprecated
    * Deprecated at v0.52.2, to be removed at >= v1.0.0. Use 'onChange' instead.
    */

--- a/src/components/SearchBox/SearchBox.scss
+++ b/src/components/SearchBox/SearchBox.scss
@@ -17,8 +17,16 @@ $SearchBox-height: 36px;
   color: $ms-color-neutralPrimary;
   position: relative;
   margin-bottom: 10px;
-  display: inline-block;
-  width: 100%;
+
+  &.is-active {
+    .ms-SearchBox-field {
+      @include padding-left(8px);
+    }
+
+    .ms-SearchBox-icon {
+      display: none;
+    }
+  }
 
   // State: Disabled searchbox
   &.is-disabled {
@@ -26,6 +34,7 @@ $SearchBox-height: 36px;
     .ms-SearchBox-icon {
       color: $ms-color-neutralTertiaryAlt;
     }
+
     .ms-SearchBox-field {
       background-color: $ms-color-neutralLighter;
       border-color: $ms-color-neutralLighter;
@@ -35,21 +44,8 @@ $SearchBox-height: 36px;
   }
 
   // State: Active searchbox
-  &.is-active {
-
-    .ms-SearchBox-closeButton {
-      display: block;
-      outline: transparent 1px solid;
-      padding: 0px;
-
-      .ms-Icon--Clear {
-        line-height: $SearchBox-height;
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%,-50%);
-      }
-    }
+  &.can-clear .ms-SearchBox-clearButton {
+    display: block;
   }
 
   &:hover {
@@ -68,20 +64,20 @@ $SearchBox-height: 36px;
   }
 }
 
-.ms-SearchBox-field {
+input.ms-SearchBox-field {
   position: relative;
   @include ms-u-normalize;
   border: 1px solid $ms-color-themeTertiary;
   outline: transparent 1px solid;
   border-radius: 0;
-  font-weight: $ms-font-weight-semilight;
-  font-size: $ms-font-size-m;
+  font-weight: inherit;
+  font-family: inherit;
+  font-size: inherit;
   color: $ms-color-black;
   height: $SearchBox-height;
-  @include padding(6px, 3px, 7px, $SearchBox-field-padding-left);
+  @include padding(6px, 38px, 7px, 31px);
   width: 100%;
   background-color: transparent;
-  z-index: $ms-zIndex-middle;
   transition: padding-left $ms-duration1;
 
   &:focus {
@@ -94,43 +90,37 @@ $SearchBox-height: 36px;
   }
 }
 
-.ms-SearchBox-closeButton {
+.ms-SearchBox-clearButton {
+  display: none;
   border: none;
   cursor: pointer;
   position: absolute;
   top: 0;
-  height: $SearchBox-height;
-  width: 40px;
-  background-color: $ms-color-themePrimary;
-  text-align: center;
-  display: none;
-  font-size: 16px;
-  color: $ms-color-white;
-  z-index: $ms-zIndex-front;
   @include right(0);
-  @include left(auto);
-}
 
-.ms-SearchBox-label {
-  position: absolute;
-  top: 0;
-  line-height: $SearchBox-height;
+  width: 40px;
   height: $SearchBox-height;
-  color: $ms-color-neutralSecondary;
-  z-index: 10;
-  @include padding-left(12px);
-  @include left(0);
+  line-height: $SearchBox-height;
+
+  vertical-align: top;
+
+  color: $ms-color-themePrimary;
+
+  text-align: center;
+  font-size: 16px;
 }
 
 .ms-SearchBox-icon {
   font-size: $ms-font-size-l;
   color: $ms-color-neutralSecondaryAlt;
-  position: relative;
-  top: 50%;
-  transform: translateY(-50%);
+  position: absolute;
+  @include left(8px);
+  top: 0;
+  height: $SearchBox-height;
+  line-height: $SearchBox-height;
+  vertical-align: top;
   font-size: 16px;
   width: 16px;
   color: #0078d7;
-  vertical-align: top;
   @include margin-right(6px);
 }

--- a/src/components/SearchBox/SearchBox.scss
+++ b/src/components/SearchBox/SearchBox.scss
@@ -17,8 +17,11 @@ $SearchBox-height: 36px;
   color: $ms-color-neutralPrimary;
   position: relative;
   margin-bottom: 10px;
+  border: 1px solid $ms-color-themeTertiary;
 
   &.is-active {
+    border-color: $ms-color-themeDarker;
+
     .ms-SearchBox-field {
       @include padding-left(8px);
     }
@@ -30,6 +33,7 @@ $SearchBox-height: 36px;
 
   // State: Disabled searchbox
   &.is-disabled {
+    border-color: $ms-color-neutralLighter;
 
     .ms-SearchBox-icon {
       color: $ms-color-neutralTertiaryAlt;
@@ -37,7 +41,6 @@ $SearchBox-height: 36px;
 
     .ms-SearchBox-field {
       background-color: $ms-color-neutralLighter;
-      border-color: $ms-color-neutralLighter;
       pointer-events: none;
       cursor: default;
     }
@@ -67,14 +70,14 @@ $SearchBox-height: 36px;
 input.ms-SearchBox-field {
   position: relative;
   @include ms-u-normalize;
-  border: 1px solid $ms-color-themeTertiary;
+  border: none;
   outline: transparent 1px solid;
-  border-radius: 0;
   font-weight: inherit;
   font-family: inherit;
   font-size: inherit;
   color: $ms-color-black;
-  height: $SearchBox-height;
+  height: $SearchBox-height - 2;
+  line-height: $SearchBox-height - 2;
   @include padding(6px, 38px, 7px, 31px);
   width: 100%;
   background-color: transparent;
@@ -82,7 +85,6 @@ input.ms-SearchBox-field {
 
   &:focus {
     @include padding-right(32px);
-    border-color: $ms-color-themeDarker;
   }
 
   &::-ms-clear {

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -118,7 +118,6 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
     }
   }
 
-
   private _callOnChange(newValue: string): void {
     let { onChange } = this.props;
 

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -6,7 +6,8 @@ import {
   css,
   getId,
   elementContains,
-  getDocument
+  getDocument,
+  KeyCodes
 } from '../../Utilities';
 import './SearchBox.scss';
 
@@ -33,7 +34,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
     }
 
     this.state = {
-      value: props.value,
+      value: props.value || '',
       hasFocus: false,
       id: getId('SearchBox')
     };
@@ -55,23 +56,23 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
       <div
         ref={ this._resolveRef('_rootElement') }
         className={ css('ms-SearchBox', className, {
-          'is-active': hasFocus
+          'is-active': hasFocus,
+          'can-clear': value.length > 0
         }) }
         { ...{ onFocusCapture: this._onFocusCapture } }
         >
-        { !hasFocus && !value ? <label className='ms-SearchBox-label' htmlFor={ id }>
-          <i className='ms-SearchBox-icon ms-Icon ms-Icon--Search'></i>
-          <span className='ms-SearchBox-text'>{ labelText }</span>
-        </label> : null }
+        <i className='ms-SearchBox-icon ms-Icon ms-Icon--Search'></i>
         <input
           id={ id }
           className='ms-SearchBox-field'
+          placeholder={ labelText }
           onChange={ this._onInputChange }
+          onKeyDown={ this._onKeyDown }
           value={ value }
           ref={ this._resolveRef('_inputElement') }
           />
         <div
-          className='ms-SearchBox-closeButton'
+          className='ms-SearchBox-clearButton'
           onClick={ this._onClearClick }
           >
           <i className='ms-Icon ms-Icon--Clear' />
@@ -99,6 +100,29 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
     });
 
     this._events.on(getDocument().body, 'focus', this._handleDocumentFocus, true);
+  }
+
+  @autobind
+  private _onKeyDown(ev: React.KeyboardEvent<HTMLInputElement>) {
+    switch (ev.which) {
+
+      case KeyCodes.escape:
+        this._onClearClick(ev);
+        break;
+
+      case KeyCodes.enter:
+        if (this.props.onSearch && this.state.value.length > 0) {
+          this.props.onSearch(this.state.value);
+        }
+        break;
+
+      default:
+        return;
+    }
+
+    // We only get here if the keypress has been handled.
+    ev.preventDefault();
+    ev.stopPropagation();
   }
 
   @autobind

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -109,7 +109,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
 
   private _handleDocumentFocus(ev: FocusEvent) {
     if (!elementContains(this._rootElement, ev.target as HTMLElement)) {
-      this._events.off();
+      this._events.off(getDocument().body, 'focus');
       this.setState({
         hasFocus: false
       });

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -70,12 +70,12 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
           value={ value }
           ref={ this._resolveRef('_inputElement') }
           />
-        <button
+        <div
           className='ms-SearchBox-closeButton'
           onClick={ this._onClearClick }
           >
           <i className='ms-Icon ms-Icon--Clear' />
-        </button>
+        </div>
       </div>
     );
   }
@@ -88,6 +88,8 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
     this._callOnChange('');
     ev.stopPropagation();
     ev.preventDefault();
+
+    this._inputElement.focus();
   }
 
   @autobind

--- a/src/demo/pages/SearchBoxPage/examples/SearchBox.Small.Example.tsx
+++ b/src/demo/pages/SearchBoxPage/examples/SearchBox.Small.Example.tsx
@@ -8,11 +8,10 @@ export class SearchBoxSmallExample extends React.Component<any, any> {
   public render() {
     return (
       <div className='ms-SearchBoxSmallExample'>
-        <SearchBox onChange={
-          (newValue) => {
-            console.log('Search box value changed to: ' + newValue);
-          }
-        } />
+        <SearchBox
+          onChange={ (newValue) => console.log('SearchBox onChange fired: ' + newValue) }
+          onSearch={ (newValue) => console.log('SearchBox onSearch fired: ' + newValue) }
+          />
       </div>
     );
   }


### PR DESCRIPTION
Addresses https://github.com/OfficeDev/office-ui-fabric-react/issues/518

The event on the button was using onMouseDown. It should use onClick. Otherwise, onClick fires and is never canceled, which causes forms to submit the action.

Additionally you were not able to tab to the clear button. Now you can without having it disappear.