### PR TITLE
The CommandBar button was dealing with the onClick event incorrectly …

### DIFF
--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -155,7 +155,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
             { ...getNativeProps(item, buttonProperties) }
             id={ this._id + item.key }
             className={ classNameValue }
-            onClick={ this._onItemClick.bind(this, item) }
+            onClick={ (ev) => this._onItemClick(ev, item) }
             data-command-key={ index }
             aria-haspopup={ !!(item.items && item.items.length) }
             role='menuitem'
@@ -258,7 +258,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
     });
   }
 
-  private _onItemClick(item, ev) {
+  private _onItemClick(ev, item) {
     if (item.key === this.state.expandedMenuItemKey || !item.items || !item.items.length) {
       this._onContextMenuDismiss();
     } else {
@@ -270,7 +270,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
       });
     }
     if (item.onClick) {
-      item.onClick(item, ev);
+      item.onClick(ev, item);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [ ] Include a change request file if publishing (Run `npmx change` to generate it.)
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

The onClick event of the CommandBar was not working as designed, as a result the parameters were being passed in the incorrect order. This would propagate down to my custom onClick and mean that I would have to implicitly reference the parameters as "any" so I could effectively switch the order and utilise the event parameter.


…and as a result the parameters were passed incorrectly, they were basically reversed.