### PR TITLE
Clean deprecated rootProps from Dialog Close button

### DIFF
--- a/common/changes/fixPopupCloseButtonRootProps_2017-01-11-16-17.json
+++ b/common/changes/fixPopupCloseButtonRootProps_2017-01-11-16-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Clean deprecated rootProps from Dialog Close button.",
+      "type": "patch"
+    }
+  ],
+  "email": "v-panu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
@@ -132,7 +132,6 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
                       className='ms-Dialog-button ms-Dialog-button--close'
                       buttonType={ ButtonType.icon }
                       icon='Cancel'
-                      rootProps={ { title: closeButtonAriaLabel } }
                       ariaLabel={ closeButtonAriaLabel }
                       onClick={ onDismiss }
                       />


### PR DESCRIPTION
#### Pull request checklist

- NO Addresses an existing issue: #0000
- [X] Include a change request file if publishing <!-- see notes below -->
- [X] ~~New feature,~~ bugfix, ~~or enhancement~~
  - NO Includes tests
- NO Documentation update

#### Description of changes

Dialogs with close button was showing this warning:

```
Button property 'rootProps' was used but has been deprecated.
```

The line was not needed, as there was already a flattened prop `ariaLabel`.
I've put up a codepen to confirm aria-label is properly generated without rootProps: http://codepen.io/pablonete/pen/bgEXea
