### PR TITLE
Fixing npm start to run rush build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ This will run `gulp serve` from the office-ui-fabric-react package folder, which
 
 To build all packages in the repo, you can use `npm run build`.
 
-To run other Gulp commands such as clean or deploy, just prepend the command with `npm run gulp` and this will run the command from within the project context.
-
-`npm run gulp clean`
-`npm run gulp deploy`
-...
-
 ## Get started
 
 ### Tutorial

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "postinstall": "rush install && rush link",
-    "test": "rush build",
+    "test": "rush build --production",
     "start": "gulp --gulpfile packages/office-ui-fabric-react/gulpfile.js serve",
     "build": "rush build --production --clean",
     "change": "rush change"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postinstall": "rush install && rush link",
     "test": "rush build",
     "start": "gulp --gulpfile packages/office-ui-fabric-react/gulpfile.js serve",
-    "gulp": "gulp --gulpfile packages/office-ui-fabric-react/gulpfile.js",
+    "build": "rush build --production --clean",
     "change": "rush change"
   },
   "license": "MIT",

--- a/packages/office-ui-fabric-react/gulpfile.js
+++ b/packages/office-ui-fabric-react/gulpfile.js
@@ -1,6 +1,7 @@
 'use strict';
 
 let build = require('@microsoft/web-library-build');
+let serial = build.serial;
 let buildConfig = build.getConfig();
 let gulp = require('gulp');
 let configFile = "./ftpconfig.json";
@@ -186,6 +187,38 @@ let defaultTasks = build.serial(
 );
 
 build.task('default', defaultTasks);
+
+// Disable certain subtasks to speed up serve.
+build.karma.isEnabled = () => isProduction;
+build.tslint.isEnabled = () => isProduction;
+
+// alternative serve approach.
+// Set up a "rushBuild" subTask that will spawn rush build
+let spawn = require('child_process').spawn;
+let rawStdout = new fs.SyncWriteStream(1, { autoClose: false });
+
+let rushBuild = build.subTask('rushbuild', (gulp, options, done) => {
+  let child = spawn(
+    'rush',
+    ['build', '--to', 'office-ui-fabric-react']
+  );
+
+  child.stdout.on('data', data => rawStdout.write(data));
+  child.on('close', done);
+});
+
+const sourceMatch = [
+  'src/**/*.{ts,tsx,scss,js,txt,html}',
+  '!src/**/*.scss.ts'
+];
+
+build.task('serve', serial(
+  rushBuild,
+  build.serve,
+  build.watch(sourceMatch, serial(
+    rushBuild,
+    build.reload
+  ))));
 
 // initialize tasks.
 build.initialize(gulp);

--- a/packages/office-ui-fabric-react/gulpfile.js
+++ b/packages/office-ui-fabric-react/gulpfile.js
@@ -176,6 +176,8 @@ let runSSRTests = build.subTask('run-ssr-tests', function (gulp, buildOptions, d
   done();
 });
 
+runSSRTests.isEnabled = () => isProduction;
+
 let defaultTasks = build.serial(
   build.preCopy,
   build.sass,
@@ -188,9 +190,10 @@ let defaultTasks = build.serial(
 
 build.task('default', defaultTasks);
 
-// Disable certain subtasks to speed up serve.
+// Disable certain subtasks in non production builds to speed up serve.
 build.karma.isEnabled = () => isProduction;
 build.tslint.isEnabled = () => isProduction;
+build.clean.isEnabled = () => isProduction;
 
 // alternative serve approach.
 // Set up a "rushBuild" subTask that will spawn rush build


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #881
- [X] Documentation update

#### Description of changes

Running `npm start` from a fresh enlistment will now build all of the packages in the correct order and then spawn the express server and browser and live reload on file changes. Changing the source should reload the page. For now if you change utilities, it won't trigger the build. I need a better way to extract source match globs from each project.

But this should put us back into a nice working order.