### PR TITLE
Remove line-height from SearchBox to show correct cursor size in iOS

### DIFF
--- a/common/changes/bfix-removeSearchBoxLineHeight_2017-01-06-00-24.json
+++ b/common/changes/bfix-removeSearchBoxLineHeight_2017-01-06-00-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SearchBox: Remove line-height to show correct cursor size in iOS",
+      "type": "patch"
+    }
+  ],
+  "email": "cschleid@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
@@ -77,7 +77,6 @@ input.ms-SearchBox-field {
   font-size: inherit;
   color: $ms-color-black;
   height: $SearchBox-height - 2;
-  line-height: $SearchBox-height - 2;
   @include padding(6px, 38px, 7px, 31px);
   width: 100%;
   background-color: transparent;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #752
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New bugfix

#### Description of changes

Remove `line-height` from `SearchBox` style. 