### PR TITLE
Dropdown: Fixing a Safari scroll issue causing it to dismiss prematurely

### DIFF
--- a/common/changes/dropdown-update_2016-11-29-18-52.json
+++ b/common/changes/dropdown-update_2016-11-29-18-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Fixing an issue causing Safari to avoid opening the items in scroll cases.",
+      "type": "minor"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -85,6 +85,11 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
   onLayerMounted?: () => void;
 
   /**
+   * Optional callback that is called once the callout has been correctly positioned.
+   */
+  onPositioned?: () => void;
+
+  /**
    * Callback when the Callout tries to close.
    */
   onDismiss?: (ev?: any) => void;

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -19,7 +19,7 @@ import { BaseComponent } from '../../common/BaseComponent';
 import './Callout.scss';
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
-const OFF_SCREEN_POSITION = { top: 0, left: -9999 };
+const OFF_SCREEN_POSITION = { top: -9999, left: 0 };
 const BORDER_WIDTH: number = 1;
 const SPACE_FROM_EDGE: number = 8;
 export interface ICalloutState {

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -19,7 +19,7 @@ import { BaseComponent } from '../../common/BaseComponent';
 import './Callout.scss';
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
-const OFF_SCREEN_POSITION = { top: -9999, left: 0 };
+const OFF_SCREEN_POSITION = { top: 0, left: -9999 };
 const BORDER_WIDTH: number = 1;
 const SPACE_FROM_EDGE: number = 8;
 export interface ICalloutState {
@@ -153,6 +153,12 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
     }
   }
 
+  protected _dismissOnScroll(ev: Event) {
+    if (this.state.positions) {
+      this._dismissOnLostFocus(ev);
+    }
+  }
+
   protected _dismissOnLostFocus(ev: Event) {
     let target = ev.target as HTMLElement;
     if (ev.target !== this._targetWindow &&
@@ -176,7 +182,7 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
   protected _onComponentDidMount() {
     // This is added so the callout will dismiss when the window is scrolled
     // but not when something inside the callout is scrolled.
-    this._events.on(this._targetWindow, 'scroll', this._dismissOnLostFocus, true);
+    this._events.on(this._targetWindow, 'scroll', this._dismissOnScroll, true);
     this._events.on(this._targetWindow, 'resize', this.dismiss, true);
     this._events.on(this._targetWindow, 'focus', this._dismissOnLostFocus, true);
     this._events.on(this._targetWindow, 'click', this._dismissOnLostFocus, true);
@@ -224,6 +230,9 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
         });
       } else {
         this._positionAttempts = 0;
+        if (this.props.onPositioned) {
+          this.props.onPositioned();
+        }
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -34,6 +34,7 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
     focusZone: FocusZone
   };
 
+  private _focusZone: FocusZone;
   private _optionList: HTMLElement;
   private _dropDown: HTMLDivElement;
   private _dropdownLabel: HTMLElement;
@@ -107,9 +108,10 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
             targetElement={ this._dropDown }
             directionalHint={ DirectionalHint.bottomLeftEdge }
             onDismiss={ this._onDismiss }
+            onPositioned={ this._onPositioned }
             >
             <FocusZone
-              ref={ fz => fz && fz.focus() }
+              ref={ this._resolveRef('_focusZone') }
               direction={ FocusZoneDirection.vertical }
               defaultActiveElement={ '#' + id + '-list' + selectedIndex }
               >
@@ -170,6 +172,11 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
   @autobind
   private _onRenderItem(item: IDropdownOption): JSX.Element {
     return <span>{ item.text }</span>;
+  }
+
+  @autobind
+  private _onPositioned() {
+    this._focusZone.focus();
   }
 
   private _onItemClick(index) {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #624
- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
- [X] Documentation update

#### Description of changes

Callout needs a new callback `onPositioned` which is called once positioning is complete (and the content is positioned on the screen rather than off the screen.) Dropdown should avoiding setting focus to an item until the dropdown has been positioned. 

#### Focus areas to test

Safari should now function correctly if you drop it down and the selected item is in a scrolled down location within the dropdown.



