### PR TITLE
DetailsList: Fixing a bug in MarqueeSelection, adding overridability for selection clear behavior

### DIFF
--- a/common/changes/selection-fixes_2017-01-19-00-36.json
+++ b/common/changes/selection-fixes_2017-01-19-00-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: adding `selectionPreservedOnEmptyClick` attribute for overriding the default behavior of clearing selection when clicks occur on non-focusable targets (body, spans, etc).",
+      "type": "minor"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -52,6 +52,12 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
   /** Controls how/if the details list manages selection. */
   selectionMode?: SelectionMode;
 
+  /**
+   * By default, selection is cleared when clicking on an empty (non-focusable) section of the screen. Setting this value to true
+   * overrides that behavior and maintains selection.
+   **/
+  selectionPreservedOnEmptyClick?: boolean;
+
   /** Controls how the columns are adjusted. */
   layoutMode?: DetailsListLayoutMode;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -55,6 +55,7 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
   /**
    * By default, selection is cleared when clicking on an empty (non-focusable) section of the screen. Setting this value to true
    * overrides that behavior and maintains selection.
+   * @default false
    **/
   selectionPreservedOnEmptyClick?: boolean;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -189,6 +189,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
       onColumnHeaderClick,
       onColumnHeaderContextMenu,
       selectionMode,
+      selectionPreservedOnEmptyClick,
       ariaLabel,
       ariaLabelForGrid,
       rowElementEventMap,
@@ -274,6 +275,7 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
               <SelectionZone
                 ref='selectionZone'
                 selection={ selection }
+                selectionPreservedOnEmptyClick={ selectionPreservedOnEmptyClick }
                 selectionMode={ selectionMode }
                 onItemInvoked={ onItemInvoked }>
                 { groups ? (

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.scss
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.scss
@@ -7,7 +7,7 @@
 
 .ms-MarqueeSelection-dragMask {
   position: absolute;
-  background: rgba(255, 0, 0, .5);
+  background: rgba(255, 0, 0, 0);
   left: 0;
   top: 0;
   right: 0;

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.scss
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.scss
@@ -7,7 +7,7 @@
 
 .ms-MarqueeSelection-dragMask {
   position: absolute;
-  background: rgba(255, 0, 0, 0);
+  background: rgba(255, 0, 0, .5);
   left: 0;
   top: 0;
   right: 0;

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -137,7 +137,8 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
         this._selectedIndicies = {};
         this._events.on(window, 'mousemove', this._onMouseMove);
         this._events.on(this._scrollableParent, 'scroll', this._onMouseMove);
-        this._events.on(window, 'mouseup', this._onMouseUp, true);
+        this._events.on(window, 'click', this._onMouseUp, true);
+
         this._autoScroll = new AutoScroll(this.refs.root);
         this._scrollTop = this._scrollableSurface.scrollTop;
         this._rootRect = this.refs.root.getBoundingClientRect();
@@ -206,15 +207,6 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
     this._autoScroll = this._dragOrigin = this._lastMouseEvent = this._selectedIndicies = this._itemRectCache = undefined;
 
     if (this.state.dragRect) {
-
-      // When we've moused up from selection, make sure the click doesn't get executed.
-      let clickRemovalCallback = (clickEvent) => {
-        this._events.off(ev.target, 'click', clickRemovalCallback);
-        clickEvent.preventDefault();
-        clickEvent.stopPropagation();
-      };
-
-      this._events.on(ev.target, 'click', clickRemovalCallback, true);
 
       this.setState({
         dragRect: undefined

--- a/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/examples/DetailsList.Basic.Example.tsx
@@ -40,12 +40,13 @@ export class DetailsListBasicExample extends React.Component<any, any> {
         <TextField
           label='Filter by name:'
           onChanged={ text => this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items }) }
-        />
+          />
         <MarqueeSelection selection={ this._selection }>
           <DetailsList
             items={ items }
             setKey='set'
             selection={ this._selection }
+            selectionPreservedOnEmptyClick={ true }
             onItemInvoked={ (item) => alert(`Item invoked: ${item.name}`) }
             onRenderItemColumn={ this._onRenderItemColumn }
             />
@@ -71,7 +72,7 @@ export class DetailsListBasicExample extends React.Component<any, any> {
       case 1:
         return '1 item selected: ' + (this._selection.getSelection()[0] as any).name;
       default:
-        return `${ selectionCount } items selected`;
+        return `${selectionCount} items selected`;
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -43,6 +43,7 @@ export interface ISelectionZoneProps extends React.Props<SelectionZone> {
   selection: ISelection;
   layout?: ISelectionLayout;
   selectionMode?: SelectionMode;
+  selectionPreservedOnEmptyClick?: boolean;
   isSelectedOnFocus?: boolean;
   onItemInvoked?: (item?: any, index?: number, ev?: Event) => void;
 }
@@ -374,7 +375,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   }
 
   private _tryClearOnEmptyClick(ev: MouseEvent) {
-    if (this._isNonHandledClick(ev.target as HTMLElement)) {
+    if (
+      !this.props.selectionPreservedOnEmptyClick &&
+      this._isNonHandledClick(ev.target as HTMLElement)
+    ) {
       this.props.selection.setAllSelected(false);
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #828 
- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### Description of changes

When you would use MarqueeSelection to select a bunch of rows, the mouseup event was being used to identify the completion of the selection. This would ultimately cause a click event to occur immediately after, which if registered on a empty element, would clear selection. There was a pre-existing workaround for this issue, but it turns out that it wasn't fullproof and a better fix is just to use the click event for completing the marquee selection.

We also added a `selectionPreservedOnEmptyClick` attribute to avoid the "clear on clicking on an empty area" behavior to address issue #828.

#### Focus areas to test

Marquee select and end the box selection on a dead area.

Try the new attribute to ensure clicking on a dead area doesn't clear selection.
