### PR TITLE
ChoiceGroup and CheckBox:  Fix `name` prop

### DIFF
--- a/common/changes/leddie24-fix-name-prop-ChoiceGroup-CheckBox_2017-01-13-22-13.json
+++ b/common/changes/leddie24-fix-name-prop-ChoiceGroup-CheckBox_2017-01-13-22-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup and CheckBox: Fix `name` prop not being set properly on radio and input elements",
+      "type": "patch"
+    }
+  ],
+  "email": "v-edwliu@microsoft.com"
+}

--- a/common/changes/leddie24-fix-name-prop-ChoiceGroup-CheckBox_2017-01-13-22-13.json
+++ b/common/changes/leddie24-fix-name-prop-ChoiceGroup-CheckBox_2017-01-13-22-13.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "ChoiceGroup and CheckBox: Fix `name` prop not being set properly on radio and input elements",
-      "type": "patch"
+      "comment": "ChoiceGroup and CheckBox: Added props to set a custom 'name' attribute on rendered elements.",
+      "type": "minor"
     }
   ],
   "email": "v-edwliu@microsoft.com"

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Checkbox } from './Checkbox';
 
 /**
  * Checkbox class interface.

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
@@ -15,7 +15,7 @@ export interface ICheckbox {
 /**
  * Checkbox properties.
  */
-export interface ICheckboxProps extends React.Props<Checkbox> {
+export interface ICheckboxProps extends React.HTMLProps<HTMLElement> {
   /**
    * Additional class name to provide on the root element, in addition to the ms-Checkbox class.
    */
@@ -55,9 +55,4 @@ export interface ICheckboxProps extends React.Props<Checkbox> {
    * precedence over the later.
    */
   inputProps?: React.HTMLProps<HTMLInputElement>;
-
-  /**
-   * Name attribute for inputs
-   */
-  name?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
@@ -55,4 +55,9 @@ export interface ICheckboxProps extends React.Props<Checkbox> {
    * precedence over the later.
    */
   inputProps?: React.HTMLProps<HTMLInputElement>;
+
+  /**
+   * Name attribute for inputs
+   */
+  name?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -46,7 +46,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
 
     const { isFocused } = this.state;
     const isChecked = checked === undefined ? this.state.isChecked : checked;
-
+    const inputName = (inputProps && inputProps.name) ? inputProps.name : this._id;
     return (
       <div
         className={ css('ms-Checkbox', className, { 'is-inFocus': isFocused }) }
@@ -58,7 +58,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
           disabled={ disabled }
           ref={ this._resolveRef('_checkBox') }
           id={ this._id }
-          name={ this._id }
+          name={ inputName }
           className='ms-Checkbox-input'
           type='checkbox'
           onChange={ this._onChange }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -47,7 +47,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
 
     const { isFocused } = this.state;
     const isChecked = checked === undefined ? this.state.isChecked : checked;
-    const inputName = (inputProps && inputProps.name) ? inputProps.name : this._id;
+    
     return (
       <div
         className={ css('ms-Checkbox', className, { 'is-inFocus': isFocused }) }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -47,7 +47,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
 
     const { isFocused } = this.state;
     const isChecked = checked === undefined ? this.state.isChecked : checked;
-    
+
     return (
       <div
         className={ css('ms-Checkbox', className, { 'is-inFocus': isFocused }) }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -41,7 +41,8 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
       defaultChecked,
       disabled,
       inputProps,
-      label
+      label,
+      name
     } = this.props;
 
     const { isFocused } = this.state;
@@ -58,7 +59,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
           disabled={ disabled }
           ref={ this._resolveRef('_checkBox') }
           id={ this._id }
-          name={ inputName }
+          name={ name || this._id }
           className='ms-Checkbox-input'
           type='checkbox'
           onChange={ this._onChange }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -19,7 +19,7 @@ export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement> {
   /**
    * HTML Attribute for choice group options
    */
-  choiceGroupName?: string;
+  name?: string;
 }
 
 export interface IChoiceGroupOption {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -15,6 +15,11 @@ export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement> {
    * Descriptive label for the choice group.
    */
   label?: string;
+
+  /**
+   * HTML Attribute for choice group options
+   */
+  choiceGroupName?: string;
 }
 
 export interface IChoiceGroupOption {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -15,11 +15,6 @@ export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement> {
    * Descriptive label for the choice group.
    */
   label?: string;
-
-  /**
-   * HTML Attribute for choice group options
-   */
-  name?: string;
 }
 
 export interface IChoiceGroupOption {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -78,7 +78,7 @@ export class ChoiceGroup extends React.Component<IChoiceGroupProps, IChoiceGroup
                 id={ `${this._id}-${option.key}` }
                 className='ms-ChoiceField-input'
                 type='radio'
-                name={ this._id }
+                name={ this.props.choiceGroupName || this._id }
                 disabled={ option.isDisabled || option.disabled || this.props.disabled }
                 checked={ option.key === keyChecked }
                 onChange={ this._onChange.bind(this, option) }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -78,7 +78,7 @@ export class ChoiceGroup extends React.Component<IChoiceGroupProps, IChoiceGroup
                 id={ `${this._id}-${option.key}` }
                 className='ms-ChoiceField-input'
                 type='radio'
-                name={ this.props.choiceGroupName || this._id }
+                name={ this.props.name || this._id }
                 disabled={ option.isDisabled || option.disabled || this.props.disabled }
                 checked={ option.key === keyChecked }
                 onChange={ this._onChange.bind(this, option) }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #809 
- [x] Include a change request file if publishing <!-- see notes below -->

#### Description of changes

Adds optional choiceGroupName prop to ChoiceGroup, which sets the name property on radio elements.

Fixes CheckBox so inputProps are correctly set for name attribute.  Falls back to generated name if name isn't set in inputProps.