### PR TITLE
Fixed missing overlay switch

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -136,10 +136,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
               })
             }
             >
-            <Overlay
-              isDarkThemed={false}
-              onClick={isLightDismiss ? this._onPanelClick : null}
-              />
+            { overlay }
             <FocusTrapZone
               className='ms-Panel-main'
               elementToFocusOnDismiss={elementToFocusOnDismiss}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #0570
- [ ] Include a change request file if publishing (Run `npmx change` to generate it.)
- [ ] New feature, bugfix, or enhancement
- [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Fixed previous change that appears to have been merged wrong.

#### Focus areas to test

Check that modal overlay displays or doesn't based on isBlocking switch.


Overlay control was hard coded into the render instead of using the variable that defines how it should render.