### PR TITLE
Calendar: handle invalid starting dates

### DIFF
--- a/common/changes/calendar-handle-invalid-date_2016-12-12-18-28.json
+++ b/common/changes/calendar-handle-invalid-date_2016-12-12-18-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Calendar: handle invalid starting dates",
+      "type": "patch"
+    }
+  ],
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.test.tsx
@@ -64,6 +64,27 @@ describe('Calendar', () => {
     goToToday: 'Go to today'
   };
 
+  it('can handle invalid starting dates', () => {
+    // Arrange
+    let defaultDate = new Date('invalid');
+
+    // Act
+    try {
+      let renderedComponent = ReactTestUtils.renderIntoDocument(
+        <Calendar
+          strings={ dayPickerStrings }
+          isMonthPickerVisible={ true }
+          value={ defaultDate }
+          />) as Calendar;
+
+      let today = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-day--today') as HTMLElement;
+
+      expect(+today.innerText).to.be.equal(new Date().getDate());
+    } catch (err) {
+      expect.fail(err, null, 'Encountered error trying to render a Calendar with an invalid date');
+    }
+  });
+
   describe('Test rendering simplest calendar', () => {
     let renderedComponent: Calendar;
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -41,7 +41,9 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
   constructor(props: ICalendarProps) {
     super();
 
-    let currentDate = props.value || new Date();
+    let currentDate = props.value && !isNaN(props.value.getTime()) ?
+      props.value
+      : new Date();
     this.state = {
       selectedDate: currentDate,
       navigatedDate: currentDate


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #685 
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Description of changes

Calendar now verifies that the starting date passed in is a valid date. If not, it defaults to today.


