### PR TITLE
DetailsList: Removing group key generation that was causing groups to re-render unnecessarily

### DIFF
--- a/common/changes/details-list-flicker_2017-01-11-20-10.json
+++ b/common/changes/details-list-flicker_2017-01-11-20-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: when adding new items in a grouped DetailsList scenario, the group is no longer recreated.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.scss
@@ -25,7 +25,7 @@ $groupHeader-ease-in-back: cubic-bezier(0.600, -0.280, 0.735, 0.045);
   @include focus-border();
   display: inline-block;
   cursor: default;
-  padding: 8px;
+  padding: 6px;
   transform: translateY(50%);
   margin-top: -12px;
   box-sizing: border-box;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -159,7 +159,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
     return (!group || group.count > 0) ? (
       <GroupedListSection
         ref={ 'group_' + groupIndex }
-        key={ group.key }
+        key={ this._getGroupKey(group, groupIndex) }
         dragDropEvents={ dragDropEvents }
         dragDropHelper={ dragDropHelper }
         eventsToRegister={ eventsToRegister }
@@ -179,6 +179,10 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
         viewport={ viewport }
         />
     ) : null;
+  }
+
+  private _getGroupKey(group: IGroup, index: number): string {
+    return 'group-' + ((group && group.key) ? group.key : String(index));
   }
 
   private _getGroupNestingDepth(): number {
@@ -206,6 +210,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
 
       group.isCollapsed = !group.isCollapsed;
       this._updateIsSomeGroupExpanded();
+      // this.forceUpdate();
       this.setState({}, this.forceUpdate);
     }
   }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -159,7 +159,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
     return (!group || group.count > 0) ? (
       <GroupedListSection
         ref={ 'group_' + groupIndex }
-        key={ this._getGroupKey(group) }
+        key={ group.key }
         dragDropEvents={ dragDropEvents }
         dragDropHelper={ dragDropHelper }
         eventsToRegister={ eventsToRegister }
@@ -178,14 +178,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
         selection={ selection }
         viewport={ viewport }
         />
-      ) : null;
-  }
-
-  @autobind
-  private _getGroupKey(group: IGroup): string {
-    return 'group-' + (group ?
-      group.key + '-' + group.count :
-      '');
+    ) : null;
   }
 
   private _getGroupNestingDepth(): number {
@@ -213,7 +206,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
 
       group.isCollapsed = !group.isCollapsed;
       this._updateIsSomeGroupExpanded();
-      this.setState({ }, this.forceUpdate);
+      this.setState({}, this.forceUpdate);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -210,8 +210,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
 
       group.isCollapsed = !group.isCollapsed;
       this._updateIsSomeGroupExpanded();
-      // this.forceUpdate();
-      this.setState({}, this.forceUpdate);
+      this.forceUpdate();
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -290,7 +290,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
     return (!subGroup || subGroup.count > 0) ? (
       <GroupedListSection
         ref={ 'subGroup_' + subGroupIndex }
-        key={ this._getGroupKey(subGroup, subGroupIndex) }
+        key={ subGroup.key }
         dragDropEvents={ dragDropEvents }
         dragDropHelper={ dragDropHelper }
         eventsToRegister={ eventsToRegister }
@@ -308,12 +308,6 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
         viewport={ viewport }
         />
     ) : null;
-  }
-
-  private _getGroupKey(group: IGroup, groupIndex: number): string {
-    return 'group-' + (group ?
-      group.key + '-' + group.count :
-      '');
   }
 
   /**

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -290,7 +290,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
     return (!subGroup || subGroup.count > 0) ? (
       <GroupedListSection
         ref={ 'subGroup_' + subGroupIndex }
-        key={ subGroup.key }
+        key={ this._getGroupKey(subGroup, subGroupIndex) }
         dragDropEvents={ dragDropEvents }
         dragDropHelper={ dragDropHelper }
         eventsToRegister={ eventsToRegister }
@@ -308,6 +308,10 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
         viewport={ viewport }
         />
     ) : null;
+  }
+
+  private _getGroupKey(group, index) {
+    return 'group-' + ((group && group.key) ? group.key : String(group.level) + String(index));
   }
 
   /**

--- a/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/DetailsListPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/DetailsListPage.tsx
@@ -27,8 +27,11 @@ const DetailsListCustomGroupHeadersExampleCode = require('./examples/DetailsList
 import { DetailsListAdvancedExample } from './examples/DetailsList.Advanced.Example';
 const DetailsListAdvancedExampleCode = require('./examples/DetailsList.Advanced.Example.tsx');
 
+import { DetailsListGroupedExample } from './examples/DetailsList.Grouped.Example';
+const DetailsListGroupedExampleCode = require('./examples/DetailsList.Grouped.Example.tsx');
+
 export class DetailsListPage extends React.Component<IComponentDemoPageProps, any> {
- private _url: string;
+  private _url: string;
 
   constructor() {
     super();
@@ -44,6 +47,9 @@ export class DetailsListPage extends React.Component<IComponentDemoPageProps, an
           <div>
             <ExampleCard title='Simple DetailsList with 500 items, filtering, marquee selection' isOptIn={ true } code={ DetailsListBasicExampleCode }>
               <DetailsListBasicExample />
+            </ExampleCard>
+            <ExampleCard title='Simple Grouped DetailsList' isOptIn={ true } code={ DetailsListGroupedExampleCode }>
+              <DetailsListGroupedExample />
             </ExampleCard>
             <ExampleCard title='Rendering custom item columns with sorting' isOptIn={ true } code={ DetailsListCustomColumnsExampleCode }>
               <DetailsListCustomColumnsExample />

--- a/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/examples/DetailsList.Grouped.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/examples/DetailsList.Grouped.Example.tsx
@@ -1,0 +1,123 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+import {
+  Button,
+  DetailsList,
+  Fabric
+} from '../../../../index';
+
+let _columns = [
+  {
+    key: 'name',
+    name: 'Name',
+    fieldName: 'name',
+    minWidth: 100,
+    maxWidth: 200,
+    isResizable: true
+  },
+  {
+    key: 'color',
+    name: 'Color',
+    fieldName: 'color',
+    minWidth: 100,
+    maxWidth: 200
+  }
+];
+let _items = [
+  {
+    key: 'a',
+    name: 'a',
+    color: 'red'
+  },
+  {
+    key: 'b',
+    name: 'b',
+    color: 'red'
+  },
+  {
+    key: 'c',
+    name: 'c',
+    color: 'blue'
+  },
+  {
+    key: 'd',
+    name: 'd',
+    color: 'blue'
+  },
+  {
+    key: 'e',
+    name: 'e',
+    color: 'blue'
+  }
+];
+
+function groupBy(items, fieldName) {
+  let groups = items.reduce((currentGroups, currentItem, index) => {
+    let lastGroup = currentGroups[currentGroups.length - 1];
+    let fieldValue = currentItem[fieldName];
+
+    if (!lastGroup || lastGroup.value !== fieldValue) {
+      currentGroups.push({
+        key: 'group' + fieldValue + index,
+        name: `By "${fieldValue}"`,
+        value: fieldValue,
+        startIndex: index,
+        level: 0,
+        count: 0
+      });
+    }
+    if (lastGroup) {
+      lastGroup.count = index - lastGroup.startIndex;
+    }
+    return currentGroups;
+  }, []);
+
+  // Fix last group count
+  let lastGroup = groups[groups.length - 1];
+
+  if (lastGroup) {
+    lastGroup.count = items.length - lastGroup.startIndex;
+  }
+
+  return groups;
+}
+
+
+export class DetailsListGroupedExample extends React.Component<any, any> {
+  constructor() {
+    super();
+
+    this.state = {
+      items: _items
+    };
+  }
+
+  public render() {
+    let { items } = this.state;
+
+    return (
+      <Fabric className='foo'>
+        <Button onClick={ () => this._addItem() }>Add an item</Button>
+        <DetailsList
+          items={ items }
+          groups={ groupBy(items, 'color') }
+          columns={ _columns }
+          />
+      </Fabric>
+    );
+  }
+
+  private _addItem() {
+    let items = this.state.items;
+
+    this.setState({
+      items: items.concat([{
+        key: 'item-' + items.length,
+        name: 'New item ' + items.length,
+        color: 'blue'
+      }])
+    });
+  }
+
+}

--- a/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/examples/DetailsList.Grouped.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/examples/DetailsList.Grouped.Example.tsx
@@ -83,7 +83,6 @@ function groupBy(items, fieldName) {
   return groups;
 }
 
-
 export class DetailsListGroupedExample extends React.Component<any, any> {
   constructor() {
     super();


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #795
- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### Description of changes

Updating GroupedList code to use the group.key for the group key, rather than generating based on start index and count, which is currently causing repaints if either change.

Added an example to demonstrate using grouping in details list, and added a button to append another item to the list.
