### PR TITLE
Pivot state updates may be asynchronous. and it should not rely on this.state for calculating the next state.

### DIFF
--- a/common/changes/xingwa-pivot_2017-01-23-11-55.json
+++ b/common/changes/xingwa-pivot_2017-01-23-11-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pivot: state updates may be asynchronous, and it should not rely on this.state for calculating the next state.",
+      "type": "patch"
+    }
+  ],
+  "email": "xingwa@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -67,20 +67,22 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
   public componentWillReceiveProps(nextProps: IPivotProps) {
     const links: IPivotItemProps[] = this._getPivotLinks(nextProps);
 
-    let selectedKey: string;
-    if (this._isKeyValid(nextProps.selectedKey)) {
-      selectedKey = nextProps.selectedKey;
-    } else if (this._isKeyValid(this.state.selectedKey)) {
-      selectedKey = this.state.selectedKey;
-    } else {
-      selectedKey = links[0].itemKey;
-    }
+    this.setState((prevState, props) => {
+      let selectedKey: string;
+      if (this._isKeyValid(nextProps.selectedKey)) {
+        selectedKey = nextProps.selectedKey;
+      } else if (this._isKeyValid(prevState.selectedKey)) {
+        selectedKey = prevState.selectedKey;
+      } else {
+        selectedKey = links[0].itemKey;
+      }
 
-    this.setState((prevState, props) => ({
-      links: links,
-      selectedKey,
-      selectedTabId: this._keyToTabIds[selectedKey],
-    }) as IPivotState);
+      return {
+        links: links,
+        selectedKey,
+        selectedTabId: this._keyToTabIds[selectedKey],
+      } as IPivotState;
+    });
   }
 
   public render() {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #722 
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes
I had a [PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/722/files) to fix issue#722 before, but the fix was reverted due to recent code change. So this is to get it back.

Fix description:
To fix it, use a second form of setState() that accepts a function rather than an object. That function will receive the previous state as the first argument.

#### Focus areas to test

React reference: https://facebook.github.io/react/docs/state-and-lifecycle.html