### PR TITLE
DocumentCard: Fix for zero views scenario

### DIFF
--- a/src/components/DocumentCard/DocumentCardActions.tsx
+++ b/src/components/DocumentCard/DocumentCardActions.tsx
@@ -19,7 +19,7 @@ export class DocumentCardActions extends React.Component<IDocumentCardActionsPro
           );
         }) }
 
-        { views && (
+        { views > 0 && (
         <div className='ms-DocumentCardActions-views'>
           <i className='ms-Icon ms-Icon--View' />
           { views }


### PR DESCRIPTION
When using the views property, 0 is a real scenario. Since 0 is evaluated as false it renders in a layout bug like this
![zerodocs](https://cloud.githubusercontent.com/assets/8503139/20319895/21bb4160-ab70-11e6-9a5b-e5993bb9a9b2.PNG)

You can debate how to solve this, but I chose to go with how Delve looks to have solved it - by not displaying it at all when there are 0 views. This is how it looks after the fix when setting views to 0:
![zerodocs-fixed](https://cloud.githubusercontent.com/assets/8503139/20319938/5515ac12-ab70-11e6-872e-d1ee241b0a54.PNG)

