### PR TITLE
Correcting references which are causing problems for AMD

### DIFF
--- a/src/components/GroupedList/GroupHeader.tsx
+++ b/src/components/GroupedList/GroupHeader.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import {
-  IGroupDividerProps
-} from './index';
+import { IGroupDividerProps } from './GroupedList.Props';
 import { SelectionMode } from '../../utilities/selection/index';
 import { Check } from '../Check/Check';
 import { GroupSpacer } from './GroupSpacer';

--- a/src/components/Tooltip/TooltipHost.Props.ts
+++ b/src/components/Tooltip/TooltipHost.Props.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TooltipHost } from './TooltipHost';
-import { ITooltipProps, TooltipDelay } from '../../index';
+import { ITooltipProps, TooltipDelay } from './Tooltip.Props';
 import { DirectionalHint } from '../../common/DirectionalHint';
 
 /**

--- a/src/components/Tooltip/TooltipHost.tsx
+++ b/src/components/Tooltip/TooltipHost.tsx
@@ -5,7 +5,8 @@ import { BaseComponent } from '../../common/BaseComponent';
 import { ITooltipHostProps } from './TooltipHost.Props';
 import { getNativeProps, divProperties } from '../../utilities/properties';
 import { autobind } from '../../utilities/autobind';
-import { Tooltip, TooltipDelay } from './index';
+import { Tooltip } from './Tooltip';
+import { TooltipDelay } from './Tooltip.Props';
 
 export class TooltipHost extends BaseComponent<ITooltipHostProps, any> {
 


### PR DESCRIPTION
Is there any way we can prevent these types of issues? We are using office-ui-fabric-react through AMD and it's becoming harder to update to newer versions.