### PR TITLE
Add optional selectedKey to Pivot

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.Props.ts
@@ -19,6 +19,13 @@ export interface IPivotProps extends React.Props<Pivot> {
   initialSelectedKey?: string;
 
   /**
+   * The key of the selected pivot item.
+   *
+   * If set, this will override the Pivot's selected item state.
+   */
+  selectedKey?: string;
+
+  /**
    * Callback issued when the selected pivot item is changed
    */
   onLinkClick?: (item?: PivotItem, ev?: React.MouseEvent<HTMLElement>) => void;

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -46,6 +46,8 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
       selectedKey = props.initialSelectedKey;
     } else if (props.initialSelectedIndex) {
       selectedKey = links[props.initialSelectedIndex].itemKey;
+    } else if (props.selectedKey) {
+      selectedKey = props.selectedKey;
     } else {
       selectedKey = links[0].itemKey;
     }
@@ -61,9 +63,11 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
 
   public componentWillReceiveProps(nextProps: IPivotProps) {
     const links: IPivotItemProps[] = this._getPivotLinks(nextProps);
-    const selectedKey: string = this._isKeyValid(this.state.selectedKey)
-      ? this.state.selectedKey
-      : links[0].itemKey;
+    const selectedKey: string = this._isKeyValid(nextProps.selectedKey)
+    ? nextProps.selectedKey
+    : (this._isKeyValid(this.state.selectedKey)
+     ? this.state.selectedKey
+     : links[0].itemKey);
 
     this.setState({
       links,

--- a/packages/office-ui-fabric-react/src/demo/pages/PivotPage/PivotPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PivotPage/PivotPage.tsx
@@ -12,6 +12,7 @@ import { PivotTabsLargeExample } from './examples/Pivot.TabsLarge.Example';
 import { PivotFabricExample } from './examples/Pivot.Fabric.Example';
 import { PivotOnChangeExample } from './examples/Pivot.OnChange.Example';
 import { PivotRemoveExample } from './examples/Pivot.Remove.Example';
+import { PivotOverrideExample } from './examples/Pivot.Override.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
@@ -23,6 +24,7 @@ const PivotTabsExampleCode = require('./examples/Pivot.Tabs.Example.tsx');
 const PivotTabsLargesExampleCode = require('./examples/Pivot.TabsLarge.Example.tsx');
 const PivotFabricExampleCode = require('./examples/Pivot.Fabric.Example.tsx');
 const PivotOnChangeExampleCode = require('./examples/Pivot.OnChange.Example.tsx');
+const PivotOverrideExampleCode = require('./examples/Pivot.Override.Example.tsx');
 
 export class PivotPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -59,6 +61,9 @@ export class PivotPage extends React.Component<IComponentDemoPageProps, any> {
             </ExampleCard>
             <ExampleCard title='Show/Hide pivot item' code={ PivotRemoveExampleCode }>
               <PivotRemoveExample />
+            </ExampleCard>
+            <ExampleCard title='Override selected item' code={ PivotOverrideExampleCode }>
+              <PivotOverrideExample />
             </ExampleCard>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/demo/pages/PivotPage/examples/Pivot.Override.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PivotPage/examples/Pivot.Override.Example.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import {
+  Label,
+  Button,
+  Pivot,
+  PivotItem
+} from '../../../../index';
+
+export class PivotOverrideExample extends React.Component<any, any> {
+  constructor(props: any) {
+    super(props);
+
+    this.state = {
+      selectedKey: 0
+    };
+
+    this._handleClick = this._handleClick.bind(this);
+  }
+
+  public render() {
+    return (
+      <div>
+        <Pivot selectedKey={`${this.state.selectedKey}`}>
+          <PivotItem linkText='My Files' itemKey="0">
+            <Label>Pivot #1</Label>
+          </PivotItem>
+          <PivotItem linkText='Recent' itemKey="1">
+            <Label>Pivot #2</Label>
+          </PivotItem>
+          <PivotItem linkText='Shared with me' itemKey="2">
+            <Label>Pivot #3</Label>
+          </PivotItem>
+        </Pivot>
+        <Button onClick={ this._handleClick }>
+          Select next item
+        </Button>
+      </div>
+    );
+  }
+
+  private _handleClick(): void {
+    this.setState({ selectedKey: (this.state.selectedKey + 1) % 3 });
+  }
+}
+


### PR DESCRIPTION
This allows overriding the internal state to force an item to be
selected.

Re #479.

#### Pull request checklist

- [X] Addresses an existing issue: #479 
- [ ] Include a change request file if publishing (Run `npmx change` to generate it.)
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Adds optional selectedKey property to Pivot to allow overriding internal state.

#### Focus areas to test

Pivot.


