### PR TITLE
Focus: IE will now return false for elements that are not tabbable.

### DIFF
--- a/common/changes/focus_2016-12-09-22-12.json
+++ b/common/changes/focus_2016-12-09-22-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Focus: IE will now return false for elements that are not tabbable.",
+      "type": "patch"
+    }
+  ],
+  "email": "yimwu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/focus.ts
+++ b/packages/office-ui-fabric-react/src/utilities/focus.ts
@@ -159,7 +159,11 @@ export function isElementTabbable(element: HTMLElement): boolean {
   }
 
   // In IE, element.tabIndex is default to 0. We need to use element get tabIndex attribute to get the correct tabIndex
-  const tabIndex = !!element && (element.getAttribute ? parseInt(element.getAttribute('tabIndex'), 10) : element.tabIndex);
+  let tabIndex = -1;
+
+  if (element && element.getAttribute) {
+    tabIndex = parseInt(element.getAttribute('tabIndex'), 10);
+  }
 
   return (
     !!element &&

--- a/packages/office-ui-fabric-react/src/utilities/focus.ts
+++ b/packages/office-ui-fabric-react/src/utilities/focus.ts
@@ -158,13 +158,16 @@ export function isElementTabbable(element: HTMLElement): boolean {
     return false;
   }
 
+  // In IE, element.tabIndex is default to 0. We need to use element get tabIndex attribute to get the correct tabIndex
+  const tabIndex = !!element && (element.getAttribute ? parseInt(element.getAttribute('tabIndex'), 10) : element.tabIndex);
+
   return (
     !!element &&
     (element.tagName === 'A' ||
       (element.tagName === 'BUTTON') ||
       (element.tagName === 'INPUT') ||
       (element.tagName === 'TEXTAREA') ||
-      (element.tabIndex >= 0) ||
+      (tabIndex >= 0) ||
       (element.getAttribute && (
         element.getAttribute(IS_FOCUSABLE_ATTRIBUTE) === 'true') ||
         element.getAttribute('role') === 'button')


### PR DESCRIPTION
#### Pull request checklist

- [no ] Addresses an existing issue: #0000
- [ yes] Include a change request file if publishing (Run `npmx change` to generate it.)
- [ bugfix] New feature, bugfix, or enhancement
  - [ no. already has unit test but this is IE specific ] Includes tests
- [ no ] Documentation update

#### Description of changes

In IE, element.tabIndex is default to 0. We need to use element get tabIndex attribute to get the correct tabIndex.

With the fix, IE will now return false for elements that are not tabbable.

#### Focus areas to test
Verify focus zone still work as expected in both IE and Chrome.



