### PR TITLE
Dialog: Animate when opening and closing

### DIFF
--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -59,8 +59,13 @@ $Dialog-default-max-width: 340px;
 }
 
 // State: The dialog is animating open
-.ms-Dialog.ms-Dialog-animateIn {
-  @include ms-u-fadeIn100;
+.ms-Dialog.is-animatingOpen {
+  @include ms-u-fadeIn200;
+}
+
+// State: The dialog is animating closed
+.ms-Dialog.is-animatingClose {
+  @include ms-u-fadeOut200;
 }
 
 // The actual dialog element

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -25,18 +25,7 @@ $Dialog-default-max-width: 340px;
   width:  100%;
   top:  0;
   @include left(0);
-
-  // Fallback for IE9
-  display: block;
-  line-height: 100vh;
-  text-align: center;
-
-  &::before {
-    @include dialogPositioningIE9Fallback();
-    content: "";
-    height: 100%;
-    width: 0;
-  }
+  display: none; // Hidden by default
 
   .ms-Button.ms-Button--compound {
     display: block;
@@ -48,6 +37,30 @@ $Dialog-default-max-width: 340px;
       opacity: 0;
     }
   }
+}
+
+// State: The dialog is open
+.ms-Dialog.is-open {
+  display: block;
+}
+
+// Fallback for IE9 when dialog is open
+.ms-Dialog.is-open {
+  display: block;
+  line-height: 100vh;
+  text-align: center;
+
+  &::before {
+    @include dialogPositioningIE9Fallback();
+    content: "";
+    height: 100%;
+    width: 0;
+  }
+}
+
+// State: The dialog is animating open
+.ms-Dialog.ms-Dialog-animateIn {
+  @include ms-u-fadeIn100;
 }
 
 // The actual dialog element

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -9,13 +9,19 @@ import { css } from '../../utilities/css';
 import { Popup } from '../Popup/index';
 import { withResponsiveMode, ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 import { getId } from '../../utilities/object';
+import { BaseComponent } from '../../common/BaseComponent';
 import './Dialog.scss';
 
-// @TODO - need to add animations, pending Fabric Team + Coulton work
 // @TODO - need to change this to a panel whenever the breakpoint is under medium (verify the spec)
 
+export interface IDialogState {
+  isOpen?: boolean;
+  isAnimatingOpen?: boolean;
+  id?: string;
+}
+
 @withResponsiveMode
-export class Dialog extends React.Component<IDialogProps, any> {
+export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
 
   public static defaultProps: IDialogProps = {
     isOpen: false,
@@ -32,12 +38,32 @@ export class Dialog extends React.Component<IDialogProps, any> {
 
     this.state = {
       id: getId('Dialog'),
+      isAnimatingOpen: props.isOpen
     };
   }
 
+  public componentDidMount() {
+    if (this.state.isOpen) {
+      this._async.setTimeout(() => {
+        this.setState({
+          isAnimatingOpen: false
+        });
+      }, 2000);
+    }
+  }
+
+  public componentWillReceiveProps(newProps: IDialogProps) {
+    if (newProps.isOpen !== this.state.isOpen) {
+      this.setState({
+        isOpen: newProps.isOpen,
+        isAnimatingOpen: newProps.isOpen ? true : false
+      });
+    }
+  }
+
   public render() {
-    let { isOpen, type, isDarkOverlay, onDismiss, title, subText, isBlocking, responsiveMode, elementToFocusOnDismiss, ignoreExternalFocusing, forceFocusInsideTrap, firstFocusableSelector, closeButtonAriaLabel, onLayerMounted, isClickableOutsideFocusTrap} = this.props;
-    let { id } = this.state;
+    let { type, isDarkOverlay, onDismiss, title, subText, isBlocking, responsiveMode, elementToFocusOnDismiss, ignoreExternalFocusing, forceFocusInsideTrap, firstFocusableSelector, closeButtonAriaLabel, onLayerMounted, isClickableOutsideFocusTrap} = this.props;
+    let { id, isOpen, isAnimatingOpen } = this.state;
     // @TODO - the discussion on whether the Dialog contain a property for rendering itself is still being discussed
     if (!isOpen) {
       return null;
@@ -46,7 +72,9 @@ export class Dialog extends React.Component<IDialogProps, any> {
     let subTextContent;
     const dialogClassName = css('ms-Dialog', this.props.className, {
       'ms-Dialog--lgHeader': type === DialogType.largeHeader,
-      'ms-Dialog--close': type === DialogType.close
+      'ms-Dialog--close': type === DialogType.close,
+      'is-open': isOpen,
+      'ms-Dialog-animateIn': isAnimatingOpen
     });
     let groupings = this._groupChildren();
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -46,16 +46,6 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
     };
   }
 
-  public componentDidMount() {
-    if (this.state.isOpen) {
-      this._async.setTimeout(() => {
-        this.setState({
-          isAnimatingOpen: false
-        });
-      }, 2000);
-    }
-  }
-
   public componentWillReceiveProps(newProps: IDialogProps) {
     // Opening the dialog
     if (newProps.isOpen && !this.state.isOpen) {
@@ -177,19 +167,23 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
 
   // Watch for completed animations and set the state
   private _onAnimationEnd(ev: AnimationEvent) {
+
+    // The dialog has just opened (faded in)
     if (ev.animationName.indexOf('fadeIn') > -1) {
       this.setState({
         isOpen: true,
         isAnimatingOpen: false
       });
     }
+
+    // The dialog has just closed (faded out)
     if (ev.animationName.indexOf('fadeOut') > -1) {
       this.setState({
         isOpen: false,
         isAnimatingClose: false
       });
 
-      // Dialog has closed, call the onDismiss callback
+      // Call the onDismiss callback
       if (this.props.onDismiss) {
         this.props.onDismiss();
       }


### PR DESCRIPTION
Fixes #86

This PR adds a fade in animation when the Dialog is opened, and a fadeOut animation when it's closed.

![animatedialog](https://cloud.githubusercontent.com/assets/1382445/20198259/853ec606-a758-11e6-805a-49d30c98cc57.gif)
