### PR TITLE
Image: now correctly adjusts to width/height changes.

### DIFF
--- a/common/changes/image-sizing_2016-11-22-01-08.json
+++ b/common/changes/image-sizing_2016-11-22-01-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Image: now adjusts correctly with width/height changes.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -1,0 +1,68 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
+import * as ReactDOM from 'react-dom';
+import * as ReactTestUtils from 'react-addons-test-utils';
+
+let { expect } = chai;
+
+import { Image } from './Image';
+import { ImageFit } from './Image.Props';
+
+describe('Image', () => {
+
+  it('renders an image', (done) => {
+    ReactTestUtils.renderIntoDocument(
+      <Image
+        src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        onLoad={ () => {
+          done();
+        } }
+        />
+    );
+  });
+
+  it('can render a covered square image in landscape', (done) => {
+    let component = ReactTestUtils.renderIntoDocument(
+      <Image
+        src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        width={ 3 }
+        height={ 1 }
+        imageFit={ ImageFit.cover }
+        onLoad={ () => {
+          let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+          let image = renderedDOM.querySelector('.ms-Image-image');
+
+          try {
+            expect(image.className).to.contain('ms-Image-image--portrait');
+          } catch (e) { done(e); }
+
+          done();
+        } }
+        />
+    );
+  });
+
+  it('can render a covered square image in portrait', (done) => {
+    let component = ReactTestUtils.renderIntoDocument(
+      <Image
+        src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        width={ 1 }
+        height={ 3 }
+        imageFit={ ImageFit.cover }
+        onLoad={ () => {
+          let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+          let image = renderedDOM.querySelector('.ms-Image-image');
+
+          try {
+            expect(image.className).to.contain('ms-Image-image--landscape');
+          } catch (e) { done(e); }
+
+          done();
+        } }
+        />
+    );
+  });
+
+});

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -15,15 +15,15 @@ export enum CoverStyle {
 }
 
 export const CoverStyleMap = {
-  [ CoverStyle.landscape ]: 'ms-Image-image--landscape',
-  [ CoverStyle.portrait ]: 'ms-Image-image--portrait'
+  [CoverStyle.landscape]: 'ms-Image-image--landscape',
+  [CoverStyle.portrait]: 'ms-Image-image--portrait'
 };
 
 export const ImageFitMap = {
-  [ ImageFit.center ]: 'ms-Image-image--center',
-  [ ImageFit.contain ]: 'ms-Image-image--contain',
-  [ ImageFit.cover ]: 'ms-Image-image--cover',
-  [ ImageFit.none ]: 'ms-Image-image--none'
+  [ImageFit.center]: 'ms-Image-image--center',
+  [ImageFit.contain]: 'ms-Image-image--contain',
+  [ImageFit.cover]: 'ms-Image-image--cover',
+  [ImageFit.none]: 'ms-Image-image--none'
 };
 
 export enum ImageLoadState {
@@ -65,13 +65,13 @@ export class Image extends React.Component<IImageProps, IImageState> {
     }
   }
 
-  public componentWillReceiveProps(nextProps) {
+  public componentWillReceiveProps(nextProps: IImageProps) {
     if (this.state.loadState === ImageLoadState.loaded) {
-      let { nextHeight, nextWidth } = nextProps;
+      let { height: nextHeight, width: nextWidth } = nextProps;
       let { height, width } = this.props;
 
       if (height !== nextHeight || width !== nextWidth) {
-        this._computeCoverStyle();
+        this._computeCoverStyle(nextProps);
       }
     }
   }
@@ -122,7 +122,7 @@ export class Image extends React.Component<IImageProps, IImageState> {
     let { image } = this.refs;
     let isLoaded = (src && image.naturalWidth > 0 && image.naturalHeight > 0);
 
-    this._computeCoverStyle();
+    this._computeCoverStyle(this.props);
 
     if (isLoaded && loadState !== ImageLoadState.loaded && loadState !== ImageLoadState.errorLoaded) {
       this._events.off();
@@ -134,12 +134,12 @@ export class Image extends React.Component<IImageProps, IImageState> {
     return isLoaded;
   }
 
-  private _computeCoverStyle() {
-    let { imageFit } = this.props;
+  private _computeCoverStyle(props: IImageProps) {
+    let { imageFit } = props;
     if (imageFit === ImageFit.cover || imageFit === ImageFit.contain) {
       let { image } = this.refs;
       if (image) {
-        let { width, height } = this.props;
+        let { width, height } = props;
 
         let desiredRatio = (width as number) / (height as number);
         let naturalRatio = image.naturalWidth / image.naturalHeight;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #478 
- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests

#### Description of changes

Image was not respecting new width/height values. Now it does.

#### Focus areas to test

The codepen to flip width/height now works (i tested it.)


