### PR TITLE
ColorPicker: Ensure it reacts to props changes

### DIFF
--- a/common/changes/color-picker-statefix_2016-12-29-07-52.json
+++ b/common/changes/color-picker-statefix_2016-12-29-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix for color picker not responding to prop changes",
+      "type": "patch"
+    }
+  ],
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -1,18 +1,15 @@
 /* tslint:disable:no-unused-variable */
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
-
 import * as ReactTestUtils from 'react-addons-test-utils';
+import { ColorPicker } from './ColorPicker';
 
 let { expect } = chai;
 
-import { ColorPicker } from './ColorPicker';
-
 describe('ColorPicker', () => {
-
   it('Props are correctly parsed', () => {
     let component = ReactTestUtils.renderIntoDocument(
-      <ColorPicker color='#FFFFFF'/>
+      <ColorPicker color='#FFFFFF' />
     ) as ColorPicker;
 
     expect(component.state.color.hex).to.equal('ffffff');
@@ -20,10 +17,23 @@ describe('ColorPicker', () => {
 
   it('Reacts to props changes', () => {
     let component = ReactTestUtils.renderIntoDocument(
-      <ColorPicker color='#FFFFFF'/>
+      <ColorPicker color='#FFFFFF' />
     ) as ColorPicker;
 
     component.componentWillReceiveProps({ color: '#AEAEAE' });
     expect(component.state.color.hex).to.equal('aeaeae');
+  });
+
+  it('onColorChange is called', () => {
+    let color = '#FFFFFF';
+    let component = ReactTestUtils.renderIntoDocument(
+      <ColorPicker color={ color } onColorChanged={ str => color = str } />
+    ) as ColorPicker;
+
+    const newColor = '#AEAEAE';
+    component.componentWillReceiveProps({ color: newColor });
+
+    expect(component.state.color.hex).to.equal('aeaeae');
+    expect(color).to.equal(newColor);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -1,0 +1,30 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
+import * as ReactDOM from 'react-dom';
+import * as ReactTestUtils from 'react-addons-test-utils';
+
+let { expect } = chai;
+
+import { ColorPicker } from './ColorPicker';
+
+describe('ColorPicker', () => {
+
+  it('Props are correctly parsed', () => {
+    let component = ReactTestUtils.renderIntoDocument(
+      <ColorPicker color='#FFFFFF'/>
+    ) as ColorPicker;
+
+    expect(component.state.color.hex).to.equal('ffffff');
+  });
+
+  it('Reacts to props changes', () => {
+    let component = ReactTestUtils.renderIntoDocument(
+      <ColorPicker color='#FFFFFF'/>
+    ) as ColorPicker;
+
+    component.componentWillReceiveProps({ color: '#AEAEAE' });
+    expect(component.state.color.hex).to.equal('aeaeae');
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 
-import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-addons-test-utils';
 
 let { expect } = chai;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -31,13 +31,27 @@ export interface IColor {
   str: string;
 }
 
-export class ColorPicker extends React.Component<IColorPickerProps, any> {
+export class ColorPicker extends React.Component<IColorPickerProps, IColorPickerState> {
   constructor(props: IColorPickerProps) {
     super(props);
 
     this.state = {
       color: getColorFromString(props.color)
-    };
+    } as IColorPickerState;
+  }
+
+  public componentWillReceiveProps(newProps: IColorPickerProps) {
+    const { onColorChanged } = this.props;
+
+    if (newProps.color !== undefined && newProps.color !== this.state.color.str) {
+      if (onColorChanged) {
+        onColorChanged(newProps.color);
+      }
+
+      this.setState({
+        color: getColorFromString(newProps.color),
+      } as IColorPickerState);
+    }
   }
 
   public render() {
@@ -75,10 +89,10 @@ export class ColorPicker extends React.Component<IColorPickerProps, any> {
             <tbody>
               <tr>
                 <td><TextField className='ms-ColorPicker-input' value={ color.hex } /></td>
-                <td style={ { width: '18%' } }><TextField className='ms-ColorPicker-input' value={ color.r } /></td>
-                <td style={ { width: '18%' } }><TextField className='ms-ColorPicker-input' value={ color.g } /></td>
-                <td style={ { width: '18%' } }><TextField className='ms-ColorPicker-input' value={ color.b } /></td>
-                <td style={ { width: '18%' } }><TextField className='ms-ColorPicker-input' value={ color.a } /></td>
+                <td style={ { width: '18%' } }><TextField className='ms-ColorPicker-input' value={ String(color.r) } /></td>
+                <td style={ { width: '18%' } }><TextField className='ms-ColorPicker-input' value={ String(color.g) } /></td>
+                <td style={ { width: '18%' } }><TextField className='ms-ColorPicker-input' value={ String(color.b) } /></td>
+                <td style={ { width: '18%' } }><TextField className='ms-ColorPicker-input' value={ String(color.a) } /></td>
               </tr>
             </tbody>
           </table>
@@ -108,7 +122,7 @@ export class ColorPicker extends React.Component<IColorPickerProps, any> {
     if (newColor.str !== this.state.color.str) {
       this.setState({
         color: newColor
-      });
+      } as IColorPickerState);
 
       if (onColorChanged) {
         onColorChanged(newColor.str);

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -41,16 +41,8 @@ export class ColorPicker extends React.Component<IColorPickerProps, IColorPicker
   }
 
   public componentWillReceiveProps(newProps: IColorPickerProps) {
-    const { onColorChanged } = this.props;
-
-    if (newProps.color !== undefined && newProps.color !== this.state.color.str) {
-      if (onColorChanged) {
-        onColorChanged(newProps.color);
-      }
-
-      this.setState({
-        color: getColorFromString(newProps.color),
-      } as IColorPickerState);
+    if (newProps.color) {
+      this._updateColor(getColorFromString(newProps.color));
     }
   }
 
@@ -122,12 +114,11 @@ export class ColorPicker extends React.Component<IColorPickerProps, IColorPicker
     if (newColor.str !== this.state.color.str) {
       this.setState({
         color: newColor
-      } as IColorPickerState);
-
-      if (onColorChanged) {
-        onColorChanged(newColor.str);
-      }
+      } as IColorPickerState, () => {
+        if (onColorChanged) {
+          onColorChanged(newColor.str);
+        }
+      });
     }
   }
-
 }


### PR DESCRIPTION
#### Pull request checklist
- [x] Addresses an existing issue: #721
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)
- [x] Bugfix
  - [x] Includes tests

#### Description of changes
color pickers doesn't react to props changes from parent component. Currently, the props are treated as one time properties and `render()` method uses only the `state`. 
We need to listen to prop changes using `componentWillRecieveProps` and set new props as internal state of the component before a re-render is performed. 

#### Focus areas to test



