### PR TITLE
Fix Button hover states

### DIFF
--- a/common/changes/miwhea-fix-button-hover-states_2016-11-30-22-21.json
+++ b/common/changes/miwhea-fix-button-hover-states_2016-11-30-22-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Button hover styles",
+      "type": "patch"
+    }
+  ],
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/Button.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.scss
@@ -111,6 +111,10 @@ $button-commandButtonHeight: 40px;
   &:hover {
     background-color: $ms-color-themeDark;
     border-color: $ms-color-themeDark;
+
+    .ms-Button-label {
+      color: $ms-color-white;
+    }
   }
 
   &:focus {
@@ -169,6 +173,8 @@ $button-commandButtonHeight: 40px;
 
   &:hover,
   &:focus {
+    background-color: transparent;
+
     .ms-Button-icon {
       color: $ms-color-themeDark;
     }
@@ -309,6 +315,8 @@ $button-commandButtonHeight: 40px;
 
   &:hover,
   &:focus {
+    background-color: transparent;
+
     .ms-Button-icon,
     .ms-Button-label {
       color: $ms-color-themeDarker;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #635
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)

#### Description of changes

PR #617 introduced a regression where some button types (primary, hero, and command) took on the hover style of the default button type, rather than their own hover style. This PR fixes that by adding additional styles to the `:hover` and `:active` states of these buttons.

#### Focus areas to test

Hover and click the buttons, comparing the result to what's currently on the [Button documentation page](http://dev.office.com/fabric#/components/button).


