### PR TITLE
Fixing default LayerHost to render in a fixed position high z-index container.

### DIFF
--- a/common/changes/layerhost-fix_2016-11-23-20-43.json
+++ b/common/changes/layerhost-fix_2016-11-23-20-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Changing default LayerHost to render on a fixed position high zindex surface. Fixing a bug in the logic of determining if focus moves should cause Callout to dismiss (it shouldn't if the focused element is the callout target.) Removing max height from Dropdown ul/li.LayerHost: default host now renders on fixed high z-index surface.",
+      "type": "minor"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -4,11 +4,11 @@ import * as React from 'react';
 import { ICalloutProps } from './Callout.Props';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import {
-    autobind,
-    css,
-    elementContains,
-    getWindow,
-    getDocument
+  autobind,
+  css,
+  elementContains,
+  getWindow,
+  getDocument
 } from '../../Utilities';
 import { getRelativePositions, IPositionInfo, IPositionProps } from '../../utilities/positioning';
 import { IRectangle } from '../../common/IRectangle';
@@ -23,254 +23,254 @@ const OFF_SCREEN_POSITION = { top: -9999, left: 0 };
 const BORDER_WIDTH: number = 1;
 const SPACE_FROM_EDGE: number = 8;
 export interface ICalloutState {
-    positions?: any;
-    slideDirectionalClassName?: string;
-    calloutElementRect?: ClientRect;
+  positions?: any;
+  slideDirectionalClassName?: string;
+  calloutElementRect?: ClientRect;
 }
 
 export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> {
 
-    public static defaultProps = {
-        isBeakVisible: true,
-        beakWidth: 16,
-        gapSpace: 16,
-        directionalHint: DirectionalHint.bottomAutoEdge
+  public static defaultProps = {
+    isBeakVisible: true,
+    beakWidth: 16,
+    gapSpace: 16,
+    directionalHint: DirectionalHint.bottomAutoEdge
+  };
+
+  private _didSetInitialFocus: boolean;
+  private _hostElement: HTMLDivElement;
+  private _calloutElement: HTMLDivElement;
+  private _targetWindow: Window;
+  private _bounds: IRectangle;
+  private _maxHeight: number;
+  private _positionAttempts: number;
+  private _target: HTMLElement | MouseEvent;
+
+  constructor(props: ICalloutProps) {
+    super(props, { 'beakStyle': 'beakWidth' });
+
+    this._didSetInitialFocus = false;
+    this.state = {
+      positions: null,
+      slideDirectionalClassName: null,
+      calloutElementRect: null
+    };
+    this._positionAttempts = 0;
+  }
+
+  public componentDidUpdate() {
+    this._setInitialFocus();
+    this._updatePosition();
+  }
+
+  public componentWillMount() {
+    let target = this.props.targetElement ? this.props.targetElement : this.props.target;
+    this._setTargetWindowAndElement(target);
+  }
+
+  public componentWillUpdate(newProps: ICalloutProps) {
+    if (newProps.targetElement !== this.props.targetElement || newProps.target !== this.props.target) {
+      let newTarget = newProps.targetElement ? newProps.targetElement : newProps.target;
+      this._setTargetWindowAndElement(newTarget);
+    }
+  }
+  public componentDidMount() {
+    this._onComponentDidMount();
+  }
+
+  public render() {
+    // If there is no target window then we are likely in server side rendering and we should not render anything.
+    if (!this._targetWindow) {
+      return null;
+    }
+    let {
+      className,
+      target,
+      targetElement,
+      isBeakVisible,
+      beakStyle,
+      children,
+      beakWidth } = this.props;
+    let { positions, slideDirectionalClassName } = this.state;
+    let beakStyleWidth = beakWidth;
+
+    // This is here to support the old way of setting the beak size until version 1.0.0.
+    // beakStyle is now deprecated and will be be removed at version 1.0.0
+    if (beakStyle === 'ms-Callout-smallbeak') {
+      beakStyleWidth = 16;
+    }
+
+    let beakReactStyle: React.CSSProperties = {
+      top: positions && positions.beak ? positions.beak.top : BEAK_ORIGIN_POSITION.top,
+      left: positions && positions.beak ? positions.beak.left : BEAK_ORIGIN_POSITION.left,
+      height: beakStyleWidth,
+      width: beakStyleWidth
     };
 
-    private _didSetInitialFocus: boolean;
-    private _hostElement: HTMLDivElement;
-    private _calloutElement: HTMLDivElement;
-    private _targetWindow: Window;
-    private _bounds: IRectangle;
-    private _maxHeight: number;
-    private _positionAttempts: number;
-    private _target: HTMLElement | MouseEvent;
+    let contentMaxHeight: number = this._getMaxHeight();
+    let beakVisible: boolean = isBeakVisible && (!!targetElement || !!target);
+    let content = (
+      <div ref={ this._resolveRef('_hostElement') } className={ 'ms-Callout-container' }>
+        <div
+          className={
+            css(
+              'ms-Callout',
+              className,
+              slideDirectionalClassName ? `ms-u-${slideDirectionalClassName}` : ''
+            ) }
+          style={ positions ? positions.callout : OFF_SCREEN_POSITION }
+          ref={ this._resolveRef('_calloutElement') }
+          >
 
-    constructor(props: ICalloutProps) {
-        super(props, { 'beakStyle': 'beakWidth' });
+          { beakVisible ? (
+            <div
+              className={ 'ms-Callout-beak' }
+              style={ beakReactStyle }
+              />) : (null) }
 
-        this._didSetInitialFocus = false;
-        this.state = {
-            positions: null,
-            slideDirectionalClassName: null,
-            calloutElementRect: null
-        };
+          { beakVisible ?
+            (<div className='ms-Callout-beakCurtain' />) :
+            (null) }
+
+          <Popup
+            className='ms-Callout-main'
+            onDismiss={ (ev: any) => this.dismiss() }
+            shouldRestoreFocus={ true }
+            style={ { maxHeight: contentMaxHeight } }>
+            { children }
+          </Popup>
+        </div>
+      </div>
+    );
+    return content;
+  }
+
+  public dismiss() {
+    let { onDismiss } = this.props;
+
+    if (onDismiss) {
+      onDismiss();
+    }
+  }
+
+  protected _dismissOnLostFocus(ev: Event) {
+    let target = ev.target as HTMLElement;
+
+    if (ev.target !== this._targetWindow &&
+      this._hostElement &&
+      !elementContains(this._hostElement, target) &&
+      ((this._target as MouseEvent).stopPropagation ||
+        (!this._target || (target !== this._target && !elementContains(this._target as HTMLElement, target))))) {
+      this.dismiss();
+    }
+  }
+
+  @autobind
+  protected _setInitialFocus() {
+    if (this.props.setInitialFocus && !this._didSetInitialFocus && this.state.positions) {
+      this._didSetInitialFocus = true;
+      focusFirstChild(this._calloutElement);
+    }
+  }
+
+  @autobind
+  protected _onComponentDidMount() {
+    // This is added so the callout will dismiss when the window is scrolled
+    // but not when something inside the callout is scrolled.
+    this._events.on(this._targetWindow, 'scroll', this._dismissOnLostFocus, true);
+    this._events.on(this._targetWindow, 'resize', this.dismiss, true);
+    this._events.on(this._targetWindow, 'focus', this._dismissOnLostFocus, true);
+    this._events.on(this._targetWindow, 'click', this._dismissOnLostFocus, true);
+
+    if (this.props.onLayerMounted) {
+      this.props.onLayerMounted();
+    }
+
+    this._updatePosition();
+  }
+
+  private _updatePosition() {
+    let { positions } = this.state;
+    let hostElement: HTMLElement = this._hostElement;
+    let calloutElement: HTMLElement = this._calloutElement;
+
+    if (hostElement && calloutElement) {
+      let currentProps: IPositionProps;
+      currentProps = assign(currentProps, this.props);
+      currentProps.bounds = this._getBounds();
+      // Temporary to be removed when targetElement is removed. Currently deprecated.
+      if (this.props.targetElement) {
+        currentProps.targetElement = this._target as HTMLElement;
+      } else {
+        currentProps.target = this._target;
+      }
+      let positionInfo: IPositionInfo = getRelativePositions(currentProps, hostElement, calloutElement);
+
+      // Set the new position only when the positions are not exists or one of the new callout positions are different.
+      // The position should not change if the position is within 2 decimal places.
+      if ((!positions && positionInfo) ||
+        (positions && positionInfo &&
+          (positions.callout.top.toFixed(2) !== positionInfo.calloutPosition.top.toFixed(2) ||
+            positions.callout.left.toFixed(2) !== positionInfo.calloutPosition.left.toFixed(2))
+          && this._positionAttempts < 5)) {
+        // We should not reposition the callout more than a few times, if it is then the content is likely resizing
+        // and we should stop trying to reposition to prevent a stack overflow.
+        this._positionAttempts++;
+        this.setState({
+          positions: {
+            callout: positionInfo.calloutPosition,
+            beak: positionInfo.beakPosition,
+          },
+          slideDirectionalClassName: positionInfo.directionalClassName
+        });
+      } else {
         this._positionAttempts = 0;
+      }
     }
+  }
 
-    public componentDidUpdate() {
-        this._setInitialFocus();
-        this._updatePosition();
-    }
+  private _getBounds(): IRectangle {
+    if (!this._bounds) {
+      let currentBounds = this.props.bounds;
 
-    public componentWillMount() {
-        let target = this.props.targetElement ? this.props.targetElement : this.props.target;
-        this._setTargetWindowAndElement(target);
-    }
-
-    public componentWillUpdate(newProps: ICalloutProps) {
-        if (newProps.targetElement !== this.props.targetElement || newProps.target !== this.props.target) {
-            let newTarget = newProps.targetElement ? newProps.targetElement : newProps.target;
-            this._setTargetWindowAndElement(newTarget);
-        }
-    }
-    public componentDidMount() {
-        this._onComponentDidMount();
-    }
-
-    public render() {
-        // If there is no target window then we are likely in server side rendering and we should not render anything.
-        if (!this._targetWindow) {
-            return null;
-        }
-        let {
-            className,
-            target,
-            targetElement,
-            isBeakVisible,
-            beakStyle,
-            children,
-            beakWidth } = this.props;
-        let { positions, slideDirectionalClassName } = this.state;
-        let beakStyleWidth = beakWidth;
-
-        // This is here to support the old way of setting the beak size until version 1.0.0.
-        // beakStyle is now deprecated and will be be removed at version 1.0.0
-        if (beakStyle === 'ms-Callout-smallbeak') {
-            beakStyleWidth = 16;
-        }
-
-        let beakReactStyle: React.CSSProperties = {
-            top: positions && positions.beak ? positions.beak.top : BEAK_ORIGIN_POSITION.top,
-            left: positions && positions.beak ? positions.beak.left : BEAK_ORIGIN_POSITION.left,
-            height: beakStyleWidth,
-            width: beakStyleWidth
+      if (!currentBounds) {
+        currentBounds = {
+          top: 0 + SPACE_FROM_EDGE,
+          left: 0 + SPACE_FROM_EDGE,
+          right: this._targetWindow.innerWidth - SPACE_FROM_EDGE,
+          bottom: this._targetWindow.innerHeight - SPACE_FROM_EDGE,
+          width: this._targetWindow.innerWidth - SPACE_FROM_EDGE * 2,
+          height: this._targetWindow.innerHeight - SPACE_FROM_EDGE * 2
         };
-
-        let contentMaxHeight: number = this._getMaxHeight();
-        let beakVisible: boolean = isBeakVisible && (!!targetElement || !!target);
-        let content = (
-            <div ref={ this._resolveRef('_hostElement') } className={ 'ms-Callout-container' }>
-                <div
-                    className={
-                        css(
-                            'ms-Callout',
-                            className,
-                            slideDirectionalClassName ? `ms-u-${slideDirectionalClassName}` : ''
-                        ) }
-                    style={ positions ? positions.callout : OFF_SCREEN_POSITION }
-                    ref={ this._resolveRef('_calloutElement') }
-                    >
-
-                    { beakVisible ? (
-                        <div
-                            className={ 'ms-Callout-beak' }
-                            style={ beakReactStyle }
-                            />) : (null) }
-
-                    { beakVisible ?
-                        (<div className='ms-Callout-beakCurtain' />) :
-                        (null) }
-
-                    <Popup
-                        className='ms-Callout-main'
-                        onDismiss={ (ev: any) => this.dismiss() }
-                        shouldRestoreFocus={ true }
-                        style={ { maxHeight: contentMaxHeight } }>
-                        { children }
-                    </Popup>
-                </div>
-            </div>
-        );
-        return content;
+      }
+      this._bounds = currentBounds;
     }
+    return this._bounds;
+  }
 
-    public dismiss() {
-        let { onDismiss } = this.props;
-
-        if (onDismiss) {
-            onDismiss();
-        }
+  private _getMaxHeight(): number {
+    if (!this._maxHeight) {
+      this._maxHeight = this._getBounds().height - BORDER_WIDTH * 2;
     }
+    return this._maxHeight;
+  }
 
-    protected _dismissOnLostFocus(ev: Event) {
-        let target = ev.target as HTMLElement;
-
-        if (ev.target !== this._targetWindow &&
-            this._hostElement &&
-            !elementContains(this._hostElement, target) &&
-            ((this._target as MouseEvent).stopPropagation ||
-                (!this._target || !elementContains(this._target as HTMLElement, target)))) {
-            this.dismiss();
-        }
+  private _setTargetWindowAndElement(target: HTMLElement | string | MouseEvent): void {
+    if (target) {
+      if (typeof target === 'string') {
+        let currentDoc: Document = getDocument();
+        this._target = currentDoc ? currentDoc.querySelector(target) as HTMLElement : null;
+        this._targetWindow = getWindow();
+      } else if ((target as MouseEvent).stopPropagation) {
+        this._target = target;
+        this._targetWindow = getWindow((target as MouseEvent).toElement as HTMLElement);
+      } else {
+        let targetElement: HTMLElement = target as HTMLElement;
+        this._target = target;
+        this._targetWindow = getWindow(targetElement);
+      }
+    } else {
+      this._targetWindow = getWindow();
     }
-
-    @autobind
-    protected _setInitialFocus() {
-        if (this.props.setInitialFocus && !this._didSetInitialFocus && this.state.positions) {
-            this._didSetInitialFocus = true;
-            focusFirstChild(this._calloutElement);
-        }
-    }
-
-    @autobind
-    protected _onComponentDidMount() {
-        // This is added so the callout will dismiss when the window is scrolled
-        // but not when something inside the callout is scrolled.
-        this._events.on(this._targetWindow, 'scroll', this._dismissOnLostFocus, true);
-        this._events.on(this._targetWindow, 'resize', this.dismiss, true);
-        this._events.on(this._targetWindow, 'focus', this._dismissOnLostFocus, true);
-        this._events.on(this._targetWindow, 'click', this._dismissOnLostFocus, true);
-
-        if (this.props.onLayerMounted) {
-            this.props.onLayerMounted();
-        }
-
-        this._updatePosition();
-    }
-
-    private _updatePosition() {
-        let { positions } = this.state;
-        let hostElement: HTMLElement = this._hostElement;
-        let calloutElement: HTMLElement = this._calloutElement;
-
-        if (hostElement && calloutElement) {
-            let currentProps: IPositionProps;
-            currentProps = assign(currentProps, this.props);
-            currentProps.bounds = this._getBounds();
-            // Temporary to be removed when targetElement is removed. Currently deprecated.
-            if (this.props.targetElement) {
-                currentProps.targetElement = this._target as HTMLElement;
-            } else {
-                currentProps.target = this._target;
-            }
-            let positionInfo: IPositionInfo = getRelativePositions(currentProps, hostElement, calloutElement);
-
-            // Set the new position only when the positions are not exists or one of the new callout positions are different.
-            // The position should not change if the position is within 2 decimal places.
-            if ((!positions && positionInfo) ||
-                (positions && positionInfo &&
-                    (positions.callout.top.toFixed(2) !== positionInfo.calloutPosition.top.toFixed(2) ||
-                        positions.callout.left.toFixed(2) !== positionInfo.calloutPosition.left.toFixed(2))
-                    && this._positionAttempts < 5)) {
-                // We should not reposition the callout more than a few times, if it is then the content is likely resizing
-                // and we should stop trying to reposition to prevent a stack overflow.
-                this._positionAttempts++;
-                this.setState({
-                    positions: {
-                        callout: positionInfo.calloutPosition,
-                        beak: positionInfo.beakPosition,
-                    },
-                    slideDirectionalClassName: positionInfo.directionalClassName
-                });
-            } else {
-                this._positionAttempts = 0;
-            }
-        }
-    }
-
-    private _getBounds(): IRectangle {
-        if (!this._bounds) {
-            let currentBounds = this.props.bounds;
-
-            if (!currentBounds) {
-                currentBounds = {
-                    top: 0 + SPACE_FROM_EDGE,
-                    left: 0 + SPACE_FROM_EDGE,
-                    right: this._targetWindow.innerWidth - SPACE_FROM_EDGE,
-                    bottom: this._targetWindow.innerHeight - SPACE_FROM_EDGE,
-                    width: this._targetWindow.innerWidth - SPACE_FROM_EDGE * 2,
-                    height: this._targetWindow.innerHeight - SPACE_FROM_EDGE * 2
-                };
-            }
-            this._bounds = currentBounds;
-        }
-        return this._bounds;
-    }
-
-    private _getMaxHeight(): number {
-        if (!this._maxHeight) {
-            this._maxHeight = this._getBounds().height - BORDER_WIDTH * 2;
-        }
-        return this._maxHeight;
-    }
-
-    private _setTargetWindowAndElement(target: HTMLElement | string | MouseEvent): void {
-        if (target) {
-            if (typeof target === 'string') {
-                let currentDoc: Document = getDocument();
-                this._target = currentDoc ? currentDoc.querySelector(target) as HTMLElement : null;
-                this._targetWindow = getWindow();
-            } else if ((target as MouseEvent).stopPropagation) {
-                this._target = target;
-                this._targetWindow = getWindow((target as MouseEvent).toElement as HTMLElement);
-            } else {
-                let targetElement: HTMLElement = target as HTMLElement;
-                this._target = target;
-                this._targetWindow = getWindow(targetElement);
-            }
-        } else {
-            this._targetWindow = getWindow();
-        }
-    }
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -365,17 +365,16 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   }
 
   private _onItemClick(item: any, ev: MouseEvent) {
-    if (item.key !== this.state.expandedMenuItemKey) {
-      if (!item.items || !item.items.length) { // This is an item without a menu. Click it.
-        this._executeItemClick(item, ev);
-      } else {
-        if (item.key === this.state.dismissedMenuItemKey) { // This has an expanded sub menu. collapse it.
-          this._onSubMenuDismiss(ev);
-        } else { // This has a collapsed sub menu. Expand it.
-          this._onItemSubMenuExpand(item, ev.currentTarget as HTMLElement);
-        }
+    if (!item.items || !item.items.length) { // This is an item without a menu. Click it.
+      this._executeItemClick(item, ev);
+    } else {
+      if (item.key === this.state.expandedMenuItemKey) { // This has an expanded sub menu. collapse it.
+        this._onSubMenuDismiss(ev);
+      } else { // This has a collapsed sub menu. Expand it.
+        this._onItemSubMenuExpand(item, ev.currentTarget as HTMLElement);
       }
     }
+
     ev.stopPropagation();
     ev.preventDefault();
   }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -158,7 +158,6 @@ $DropDown-item-height: 36px;
   background-color: $ms-color-white;
   list-style-type: none;
   width: 100%;
-  max-height: 200px;
   overflow-y: scroll;
   top: auto;
   right: auto;

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.Props.ts
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
 export interface ILayerHostProps extends React.HTMLProps<HTMLDivElement> {
-
+  /**
+   * Optional boolean specifying that the host is the default layer host. This controls some
+   * basic css rules to set the host to position: fixed so that the the content within will be placed
+   * relative to the page regardless of scroll position, and with a large z-index (1000000) so that it
+   * will render on top of the rendered DOM markup.
+   */
+  isDefault?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.scss
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.scss
@@ -1,0 +1,9 @@
+.ms-LayerHost--default .ms-LayerHost-overlay {
+  position: fixed;
+  z-index: 1000000;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  visibility: hidden;
+}

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.tsx
@@ -12,6 +12,7 @@ import {
 import { ProjectedLayer } from './ProjectedLayer';
 import { ILayerProps } from './Layer.Props';
 import { ILayerHostProps } from './LayerHost.Props';
+import './Layerhost.scss';
 
 export interface ILayer {
   id: string;
@@ -59,7 +60,7 @@ export class LayerHost extends BaseComponent<ILayerHostProps, {}> {
       hostElement.id = DEFAULT_HOST_ID;
       doc.body.appendChild(hostElement);
 
-      let defaultHost = ReactDOM.render(<LayerHost />, hostElement) as LayerHost;
+      let defaultHost = ReactDOM.render(<LayerHost isDefault />, hostElement) as LayerHost;
 
       hostElement[DEFAULT_HOST_ID] = defaultHost;
 
@@ -88,19 +89,19 @@ export class LayerHost extends BaseComponent<ILayerHostProps, {}> {
     let divProps = getNativeProps(this.props, divProperties);
 
     return (
-      <div { ...divProps } className={ css('ms-LayerHost', this.props.className) }>
+      <div { ...divProps } className={ css('ms-LayerHost', this.props.className, { 'ms-LayerHost--default': this.props.isDefault }) }>
         <Fabric>
           { this.props.children }
           <div className='ms-LayerHost-overlay'>
             { this._layers.map(layer => (
               <ProjectedLayer
-                key={layer.id }
+                key={ layer.id }
                 layerId={ layer.id }
                 parentElement={ layer.parentElement }
                 defaultRemoteProps={ layer.props }
                 ref={ this._resolveLayer }
                 />
-            ))}
+            )) }
           </div>
         </Fabric>
       </div>

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.tsx
@@ -12,7 +12,7 @@ import {
 import { ProjectedLayer } from './ProjectedLayer';
 import { ILayerProps } from './Layer.Props';
 import { ILayerHostProps } from './LayerHost.Props';
-import './Layerhost.scss';
+import './LayerHost.scss';
 
 export interface ILayer {
   id: string;


### PR DESCRIPTION
- Default LayerHost is now rendered on a high z-index fixed position surface. This is the intent, but it wasn't the default, which is causing basic usage bugs.
- Dropdown max height removed from css, since Callout will gate it intelligently.
- Fixing a bug in the logic of determining if focus moves should cause Callout to dismiss (it shouldn't if the focused element is the callout target.)

#### Pull request checklist

- [X] Addresses an existing issue: #603
- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
- [X] Documentation update

#### Description of changes

This adjusts the CSS for LayerHost to render on a fixed position high z-index surface, so that we don't end up with positioning bugs or z-index issues.






