### PR TITLE
Fix #695: Adding id and role to tooltip

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
@@ -25,7 +25,7 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
   };
 
   public render() {
-    let { targetElement, content, calloutProps, directionalHint, delay } = this.props;
+    let { targetElement, content, calloutProps, directionalHint, delay, id } = this.props;
 
     return (
       <Callout
@@ -36,7 +36,7 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
         { ...getNativeProps(this.props, divProperties) }
       >
         <div className='ms-Tooltip-content'>
-          <p className='ms-Tooltip-subText'>
+          <p className='ms-Tooltip-subText' id={ id } role='tooltip'>
             { content }
           </p>
         </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #695
- [ ] Include a change request file if publishing (Run `npmx change` to generate it.)
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes
1 TooltipHost supports ID attribute to enable aria-describeby on wrapped component but Tooltip doesn't render it in content dom. 
2. role='tooltip' is required to implement tooltip aria pattern. https://www.w3.org/TR/wai-aria-practices-1.1/#tooltip

#### Focus areas to test

(optional)


