### PR TITLE
List: add scrollToIndex

### DIFF
--- a/common/changes/listScrollToIndex_2017-01-25-01-42.json
+++ b/common/changes/listScrollToIndex_2017-01-25-01-42.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: add 'scrollToIndex' method",
+      "type": "minor"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "email": "cschleid@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.Props.ts
@@ -25,7 +25,7 @@ export interface IListProps extends React.Props<List> {
    * Method called by the list to get the pixel height for a given page. By default, we measure the first
    * page's height and default all other pages to that height when calculating the surface space. It is
    * ideal to be able to adequately predict page heights in order to keep the surface space from jumping
-   * in pixels, which has been seen to cause browser perforamnce issues.
+   * in pixels, which has been seen to cause browser performance issues.
    */
   getPageHeight?: (itemIndex?: number, visibleRect?: IRectangle) => number;
 

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -145,6 +145,35 @@ export class List extends BaseComponent<IListProps, IListState> {
     this._scrollingToIndex = -1;
   }
 
+  /**
+   * Scroll to the given index.
+   *
+   * Note: with items of variable height and no passed in `getPageHeight` method, the list might jump after scrolling
+   * when windows before/ahead are being rendered, and the estimated height is replaced using actual elements.
+   *
+   * @param index Index of item to scroll to
+   */
+  public scrollToIndex(index: number): void {
+    const { startIndex } = this.props;
+    const renderCount = this._getRenderCount();
+    const endIndex = startIndex + renderCount;
+
+    let scrollTop = 0;
+
+    let itemsPerPage = 1;
+    for (let itemIndex = startIndex; itemIndex < endIndex; itemIndex += itemsPerPage) {
+      itemsPerPage = this._getItemCountForPage(itemIndex, this._allowedRect);
+
+      const requestedIndexIsInPage = itemIndex <= index && (itemIndex + itemsPerPage) > index;
+      if (requestedIndexIsInPage) {
+        this._scrollElement.scrollTop = scrollTop;
+        break;
+      }
+
+      scrollTop += this._getPageHeight(itemIndex, itemsPerPage, this._surfaceRect);
+    }
+  }
+
   public componentDidMount() {
 
     this._updatePages();


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #649
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature

#### Description of changes

Add `scrollToIndex` method to list to scroll to the given index. Basically follows what was removed in this commit: https://github.com/OfficeDev/office-ui-fabric-react/commit/b3a92fef2007e2a85de3608873ed7a093dee3f66