### PR TITLE
Dropdown should only update state when props are actually changed

### DIFF
--- a/common/changes/eliblock-dropDownFix_2016-11-24-02-14.json
+++ b/common/changes/eliblock-dropDownFix_2016-11-24-02-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown should only update state when props are actually changed",
+      "type": "patch"
+    }
+  ],
+  "email": "eliblock@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -53,10 +53,17 @@ export class Dropdown extends BaseComponent<IDropdownProps, any> {
   }
 
   public componentWillReceiveProps(newProps: IDropdownProps) {
-    this.setState({
-      selectedIndex: this._getSelectedIndex(newProps.options, newProps.selectedKey),
-      isDisabled: newProps.isDisabled !== undefined ? newProps.isDisabled : newProps.disabled
-    });
+    if (newProps.selectedKey !== this.props.selectedKey) {
+      this.setState({
+        selectedIndex: this._getSelectedIndex(newProps.options, newProps.selectedKey)
+      });
+    }
+
+    if (newProps.isDisabled !== this.props.isDisabled) {
+      this.setState({
+        isDisabled: newProps.isDisabled !== undefined ? newProps.isDisabled : newProps.disabled
+      });
+    }
   }
 
   public render() {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #567
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

componentWillReceiveProps() always blows away the state any time new props are available. It should be careful to only perform state transitions when the prop values are actually changed.

#### Focus areas to test

(optional)



