### PR TITLE
Callout: Move deprecated props to bottom

### DIFF
--- a/common/changes/callout-deprecated-docs_2016-12-29-16-43.json
+++ b/common/changes/callout-deprecated-docs_2016-12-29-16-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed location of deprecated props",
+      "type": "patch"
+    }
+  ],
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -15,12 +15,6 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
   target?: HTMLElement | string | MouseEvent;
 
   /**
-   * The element that the Callout should be positioned based on.
-   * @deprecated at version 0.72.1 and will no longer exist after 1.0 use target instead
-   */
-  targetElement?: HTMLElement;
-
-  /**
    * How the element should be positioned
    * @default DirectionalHint.BottomAutoEdge
    */
@@ -68,12 +62,6 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
   coverTarget?: boolean;
 
   /**
-    * @deprecated
-    * Deprecated at v0.59.1, to be removed at >= v1.0.0. Pass in a beakWidth to dictate size.
-    */
-  beakStyle?: string;
-
-  /**
    * CSS class to apply to the callout.
    * @default null
    */
@@ -107,4 +95,16 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
    * @returns True if focus was set, false if it was not.
    */
   setInitialFocus?: boolean;
+
+  /**
+    * @deprecated
+    * Deprecated at v0.59.1, to be removed at >= v1.0.0. Pass in a beakWidth to dictate size.
+    */
+  beakStyle?: string;
+
+  /**
+   * @deprecated
+   * Deprecated at  v0.72.1 and will no longer exist after 1.0 use target instead.
+   */
+  targetElement?: HTMLElement;
 }

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -104,7 +104,7 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
 
   /**
    * @deprecated
-   * Deprecated at  v0.72.1 and will no longer exist after 1.0 use target instead.
+   * Deprecated at v0.72.1 and will no longer exist after 1.0 use target instead.
    */
   targetElement?: HTMLElement;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #724
- [x] Include a change request file if publishing (Run `npmx change` to generate it.)

#### Description of changes

Deprecated props need to be at the end of the list of component props otherwise any subsequent props are placed into deprecated section. Therefore moved deprecated props to bottom of the list. 

