### PR TITLE
RTL utility: now correctly returns rtl value in HTML attribute on first read.

### DIFF
--- a/common/changes/rtl_2017-01-25-03-41.json
+++ b/common/changes/rtl_2017-01-25-03-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "rtl utility should read rtl attribute on first read.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/src/rtl.ts
+++ b/packages/utilities/src/rtl.ts
@@ -1,7 +1,8 @@
 import { KeyCodes } from './KeyCodes';
 import { getDocument } from './dom';
 
-let _isRTL: boolean = false;
+// Default to undefined so that we initialize on first read.
+let _isRTL: boolean;
 
 /**
  * Gets the rtl state of the page (returns true if in rtl.)
@@ -16,7 +17,7 @@ export function getRTL(): boolean {
       throw new Error(
         'getRTL was called in a server environment without setRTL being called first. ' +
         'Call setRTL to set the correct direction first.'
-        );
+      );
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #845
- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement

#### Description of changes

The _rtl value was being initialized as false, thus preventing it from being initialized on first read.
