### PR TITLE
Margin between PivotItem text and count

### DIFF
--- a/common/changes/bfix-pivotItemCountSpacing_2016-12-06-17-12.json
+++ b/common/changes/bfix-pivotItemCountSpacing_2016-12-06-17-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pivot: Add space between text and count (if used) for PivotItem. Also fixes rtl display of text and count.",
+      "type": "patch"
+    }
+  ],
+  "email": "cschleid@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.scss
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.scss
@@ -68,6 +68,11 @@
     visibility: hidden;
   }
 
+  .ms-Pivot-text,
+  .ms-Pivot-count {
+    display: inline-block;
+  }
+
   // Spacing between text and count
   .ms-Pivot-count {
     @include margin-left(4px);

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.scss
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.scss
@@ -68,6 +68,11 @@
     visibility: hidden;
   }
 
+  // Spacing between text and count
+  .ms-Pivot-count {
+    @include margin-left(4px);
+  }
+
   //== State: Selected
   &.is-selected {
     font-weight: $ms-font-weight-semibold;
@@ -129,10 +134,6 @@
 .ms-Pivot.ms-Pivot--large {
   .ms-Pivot-link {
     font-size: $ms-font-size-l;
-
-    .ms-Pivot-count {
-      @include margin-left(4px);
-    }
   }
 
   .ms-Pivot-link.ms-Pivot-link--overflow {

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IPivotProps } from './Pivot.Props';
-import { IPivotItemProps} from './PivotItem.Props';
+import { IPivotItemProps } from './PivotItem.Props';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { KeyCodes } from '../../utilities/KeyCodes';
 import { PivotItem } from './PivotItem';
@@ -118,7 +118,7 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
         role='tab'
         aria-controls={ id + '-panel' }
         aria-selected={ this.state.selectedKey === itemKey }>
-        { link.linkText }
+        <span className='ms-Pivot-text'>{ link.linkText }</span>
         { countText }
       </a>
     );


### PR DESCRIPTION
#### Pull request checklist

- [X ] Addresses an existing issue: #655 

#### Description of changes

Apply 4px spacing between pivot item text and count, not only with large modifier