### PR TITLE
Calendar: focus now set only after the Callout has been positioned.

### DIFF
--- a/common/changes/calendar-focus_2016-12-01-22-56.json
+++ b/common/changes/calendar-focus_2016-12-01-22-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker: now renders correctly when scrolled down in Safari.",
+      "type": "minor"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { Calendar } from './Calendar';
 
+export interface ICalendar {
+  /** Sets focus to the selected date. */
+  focus(): void;
+}
+
 export interface ICalendarProps extends React.Props<Calendar> {
   /**
   * Callback issued when a date is selected
@@ -30,8 +35,9 @@ export interface ICalendarProps extends React.Props<Calendar> {
   firstDayOfWeek?: DayOfWeek;
 
   /**
-   * Whether to focus on the calendar when mounted.
-   * @default true
+   * @deprecated
+   * This property has been removed at 0.80.0 in place of the focus method, to be removed @ 1.0.0.
+   *
    */
   shouldFocusOnMount?: boolean;
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   DayOfWeek,
+  ICalendar,
   ICalendarProps
 } from './Calendar.Props';
 import { CalendarDay } from './CalendarDay';
@@ -19,14 +20,13 @@ export interface ICalendarState {
   selectedDate?: Date;
 }
 
-export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> {
+export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> implements ICalendar {
   public static defaultProps: ICalendarProps = {
     onSelectDate: null,
     onDismiss: null,
     isMonthPickerVisible: true,
     value: null,
     firstDayOfWeek: DayOfWeek.Sunday,
-    shouldFocusOnMount: true,
     strings: null
   };
 
@@ -56,12 +56,6 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> {
     this.setState({
       selectedDate: value || new Date()
     });
-  }
-
-  public componentDidMount() {
-    if (this.props.shouldFocusOnMount) {
-      this.refs.dayPicker.focus();
-    }
   }
 
   public componentDidUpdate() {
@@ -107,6 +101,12 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> {
         </div>
       </div>
     );
+  }
+
+  public focus() {
+    if (this.refs.dayPicker) {
+      this.refs.dayPicker.focus();
+    }
   }
 
   @autobind

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.scss
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.scss
@@ -43,6 +43,7 @@ $Callout-smallbeak-slant-width: 16px;
 // The actual callout element
 .ms-Callout-main {
   background-color: $ms-color-white;
+  overflow-x: hidden;
   overflow-y: auto;
   position: relative;
 }

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -19,7 +19,7 @@ import { BaseComponent } from '../../common/BaseComponent';
 import './Callout.scss';
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
-const OFF_SCREEN_POSITION = { top: -9999, left: 0 };
+const OFF_SCREEN_STYLE = { opacity: 0 };
 const BORDER_WIDTH: number = 1;
 const SPACE_FROM_EDGE: number = 8;
 export interface ICalloutState {
@@ -118,7 +118,7 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
               className,
               slideDirectionalClassName ? `ms-u-${slideDirectionalClassName}` : ''
             ) }
-          style={ positions ? positions.callout : OFF_SCREEN_POSITION }
+          style={ positions ? positions.callout : OFF_SCREEN_STYLE }
           ref={ this._resolveRef('_calloutElement') }
           >
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -56,6 +56,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     textField: TextField;
   };
 
+  private _calendar: Calendar;
   private _datepicker: HTMLDivElement;
   private _preventFocusOpeningPicker: boolean;
   private _focusOnSelectedDateOnUpdate: boolean;
@@ -123,7 +124,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
             targetElement={ this._datepicker }
             directionalHint={ DirectionalHint.bottomLeftEdge }
             onDismiss={ this._calendarDismissed }
-            setInitialFocus={ false }
+            onPositioned={ this._onCalloutPositioned }
             >
             <Calendar
               onSelectDate={ this._onSelectDate }
@@ -132,7 +133,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
               value={ selectedDate }
               firstDayOfWeek={ firstDayOfWeek }
               strings={ strings }
-              shouldFocusOnMount={ true }
+              ref={ this._resolveRef('_calendar') }
               >
             </Calendar>
           </Callout>
@@ -155,6 +156,11 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       onSelectDate(date);
     }
   };
+
+  @autobind
+  private _onCalloutPositioned() {
+    this._calendar.focus();
+  }
 
   @autobind
   private _onTextFieldFocus(ev: React.FocusEvent<HTMLElement>) {

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.scss
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.scss
@@ -6,4 +6,5 @@
   width: 100vw;
   height: 100vh;
   visibility: hidden;
+  overflow: hidden;
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue:  #624 
- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
- [X] Documentation update

#### Description of changes

The recent Calendar refactor was pulling focus to itself before the Callout would have a chance to position itself. I've updated it to wait for positioning to complete before setting focus. I've also updated the Callout to use opacity: 0 to hide unpositioned content rather than an "offscreen position" which may cause scrolling. This reduces the likelyhood of causing an unanticipated body scroll in the browser.

