### PR TITLE
Added animation to tooltip so that delay would actually work

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.scss
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.scss
@@ -5,6 +5,7 @@
 // --------------------------------------------------
 // Tooltip styles
 .ms-Tooltip {
+    @include ms-u-fadeIn200;
     max-width: 364px;
     background: $ms-color-white;
     padding: 8px;


### PR DESCRIPTION
I swear this worked when I created the tooltip. Was the animation on another component? I didn't see an animation being removed from the callout (which the tooltip uses). So not sure what changed to remove the animation.