### PR TITLE
DetailsList: deselect selection when clicking on non-focusable entity in the ux.

### DIFF
--- a/common/changes/detailslist-deselect_2016-11-21-20-49.json
+++ b/common/changes/detailslist-deselect_2016-11-21-20-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "DetailsList: clicking on an empty area of the page should clear the selection.",
+      "packageName": "office-ui-fabric-react",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -214,6 +214,7 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
       ev.stopPropagation();
     }
 
+    // When we've moused up from selection, make sure the click doesn't get executed.
     let clickRemovalCallback = (clickEvent) => {
       this._events.off(ev.target, 'click', clickRemovalCallback);
       clickEvent.preventDefault();

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -213,6 +213,14 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
       ev.preventDefault();
       ev.stopPropagation();
     }
+
+    let clickRemovalCallback = (clickEvent) => {
+      this._events.off(ev.target, 'click', clickRemovalCallback);
+      clickEvent.preventDefault();
+      clickEvent.stopPropagation();
+    };
+
+    this._events.on(ev.target, 'click', clickRemovalCallback, true);
   }
 
   private _evaluateSelection(dragRect: IRectangle) {

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -3,8 +3,9 @@ import {
   BaseComponent,
   KeyCodes,
   autobind,
-  getParent
- } from '../../Utilities';
+  getParent,
+  getDocument
+} from '../../Utilities';
 import { SelectionLayout } from './SelectionLayout';
 import {
   ISelection,
@@ -12,6 +13,10 @@ import {
   SelectionDirection,
   SelectionMode
 } from './interfaces';
+import {
+  isElementTabbable
+} from '../../utilities/focus';
+
 
 // Selection definitions:
 //
@@ -62,6 +67,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   public componentDidMount() {
     // Track the latest modifier keys globally.
     this._events.on(window, 'keydown keyup', this._updateModifiers);
+    this._events.on(window, 'click', this._tryClearOnEmptyClick);
   }
 
   public render() {
@@ -78,7 +84,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
           onFocusCapture: this._onFocus
         } }
         >
-        {this.props.children }
+        { this.props.children }
       </div>
     );
   }
@@ -338,6 +344,12 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     this._clearAndSelectIndex(index);
   }
 
+  private _tryClearOnEmptyClick(ev: MouseEvent) {
+    if (this._isNonHandledClick(ev.target as HTMLElement)) {
+      this.props.selection.setAllSelected(false);
+    }
+  }
+
   private _clearAndSelectIndex(index: number) {
     let { selection } = this.props;
     let isAlreadySingleSelected = selection.getSelectedCount() === 1 && selection.isIndexSelected(index);
@@ -367,7 +379,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
       let indexValue = target.getAttribute(SELECTION_INDEX_ATTRIBUTE_NAME);
       let index = Number(indexValue);
 
-      if (indexValue !== null && index >= 0 && index < selection.getItems().length ) {
+      if (indexValue !== null && index >= 0 && index < selection.getItems().length) {
         break;
       }
 
@@ -385,7 +397,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     return Number(itemRoot.getAttribute(SELECTION_INDEX_ATTRIBUTE_NAME));
   }
 
-  private _hasAttribute(element: HTMLElement, attributeName: string) {
+  private _hasAttribute(element: HTMLElement, attributeName: string): boolean {
     let isToggle = false;
 
     while (!isToggle && element !== this.refs.root) {
@@ -396,8 +408,24 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     return isToggle;
   }
 
-  private _isInputElement(element: HTMLElement) {
+  private _isInputElement(element: HTMLElement): boolean {
     return element.tagName === 'INPUT' || element.tagName === 'TEXTAREA';
+  }
+
+  private _isNonHandledClick(element: HTMLElement): boolean {
+    let doc = getDocument();
+
+    if (doc && element) {
+      while (element !== doc.body) {
+        if (isElementTabbable(element)) {
+          return false;
+        }
+
+        element = getParent(element);
+      }
+    }
+
+    return true;
   }
 
 }

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -17,7 +17,6 @@ import {
   isElementTabbable
 } from '../../utilities/focus';
 
-
 // Selection definitions:
 //
 // Anchor index: the point from which a range selection starts.

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -4,7 +4,8 @@ import {
   KeyCodes,
   autobind,
   getParent,
-  getDocument
+  getDocument,
+  getWindow
 } from '../../Utilities';
 import { SelectionLayout } from './SelectionLayout';
 import {
@@ -64,9 +65,11 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   private _shouldIgnoreFocus: boolean;
 
   public componentDidMount() {
+    let win = getWindow(this.refs.root);
+
     // Track the latest modifier keys globally.
-    this._events.on(window, 'keydown keyup', this._updateModifiers);
-    this._events.on(window, 'click', this._tryClearOnEmptyClick);
+    this._events.on(win, 'keydown keyup', this._updateModifiers);
+    this._events.on(win, 'click', this._tryClearOnEmptyClick);
   }
 
   public render() {


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
 
#### Description of changes

SelectionZone: when the user clicks on a non-interactive area in the UX, clear selection.

#### Focus areas to test

DetailsList; select something. Click away. watch it deselect. Click on anything in the ux that's interactable. Does not auto-deselect.


