### PR TITLE
Removed closing bracket preference in vscode/settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,6 @@
   "editor.detectIndentation": false,
   // When enabled, will trim trailing whitespace when you save a file.
   "files.trimTrailingWhitespace": true,
-  // Controls if the editor should automatically close brackets after opening them
-  "editor.autoClosingBrackets": false,
   // Controls whether the editor should render whitespace characters
   "editor.renderWhitespace": "all",
   // Controls if the editor will insert spaces for tabs. Accepted values:  "auto", true, false. If set to "auto", the value will be guessed when a file is opened.


### PR DESCRIPTION
#### Description of changes

Removed closing bracket preference in vscode/settings. The default of this is already true (no need to set it to true). This isn't a coding standard setting, it's a personal choice that should be made in each users' settings. 




