### PR TITLE
Making contextual menu icon color optional

### DIFF
--- a/common/changes/master_2016-11-21-07-49.json
+++ b/common/changes/master_2016-11-21-07-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding None value to IconName to support custom icons",
+      "type": "minor"
+    }
+  ],
+  "email": "serkani@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.scss
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.scss
@@ -90,7 +90,6 @@ a.ms-ContextualMenu-link {
 }
 
 .ms-ContextualMenu-icon {
-  color: $ms-color-themePrimary;
   display: inline-block;
   min-height: 1px;
   max-height: $ContextualMenu-itemHeight;
@@ -98,6 +97,10 @@ a.ms-ContextualMenu-link {
   text-align: center;
   vertical-align: top;
   margin: 0px 4px;
+}
+
+.ms-ContextualMenu-iconColor {
+  color: $ms-color-themePrimary;
 }
 
 .ms-ContextualMenu-itemText {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -14,7 +14,11 @@ import {
 } from '../../utilities/properties';
 import { Callout } from '../../Callout';
 import { BaseComponent } from '../../common/BaseComponent';
-import { Icon, IconName } from '../../Icon';
+import {
+  Icon,
+  IconName,
+  IIconProps
+} from '../../Icon';
 import './ContextualMenu.scss';
 
 export interface IContextualMenuState {
@@ -238,10 +242,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   }
 
   private _renderAnchorMenuItem(item: IContextualMenuItem, index: number, hasCheckmarks: boolean, hasIcons: boolean): JSX.Element {
-    // Only present to allow continued use of item.icon which is deprecated.
-    let iconProps = item.iconProps ? item.iconProps : {
-      iconName: IconName[item.icon]
-    };
     return (
       <div>
         <a
@@ -251,9 +251,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
           role='menuitem'
           onClick={ this._onAnchorClick.bind(this, item) }>
           { (hasIcons) ? (
-            <Icon { ...iconProps } className={ 'ms-ContextualMenu-icon' } />)
-            : null
-          }
+            this._renderIcon(item)
+          ) : (null) }
           <span className='ms-ContextualMenu-linkText ms-fontWeight-regular'> { item.name } </span>
         </a>
       </div >);
@@ -297,10 +296,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderMenuItemChildren(item: IContextualMenuItem, index: number, hasCheckmarks: boolean, hasIcons: boolean) {
     let isItemChecked: boolean = item.isChecked || item.checked;
-    // Only present to allow continued use of item.icon which is deprecated.
-    let iconProps = item.iconProps ? item.iconProps : {
-      iconName: IconName[item.icon]
-    };
     return (
       <div className='ms-ContextualMenu-linkContent'>
         { (hasCheckmarks) ? (
@@ -310,7 +305,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
             onClick={ this._onItemClick.bind(this, item) } />
         ) : (null) }
         { (hasIcons) ? (
-          <Icon { ...iconProps } className={ 'ms-ContextualMenu-icon' } />
+          this._renderIcon(item)
         ) : (null) }
         <span className='ms-ContextualMenu-itemText ms-fontWeight-regular'>{ item.name }</span>
         { (item.items && item.items.length) ? (
@@ -318,6 +313,18 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         ) : (null) }
       </div>
     );
+  }
+
+  private _renderIcon(item: IContextualMenuItem) {
+    // Only present to allow continued use of item.icon which is deprecated.
+    let iconProps: IIconProps = item.iconProps ? item.iconProps : {
+      iconName: IconName[item.icon]
+    };
+    // Use the default icon color for the known icon names
+    let iconColorClassName = iconProps.iconName === IconName.None ? '' : 'ms-ContextualMenu-iconColor';
+    let iconClassName = css('ms-ContextualMenu-icon', iconColorClassName, iconProps.className);
+
+    return <Icon { ...iconProps } className={ iconClassName } />;
   }
 
   @autobind

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -10,7 +10,8 @@ import {
 } from '../../Utilities';
 
 export const Icon: (props: IIconProps) => JSX.Element = (props: IIconProps) => {
-  let iconName = IconName[props.iconName];
+  let customIcon = props.iconName === IconName.None;
+  let className = css('ms-Icon', customIcon ? '' : ('ms-Icon--' + IconName[props.iconName]), props.className);
 
-  return <i { ...getNativeProps(props, htmlElementProperties) } className={ css('ms-Icon', 'ms-Icon--' + iconName, props.className) } />;
+  return <i { ...getNativeProps(props, htmlElementProperties) } className={ className } />;
 };

--- a/packages/office-ui-fabric-react/src/components/Icon/IconName.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/IconName.ts
@@ -103,6 +103,7 @@ export enum IconName {
   Mute,
   new,
   NewFolder,
+  None,
   OfficeLogo,
   OfficeVideoLogo,
   OneDrive,

--- a/packages/office-ui-fabric-react/src/demo/app.tsx
+++ b/packages/office-ui-fabric-react/src/demo/app.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 import * as ReactDOM from 'react-dom';
-import { App }from './components/App/App';
+import { App } from './components/App/App';
 import { AppState } from './components/App/AppState';
 import { Router, Route } from '../utilities/router/index';
 import { GettingStartedPage } from './pages/GettingStartedPage/GettingStartedPage';
@@ -42,7 +42,7 @@ function _onLoad() {
 
   ReactDOM.render(
     <Fabric>
-      <Router onNewRouteLoaded = { _scrollAnchorLink }>
+      <Router onNewRouteLoaded={ _scrollAnchorLink }>
         { _getRoutes() }
       </Router>
     </Fabric>,


### PR DESCRIPTION
These changes will enable user to use their own styles for icons if they want. The main motivation was to be able to make default blue icon color optional. 

There might be some icons out of office-fabric and have their own colors defined globally. 