### PR TITLE
Persona/fix width

### DIFF
--- a/common/changes/persona-fix-width_2016-12-01-22-35.json
+++ b/common/changes/persona-fix-width_2016-12-01-22-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove extraneous 'width: 100%' from Persona css",
+      "type": "patch"
+    }
+  ],
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -226,7 +226,6 @@ $ms-Persona-presenceSizeXl: 28px;
   @include text-align(left);
   @include padding-left($ms-Persona-sizeMd + $ms-Persona-imageDetailsLgSpace);
   display: table-cell;
-  width: 100%;
 }
 
 .ms-Persona-primaryText,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #641 
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)
- [x] New feature, bugfix, or enhancement

#### Description of changes

Change Persona control CSS to remove extraneous `width: 100%` property that causes issues on MacOS Safari

