### PR TITLE
Create gulp alias so that gulp commands can be called from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ This will run `gulp serve` from the office-ui-fabric-react package folder, which
 
 To build all packages in the repo, you can use `npm run build`.
 
+To run other Gulp commands such as clean or deploy, just prepend the command with `npm run gulp` and this will run the command from within the project context.
+
+`npm run gulp clean`
+`npm run gulp deploy`
+...
+
 ## Get started
 
 ### Tutorial

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postinstall": "npmx install && npmx link",
     "test": "npmx build",
     "start": "gulp --gulpfile packages/office-ui-fabric-react/gulpfile.js serve",
+    "gulp": "gulp --gulpfile packages/office-ui-fabric-react/gulpfile.js",
     "change": "npmx change"
   },
   "license": "MIT",


### PR DESCRIPTION
#### Pull request checklist
- [x] Documentation update

#### Description of changes

Create gulp alias so that gulp commands can be called from root.
Works with `npm run gulp deploy`, `npm run gulp clean` and others. 

#### Focus areas to test

Test various gulp command via `npm run gulp ...` to see how it handles more complex commands



