### PR TITLE
TextField: No longer logs console warning when using defaultValue.

### DIFF
--- a/common/changes/textfield-fixes_2016-11-23-21-07.json
+++ b/common/changes/textfield-fixes_2016-11-23-21-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: defaultValue no longer provides a warning.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/tests.js
+++ b/packages/office-ui-fabric-react/src/common/tests.js
@@ -1,4 +1,13 @@
-/** This is a test entry point to help karma-webpack find all tests in the project. Do not modify. */
+'use strict';
+
+/**
+ * This is a test entry point to help karma-webpack find all tests in the project.
+ **/
+
+// Before loading modules, treat errors and warnings as test failures.
+console.error = console.warn = function (warning) {
+  throw new Error(warning);
+}
 
 var context = require.context('..', true, /.+\.test\.js?$/);
 

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -8,7 +8,6 @@ import { Button } from './Button';
 
 let { expect } = chai;
 
-
 describe('Button', () => {
 
   it('can render without an onClick.', () => {

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -1,0 +1,45 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+/* tslint:enable:no-unused-variable */
+
+import * as ReactTestUtils from 'react-addons-test-utils';
+
+let { expect } = chai;
+
+import { Button } from './Button';
+
+describe('Button', () => {
+
+  it('can render without an onClick.', () => {
+    const button = ReactTestUtils.renderIntoDocument<Button>(
+      <Button>Hello</Button>
+    );
+    const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance);
+    console.log(renderedDOM.tagName);
+    expect(renderedDOM.tagName).equals('BUTTON', 'A Button with no onClick renders as a span');
+  });
+
+  it('can render with an onClick.', () => {
+    let onClick = () => null;
+
+    const button = ReactTestUtils.renderIntoDocument<Button>(
+      <Button onClick={ onClick }>Hello</Button>
+    );
+    const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance);
+    console.log(renderedDOM.tagName);
+    expect(renderedDOM.tagName).equals('BUTTON', 'A Button with onClick renders as a button');
+  });
+
+  it('can render with an href', () => {
+    let onClick = () => null;
+
+    const button = ReactTestUtils.renderIntoDocument<Button>(
+      <Button href='http://www.microsoft.com' target='_blank'>Hello</Button>
+    );
+    const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance);
+    console.log(renderedDOM.tagName);
+    expect(renderedDOM.tagName).equals('A', 'A Button with an href renders as an anchor');
+  });
+
+});

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -4,10 +4,10 @@ import * as ReactDOM from 'react-dom';
 /* tslint:enable:no-unused-variable */
 
 import * as ReactTestUtils from 'react-addons-test-utils';
+import { Button } from './Button';
 
 let { expect } = chai;
 
-import { Button } from './Button';
 
 describe('Button', () => {
 
@@ -32,8 +32,6 @@ describe('Button', () => {
   });
 
   it('can render with an href', () => {
-    let onClick = () => null;
-
     const button = ReactTestUtils.renderIntoDocument<Button>(
       <Button href='http://www.microsoft.com' target='_blank'>Hello</Button>
     );

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
@@ -12,116 +12,116 @@ import { IChoiceGroupOption } from './ChoiceGroup.Props';
 
 describe('ChoiceGroup', () => {
 
-    it('Can change options.', () => {
-        const options: IChoiceGroupOption[] = [
-            { key: '1', text: '1' },
-            { key: '2', text: '2' },
-            { key: '3', text: '3' }
-        ];
-        let exception;
-        let threwException = false;
-        let choiceGroup;
-        try {
-            choiceGroup = ReactTestUtils.renderIntoDocument<ChoiceGroup>(
-                <ChoiceGroup
-                    label='testgroup'
-                    options={options}
-                    required={true}
-                    />
-            );
-        } catch (e) {
-            exception = e;
-            threwException = true;
-        }
-        expect(threwException).to.be.false;
+  it('Can change options.', () => {
+    const options: IChoiceGroupOption[] = [
+      { key: '1', text: '1' },
+      { key: '2', text: '2' },
+      { key: '3', text: '3' }
+    ];
+    let exception;
+    let threwException = false;
+    let choiceGroup;
+    try {
+      choiceGroup = ReactTestUtils.renderIntoDocument<ChoiceGroup>(
+        <ChoiceGroup
+          label='testgroup'
+          options={ options }
+          required={ true }
+          />
+      );
+    } catch (e) {
+      exception = e;
+      threwException = true;
+    }
+    expect(threwException).to.be.false;
 
-        let renderedDOM = ReactDOM.findDOMNode(choiceGroup as React.ReactInstance);
-        let choiceOptions = renderedDOM.querySelectorAll('.ms-ChoiceField-input');
+    let renderedDOM = ReactDOM.findDOMNode(choiceGroup as React.ReactInstance);
+    let choiceOptions = renderedDOM.querySelectorAll('.ms-ChoiceField-input');
 
-        expect((choiceOptions[0] as HTMLInputElement).checked).to.be.eq(false, 'Choice 1 was true before click');
-        expect((choiceOptions[1] as HTMLInputElement).checked).to.be.eq(false, 'Choice 2 was true before click');
-        expect((choiceOptions[2] as HTMLInputElement).checked).to.be.eq(false, 'Choice 3 was true before click');
+    expect((choiceOptions[0] as HTMLInputElement).checked).to.be.eq(false, 'Choice 1 was true before click');
+    expect((choiceOptions[1] as HTMLInputElement).checked).to.be.eq(false, 'Choice 2 was true before click');
+    expect((choiceOptions[2] as HTMLInputElement).checked).to.be.eq(false, 'Choice 3 was true before click');
 
-        ReactTestUtils.Simulate.change(choiceOptions[0]);
+    ReactTestUtils.Simulate.change(choiceOptions[0]);
 
-        expect((choiceOptions[0] as HTMLInputElement).checked).to.be.eq(true, 'Choice 1 was false after click 1');
-        expect((choiceOptions[1] as HTMLInputElement).checked).to.be.eq(false, 'Choice 2 was true after click 1');
-        expect((choiceOptions[2] as HTMLInputElement).checked).to.be.eq(false, 'Choice 3 was true after click 1');
+    expect((choiceOptions[0] as HTMLInputElement).checked).to.be.eq(true, 'Choice 1 was false after click 1');
+    expect((choiceOptions[1] as HTMLInputElement).checked).to.be.eq(false, 'Choice 2 was true after click 1');
+    expect((choiceOptions[2] as HTMLInputElement).checked).to.be.eq(false, 'Choice 3 was true after click 1');
 
-        ReactTestUtils.Simulate.change(choiceOptions[1]);
+    ReactTestUtils.Simulate.change(choiceOptions[1]);
 
-        expect((choiceOptions[0] as HTMLInputElement).checked).to.be.eq(false, 'Choice 1 was true after click 2');
-        expect((choiceOptions[1] as HTMLInputElement).checked).to.be.eq(true, 'Choice 2 was false after click 2');
-        expect((choiceOptions[2] as HTMLInputElement).checked).to.be.eq(false, 'Choice 3 was true after click 2');
+    expect((choiceOptions[0] as HTMLInputElement).checked).to.be.eq(false, 'Choice 1 was true after click 2');
+    expect((choiceOptions[1] as HTMLInputElement).checked).to.be.eq(true, 'Choice 2 was false after click 2');
+    expect((choiceOptions[2] as HTMLInputElement).checked).to.be.eq(false, 'Choice 3 was true after click 2');
 
-        ReactTestUtils.Simulate.change(choiceOptions[0]);
+    ReactTestUtils.Simulate.change(choiceOptions[0]);
 
-        expect((choiceOptions[0] as HTMLInputElement).checked).to.be.eq(true, 'Choice 1 was false after click 3');
-        expect((choiceOptions[1] as HTMLInputElement).checked).to.be.eq(false, 'Choice 2 was true after click 3');
-        expect((choiceOptions[2] as HTMLInputElement).checked).to.be.eq(false, 'Choice 3 was true after click 3');
-    });
+    expect((choiceOptions[0] as HTMLInputElement).checked).to.be.eq(true, 'Choice 1 was false after click 3');
+    expect((choiceOptions[1] as HTMLInputElement).checked).to.be.eq(false, 'Choice 2 was true after click 3');
+    expect((choiceOptions[2] as HTMLInputElement).checked).to.be.eq(false, 'Choice 3 was true after click 3');
+  });
 
-    it('An individual choice option can be disabled', () => {
-        const options: IChoiceGroupOption[] = [
-            { key: '1', text: '1', disabled: true },
-            { key: '2', text: '2' },
-            { key: '3', text: '3' }
-        ];
-        let exception;
-        let threwException = false;
-        let choiceGroup;
-        try {
-            choiceGroup = ReactTestUtils.renderIntoDocument<ChoiceGroup>(
-                <ChoiceGroup
-                    label='testgroup'
-                    options={options}
-                    required={true}
-                    />
-            );
-        } catch (e) {
-            exception = e;
-            threwException = true;
-        }
-        expect(threwException).to.be.false;
+  it('An individual choice option can be disabled', () => {
+    const options: IChoiceGroupOption[] = [
+      { key: '1', text: '1', disabled: true },
+      { key: '2', text: '2' },
+      { key: '3', text: '3' }
+    ];
+    let exception;
+    let threwException = false;
+    let choiceGroup;
+    try {
+      choiceGroup = ReactTestUtils.renderIntoDocument<ChoiceGroup>(
+        <ChoiceGroup
+          label='testgroup'
+          options={ options }
+          required={ true }
+          />
+      );
+    } catch (e) {
+      exception = e;
+      threwException = true;
+    }
+    expect(threwException).to.be.false;
 
-        let renderedDOM = ReactDOM.findDOMNode(choiceGroup as React.ReactInstance);
-        let choiceOptions = renderedDOM.querySelectorAll('.ms-ChoiceField-input');
+    let renderedDOM = ReactDOM.findDOMNode(choiceGroup as React.ReactInstance);
+    let choiceOptions = renderedDOM.querySelectorAll('.ms-ChoiceField-input');
 
-        expect((choiceOptions[0] as HTMLInputElement).disabled).to.be.eq(true, 'Disabled option 1 is not disabled');
-        expect((choiceOptions[1] as HTMLInputElement).disabled).to.be.eq(false, 'Not disabled option 2 is disabled');
-        expect((choiceOptions[2] as HTMLInputElement).disabled).to.be.eq(false, 'Not disabled option 2 is disabled');
-    });
+    expect((choiceOptions[0] as HTMLInputElement).disabled).to.be.eq(true, 'Disabled option 1 is not disabled');
+    expect((choiceOptions[1] as HTMLInputElement).disabled).to.be.eq(false, 'Not disabled option 2 is disabled');
+    expect((choiceOptions[2] as HTMLInputElement).disabled).to.be.eq(false, 'Not disabled option 2 is disabled');
+  });
 
-    it('When choicegroup is disabled all choice options are disabled', () => {
-        const options: IChoiceGroupOption[] = [
-            { key: '1', text: '1' },
-            { key: '2', text: '2' },
-            { key: '3', text: '3' }
-        ];
-        let exception;
-        let threwException = false;
-        let choiceGroup;
-        try {
-            choiceGroup = ReactTestUtils.renderIntoDocument<ChoiceGroup>(
-                <ChoiceGroup
-                    label='testgroup'
-                    options={options}
-                    required={true}
-                    disabled={true}
-                    />
-            );
-        } catch (e) {
-            exception = e;
-            threwException = true;
-        }
-        expect(threwException).to.be.false;
+  it('When choicegroup is disabled all choice options are disabled', () => {
+    const options: IChoiceGroupOption[] = [
+      { key: '1', text: '1' },
+      { key: '2', text: '2' },
+      { key: '3', text: '3' }
+    ];
+    let exception;
+    let threwException = false;
+    let choiceGroup;
+    try {
+      choiceGroup = ReactTestUtils.renderIntoDocument<ChoiceGroup>(
+        <ChoiceGroup
+          label='testgroup'
+          options={ options }
+          required={ true }
+          disabled={ true }
+          />
+      );
+    } catch (e) {
+      exception = e;
+      threwException = true;
+    }
+    expect(threwException).to.be.false;
 
-        let renderedDOM = ReactDOM.findDOMNode(choiceGroup as React.ReactInstance);
-        let choiceOptions = renderedDOM.querySelectorAll('.ms-ChoiceField-input');
+    let renderedDOM = ReactDOM.findDOMNode(choiceGroup as React.ReactInstance);
+    let choiceOptions = renderedDOM.querySelectorAll('.ms-ChoiceField-input');
 
-        expect((choiceOptions[0] as HTMLInputElement).disabled).to.be.eq(true, 'Disabled option 1 is not disabled');
-        expect((choiceOptions[1] as HTMLInputElement).disabled).to.be.eq(true, 'Disabled option 2 is not disabled');
-        expect((choiceOptions[2] as HTMLInputElement).disabled).to.be.eq(true, 'Disabled option 3 is not disabled');
-    });
+    expect((choiceOptions[0] as HTMLInputElement).disabled).to.be.eq(true, 'Disabled option 1 is not disabled');
+    expect((choiceOptions[1] as HTMLInputElement).disabled).to.be.eq(true, 'Disabled option 2 is not disabled');
+    expect((choiceOptions[2] as HTMLInputElement).disabled).to.be.eq(true, 'Disabled option 3 is not disabled');
+  });
 
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -20,6 +20,7 @@ export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
   let selected = props.isSelected || props.selected;
   return (
     <button
+      type='button'
       className='ms-DetailsRow-check'
       role='button'
       aria-pressed={ selected }

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -206,6 +206,16 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
     this._autoScroll = this._dragOrigin = this._lastMouseEvent = this._selectedIndicies = this._itemRectCache = undefined;
 
     if (this.state.dragRect) {
+
+      // When we've moused up from selection, make sure the click doesn't get executed.
+      let clickRemovalCallback = (clickEvent) => {
+        this._events.off(ev.target, 'click', clickRemovalCallback);
+        clickEvent.preventDefault();
+        clickEvent.stopPropagation();
+      };
+
+      this._events.on(ev.target, 'click', clickRemovalCallback, true);
+
       this.setState({
         dragRect: undefined
       });
@@ -214,14 +224,6 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
       ev.stopPropagation();
     }
 
-    // When we've moused up from selection, make sure the click doesn't get executed.
-    let clickRemovalCallback = (clickEvent) => {
-      this._events.off(ev.target, 'click', clickRemovalCallback);
-      clickEvent.preventDefault();
-      clickEvent.stopPropagation();
-    };
-
-    this._events.on(ev.target, 'click', clickRemovalCallback, true);
   }
 
   private _evaluateSelection(dragRect: IRectangle) {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.Props.ts
@@ -97,6 +97,16 @@ export interface ITextFieldProps extends React.HTMLProps<HTMLInputElement | HTML
   deferredValidationTime?: number;
 
   /**
+   * Optional class anme that is added to the container of the component.
+   */
+  className?: string;
+
+  /**
+   * Optional class name that is added specifically to the input/textarea element.
+   */
+  inputClassName?: string;
+
+  /**
    * Aria Label for textfield, if any.
    */
   ariaLabel?: string;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -221,4 +221,15 @@ describe('TextField', () => {
 
     expect(renderedDOM.querySelector('input').value).equals('initial value');
   });
+
+  it('can render a default value as a textarea', () => {
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <TextField
+        defaultValue='initial value'
+        multiline={ true }
+        />
+    );
+
+    expect(renderedDOM.querySelector('textarea').value).equals('initial value');
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -32,7 +32,7 @@ describe('TextField', () => {
       <TextField
         label={ exampleLabel }
         value={ exampleValue }
-      />
+        />
     );
 
     // Assert on the input element.
@@ -60,7 +60,7 @@ describe('TextField', () => {
       <TextField
         label='text-field-label'
         value='whatever value'
-      />
+        />
     );
 
     const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
@@ -105,7 +105,7 @@ describe('TextField', () => {
           label='text-field-label'
           value='whatever value'
           onGetErrorMessage={ validator }
-        />
+          />
       );
 
       const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
@@ -125,7 +125,7 @@ describe('TextField', () => {
           label='text-field-label'
           value='whatever value'
           onGetErrorMessage={ validator }
-        />
+          />
       );
 
       const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
@@ -141,7 +141,7 @@ describe('TextField', () => {
           label='text-field-label'
           value='whatever value'
           onGetErrorMessage={ () => errorMessage }
-        />
+          />
       );
 
       assertErrorMessage(renderedDOM, errorMessage);
@@ -153,7 +153,7 @@ describe('TextField', () => {
           label='text-field-label'
           value='whatever value'
           onGetErrorMessage={ () => Promise.resolve(errorMessage) }
-        />
+          />
       );
 
       // The Promise based validation need to assert with async pattern.
@@ -166,7 +166,7 @@ describe('TextField', () => {
           label='text-field-label'
           value='whatever value'
           onGetErrorMessage={ () => '' }
-        />
+          />
       );
 
       assertErrorMessage(renderedDOM, /* exist */ false);
@@ -179,7 +179,7 @@ describe('TextField', () => {
         <TextField
           label='text-field-label'
           onGetErrorMessage={ (value: string) => actualValue = value }
-        />
+          />
       );
 
       assertErrorMessage(renderedDOM, /* exist */ false);
@@ -195,7 +195,7 @@ describe('TextField', () => {
         <TextField
           value='initial value'
           onGetErrorMessage={ validator }
-        />
+          />
       );
 
       assertErrorMessage(renderedDOM, errorMessage);
@@ -204,11 +204,21 @@ describe('TextField', () => {
         <TextField
           value=''
           onGetErrorMessage={ validator }
-        />,
+          />,
         renderedDOM.parentElement
       );
 
       return delay(250).then(() => assertErrorMessage(renderedDOM, /* exist */ false));
     });
+  });
+
+  it('can render a default value', () => {
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <TextField
+        defaultValue='initial value'
+        />
+    );
+
+    expect(renderedDOM.querySelector('input').value).equals('initial value');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -200,7 +200,7 @@ export class TextField extends React.Component<ITextFieldProps, ITextFieldState>
       textFieldClassName = 'ms-TextField-field';
     }
 
-    return css(textFieldClassName, {
+    return css(textFieldClassName, this.props.inputClassName, {
       'ms-TextField-invalid': !!errorMessage
     });
   }
@@ -215,7 +215,7 @@ export class TextField extends React.Component<ITextFieldProps, ITextFieldState>
   }
 
   private _renderTextArea(): React.ReactElement<React.HTMLProps<HTMLAreaElement>> {
-    let textAreaProps = getNativeProps(this.props, textAreaProperties);
+    let textAreaProps = getNativeProps(this.props, textAreaProperties, ['defaultValue']);
 
     return (
       <textarea
@@ -235,7 +235,7 @@ export class TextField extends React.Component<ITextFieldProps, ITextFieldState>
   }
 
   private _renderInput(): React.ReactElement<React.HTMLProps<HTMLInputElement>> {
-    let inputProps = getNativeProps<React.HTMLProps<HTMLInputElement>>(this.props, inputProperties);
+    let inputProps = getNativeProps<React.HTMLProps<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
 
     return (
       <input


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #601, #462 
- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests

#### Description of changes

- TextField no longer generates a React console warning when using defaultValue. Tests added.
- Tests will now fail if React throws console errors or deprecation throws console warnings.



