### PR TITLE
Removes zindex from details header resizing.

### DIFF
--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -88,7 +88,6 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
     bottom: 0;
     top: 0;
     height: inherit;
-    z-index: 99;
     background: transparent;
   }
 


### PR DESCRIPTION
This also has a side-effect which is that you can't resize in the middle of a row any more.

That may be acceptable since it's parity with explorer.

Removing zindex AND preserving the in-row resizing would be a much trickier fix. I'm not quite sure how to do it, other than to render the resizers at the bottom of the list after the content so that it overlays it.
