### PR TITLE
Popup: focus will only be restored on unmount if it hasn't been moved away from body.

### DIFF
--- a/common/changes/popup-focus_2016-12-01-00-54.json
+++ b/common/changes/popup-focus_2016-12-01-00-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Popup: Avoid restoring focus when focus has been set explicitly elsewhere in the app.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -46,10 +46,10 @@ export class Popup extends BaseComponent<IPopupProps, {}> {
       // apply the correct focus. Without the setTimeout, we end up focusing the correct thing, and then React wants
       // to reset the focus back to the thing it thinks should have been focused.
       setTimeout(() => {
-        if (this._originalFocusedElement) {
+        if (this._originalFocusedElement && getDocument().activeElement === getDocument().body) {
           this._originalFocusedElement.focus();
         }
-      }, 0);
+      }, 20);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -49,7 +49,7 @@ export class Popup extends BaseComponent<IPopupProps, {}> {
         if (this._originalFocusedElement && getDocument().activeElement === getDocument().body) {
           this._originalFocusedElement.focus();
         }
-      }, 20);
+      }, 0);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/demo/pages/CalloutPage/examples/Callout.Cover.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/CalloutPage/examples/Callout.Cover.Example.tsx
@@ -51,7 +51,7 @@ export class CalloutCoverExample extends React.Component<any, ICalloutCoverExamp
     // ms-Callout-smallbeak is used in this directional example to reflect all the positions. Large beak will disable some position to avoid beak over the callout edge.
     return (
       <div className='ms-CalloutExample'>
-         <div className='ms-CalloutExample-configArea'>
+        <div className='ms-CalloutExample-configArea'>
           <Dropdown
             label='Directional hint'
             selectedKey={ DirectionalHint[directionalHint] }
@@ -62,15 +62,16 @@ export class CalloutCoverExample extends React.Component<any, ICalloutCoverExamp
           <Button onClick={ this._onShowMenuClicked } >{ isCalloutVisible ? 'Hide callout' : 'Show callout' }</Button>
         </div>
         { isCalloutVisible ? (
-        <Callout
-          className='ms-CalloutExample-callout'
-          onDismiss={ this._onDismiss }
-          targetElement={ this._menuButtonElement }
-          directionalHint={ directionalHint }
-          coverTarget={ true }
-          isBeakVisible={ false }
-          gapSpace={ 0 }
-         >
+          <Callout
+            className='ms-CalloutExample-callout'
+            onDismiss={ this._onDismiss }
+            targetElement={ this._menuButtonElement }
+            directionalHint={ directionalHint }
+            coverTarget={ true }
+            isBeakVisible={ false }
+            setInitialFocus={ true }
+            gapSpace={ 0 }
+            >
             <div className='ms-CalloutExample-header'>
               <p className='ms-CalloutExample-title'>
                 I'm covering the target!
@@ -78,10 +79,10 @@ export class CalloutCoverExample extends React.Component<any, ICalloutCoverExamp
             </div>
             <div className='ms-CalloutExample-inner'>
               <div className='ms-CalloutExample-content'>
-              <Button onClick={ this._onShowMenuClicked }> Click to dismiss </Button>
+                <Button onClick={ this._onShowMenuClicked }> Click to dismiss </Button>
               </div>
             </div>
-         </Callout>
+          </Callout>
         ) : (null) }
       </div>
     );


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
- [X] Documentation update

#### Description of changes

Popup was restoring focus even in scenarios in which focus was manually positioned in the correct location. Now it will only attempt it if focus is set to body after unmounting.



