### PR TITLE
Layer: Change layer to use parentNode.removeChild(childnode) instead of node.remove()

### DIFF
--- a/common/changes/layer-fixforie_2016-12-20-02-05.json
+++ b/common/changes/layer-fixforie_2016-12-20-02-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Layer used node/element.remove() which is not present in ie. This change has it use parentnode.removeChild(childnode) instead",
+      "type": "patch"
+    }
+  ],
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
@@ -119,7 +119,10 @@ export class Layer extends BaseComponent<ILayerProps, {}> {
       this.props.onLayerWillUnmount();
 
       ReactDOM.unmountComponentAtNode(this._layerElement);
-      this._layerElement.remove();
+      let parentNode = this._layerElement.parentNode;
+      if (parentNode) {
+        parentNode.removeChild(this._layerElement);
+      }
       this._layerElement = undefined;
       this._hasMounted = false;
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #701 
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)
- [x] Documentation update

#### Description of changes

Fixed a bug where layer would always fail to be removed in ie because ie does not have the function node/element.remove()


