### PR TITLE
Pivot: Add icon to PivotItem

### DIFF
--- a/common/changes/feature-pivotItemIcon_2017-01-05-23-29.json
+++ b/common/changes/feature-pivotItemIcon_2017-01-05-23-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Add icon property to PivotItem",
+      "comment": "Pivot: Add icon to PivotItem",
       "type": "minor"
     }
   ],

--- a/common/changes/feature-pivotItemIcon_2017-01-05-23-29.json
+++ b/common/changes/feature-pivotItemIcon_2017-01-05-23-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add icon property to PivotItem",
+      "type": "minor"
+    }
+  ],
+  "email": "cschleid@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.scss
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.scss
@@ -73,6 +73,13 @@
   .ms-Pivot-text,
   .ms-Pivot-count {
     display: inline-block;
+
+    vertical-align: top;
+  }
+
+  // Spacing between icon and text/count
+  .ms-Pivot-icon + .ms-Pivot-text {
+    @include margin-left(4px);
   }
 
   // Spacing between text and count

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -112,12 +112,12 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
     let { id } = this.state;
 
     let count;
-    if (itemCount !== undefined && this.props.linkFormat !== PivotLinkFormat.tabs) {
+    if (itemCount !== undefined) {
       count = <span className='ms-Pivot-count'>({ itemCount })</span>;
     }
 
     let icon: JSX.Element;
-    if (itemIcon !== undefined && this.props.linkFormat !== PivotLinkFormat.tabs) {
+    if (itemIcon !== undefined) {
       icon = <span className='ms-Pivot-icon'><i className={ `ms-Icon ms-Icon--${itemIcon}` }></i></span>;
     }
 

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -108,11 +108,22 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
    * Renders a pivot link
    */
   private _renderLink(link: IPivotItemProps) {
-    const { itemKey, itemCount } = link;
+    const { itemKey, itemCount, itemIcon, linkText } = link;
     let { id } = this.state;
-    let countText;
+
+    let count;
     if (itemCount !== undefined && this.props.linkFormat !== PivotLinkFormat.tabs) {
-      countText = <span className='ms-Pivot-count'>({ itemCount })</span>;
+      count = <span className='ms-Pivot-count'>({ itemCount })</span>;
+    }
+
+    let icon: JSX.Element;
+    if (itemIcon !== undefined && this.props.linkFormat !== PivotLinkFormat.tabs) {
+      icon = <span className='ms-Pivot-icon'><i className={ `ms-Icon ms-Icon--${itemIcon}` }></i></span>;
+    }
+
+    let text: JSX.Element;
+    if (linkText !== undefined) {
+      text = <span className='ms-Pivot-text'>{ link.linkText }</span>;
     }
 
     return (
@@ -126,8 +137,9 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
         role='tab'
         aria-controls={ id + '-panel' }
         aria-selected={ this.state.selectedKey === itemKey }>
-        <span className='ms-Pivot-text'>{ link.linkText }</span>
-        { countText }
+        { icon }
+        { text }
+        { count }
       </button>
     );
   }
@@ -167,7 +179,8 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
           linkText: pivotItem.props.linkText,
           ariaLabel: pivotItem.props.ariaLabel,
           itemKey: itemKey,
-          itemCount: pivotItem.props.itemCount
+          itemCount: pivotItem.props.itemCount,
+          itemIcon: pivotItem.props.itemIcon
         });
         this._keyToIndexMapping[itemKey] = index;
       }

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.Props.ts
@@ -4,7 +4,7 @@ export interface IPivotItemProps extends React.HTMLProps<HTMLDivElement> {
   /**
    * The text displayed of each pivot link.
    */
-  linkText: string;
+  linkText?: string;
 
   /**
    * An required key to uniquely identify a pivot item.
@@ -27,4 +27,8 @@ export interface IPivotItemProps extends React.HTMLProps<HTMLDivElement> {
    */
   itemCount?: number;
 
+  /**
+   * An optional icon to show next to the pivot link.
+   */
+  itemIcon?: string;
 }

--- a/packages/office-ui-fabric-react/src/demo/pages/PivotPage/PivotPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PivotPage/PivotPage.tsx
@@ -46,7 +46,7 @@ export class PivotPage extends React.Component<IComponentDemoPageProps, any> {
             <ExampleCard title='Basic example' code={ PivotBasicExampleCode }>
               <PivotBasicExample />
             </ExampleCard>
-            <ExampleCard title='Count and Icon example' code={ PivotIconCountExampleCode }>
+            <ExampleCard title='Count and Icon' code={ PivotIconCountExampleCode }>
               <PivotIconCountExample />
             </ExampleCard>
             <ExampleCard title='Large link size' code={ PivotLargeExampleCode }>

--- a/packages/office-ui-fabric-react/src/demo/pages/PivotPage/PivotPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PivotPage/PivotPage.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../components/index';
 
 import { PivotBasicExample } from './examples/Pivot.Basic.Example';
+import { PivotIconCountExample } from './examples/Pivot.IconCount.Example';
 import { PivotLargeExample } from './examples/Pivot.Large.Example';
 import { PivotTabsExample } from './examples/Pivot.Tabs.Example';
 import { PivotTabsLargeExample } from './examples/Pivot.TabsLarge.Example';
@@ -24,6 +25,7 @@ const PivotTabsExampleCode = require('./examples/Pivot.Tabs.Example.tsx');
 const PivotTabsLargesExampleCode = require('./examples/Pivot.TabsLarge.Example.tsx');
 const PivotFabricExampleCode = require('./examples/Pivot.Fabric.Example.tsx');
 const PivotOnChangeExampleCode = require('./examples/Pivot.OnChange.Example.tsx');
+const PivotIconCountExampleCode = require('./examples/Pivot.IconCount.Example.tsx');
 const PivotOverrideExampleCode = require('./examples/Pivot.Override.Example.tsx');
 
 export class PivotPage extends React.Component<IComponentDemoPageProps, any> {
@@ -43,6 +45,9 @@ export class PivotPage extends React.Component<IComponentDemoPageProps, any> {
           <div>
             <ExampleCard title='Basic example' code={ PivotBasicExampleCode }>
               <PivotBasicExample />
+            </ExampleCard>
+            <ExampleCard title='Count and Icon example' code={ PivotIconCountExampleCode }>
+              <PivotIconCountExample />
             </ExampleCard>
             <ExampleCard title='Large link size' code={ PivotLargeExampleCode }>
               <PivotLargeExample />

--- a/packages/office-ui-fabric-react/src/demo/pages/PivotPage/examples/Pivot.IconCount.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PivotPage/examples/Pivot.IconCount.Example.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import {
+  Label,
+  Pivot,
+  PivotItem
+} from '../../../../index';
+
+export class PivotIconCountExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <div>
+        <Pivot>
+          <PivotItem linkText='My Files' itemCount={ 42 } itemIcon='Emoji2'>
+            <Label>Pivot #1</Label>
+          </PivotItem>
+          <PivotItem itemCount={ 23 } itemIcon='Recent'>
+            <Label>Pivot #2</Label>
+          </PivotItem>
+          <PivotItem itemIcon='Globe'>
+            <Label>Pivot #3</Label>
+          </PivotItem>
+          <PivotItem linkText='Shared with me' itemIcon='Ringer' itemCount={ 1 }>
+            <Label>Pivot #4</Label>
+          </PivotItem>
+        </Pivot>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #750
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature
- [x] Documentation update

#### Description of changes

Add `linkIcon` property to `PivotItem` to allow showing an icon next to the pivot link.