### PR TITLE
Image: Add prop to maximize frame to parent element

### DIFF
--- a/common/changes/miwhea-image-cover-style_2017-01-09-20-19.json
+++ b/common/changes/miwhea-image-cover-style_2017-01-09-20-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Image: Recompute the cover style, even if no width or height is provided",
+      "type": "patch"
+    }
+  ],
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -26,7 +26,7 @@ export interface IImageProps extends React.HTMLProps<HTMLImageElement> {
   /**
    * If true, the image frame will expand to fill its parent container.
    */
-  shouldMaximizeFrame?: boolean;
+  maximizeFrame?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export interface IImageProps extends React.HTMLProps<HTMLImageElement>  {
+export interface IImageProps extends React.HTMLProps<HTMLImageElement> {
   /**
    * If true, adds the css class 'is-fadeIn' to the image.
    */
@@ -22,6 +22,11 @@ export interface IImageProps extends React.HTMLProps<HTMLImageElement>  {
    * Image source to display if an error occurs loading the image indicated by src.
    */
   errorSrc?: string;
+
+  /**
+   * If true, the image frame will expand to fill its parent container.
+   */
+  shouldMaximizeFrame?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Image/Image.scss
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.scss
@@ -4,6 +4,12 @@
   overflow: hidden;
 }
 
+// Modifier: The image frame should fill its parent element.
+.ms-Image--maximizeFrame {
+  height: 100%;
+  width: 100%;
+}
+
 .ms-Image-image {
   display: block;
   opacity: 0;

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -79,7 +79,7 @@ describe('Image', () => {
         <Image
           className='is-frameMaximizedPortrait'
           imageFit={ ImageFit.cover }
-          shouldMaximizeFrame
+          maximizeFrame
           src={ testImage1x1 }
           />
       </div>, root
@@ -102,7 +102,7 @@ describe('Image', () => {
           src={ testImage1x1 }
           imageFit={ ImageFit.cover }
           className='is-frameMaximizedLandscape'
-          shouldMaximizeFrame
+          maximizeFrame
           />
       </div>, root
     );

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -10,12 +10,16 @@ let { expect } = chai;
 import { Image } from './Image';
 import { ImageFit } from './Image.Props';
 
+const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
+const testImage1x2 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWP4////fyYGBgYGAB32A/+PRyXoAAAAAElFTkSuQmCC';
+const testImage2x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAAEUlEQVQImWP8////fwYGBgYAGfgD/hEzDhoAAAAASUVORK5CYII=';
+
 describe('Image', () => {
 
   it('renders an image', (done) => {
     ReactTestUtils.renderIntoDocument(
       <Image
-        src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        src={ testImage1x1 }
         onLoad={ () => {
           done();
         } }
@@ -28,7 +32,7 @@ describe('Image', () => {
     document.body.appendChild(root);
     ReactDOM.render<HTMLDivElement>(
       <Image
-        src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        src={ testImage1x1 }
         width={ 1 }
         height={ 3 }
         imageFit={ ImageFit.cover }
@@ -49,7 +53,7 @@ describe('Image', () => {
     document.body.appendChild(root);
     ReactDOM.render<HTMLDivElement>(
       <Image
-        src='data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        src={ testImage1x1 }
         width={ 3 }
         height={ 1 }
         imageFit={ ImageFit.cover }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -10,9 +10,11 @@ let { expect } = chai;
 import { Image } from './Image';
 import { ImageFit } from './Image.Props';
 
+/* tslint:disable:no-unused-variable */
 const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 const testImage1x2 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWP4////fyYGBgYGAB32A/+PRyXoAAAAAElFTkSuQmCC';
 const testImage2x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAAEUlEQVQImWP8////fwYGBgYAGfgD/hEzDhoAAAAASUVORK5CYII=';
+/* tslint:enable:no-unused-variable */
 
 describe('Image', () => {
 
@@ -64,6 +66,50 @@ describe('Image', () => {
     let image = document.querySelector('.ms-Image.is-landscapeFrame .ms-Image-image');
     try {
       expect(image.className).to.contain('ms-Image-image--portrait');
+    } catch (e) { done(e); }
+
+    done();
+  });
+
+  it('can cover a landscape (wide) parent element with a square image', (done) => {
+    let root = document.createElement('div');
+    document.body.appendChild(root);
+    ReactDOM.render<HTMLDivElement>(
+      <div style={ { width: '20px', height: '10px' } }>
+        <Image
+          className='is-frameMaximizedPortrait'
+          imageFit={ ImageFit.cover }
+          shouldMaximizeFrame
+          src={ testImage1x1 }
+          />
+      </div>, root
+    );
+
+    let image = document.querySelector('.ms-Image.is-frameMaximizedPortrait .ms-Image-image');
+    try {
+      expect(image.className).to.contain('ms-Image-image--portrait');
+    } catch (e) { done(e); }
+
+    done();
+  });
+
+  it('can cover a portrait (tall) parent element with a square image', (done) => {
+    let root = document.createElement('div');
+    document.body.appendChild(root);
+    ReactDOM.render<HTMLDivElement>(
+      <div style={ { width: '10px', height: '20px' } }>
+        <Image
+          src={ testImage1x1 }
+          imageFit={ ImageFit.cover }
+          className='is-frameMaximizedLandscape'
+          shouldMaximizeFrame
+          />
+      </div>, root
+    );
+
+    let image = document.querySelector('.ms-Image.is-frameMaximizedLandscape .ms-Image-image');
+    try {
+      expect(image.className).to.contain('ms-Image-image--landscape');
     } catch (e) { done(e); }
 
     done();

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -69,7 +69,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
 
   public render() {
     let imageProps = getNativeProps(this.props, imageProperties, ['width', 'height']);
-    let { src, alt, width, height, shouldFadeIn, className, imageFit, errorSrc, role } = this.props;
+    let { src, alt, width, height, shouldFadeIn, className, imageFit, errorSrc, role, shouldMaximizeFrame} = this.props;
     let { loadState } = this.state;
     let coverStyle = this._coverStyle;
     let loaded = loadState === ImageLoadState.loaded || loadState === ImageLoadState.errorLoaded;
@@ -79,7 +79,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     // If image dimensions aren't specified, the natural size of the image is used.
     return (
       <div
-        className={ css('ms-Image', className) }
+        className={ css('ms-Image', className, { 'ms-Image--maximizeFrame': shouldMaximizeFrame }) }
         style={ { width: width, height: height } }
         ref={ this._resolveRef('_frameElement') }
         >

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -69,7 +69,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
 
   public render() {
     let imageProps = getNativeProps(this.props, imageProperties, ['width', 'height']);
-    let { src, alt, width, height, shouldFadeIn, className, imageFit, errorSrc, role, shouldMaximizeFrame} = this.props;
+    let { src, alt, width, height, shouldFadeIn, className, imageFit, errorSrc, role, maximizeFrame} = this.props;
     let { loadState } = this.state;
     let coverStyle = this._coverStyle;
     let loaded = loadState === ImageLoadState.loaded || loadState === ImageLoadState.errorLoaded;
@@ -79,7 +79,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     // If image dimensions aren't specified, the natural size of the image is used.
     return (
       <div
-        className={ css('ms-Image', className, { 'ms-Image--maximizeFrame': shouldMaximizeFrame }) }
+        className={ css('ms-Image', className, { 'ms-Image--maximizeFrame': maximizeFrame }) }
         style={ { width: width, height: height } }
         ref={ this._resolveRef('_frameElement') }
         >

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -61,13 +61,9 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
   }
 
   public componentWillReceiveProps(nextProps: IImageProps) {
+    // If the image is not loaded, recompute the cover style.
     if (this.state.loadState === ImageLoadState.loaded) {
-      let { height: nextHeight, width: nextWidth } = nextProps;
-      let { height, width } = this.props;
-
-      if (height !== nextHeight || width !== nextWidth) {
-        this._computeCoverStyle(nextProps);
-      }
+      this._computeCoverStyle(nextProps);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/demo/pages/ImagePage/ImagePage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ImagePage/ImagePage.tsx
@@ -11,6 +11,7 @@ import { ImageCenterExample } from './examples/Image.Center.Example';
 import { ImageContainExample } from './examples/Image.Contain.Example';
 import { ImageCoverExample } from './examples/Image.Cover.Example';
 import { ImageNoneExample } from './examples/Image.None.Example';
+import { ImageMaximizeFrameExample } from './examples/Image.MaximizeFrame.Example';
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
@@ -20,6 +21,7 @@ const ImageCenterExampleCode = require('./examples/Image.Center.Example.tsx');
 const ImageContainExampleCode = require('./examples/Image.Contain.Example.tsx');
 const ImageCoverExampleCode = require('./examples/Image.Cover.Example.tsx');
 const ImageNoneExampleCode = require('./examples/Image.None.Example.tsx');
+const ImageMaximizeFrameExampleCode = require('./examples/Image.MaximizeFrame.Example.tsx');
 
 export class ImagePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -50,6 +52,9 @@ export class ImagePage extends React.Component<IComponentDemoPageProps, any> {
             </ExampleCard>
             <ExampleCard title='ImageFit: Cover' code={ ImageCoverExampleCode }>
               <ImageCoverExample />
+            </ExampleCard>
+            <ExampleCard title='Maximizing the image frame' code={ ImageMaximizeFrameExampleCode }>
+              <ImageMaximizeFrameExample />
             </ExampleCard>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/demo/pages/ImagePage/examples/Image.MaximizeFrame.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ImagePage/examples/Image.MaximizeFrame.Example.tsx
@@ -11,12 +11,12 @@ export class ImageMaximizeFrameExample extends React.Component<any, any> {
     let imageProps: IImageProps = {
       src: 'http://placehold.it/500x500',
       imageFit: ImageFit.cover,
-      shouldMaximizeFrame: true
+      maximizeFrame: true
     };
 
     return (
       <div>
-        <p>Where the exact width and height of the image's frame is not known, such as when sizing an image as a percentage of its parent, you can use the "shouldMaximizeFrame" prop to expand the frame to fill the parent element.</p>
+        <p>Where the exact width and height of the image's frame is not known, such as when sizing an image as a percentage of its parent, you can use the "maximizeFrame" prop to expand the frame to fill the parent element.</p>
         <Label>The image is placed within a landscape container.</Label>
         <div style={ { width: '200px', height: '100px' } }>
           <Image { ...imageProps as any } />

--- a/packages/office-ui-fabric-react/src/demo/pages/ImagePage/examples/Image.MaximizeFrame.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ImagePage/examples/Image.MaximizeFrame.Example.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  Image,
+  IImageProps,
+  ImageFit,
+  Label
+} from '../../../../index';
+
+export class ImageMaximizeFrameExample extends React.Component<any, any> {
+  public render() {
+    let imageProps: IImageProps = {
+      src: 'http://placehold.it/500x500',
+      imageFit: ImageFit.cover,
+      shouldMaximizeFrame: true
+    };
+
+    return (
+      <div>
+        <p>Where the exact width and height of the image's frame is not known, such as when sizing an image as a percentage of its parent, you can use the "shouldMaximizeFrame" prop to expand the frame to fill the parent element.</p>
+        <Label>The image is placed within a landscape container.</Label>
+        <div style={ { width: '200px', height: '100px' } }>
+          <Image { ...imageProps as any } />
+        </div>
+        <br />
+        <Label>The image is placed within a portrait container.</Label>
+        <div style={ { width: '100px', height: '200px' } }>
+          <Image { ...imageProps as any } />
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #767
- [x] Include a change request file if publishing
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Description of changes

Adds a new prop, `maximizeFrame`, that causes the Image frame to fill its parent container. This makes it easy to have an image that adapts to a changing layout, where the exact dimensions are unknown.

This also fixes #767 by calling `_computeCoverStyle()` whenever new props are received, even if `width` and `height` aren't provided. This fixes a bug where the cover style wasn't computed for images that have their width and height set to percentages or other values based on the parent element.

#### Focus areas to test

Use an ImageFit of 'cover' or 'contain'. Resize the image's container while using `shouldMaximizeFrame` and confirm that the correct cover style is applied.