### PR TITLE
Persona: Set height on ms-Persona-ImageArea and ms-Persona-Image

### DIFF
--- a/common/changes/leddie24-persona-imagearea-fix_2017-01-11-21-05.json
+++ b/common/changes/leddie24-persona-imagearea-fix_2017-01-11-21-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Set explicit height for ms-Persona-ImageArea and ms-Persona-Image",
+      "type": "patch"
+    }
+  ],
+  "email": "v-edwliu@microsoft.com"
+}

--- a/common/changes/leddie24-persona-imagearea-fix_2017-01-11-21-05.json
+++ b/common/changes/leddie24-persona-imagearea-fix_2017-01-11-21-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Set explicit height for ms-Persona-ImageArea and ms-Persona-Image",
+      "comment": "Persona: Set an explicit height for the image area and image.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -82,6 +82,7 @@ $ms-Persona-presenceSizeXl: 28px;
   overflow: hidden;
   text-align: center;
   flex: 0 0 $ms-Persona-sizeMd;
+  height: $ms-Persona-sizeMd;
   border-radius: 50%;
 
   @media screen and (-ms-high-contrast: active) {
@@ -321,6 +322,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-imageArea,
   .ms-Persona-image {
     flex: 0 0 $ms-Persona-sizeXs;
+    height: $ms-Persona-sizeXs;
   }
 
   .ms-Persona-placeholder {
@@ -357,6 +359,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-imageArea,
   .ms-Persona-image {
     flex: 0 0 $ms-Persona-sizeSm;
+    height: $ms-Persona-sizeSm;
   }
 
   .ms-Persona-placeholder {
@@ -393,6 +396,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-imageArea,
   .ms-Persona-image {
     flex: 0 0 $ms-Persona-sizeLg;
+    height: $ms-Persona-sizeLg;
   }
 
   .ms-Persona-placeholder {
@@ -435,6 +439,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-imageArea,
   .ms-Persona-image {
     flex: 0 0 $ms-Persona-sizeXl;
+    height: $ms-Persona-sizeXl;
   }
 
   .ms-Persona-placeholder {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file if publishing <!-- see notes below -->

#### Description of changes

Persona image height was previously 0 if not set explicitly.  This sets the height so the image will show properly.
