### PR TITLE
[property parser]: Fixed bug in property parser where all fields are marked deprecated

### DIFF
--- a/common/changes/interfaceparser-bugfix_2016-12-28-09-58.json
+++ b/common/changes/interfaceparser-bugfix_2016-12-28-09-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Bug fix for interface parser where all fields are marked deprecated",
+      "type": "patch"
+    }
+  ],
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/demo/utilities/parser/InterfaceParserHelper.ts
+++ b/packages/office-ui-fabric-react/src/demo/utilities/parser/InterfaceParserHelper.ts
@@ -132,7 +132,9 @@ export class InterfaceParserHelper extends BaseParser {
               deprecatedMessage
             });
 
-            comment = identifierName = type = defaultValue = '';
+            // resets
+            comment = identifierName = type = defaultValue = deprecatedMessage = '';
+            isDeprecated = false;
           }
           break;
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #724 
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)

#### Description of changes
Interface parser misses variable resets before it moves to next property. Due to this, it marks all props as deprecated.  

#### future work, if any.
Few tests can be added to check interface parsing logic. but its not a critical path. 