### PR TITLE
Pivot: state updates may be asynchronous 

### DIFF
--- a/common/changes/xingwa-pivot-state_2016-12-26-06-32.json
+++ b/common/changes/xingwa-pivot-state_2016-12-26-06-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pivot: state updates may be asynchronous",
+      "type": "minor"
+    }
+  ],
+  "email": "xingwa@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -61,14 +61,13 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
 
   public componentWillReceiveProps(nextProps: IPivotProps) {
     const links: IPivotItemProps[] = this._getPivotLinks(nextProps);
-    const selectedKey: string = this._isKeyValid(this.state.selectedKey)
-      ? this.state.selectedKey
-      : links[0].itemKey;
 
-    this.setState({
-      links,
-      selectedKey
-    } as IPivotState);
+    this.setState((prevState, props) => ({
+      links: links,
+      selectedKey: this._isKeyValid(prevState.selectedKey)
+        ? prevState.selectedKey
+        : links[0].itemKey
+    }) as IPivotState);
   }
 
   public render() {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file if publishing (Run `npmx change` to generate it.)

#### Description of changes
React batch multiple setState() calls into a single update when re-render Pivot.
Because this.props and this.state may be updated asynchronously, it should not rely on their values for calculating the next state.
This code may fail to update the selectedKey:
public componentWillReceiveProps(nextProps: IPivotProps) {
    this.setState({
      selectedKey: this._isKeyValid(this.state.selectedKey)
      ? this.state.selectedKey
      : links[0].itemKey;
    } );
  }
#### Focus areas to test
Fox example, this code will update both props and state. 
`<Pivot onLinkClick={ this._handleClick}>`
  private _handleClick(): void {
    this.setState({
      ......
    });
  }
React reference: https://facebook.github.io/react/docs/state-and-lifecycle.html
