### PR TITLE
Persona: Fix box-sizing of Persona control

### DIFF
--- a/common/changes/persona-fix-sizing_2017-01-13-21-56.json
+++ b/common/changes/persona-fix-sizing_2017-01-13-21-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added defined width to ms-Persona-imageArea so that the DOM width of the control reflects the true width of the content",
+      "type": "patch"
+    }
+  ],
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -83,6 +83,7 @@ $ms-Persona-presenceSizeXl: 28px;
   text-align: center;
   flex: 0 0 $ms-Persona-sizeMd;
   height: $ms-Persona-sizeMd;
+  width: $ms-Persona-sizeMd;
   border-radius: 50%;
 
   @media screen and (-ms-high-contrast: active) {
@@ -323,6 +324,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-image {
     flex: 0 0 $ms-Persona-sizeXs;
     height: $ms-Persona-sizeXs;
+    width: $ms-Persona-sizeXs;
   }
 
   .ms-Persona-placeholder {
@@ -360,6 +362,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-image {
     flex: 0 0 $ms-Persona-sizeSm;
     height: $ms-Persona-sizeSm;
+    width: $ms-Persona-sizeSm;
   }
 
   .ms-Persona-placeholder {
@@ -397,6 +400,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-image {
     flex: 0 0 $ms-Persona-sizeLg;
     height: $ms-Persona-sizeLg;
+    width: $ms-Persona-sizeLg;
   }
 
   .ms-Persona-placeholder {
@@ -440,6 +444,7 @@ $ms-Persona-presenceSizeXl: 28px;
   .ms-Persona-image {
     flex: 0 0 $ms-Persona-sizeXl;
     height: $ms-Persona-sizeXl;
+    width: $ms-Persona-sizeXl;
   }
 
   .ms-Persona-placeholder {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #813 
- [x] Include a change request file if publishing
- [x] New feature, bugfix, or enhancement

#### Description of changes

Add a defined width to `.ms-Persona-image` so that the DOM width of the control accurately represents the width of the rendered content
