### PR TITLE
TextField: Remove line-height and vertical padding from the field

### DIFF
--- a/common/changes/master_2016-12-26-07-01.json
+++ b/common/changes/master_2016-12-26-07-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed TextField clip issue",
+      "type": "patch"
+    }
+  ],
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -62,7 +62,6 @@
   font-size: $ms-font-size-m;
   color: $ms-color-neutralPrimary;
   height: 32px;
-  line-height: 32px;
   @include padding(0, 12px, 0, 12px);
   width: 100%;
   outline: 0;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -62,7 +62,8 @@
   font-size: $ms-font-size-m;
   color: $ms-color-neutralPrimary;
   height: 32px;
-  @include padding(6px, 12px, 7px, 12px);
+  line-height: 32px;
+  @include padding(0, 12px, 0, 12px);
   width: 100%;
   outline: 0;
   text-overflow: ellipsis;

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
@@ -25,7 +25,7 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
   };
 
   public render() {
-    let { targetElement, content, calloutProps, directionalHint, delay } = this.props;
+    let { targetElement, content, calloutProps, directionalHint, delay, id } = this.props;
 
     return (
       <Callout
@@ -36,7 +36,7 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
         { ...getNativeProps(this.props, divProperties) }
       >
         <div className='ms-Tooltip-content'>
-          <p className='ms-Tooltip-subText'>
+          <p className='ms-Tooltip-subText' id={ id } role='tooltip'>
             { content }
           </p>
         </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #720
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)

#### Description of changes
Removes line-height and the top and bottom padding from `ms-TextField-field`, leaving the default vertical centering from the browser and preventing text ascenders/descenders from being cut off.

#### Focus areas to test

Not applicable, change to CSS only.


