### PR TITLE
TextField: Multiline now respects rows attribute

### DIFF
--- a/common/changes/textfield-tweak_2017-01-04-22-32.json
+++ b/common/changes/textfield-tweak_2017-01-04-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: Multiline now respects rows attribute.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -184,18 +184,17 @@
 
 //== Modifier: Multiline textfield
 //
-.ms-TextField.ms-TextField--multiline {
-  .ms-TextField-field {
-    @include ms-baseFont;
-    color: $ms-color-neutralPrimary;
-    font-family: $ms-font-family-base;
-    font-size: $ms-font-size-m;
-    font-weight: $ms-font-weight-regular;
-    line-height: 17px;
-    min-height: 60px;
-    padding-top: 6px;
-    overflow: auto;
-  }
+.ms-TextField.ms-TextField--multiline .ms-TextField-field {
+  @include ms-baseFont;
+  color: $ms-color-neutralPrimary;
+  font-family: $ms-font-family-base;
+  font-size: $ms-font-size-m;
+  font-weight: $ms-font-weight-regular;
+  line-height: 17px;
+  min-height: 60px;
+  height: auto;
+  padding-top: 6px;
+  overflow: auto;
 }
 
 // @todo: https://github.com/OfficeDev/Office-UI-Fabric/issues/359

--- a/packages/office-ui-fabric-react/src/demo/pages/TextFieldPage/examples/TextField.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/TextFieldPage/examples/TextField.Basic.Example.tsx
@@ -12,7 +12,7 @@ export class TextFieldBasicExample extends React.Component<any, any> {
         <TextField label='Disabled TextField' disabled={ true } />
         <TextField label='Required TextField' required={ true } />
         <TextField label='TextField with a placeholder' placeholder='Now I am a Placeholder' ariaLabel='Please enter text here' />
-        <TextField label='Multiline TextField' multiline />
+        <TextField label='Multiline TextField' multiline rows={ 4 } />
         <TextField label='Multiline TextField Unresizable' multiline resizable={ false } />
         <TextField label='Multiline TextField with auto adjust height' multiline autoAdjustHeight />
         <TextField label='Underlined TextField' underlined />


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #737
- [X] Include a change request file if publishing <!-- see notes below! -->
- [X] Bug fix

#### Description of changes

Setting `height: auto` on multiline text fields so that they respect the rows attribute.
