### PR TITLE
Contextualmenu: submenus now expand correctly again.

### DIFF
--- a/common/changes/contextualmenu-submenu_2016-12-02-01-07.json
+++ b/common/changes/contextualmenu-submenu_2016-12-02-01-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: submenus now expand correctly again.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -133,6 +133,35 @@ describe('ContextualMenu', () => {
         }
       },
     ];
+    ReactTestUtils.renderIntoDocument<ContextualMenu>(
+      <ContextualMenu
+        items={ items }
+        />
+    );
+
+    let menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
+
+    ReactTestUtils.Simulate.keyDown(menuItem, { which: KeyCodes.right });
+
+    expect(document.querySelector('.SubMenuClass')).to.exist;
+  });
+
+  it('opens a submenu item on click', () => {
+    const items: IContextualMenuItem[] = [
+      {
+        name: 'TestText 1',
+        key: 'TestKey1',
+        subMenuProps: {
+          items: [
+            {
+              name: 'SubmenuText 1',
+              key: 'SubmenuKey1',
+              className: 'SubMenuClass'
+            }
+          ]
+        }
+      },
+    ];
 
     ReactTestUtils.renderIntoDocument<ContextualMenu>(
       <ContextualMenu
@@ -141,7 +170,8 @@ describe('ContextualMenu', () => {
     );
 
     let menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
-    ReactTestUtils.Simulate.keyDown(menuItem, { which: KeyCodes.right });
+
+    ReactTestUtils.Simulate.click(menuItem);
 
     expect(document.querySelector('.SubMenuClass')).to.exist;
   });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -373,7 +373,9 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   }
 
   private _onItemClick(item: any, ev: MouseEvent) {
-    if (!item.items || !item.items.length) { // This is an item without a menu. Click it.
+    let items = (item.subMenuProps && item.subMenuProps.items) ? item.subMenuProps.items : item.items;
+
+    if (!items || !items.length) { // This is an item without a menu. Click it.
       this._executeItemClick(item, ev);
     } else {
       if (item.key === this.state.expandedMenuItemKey) { // This has an expanded sub menu. collapse it.


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests

#### Description of changes

In the ContextualMenu props addition of subMenuProps, a bug did not account for subMenuProps.items, and was failing to open a submenu when clicking on it.


