### PR TITLE
Dropdown: data-is-focusable now set correctly.

### DIFF
--- a/common/changes/dropdown-focusable_2016-12-09-02-30.json
+++ b/common/changes/dropdown-focusable_2016-12-09-02-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: data-is-focusable now gets set correctly.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/dropdown-focusable_2016-12-09-02-30.json
+++ b/common/changes/dropdown-focusable_2016-12-09-02-30.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Dropdown: data-is-focusable now gets set correctly.",
+      "comment": "Dropdown: The `data-is-focusable` attribute now gets set correctly on the .ms-Dropdown div container.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -26,6 +26,7 @@ describe('Dropdown', () => {
     let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
 
     expect(dropdownRoot.className).not.contains('is-disabled', `shouldn't be disabled`);
+    expect(dropdownRoot.getAttribute('data-is-focusable')).equals('false', 'data-is-focusable');
 
     ReactDOM.render(
       <Dropdown
@@ -36,6 +37,7 @@ describe('Dropdown', () => {
       container);
 
     expect(dropdownRoot.className).contains('is-disabled', `should be disabled`);
+    expect(dropdownRoot.getAttribute('data-is-focusable')).equals('true', 'data-is-focusable');
   });
 
 });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -26,7 +26,7 @@ describe('Dropdown', () => {
     let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
 
     expect(dropdownRoot.className).not.contains('is-disabled', `shouldn't be disabled`);
-    expect(dropdownRoot.getAttribute('data-is-focusable')).equals('false', 'data-is-focusable');
+    expect(dropdownRoot.getAttribute('data-is-focusable')).equals('true', 'data-is-focusable');
 
     ReactDOM.render(
       <Dropdown
@@ -37,7 +37,7 @@ describe('Dropdown', () => {
       container);
 
     expect(dropdownRoot.className).contains('is-disabled', `should be disabled`);
-    expect(dropdownRoot.getAttribute('data-is-focusable')).equals('true', 'data-is-focusable');
+    expect(dropdownRoot.getAttribute('data-is-focusable')).equals('false', 'data-is-focusable');
   });
 
 });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -81,7 +81,7 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
           <label id={ id + '-label' } className='ms-Label' ref={ (dropdownLabel) => this._dropdownLabel = dropdownLabel } >{ label }</label>
         ) }
         <div
-          data-is-focusable={ disabled }
+          data-is-focusable={ !disabled }
           ref={ (c): HTMLElement => this._dropDown = c }
           id={ id }
           className={ css('ms-Dropdown', {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #667
- [X] Include a change request file if publishing (Run `npmx change` to generate it.)
- [X] New feature, bugfix, or enhancement
  - [X] Includes tests

#### Description of changes

When the dropdown component is focusable, we now set the `data-is-focusable` attribute correctly.

