### PR TITLE
Update CommandBar.scss

### DIFF
--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
@@ -137,7 +137,7 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
     }
   }
 
-  &:hover:not[disabled] {
+  &:hover:not([disabled]) {
     color: $ms-color-neutralDark;
     background-color: $ms-color-neutralLight;
 


### PR DESCRIPTION
not[disabled] isn't valid css, which breaks all hover styles. not([disabled]) is correct.

Quick PR done from github UI.