### PR TITLE
Update to Fabric Core 5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ We're excited to share our development of this project with folks outside of the
 
 All files on the Office UI Fabric React GitHub repository are subject to the MIT license. Please read the License file at the root of the project.
 
-Usage of the fonts referenced in Office UI Fabric files is subject to the [license](http://appsforoffice.microsoft.com/fabric/Segoe_UI_and_Fabric_CDN_License.txt).
+Usage of the fonts referenced in Office UI Fabric files is subject to the [license](https://spoprod-a.akamaihd.net/files/fabric/assets/license.txt).
 
 
 ## Changelog

--- a/examples/todo-app/index.html
+++ b/examples/todo-app/index.html
@@ -7,7 +7,6 @@
 
     <title>Test Page</title>
 
-    <link rel="stylesheet" type="text/css" href="https://appsforoffice.microsoft.com/fabric/2.2.0/fabric.min.css">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/15.2.0/react.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/15.2.0/react-dom.min.js"></script>
   </head>
@@ -15,3 +14,4 @@
     <script type="text/javascript" src="dist/fabric-react-example.js"></script>
   </body>
 </html>
+  <link rel="stylesheet" type="text/css" href="https://spoprod-a.akamaihd.net/files/fabric/office-ui-fabric-core/2.2.0/css/fabric.min.css">

--- a/examples/todo-app/index.html
+++ b/examples/todo-app/index.html
@@ -7,6 +7,7 @@
 
     <title>Test Page</title>
 
+    <link rel="stylesheet" type="text/css" href="https://spoprod-a.akamaihd.net/files/fabric/office-ui-fabric-core/2.2.0/css/fabric.min.css">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/15.2.0/react.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/react/15.2.0/react-dom.min.js"></script>
   </head>
@@ -14,4 +15,3 @@
     <script type="text/javascript" src="dist/fabric-react-example.js"></script>
   </body>
 </html>
-  <link rel="stylesheet" type="text/css" href="https://spoprod-a.akamaihd.net/files/fabric/office-ui-fabric-core/2.2.0/css/fabric.min.css">

--- a/ghdocs/README.md
+++ b/ghdocs/README.md
@@ -124,7 +124,7 @@ You can specify the default direction in your `index.html`. Add the `dir` attrib
 Load Office UI Fabric styles by linking to the Office UI Fabric CDN. Add the following to the `<head`> element:
 
 ```html
-<link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/2.2.0/fabric.min.css">
+<link rel="stylesheet" href="https://spoprod-a.akamaihd.net/files/fabric/office-ui-fabric-core/2.2.0/css/fabric.min.css">
 ```
 
 Save the file.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-util": "3.0.7",
     "gutil": "1.6.4",
     "highlight.js": "9.6.0",
-    "office-ui-fabric-core": "^4.0.0",
+    "office-ui-fabric-core": "^5.0.1",
     "react-addons-test-utils": "^15.1.0",
     "react-highlight": "0.8.0",
     "source-map-loader": "0.1.5",


### PR DESCRIPTION
This PR updates the dependency on Fabric Core to [version 5.0.1](https://github.com/OfficeDev/office-ui-fabric-core/releases/tag/5.0.1). It also updates the README and todo example to point to the new CDN location.

There was a breaking change in [Fabric Core 5.0.0](https://github.com/OfficeDev/office-ui-fabric-core/releases/tag/5.0.0), but this did not affect Fabric React as we're not yet using any of the responsive mixins.