### PR TITLE
SelectionZone: clicks now only clear selection within the scroll area

### DIFF
--- a/common/changes/selectionzone-fix_2017-01-26-03-49.json
+++ b/common/changes/selectionzone-fix_2017-01-26-03-49.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    },
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "SelectionZone: clicking in a non-interactive area clears selection only within the scrollable parent area. This refines the clear behavior slightly.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -3,6 +3,7 @@ import {
   BaseComponent,
   KeyCodes,
   autobind,
+  findScrollableParent,
   getParent,
   getDocument,
   getWindow,
@@ -67,10 +68,11 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
 
   public componentDidMount() {
     let win = getWindow(this.refs.root);
+    let scrollElement = findScrollableParent(this.refs.root);
 
     // Track the latest modifier keys globally.
     this._events.on(win, 'keydown keyup', this._updateModifiers);
-    this._events.on(win, 'click', this._tryClearOnEmptyClick);
+    this._events.on(scrollElement, 'click', this._tryClearOnEmptyClick);
   }
 
   public render() {


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing 

#### Description of changes

This is a minor tweak on the selection clearing logic in SelectionZone; now we will only listen within the scrollable element for clicks to clear selection, rather than the entire document.

