### PR TITLE
Fix CommandBar to respect IContextualMenuItem.subMenuProps.items property

### DIFF
--- a/common/changes/master_2017-01-06-19-15.json
+++ b/common/changes/master_2017-01-06-19-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix the prescribed use of submenuProps.items for CommandBar items",
+      "type": "patch"
+    }
+  ],
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.test.tsx
@@ -43,7 +43,7 @@ describe('CommandBar', () => {
     ) as React.Component<CommandBar, {}>;
     document.body.appendChild(ReactDOM.findDOMNode(renderedContent));
 
-    let menuItem = (renderedContent.refs['TestKey1'] as HTMLDivElement).querySelector('button') as HTMLButtonElement;
+    let menuItem = (ReactDOM.findDOMNode(renderedContent) as HTMLElement).querySelector('button') as HTMLButtonElement;
     ReactTestUtils.Simulate.click(menuItem);
 
     expect(document.querySelector('.SubMenuClass')).to.exist;
@@ -73,7 +73,7 @@ describe('CommandBar', () => {
     ) as React.Component<CommandBar, {}>;
     document.body.appendChild(ReactDOM.findDOMNode(renderedContent));
 
-    let menuItem = (renderedContent.refs['TestKey1'] as HTMLDivElement).querySelector('button') as HTMLButtonElement;
+    let menuItem = (ReactDOM.findDOMNode(renderedContent) as HTMLElement).querySelector('button') as HTMLButtonElement;
     ReactTestUtils.Simulate.click(menuItem);
 
     expect(document.querySelector('.SubMenuClass')).to.exist;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.test.tsx
@@ -1,0 +1,81 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
+import * as ReactDOM from 'react-dom';
+import * as ReactTestUtils from 'react-addons-test-utils';
+
+let { expect } = chai;
+
+import { CommandBar } from './CommandBar';
+import { IContextualMenuItem } from '../ContextualMenu/ContextualMenu.Props';
+
+describe('CommandBar', () => {
+
+  afterEach(() => {
+    for (let i = 0; i < document.body.children.length; i++) {
+      if (document.body.children[i].tagName === 'DIV') {
+        document.body.removeChild(document.body.children[i]);
+        i--;
+      }
+    }
+  });
+
+  it('opens a menu with deprecated IContextualMenuItem.items property', () => {
+    const items: IContextualMenuItem[] = [
+      {
+        name: 'TestText 1',
+        key: 'TestKey1',
+        items: [
+          {
+            name: 'SubmenuText 1',
+            key: 'SubmenuKey1',
+            className: 'SubMenuClass'
+          }
+        ]
+      },
+    ];
+
+    let renderedContent = ReactTestUtils.renderIntoDocument<CommandBar>(
+      <CommandBar
+        items={ items }
+        />
+    ) as React.Component<CommandBar, {}>;
+    document.body.appendChild(ReactDOM.findDOMNode(renderedContent));
+
+    let menuItem = (renderedContent.refs['TestKey1'] as HTMLDivElement).querySelector('button') as HTMLButtonElement;
+    ReactTestUtils.Simulate.click(menuItem);
+
+    expect(document.querySelector('.SubMenuClass')).to.exist;
+  });
+
+  it('opens a menu with IContextualMenuItem.subMenuProps.items property', () => {
+    const items: IContextualMenuItem[] = [
+      {
+        name: 'TestText 1',
+        key: 'TestKey1',
+        subMenuProps: {
+          items: [
+            {
+              name: 'SubmenuText 1',
+              key: 'SubmenuKey1',
+              className: 'SubMenuClass'
+            }
+          ]
+        }
+      },
+    ];
+
+    let renderedContent = ReactTestUtils.renderIntoDocument<CommandBar>(
+      <CommandBar
+        items={ items }
+        />
+    ) as React.Component<CommandBar, {}>;
+    document.body.appendChild(ReactDOM.findDOMNode(renderedContent));
+
+    let menuItem = (renderedContent.refs['TestKey1'] as HTMLDivElement).querySelector('button') as HTMLButtonElement;
+    ReactTestUtils.Simulate.click(menuItem);
+
+    expect(document.querySelector('.SubMenuClass')).to.exist;
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ICommandBar, ICommandBarProps } from './CommandBar.Props';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
-import { ContextualMenu, IContextualMenuItem, hasSubmenuItems } from '../../ContextualMenu';
+import { ContextualMenu, IContextualMenuItem, getSubmenuItems, hasSubmenuItems } from '../../ContextualMenu';
 import { EventGroup } from '../../utilities/eventGroup/EventGroup';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { autobind } from '../../utilities/autobind';
@@ -156,7 +156,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
 
     return <div className={ css('ms-CommandBarItem', item.className) } key={ itemKey } ref={ itemKey }>
       { (() => {
-        if (item.onClick || item.items) {
+        if (item.onClick || hasSubmenuItems(item)) {
           return <button
             { ...getNativeProps(item, buttonProperties) }
             id={ this._id + item.key }
@@ -277,13 +277,13 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
   }
 
   private _onItemClick(ev, item) {
-    if (item.key === this.state.expandedMenuItemKey || !item.items || !item.items.length) {
+    if (item.key === this.state.expandedMenuItemKey || !hasSubmenuItems(item)) {
       this._onContextMenuDismiss();
     } else {
       this.setState({
         expandedMenuId: ev.currentTarget.id,
         expandedMenuItemKey: item.key,
-        contextualMenuItems: item.items,
+        contextualMenuItems: getSubmenuItems(item),
         contextualMenuTarget: ev.currentTarget
       });
     }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -16,8 +16,11 @@ import { IContextualMenuItem } from './ContextualMenu.Props';
 describe('ContextualMenu', () => {
 
   afterEach(() => {
-    while (window.document.body.children.length) {
-      window.document.body.removeChild(window.document.body.children[0]);
+    for (let i = 0; i < document.body.children.length; i++) {
+      if (document.body.children[i].tagName === 'DIV') {
+        document.body.removeChild(document.body.children[i]);
+        i--;
+      }
     }
   });
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -78,9 +78,13 @@ interface IParsedDirectionalHint {
 }
 
 export function hasSubmenuItems(item: IContextualMenuItem) {
-  let submenuItems = item.subMenuProps ? item.subMenuProps.items : item.items;
+  let submenuItems = getSubmenuItems(item);
 
   return !!(submenuItems && submenuItems.length);
+}
+
+export function getSubmenuItems(item: IContextualMenuItem) {
+  return item.subMenuProps ? item.subMenuProps.items : item.items;
 }
 
 export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContextualMenuState> {
@@ -377,7 +381,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   }
 
   private _onItemClick(item: any, ev: MouseEvent) {
-    let items = (item.subMenuProps && item.subMenuProps.items) ? item.subMenuProps.items : item.items;
+    let items = getSubmenuItems(item);
 
     if (!items || !items.length) { // This is an item without a menu. Click it.
       this._executeItemClick(item, ev);
@@ -421,7 +425,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       }
 
       let submenuProps = {
-        items: item.items,
+        items: getSubmenuItems(item),
         target: target,
         onDismiss: this._onSubMenuDismiss,
         isSubMenu: true,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #754
- [x] Include a change request file if publishing
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Description of changes

This change fixes a bug in CommandBar when using the newly-prescribed `subMenuProps.items` in place of the now-deprecated `items` property.

#### Focus areas to test

CommandBar items using the new property to show menu items
