### PR TITLE
Integrating @types/webpack-env typings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
   },
   // Configure glob patterns for excluding files and folders in searches. Inherits all glob patterns from the file.exclude setting.
   "search.exclude": {
+    "common": true,
     "**/node_modules": true,
     "**/lib": true,
     "**/lib-amd": true,

--- a/common/npm-shrinkwrap.json
+++ b/common/npm-shrinkwrap.json
@@ -3,14 +3,14 @@
   "version": "0.0.0",
   "dependencies": {
     "@microsoft/api-extractor": {
-      "version": "1.0.1",
-      "from": "@microsoft/api-extractor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-1.0.1.tgz",
+      "version": "1.1.3",
+      "from": "@microsoft/api-extractor@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-1.1.3.tgz",
       "dependencies": {
-        "typescript": {
-          "version": "2.0.10",
-          "from": "typescript@>=2.0.3 <2.1.0",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz"
+        "@types/z-schema": {
+          "version": "3.16.31",
+          "from": "@types/z-schema@>=3.16.31 <3.17.0",
+          "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz"
         }
       }
     },
@@ -64,14 +64,14 @@
       }
     },
     "@microsoft/gulp-core-build-webpack": {
-      "version": "1.0.4",
+      "version": "1.1.0",
       "from": "@microsoft/gulp-core-build-webpack@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-webpack/-/gulp-core-build-webpack-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-webpack/-/gulp-core-build-webpack-1.1.0.tgz",
       "dependencies": {
         "@microsoft/gulp-core-build": {
-          "version": "2.0.1",
-          "from": "@microsoft/gulp-core-build@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.0.1.tgz"
+          "version": "2.1.1",
+          "from": "@microsoft/gulp-core-build@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.1.1.tgz"
         },
         "es6-promise": {
           "version": "3.1.2",
@@ -111,9 +111,9 @@
       "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz"
     },
     "@types/enzyme": {
-      "version": "2.7.1",
+      "version": "2.7.2",
       "from": "@types/enzyme@>=2.7.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-2.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-2.7.2.tgz"
     },
     "@types/es6-collections": {
       "version": "0.5.29",
@@ -151,14 +151,14 @@
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz"
     },
     "@types/mocha": {
-      "version": "2.2.37",
+      "version": "2.2.38",
       "from": "@types/mocha@>=2.2.32 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.37.tgz"
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.38.tgz"
     },
     "@types/node": {
-      "version": "6.0.60",
+      "version": "6.0.62",
       "from": "@types/node@>=6.0.45 <7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.60.tgz"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.62.tgz"
     },
     "@types/orchestrator": {
       "version": "0.0.30",
@@ -176,14 +176,14 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-0.14.57.tgz"
     },
     "@types/react-addons-test-utils": {
-      "version": "0.14.16",
+      "version": "0.14.17",
       "from": "@types/react-addons-test-utils@>=0.14.15 <0.15.0",
-      "resolved": "https://registry.npmjs.org/@types/react-addons-test-utils/-/react-addons-test-utils-0.14.16.tgz"
+      "resolved": "https://registry.npmjs.org/@types/react-addons-test-utils/-/react-addons-test-utils-0.14.17.tgz"
     },
     "@types/react-dom": {
-      "version": "0.14.20",
+      "version": "0.14.21",
       "from": "@types/react-dom@>=0.14.18 <0.15.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-0.14.20.tgz"
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-0.14.21.tgz"
     },
     "@types/rimraf": {
       "version": "0.0.28",
@@ -195,30 +195,20 @@
       "from": "@types/semver@>=5.3.30 <6.0.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.3.30.tgz"
     },
-    "@types/source-map": {
-      "version": "0.5.0",
-      "from": "@types/source-map@*",
-      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.0.tgz"
-    },
     "@types/through2": {
       "version": "2.0.32",
       "from": "@types/through2@>=2.0.31 <3.0.0",
       "resolved": "https://registry.npmjs.org/@types/through2/-/through2-2.0.32.tgz"
-    },
-    "@types/uglify-js": {
-      "version": "2.6.28",
-      "from": "@types/uglify-js@*",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-2.6.28.tgz"
     },
     "@types/vinyl": {
       "version": "1.2.30",
       "from": "@types/vinyl@>=1.2.30 <2.0.0",
       "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-1.2.30.tgz"
     },
-    "@types/webpack": {
-      "version": "1.12.36",
-      "from": "@types/webpack@>=1.12.35 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-1.12.36.tgz"
+    "@types/webpack-env": {
+      "version": "1.13.0",
+      "from": "@types/webpack-env@>=1.13.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.0.tgz"
     },
     "@types/yargs": {
       "version": "0.0.34",
@@ -527,14 +517,14 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
     },
     "body-parser": {
-      "version": "1.15.2",
+      "version": "1.16.0",
       "from": "body-parser@>=1.12.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.0.tgz",
       "dependencies": {
         "qs": {
-          "version": "6.2.0",
-          "from": "qs@6.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+          "version": "6.2.1",
+          "from": "qs@6.2.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
         }
       }
     },
@@ -626,9 +616,9 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000611",
+      "version": "1.0.30000617",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000611.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000617.tgz"
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -688,9 +678,9 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
     },
     "clean-css": {
-      "version": "3.4.23",
+      "version": "3.4.24",
       "from": "clean-css@>=3.4.20 <4.0.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.23.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.24.tgz",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
@@ -804,6 +794,16 @@
           "from": "bytes@2.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
         "negotiator": {
           "version": "0.5.3",
           "from": "negotiator@0.5.3",
@@ -853,7 +853,19 @@
     "connect": {
       "version": "3.5.0",
       "from": "connect@>=3.3.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        }
+      }
     },
     "connect-livereload": {
       "version": "0.5.4",
@@ -865,10 +877,20 @@
       "from": "connect-timeout@>=1.6.2 <1.7.0",
       "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "http-errors": {
           "version": "1.3.1",
           "from": "http-errors@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },
@@ -992,9 +1014,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         },
         "supports-color": {
-          "version": "3.1.2",
+          "version": "3.2.3",
           "from": "supports-color@>=3.1.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
         }
       }
     },
@@ -1078,9 +1100,9 @@
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.9.tgz"
     },
     "debug": {
-      "version": "2.2.0",
-      "from": "debug@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+      "version": "2.6.0",
+      "from": "debug@2.6.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1314,11 +1336,6 @@
           "version": "2.3.3",
           "from": "debug@2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
-        },
-        "ms": {
-          "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
@@ -1336,11 +1353,6 @@
           "version": "2.3.3",
           "from": "debug@2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
-        },
-        "ms": {
-          "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
@@ -1372,9 +1384,9 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "enzyme": {
-      "version": "2.7.0",
+      "version": "2.7.1",
       "from": "enzyme@>=2.7.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.7.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -1404,9 +1416,9 @@
       "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz"
     },
     "es-abstract": {
-      "version": "1.6.1",
+      "version": "1.7.0",
       "from": "es-abstract@>=1.6.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz"
     },
     "es-to-primitive": {
       "version": "1.1.1",
@@ -1527,6 +1539,16 @@
       "from": "express@>=4.14.0 <4.15.0",
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
         "qs": {
           "version": "6.2.0",
           "from": "qs@6.2.0",
@@ -1549,10 +1571,20 @@
           "from": "cookie@0.1.3",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "depd": {
           "version": "1.0.1",
           "from": "depd@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "uid-safe": {
           "version": "2.0.0",
@@ -1651,9 +1683,9 @@
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "filesize": {
-      "version": "3.3.0",
+      "version": "3.5.4",
       "from": "filesize@>=3.3.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.4.tgz"
     },
     "fill-range": {
       "version": "2.2.3",
@@ -1668,7 +1700,19 @@
     "finalhandler": {
       "version": "0.5.0",
       "from": "finalhandler@0.5.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        }
+      }
     },
     "find-index": {
       "version": "0.1.1",
@@ -2182,6 +2226,11 @@
           "from": "cookie@0.1.3",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "depd": {
           "version": "1.0.1",
           "from": "depd@>=1.0.1 <1.1.0",
@@ -2217,6 +2266,11 @@
           "from": "map-stream@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
         },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
         "qs": {
           "version": "4.0.0",
           "from": "qs@4.0.0",
@@ -2226,6 +2280,23 @@
           "version": "1.0.3",
           "from": "range-parser@>=1.0.3 <1.1.0",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "from": "raw-body@>=2.1.2 <2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "dependencies": {
+            "bytes": {
+              "version": "2.4.0",
+              "from": "bytes@2.4.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+            },
+            "iconv-lite": {
+              "version": "0.4.13",
+              "from": "iconv-lite@0.4.13",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+            }
+          }
         },
         "send": {
           "version": "0.13.2",
@@ -2709,7 +2780,7 @@
     },
     "http-errors": {
       "version": "1.5.1",
-      "from": "http-errors@>=1.5.0 <1.6.0",
+      "from": "http-errors@>=1.5.1 <1.6.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz"
     },
     "http-proxy": {
@@ -2728,9 +2799,9 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
     },
     "iconv-lite": {
-      "version": "0.4.13",
-      "from": "iconv-lite@0.4.13",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      "version": "0.4.15",
+      "from": "iconv-lite@0.4.15",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
     },
     "icss-replace-symbols": {
       "version": "1.0.2",
@@ -3077,9 +3148,9 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         },
         "supports-color": {
-          "version": "3.1.2",
+          "version": "3.2.3",
           "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -3824,11 +3895,6 @@
           "version": "2.3.3",
           "from": "debug@2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
-        },
-        "ms": {
-          "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
@@ -3889,6 +3955,11 @@
           "from": "commander@2.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "escape-string-regexp": {
           "version": "1.0.2",
           "from": "escape-string-regexp@1.0.2",
@@ -3903,6 +3974,11 @@
           "version": "0.3.0",
           "from": "minimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "supports-color": {
           "version": "1.2.0",
@@ -3921,17 +3997,27 @@
       "from": "morgan@>=1.6.1 <1.7.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "depd": {
           "version": "1.0.1",
           "from": "depd@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },
     "ms": {
-      "version": "0.7.1",
-      "from": "ms@0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      "version": "0.7.2",
+      "from": "ms@0.7.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
     "multiparty": {
       "version": "3.3.2",
@@ -3949,9 +4035,9 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
     },
     "nan": {
-      "version": "2.5.0",
+      "version": "2.5.1",
       "from": "nan@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz"
     },
     "natives": {
       "version": "1.1.0",
@@ -3974,9 +4060,9 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz"
     },
     "node-forge": {
-      "version": "0.6.47",
+      "version": "0.6.48",
       "from": "node-forge@>=0.6.42 <0.7.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.47.tgz"
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.48.tgz"
     },
     "node-gyp": {
       "version": "3.5.0",
@@ -4076,9 +4162,9 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "from": "object-assign@>=4.1.0 <4.2.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
     },
     "object-component": {
       "version": "0.0.3",
@@ -4411,9 +4497,9 @@
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz"
     },
     "postcss": {
-      "version": "5.2.10",
+      "version": "5.2.11",
       "from": "postcss@>=5.0.21 <6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.11.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
@@ -4421,9 +4507,9 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         },
         "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@>=3.1.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "version": "3.2.3",
+          "from": "supports-color@>=3.2.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
         }
       }
     },
@@ -4548,9 +4634,9 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
     "raw-body": {
-      "version": "2.1.7",
-      "from": "raw-body@>=2.1.7 <2.2.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
+      "version": "2.2.0",
+      "from": "raw-body@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz"
     },
     "rc": {
       "version": "1.1.6",
@@ -4818,9 +4904,9 @@
       "resolved": "file:temp_modules/rush-todo-app",
       "dependencies": {
         "@microsoft/gulp-core-build": {
-          "version": "2.0.1",
-          "from": "@microsoft/gulp-core-build@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.0.1.tgz",
+          "version": "2.1.1",
+          "from": "@microsoft/gulp-core-build@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build/-/gulp-core-build-2.1.1.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "3.1.2",
@@ -4835,9 +4921,9 @@
           }
         },
         "@microsoft/gulp-core-build-karma": {
-          "version": "2.0.1",
-          "from": "@microsoft/gulp-core-build-karma@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-karma/-/gulp-core-build-karma-2.0.1.tgz"
+          "version": "2.0.2",
+          "from": "@microsoft/gulp-core-build-karma@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-karma/-/gulp-core-build-karma-2.0.2.tgz"
         },
         "@microsoft/gulp-core-build-sass": {
           "version": "2.0.1",
@@ -4850,14 +4936,26 @@
           "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-serve/-/gulp-core-build-serve-2.0.1.tgz"
         },
         "@microsoft/gulp-core-build-typescript": {
-          "version": "2.1.1",
-          "from": "@microsoft/gulp-core-build-typescript@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-2.1.1.tgz"
+          "version": "2.2.1",
+          "from": "@microsoft/gulp-core-build-typescript@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/gulp-core-build-typescript/-/gulp-core-build-typescript-2.2.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "4.15.0",
+              "from": "lodash@>=4.15.0 <4.16.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+            }
+          }
         },
         "@microsoft/web-library-build": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "from": "@microsoft/web-library-build@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/web-library-build/-/web-library-build-2.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/@microsoft/web-library-build/-/web-library-build-2.2.0.tgz"
+        },
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "colors": {
           "version": "1.1.2",
@@ -4909,7 +5007,14 @@
         "gulp-typescript": {
           "version": "3.1.4",
           "from": "gulp-typescript@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.1.4.tgz"
+          "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.1.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.3 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            }
+          }
         },
         "is-extglob": {
           "version": "2.1.1",
@@ -4926,10 +5031,15 @@
           "from": "isarray@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
+        "karma-webpack": {
+          "version": "2.0.1",
+          "from": "karma-webpack@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.1.tgz"
+        },
         "lodash": {
-          "version": "4.15.0",
-          "from": "lodash@>=4.15.0 <4.16.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
+          "version": "3.10.1",
+          "from": "lodash@>=3.8.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "ordered-read-streams": {
           "version": "0.3.0",
@@ -4942,9 +5052,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
         },
         "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.41 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
         },
         "tslint": {
           "version": "4.0.2",
@@ -5025,7 +5135,19 @@
     "send": {
       "version": "0.14.1",
       "from": "send@0.14.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
+      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        }
+      }
     },
     "sequencify": {
       "version": "0.0.7",
@@ -5035,14 +5157,7 @@
     "serve-favicon": {
       "version": "2.3.2",
       "from": "serve-favicon@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
-      "dependencies": {
-        "ms": {
-          "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz"
     },
     "serve-index": {
       "version": "1.7.3",
@@ -5054,10 +5169,20 @@
           "from": "accepts@>=1.2.13 <1.3.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "http-errors": {
           "version": "1.3.1",
           "from": "http-errors@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "negotiator": {
           "version": "0.5.3",
@@ -5067,9 +5192,28 @@
       }
     },
     "serve-static": {
-      "version": "1.11.1",
+      "version": "1.11.2",
       "from": "serve-static@>=1.11.1 <1.12.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "send": {
+          "version": "0.14.2",
+          "from": "send@0.14.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz"
+        }
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -5153,10 +5297,10 @@
           "from": "debug@2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
         },
-        "ms": {
-          "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
@@ -5169,11 +5313,6 @@
           "version": "2.3.3",
           "from": "debug@2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
-        },
-        "ms": {
-          "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
@@ -5191,18 +5330,25 @@
           "version": "2.3.3",
           "from": "debug@2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
-        },
-        "ms": {
-          "version": "0.7.2",
-          "from": "ms@0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
     "socket.io-parser": {
       "version": "2.3.1",
       "from": "socket.io-parser@2.3.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        }
+      }
     },
     "source-list-map": {
       "version": "0.1.8",
@@ -5468,15 +5614,42 @@
           "from": "bytes@2.2.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
         "http-errors": {
           "version": "1.3.1",
           "from": "http-errors@>=1.3.1 <1.4.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
         },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
         "qs": {
           "version": "5.1.0",
           "from": "qs@>=5.1.0 <5.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "from": "raw-body@>=2.1.5 <2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "dependencies": {
+            "bytes": {
+              "version": "2.4.0",
+              "from": "bytes@2.4.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+            }
+          }
         }
       }
     },
@@ -5577,7 +5750,7 @@
     },
     "type-is": {
       "version": "1.6.14",
-      "from": "type-is@>=1.6.13 <1.7.0",
+      "from": "type-is@>=1.6.14 <1.7.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
     },
     "typedarray": {
@@ -5705,9 +5878,9 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "useragent": {
-      "version": "2.1.10",
+      "version": "2.1.11",
       "from": "useragent@>=2.1.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.11.tgz",
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
@@ -5922,9 +6095,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
         },
         "supports-color": {
-          "version": "3.1.2",
+          "version": "3.2.3",
           "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
         }
       }
     },
@@ -5978,9 +6151,9 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
     },
     "whatwg-fetch": {
-      "version": "2.0.1",
+      "version": "2.0.2",
       "from": "whatwg-fetch@>=0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.2.tgz"
     },
     "which": {
       "version": "1.2.12",

--- a/common/temp_modules/rush-office-ui-fabric-react/package.json
+++ b/common/temp_modules/rush-office-ui-fabric-react/package.json
@@ -10,7 +10,7 @@
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.45",
     "@types/react-addons-test-utils": "^0.14.15",
-    "@types/webpack": "^1.12.35",
+    "@types/webpack-env": "^1.13.0",
     "enzyme": "^2.7.0",
     "es6-promise": "3.2.1",
     "git-rev": "0.2.1",

--- a/common/temp_modules/rush-todo-app/package.json
+++ b/common/temp_modules/rush-todo-app/package.json
@@ -13,7 +13,7 @@
     "@types/react": "^0.14.47",
     "@types/react-addons-test-utils": "^0.14.15",
     "@types/react-dom": "^0.14.18",
-    "@types/webpack": "^1.12.35",
+    "@types/webpack-env": "^1.13.0",
     "es6-promise": ">=3.2.1 <4.0.0",
     "immutability-helper": "^2.0.0",
     "office-ui-fabric-core": ">=5.0.1 <6.0.0",
@@ -22,6 +22,6 @@
     "typescript": "^2.0.6"
   },
   "rushDependencies": {
-    "office-ui-fabric-react": ">=0.88.0 <1.0.0"
+    "office-ui-fabric-react": ">=1.3.1 <2.0.0"
   }
 }

--- a/packages/examples/todo-app/package.json
+++ b/packages/examples/todo-app/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^0.14.47",
     "@types/react-addons-test-utils": "^0.14.15",
     "@types/react-dom": "^0.14.18",
-    "@types/webpack": "^1.12.35",
+    "@types/webpack-env": "^1.13.0",
     "es6-promise": ">=3.2.1 <4.0.0",
     "immutability-helper": "^2.0.0",
     "office-ui-fabric-core": ">=5.0.1 <6.0.0",

--- a/packages/examples/todo-app/tsconfig.json
+++ b/packages/examples/todo-app/tsconfig.json
@@ -11,8 +11,7 @@
     "types": [
       "chai",
       "mocha",
-      "node",
-      "webpack"
+      "webpack-env"
     ]
   },
   "exclude": [

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -23,7 +23,7 @@
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.45",
     "@types/react-addons-test-utils": "^0.14.15",
-    "@types/webpack": "^1.12.35",
+    "@types/webpack-env": "^1.13.0",
     "enzyme": "^2.7.0",
     "es6-promise": "3.2.1",
     "git-rev": "0.2.1",

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle.tsx
@@ -11,7 +11,7 @@ import {
   getFullColorString
 } from './colors';
 
-let hsv2hex = require('color-functions/lib/hsv2hex');
+let hsv2hex = require('color-functions/lib/hsv2hex') as any;
 
 export interface IColorRectangleProps {
   color: IColor;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/colors.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/colors.ts
@@ -1,11 +1,12 @@
 import { IColor } from './IColor';
 import { assign } from '../../Utilities';
 
-let cssColor = require('color-functions/lib/css-color');
-let rgb2hex = require('color-functions/lib/rgb2hex');
-let hsv2hex = require('color-functions/lib/hsv2hex');
-let rgb2hsv = require('color-functions/lib/rgb2hsv');
-let hsv2rgb = require('color-functions/lib/hsv2rgb');
+// These will be cleaned up.
+let cssColor = require('color-functions/lib/css-color') as any;
+let rgb2hex = require('color-functions/lib/rgb2hex') as any;
+let hsv2hex = require('color-functions/lib/hsv2hex') as any;
+let rgb2hsv = require('color-functions/lib/rgb2hsv') as any;
+let hsv2rgb = require('color-functions/lib/hsv2rgb') as any;
 
 export const MAX_COLOR_SATURATION = 100;
 export const MAX_COLOR_HUE = 359;

--- a/packages/office-ui-fabric-react/src/demo/components/ExampleCard/ExampleCard.tsx
+++ b/packages/office-ui-fabric-react/src/demo/components/ExampleCard/ExampleCard.tsx
@@ -3,7 +3,7 @@ import { css } from '@uifabric/utilities';
 import './ExampleCard.scss';
 import { Button, ButtonType } from '../../../Button';
 
-const Highlight = require('react-highlight');
+const Highlight = require('react-highlight') as any;
 
 export interface IExampleCardProps {
   title: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/BreadcrumbPage/BreadcrumbPage.tsx
@@ -9,7 +9,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const BreadcrumbBasicExampleCode = require('./examples/Breadcrumb.Basic.Example.tsx');
+const BreadcrumbBasicExampleCode = require('./examples/Breadcrumb.Basic.Example.tsx') as string;
 
 export class BreadcrumbPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/ButtonPage/ButtonPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ButtonPage/ButtonPage.tsx
@@ -21,14 +21,14 @@ import { IComponentDemoPageProps } from '../../components/ComponentPage/ICompone
 import { IButtonDemoPageState } from './examples/IButtonDemoPageState';
 import './examples/Button.Basic.Example.scss';
 
-const ButtonDefaultExampleCode = require('./examples/Button.Default.Example.tsx');
-const ButtonPrimaryExampleCode = require('./examples/Button.Primary.Example.tsx');
-const ButtonCompoundExampleCode = require('./examples/Button.Compound.Example.tsx');
-const ButtonCommandExampleCode = require('./examples/Button.Command.Example.tsx');
-const ButtonHeroExampleCode = require('./examples/Button.Hero.Example.tsx');
-const ButtonIconExampleCode = require('./examples/Button.Icon.Example.tsx');
-const ButtonAnchorExampleCode = require('./examples/Button.Anchor.Example.tsx');
-const ButtonScreenReaderExampleCode = require('./examples/Button.ScreenReader.Example.tsx');
+const ButtonDefaultExampleCode = require('./examples/Button.Default.Example.tsx') as string;
+const ButtonPrimaryExampleCode = require('./examples/Button.Primary.Example.tsx') as string;
+const ButtonCompoundExampleCode = require('./examples/Button.Compound.Example.tsx') as string;
+const ButtonCommandExampleCode = require('./examples/Button.Command.Example.tsx') as string;
+const ButtonHeroExampleCode = require('./examples/Button.Hero.Example.tsx') as string;
+const ButtonIconExampleCode = require('./examples/Button.Icon.Example.tsx') as string;
+const ButtonAnchorExampleCode = require('./examples/Button.Anchor.Example.tsx') as string;
+const ButtonScreenReaderExampleCode = require('./examples/Button.ScreenReader.Example.tsx') as string;
 
 export class ButtonPage extends React.Component<IComponentDemoPageProps, IButtonDemoPageState> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/CalendarPage/CalendarPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/CalendarPage/CalendarPage.tsx
@@ -11,8 +11,8 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const CalendarButtonExampleCode = require('./examples/Calendar.Button.Example.tsx');
-const CalendarInlineExampleCode = require('./examples/Calendar.Inline.Example.tsx');
+const CalendarButtonExampleCode = require('./examples/Calendar.Button.Example.tsx') as string;
+const CalendarInlineExampleCode = require('./examples/Calendar.Inline.Example.tsx') as string;
 
 export class CalendarPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/CalloutPage/CalloutPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/CalloutPage/CalloutPage.tsx
@@ -14,10 +14,10 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const CalloutBasicExampleCode = require('./examples/Callout.Basic.Example.tsx');
-const CalloutNestedExampleCode = require('./examples/Callout.Nested.Example.tsx');
-const CalloutDirectionalExampleCode = require('./examples/Callout.Directional.Example.tsx');
-const CalloutCoverExampleCode = require('./examples/Callout.Cover.Example.tsx');
+const CalloutBasicExampleCode = require('./examples/Callout.Basic.Example.tsx') as string;
+const CalloutNestedExampleCode = require('./examples/Callout.Nested.Example.tsx') as string;
+const CalloutDirectionalExampleCode = require('./examples/Callout.Directional.Example.tsx') as string;
+const CalloutCoverExampleCode = require('./examples/Callout.Cover.Example.tsx') as string;
 
 export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -40,7 +40,7 @@ export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
               <CalloutBasicExample />
             </ExampleCard>
             <ExampleCard title='Nested callout... Callout with a commandbar with a sub menu' code={ CalloutNestedExampleCode }>
-              <CalloutNestedExample { ...cmdBarParamsTextAndIcons }/>
+              <CalloutNestedExample { ...cmdBarParamsTextAndIcons } />
             </ExampleCard>
             <ExampleCard title='Callout directional example' code={ CalloutDirectionalExampleCode }>
               <CalloutDirectionalExample />

--- a/packages/office-ui-fabric-react/src/demo/pages/CheckboxPage/CheckboxPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/CheckboxPage/CheckboxPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const CheckboxBasicExampleCode = require('./examples/Checkbox.Basic.Example.tsx');
+const CheckboxBasicExampleCode = require('./examples/Checkbox.Basic.Example.tsx') as string;
 
 export class CheckboxPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/ChoiceGroupPage/ChoiceGroupPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ChoiceGroupPage/ChoiceGroupPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const ChoiceGroupBasicExampleCode = require('./examples/ChoiceGroup.Basic.Example.tsx');
+const ChoiceGroupBasicExampleCode = require('./examples/ChoiceGroup.Basic.Example.tsx') as string;
 
 export class ChoiceGroupPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/ColorPickerPage/ColorPickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ColorPickerPage/ColorPickerPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const ColorPickerBasicExampleCode = require('./examples/ColorPicker.Basic.Example.tsx');
+const ColorPickerBasicExampleCode = require('./examples/ColorPicker.Basic.Example.tsx') as string;
 
 export class ColorPickerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/CommandBarPage/CommandBarPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/CommandBarPage/CommandBarPage.tsx
@@ -12,8 +12,8 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const CommandBarBasicExampleCode = require('./examples/CommandBar.Basic.Example.tsx');
-const CommandBarNoFocusableItemsExampleCode = require('./examples/CommandBar.NonFocusable.Example.tsx');
+const CommandBarBasicExampleCode = require('./examples/CommandBar.Basic.Example.tsx') as string;
+const CommandBarNoFocusableItemsExampleCode = require('./examples/CommandBar.NonFocusable.Example.tsx') as string;
 
 export class CommandBarPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -33,7 +33,7 @@ export class CommandBarPage extends React.Component<IComponentDemoPageProps, any
         exampleCards={
           <div>
             <ExampleCard title='CommandBar with search box and overflowing menu items' code={ CommandBarBasicExampleCode }>
-              <CommandBarBasicExample {... cmdBarParamsTextAndIcons} />
+              <CommandBarBasicExample {...cmdBarParamsTextAndIcons} />
             </ExampleCard>
             <ExampleCard title='CommandBar with non-focusable items' code={ CommandBarNoFocusableItemsExampleCode }>
               <CommandBarNonFocusableItemsExample />

--- a/packages/office-ui-fabric-react/src/demo/pages/ContextualMenuPage/ContextualMenuPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ContextualMenuPage/ContextualMenuPage.tsx
@@ -15,11 +15,11 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const ContextualMenuBasicExampleCode = require('./examples/ContextualMenu.Basic.Example.tsx');
-const ContextualMenuCheckmarksExampleCode = require('./examples/ContextualMenu.Checkmarks.Example.tsx');
-const ContextualMenuDirectionalExampleCode = require('./examples/ContextualMenu.Directional.Example.tsx');
-const ContextualMenuCustomizationExampleCode = require('./examples/ContextualMenu.Customization.Example.tsx');
-const ContextualMenuHeaderExampleCode = require('./examples/ContextualMenu.Header.Example.tsx');
+const ContextualMenuBasicExampleCode = require('./examples/ContextualMenu.Basic.Example.tsx') as string;
+const ContextualMenuCheckmarksExampleCode = require('./examples/ContextualMenu.Checkmarks.Example.tsx') as string;
+const ContextualMenuDirectionalExampleCode = require('./examples/ContextualMenu.Directional.Example.tsx') as string;
+const ContextualMenuCustomizationExampleCode = require('./examples/ContextualMenu.Customization.Example.tsx') as string;
+const ContextualMenuHeaderExampleCode = require('./examples/ContextualMenu.Header.Example.tsx') as string;
 
 export class ContextualMenuPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/DatePickerPage/DatePickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DatePickerPage/DatePickerPage.tsx
@@ -12,9 +12,9 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const DatePickerBasicExampleCode = require('./examples/DatePicker.Basic.Example.tsx');
-const DatePickerRequiredExampleCode = require('./examples/DatePicker.Required.Example.tsx');
-const DatePickerInputExampleCode = require('./examples/DatePicker.Input.Example.tsx');
+const DatePickerBasicExampleCode = require('./examples/DatePicker.Basic.Example.tsx') as string;
+const DatePickerRequiredExampleCode = require('./examples/DatePicker.Required.Example.tsx') as string;
+const DatePickerInputExampleCode = require('./examples/DatePicker.Input.Example.tsx') as string;
 
 export class DatePickerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/DetailsListPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DetailsListPage/DetailsListPage.tsx
@@ -13,22 +13,22 @@ import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 import { DetailsListBasicExample } from './examples/DetailsList.Basic.Example';
-const DetailsListBasicExampleCode = require('./examples/DetailsList.Basic.Example.tsx');
+const DetailsListBasicExampleCode = require('./examples/DetailsList.Basic.Example.tsx') as string;
 
 import { DetailsListCustomColumnsExample } from './examples/DetailsList.CustomColumns.Example';
-const DetailsListCustomColumnsExampleCode = require('./examples/DetailsList.CustomColumns.Example.tsx');
+const DetailsListCustomColumnsExampleCode = require('./examples/DetailsList.CustomColumns.Example.tsx') as string;
 
 import { DetailsListCustomRowsExample } from './examples/DetailsList.CustomRows.Example';
-const DetailsListCustomRowsExampleCode = require('./examples/DetailsList.CustomRows.Example.tsx');
+const DetailsListCustomRowsExampleCode = require('./examples/DetailsList.CustomRows.Example.tsx') as string;
 
 import { DetailsListCustomGroupHeadersExample } from './examples/DetailsList.CustomGroupHeaders.Example';
-const DetailsListCustomGroupHeadersExampleCode = require('./examples/DetailsList.CustomGroupHeaders.Example.tsx');
+const DetailsListCustomGroupHeadersExampleCode = require('./examples/DetailsList.CustomGroupHeaders.Example.tsx') as string;
 
 import { DetailsListAdvancedExample } from './examples/DetailsList.Advanced.Example';
-const DetailsListAdvancedExampleCode = require('./examples/DetailsList.Advanced.Example.tsx');
+const DetailsListAdvancedExampleCode = require('./examples/DetailsList.Advanced.Example.tsx') as string;
 
 import { DetailsListGroupedExample } from './examples/DetailsList.Grouped.Example';
-const DetailsListGroupedExampleCode = require('./examples/DetailsList.Grouped.Example.tsx');
+const DetailsListGroupedExampleCode = require('./examples/DetailsList.Grouped.Example.tsx') as string;
 
 export class DetailsListPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/DialogPage/DialogPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DialogPage/DialogPage.tsx
@@ -13,10 +13,10 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const DialogBasicExampleCode = require('./examples/Dialog.Basic.Example.tsx');
-const DialogLargeHeaderExampleCode = require('./examples/Dialog.LargeHeader.Example.tsx');
-const DialogCloseExampleCode = require('./examples/Dialog.Close.Example.tsx');
-const DialogBlockingExampleCode = require('./examples/Dialog.Blocking.Example.tsx');
+const DialogBasicExampleCode = require('./examples/Dialog.Basic.Example.tsx') as string;
+const DialogLargeHeaderExampleCode = require('./examples/Dialog.LargeHeader.Example.tsx') as string;
+const DialogCloseExampleCode = require('./examples/Dialog.Close.Example.tsx') as string;
+const DialogBlockingExampleCode = require('./examples/Dialog.Blocking.Example.tsx') as string;
 
 export class DialogPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/DocumentCardPage/DocumentCardPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DocumentCardPage/DocumentCardPage.tsx
@@ -12,9 +12,9 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const DocumentCardBasicExampleCode = require('./examples/DocumentCard.Basic.Example.tsx');
-const DocumentCardCompleteExampleCode = require('./examples/DocumentCard.Complete.Example.tsx');
-const DocumentCardCompactExampleCode = require('./examples/DocumentCard.Compact.Example.tsx');
+const DocumentCardBasicExampleCode = require('./examples/DocumentCard.Basic.Example.tsx') as string;
+const DocumentCardCompleteExampleCode = require('./examples/DocumentCard.Complete.Example.tsx') as string;
+const DocumentCardCompactExampleCode = require('./examples/DocumentCard.Compact.Example.tsx') as string;
 
 export class DocumentCardPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/DropdownPage/DropdownPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/DropdownPage/DropdownPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const DropdownBasicExampleCode = require('./examples/Dropdown.Basic.Example.tsx');
+const DropdownBasicExampleCode = require('./examples/Dropdown.Basic.Example.tsx') as string;
 
 export class DropdownPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/Facepile/FacepilePage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/Facepile/FacepilePage.tsx
@@ -12,9 +12,9 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const FacepileAddFaceExampleCode = require('./examples/Facepile.AddFace.Example.tsx');
-const FacepileBasicExampleCode = require('./examples/Facepile.Basic.Example.tsx');
-const FacepileOverflowExampleCode = require('./examples/Facepile.Overflow.Example.tsx');
+const FacepileAddFaceExampleCode = require('./examples/Facepile.AddFace.Example.tsx') as string;
+const FacepileBasicExampleCode = require('./examples/Facepile.Basic.Example.tsx') as string;
+const FacepileOverflowExampleCode = require('./examples/Facepile.Overflow.Example.tsx') as string;
 
 export class FacepilePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/FocusTrapZonePage/FocusTrapZonePage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/FocusTrapZonePage/FocusTrapZonePage.tsx
@@ -13,13 +13,13 @@ import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
 import FocusTrapZoneBoxExample from './examples/FocusTrapZone.Box.Example';
-let FocusTrapZoneBoxExampleCode = require('./examples/FocusTrapZone.Box.Example.tsx');
+let FocusTrapZoneBoxExampleCode = require('./examples/FocusTrapZone.Box.Example.tsx') as string;
 
 import FocusTrapZoneBoxExampleWithFocusableItem from './examples/FocusTrapZone.Box.FocusOnCustomElement.Example';
-let FocusTrapZoneBoxExampleWithFocusableItemCode = require('./examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx');
+let FocusTrapZoneBoxExampleWithFocusableItemCode = require('./examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx') as string;
 
 import FocusTrapZoneBoxClickExample from './examples/FocusTrapZone.Box.Click.Example';
-let FocusTrapZoneBoxClickExampleCode = require('./examples/FocusTrapZone.Box.Click.Example.tsx');
+let FocusTrapZoneBoxClickExampleCode = require('./examples/FocusTrapZone.Box.Click.Example.tsx') as string;
 
 export class FocusTrapZonePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/FocusZonePage/FocusZonePage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/FocusZonePage/FocusZonePage.tsx
@@ -12,9 +12,9 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const FocusZonePhotosExampleCode = require('./examples/FocusZone.Photos.Example.tsx');
-const FocusZoneListExampleCode = require('./examples/FocusZone.List.Example.tsx');
-const FocusZoneDisabledExampleCode = require('./examples/FocusZone.Disabled.Example.tsx');
+const FocusZonePhotosExampleCode = require('./examples/FocusZone.Photos.Example.tsx') as string;
+const FocusZoneListExampleCode = require('./examples/FocusZone.List.Example.tsx') as string;
+const FocusZoneDisabledExampleCode = require('./examples/FocusZone.Disabled.Example.tsx') as string;
 
 export class FocusZonePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -26,7 +26,7 @@ export class FocusZonePage extends React.Component<IComponentDemoPageProps, any>
 
   public render() {
     return (
-       <ComponentPage
+      <ComponentPage
         title='FocusZone'
         componentName='FocusZoneExample'
         exampleCards={

--- a/packages/office-ui-fabric-react/src/demo/pages/GettingStartedPage/GettingStartedPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/GettingStartedPage/GettingStartedPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Link } from '../../../index';
 import './GettingStartedPage.scss';
 
-const Highlight = require('react-highlight');
+const Highlight = require('react-highlight') as any;
 
 export class GettingStartedPage extends React.Component<any, any> {
   public render() {
@@ -26,7 +26,7 @@ export class GettingStartedPage extends React.Component<any, any> {
 
         <h2>Getting started</h2>
 
-        <p>{ `Integrating components into your project depends heavily on your setup. The recommended setup is to use a bundler such as ` }<Link href='https://webpack.github.io/' target='_blank'>Webpack</Link>{` which can resolve NPM package imports in your code and can bundle the specific things you import.` }</p>
+        <p>{ `Integrating components into your project depends heavily on your setup. The recommended setup is to use a bundler such as ` }<Link href='https://webpack.github.io/' target='_blank'>Webpack</Link>{ ` which can resolve NPM package imports in your code and can bundle the specific things you import.` }</p>
 
         <p>{
           `Within an npm project, you should install the package and save it as a dependency:`
@@ -46,7 +46,7 @@ export class GettingStartedPage extends React.Component<any, any> {
 
         <div className='ms-GettingStartedPage-code'>
           <Highlight className='typescript'>{
-`import * as React from 'react';
+            `import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Button } from 'office-ui-fabric-react/lib/Button';
 
@@ -65,11 +65,11 @@ ReactDOM.render(<MyPage />, document.body.firstChild);`
           <Highlight className='typescript'>{ `import { Button } from 'office-ui-fabric-react';` }</Highlight>
         </div>
 
-        <p>{`...this would work, but then unless you are using a tree-shaking bundler such as Rollup.js or Webpack 2, Webpack will assume you want every module exported from the main entry file to be included in your final bundle, which produces unnecessary large bundles and slows your page load down. Instead you can import the specific paths to trim down your bundle size:`}</p>
+        <p>{ `...this would work, but then unless you are using a tree-shaking bundler such as Rollup.js or Webpack 2, Webpack will assume you want every module exported from the main entry file to be included in your final bundle, which produces unnecessary large bundles and slows your page load down. Instead you can import the specific paths to trim down your bundle size:` }</p>
 
         <div className='ms-GettingStartedPage-code'>
           <Highlight className='typescript'>{
-`import { Button } from 'office-ui-fabric-react/lib/Button';
+            `import { Button } from 'office-ui-fabric-react/lib/Button';
 import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
 import { List } from 'office-ui-fabric-react/lib/List';`
           }</Highlight>

--- a/packages/office-ui-fabric-react/src/demo/pages/GroupedListPage/GroupedListPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/GroupedListPage/GroupedListPage.tsx
@@ -11,8 +11,8 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const GroupedListBasicExampleCode = require('./examples/GroupedList.Basic.Example.tsx');
-const GroupedListCustomExampleCode = require('./examples/GroupedList.Custom.Example.tsx');
+const GroupedListBasicExampleCode = require('./examples/GroupedList.Basic.Example.tsx') as string;
+const GroupedListCustomExampleCode = require('./examples/GroupedList.Custom.Example.tsx') as string;
 
 export class GroupedListPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -38,7 +38,7 @@ export class GroupedListPage extends React.Component<IComponentDemoPageProps, an
           </div>
         }
         propertiesTables={
-            <PropertiesTableSet componentName='GroupedList' />
+          <PropertiesTableSet componentName='GroupedList' />
         }
         overview={
           <p>Allows you to render a set of items as multiple lists with various grouping properties.</p>

--- a/packages/office-ui-fabric-react/src/demo/pages/IconPage/IconPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/IconPage/IconPage.tsx
@@ -12,9 +12,9 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const IconBasicExampleCode = require('./examples/Icon.Basic.Example.tsx');
-const IconColorExampleCode = require('./examples/Icon.Color.Example.tsx');
-const IconImageSheetExampleCode = require('./examples/Icon.ImageSheet.Example.tsx');
+const IconBasicExampleCode = require('./examples/Icon.Basic.Example.tsx') as string;
+const IconColorExampleCode = require('./examples/Icon.Color.Example.tsx') as string;
+const IconImageSheetExampleCode = require('./examples/Icon.ImageSheet.Example.tsx') as string;
 
 export class IconPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/ImagePage/ImagePage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ImagePage/ImagePage.tsx
@@ -16,12 +16,12 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const ImageDefaultExampleCode = require('./examples/Image.Default.Example.tsx');
-const ImageCenterExampleCode = require('./examples/Image.Center.Example.tsx');
-const ImageContainExampleCode = require('./examples/Image.Contain.Example.tsx');
-const ImageCoverExampleCode = require('./examples/Image.Cover.Example.tsx');
-const ImageNoneExampleCode = require('./examples/Image.None.Example.tsx');
-const ImageMaximizeFrameExampleCode = require('./examples/Image.MaximizeFrame.Example.tsx');
+const ImageDefaultExampleCode = require('./examples/Image.Default.Example.tsx') as string;
+const ImageCenterExampleCode = require('./examples/Image.Center.Example.tsx') as string;
+const ImageContainExampleCode = require('./examples/Image.Contain.Example.tsx') as string;
+const ImageCoverExampleCode = require('./examples/Image.Cover.Example.tsx') as string;
+const ImageNoneExampleCode = require('./examples/Image.None.Example.tsx') as string;
+const ImageMaximizeFrameExampleCode = require('./examples/Image.MaximizeFrame.Example.tsx') as string;
 
 export class ImagePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/LabelPage/LabelPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/LabelPage/LabelPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const LabelBasicExampleCode = require('./examples/Label.Basic.Example.tsx');
+const LabelBasicExampleCode = require('./examples/Label.Basic.Example.tsx') as string;
 
 export class LabelPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -27,11 +27,11 @@ export class LabelPage extends React.Component<IComponentDemoPageProps, any> {
         componentName='LabelExample'
         exampleCards={
           <ExampleCard title='Label' code={ LabelBasicExampleCode }>
-            <LabelBasicExample/>
+            <LabelBasicExample />
           </ExampleCard>
         }
         propertiesTables={
-            <PropertiesTableSet componentName='Label' />
+          <PropertiesTableSet componentName='Label' />
         }
         overview={
           <div>

--- a/packages/office-ui-fabric-react/src/demo/pages/LayerPage/LayerPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/LayerPage/LayerPage.tsx
@@ -12,8 +12,8 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const LayerBasicExampleCode = require('./examples/Layer.Basic.Example.tsx');
-const LayerHostedExampleCode = require('./examples/Layer.Hosted.Example.tsx');
+const LayerBasicExampleCode = require('./examples/Layer.Basic.Example.tsx') as string;
+const LayerHostedExampleCode = require('./examples/Layer.Hosted.Example.tsx') as string;
 
 export class LayerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -25,7 +25,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, any> {
 
   public render() {
     return (
-       <ComponentPage
+      <ComponentPage
         title='Layer'
         componentName='LayerExample'
         exampleCards={
@@ -47,7 +47,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, any> {
               A Layer is a technical component that does not have specific Design guidance.
             </p>
             <p>
-              {`Layers are used to render content outside of a DOM tree, at the end of the document. This allows content to escape traditional boundaries caused by "overflow: hidden" css rules and keeps it on the top without using z-index rules. This is useful for example in ContextualMenu and Tooltip scenarios, where the content should always overlay everything else.`}
+              { `Layers are used to render content outside of a DOM tree, at the end of the document. This allows content to escape traditional boundaries caused by "overflow: hidden" css rules and keeps it on the top without using z-index rules. This is useful for example in ContextualMenu and Tooltip scenarios, where the content should always overlay everything else.` }
             </p>
             <p>{
               `There are some special considerations. Due to the nature of rendering content elsewhere asynchronously, React refs within content will not be resolvable synchronously at the time the Layer is mounted. Therefore, to use refs correctly, use functional refs ( ref={ (el) => { this._root = el; } ) rather than string refs ( ref='root' ). Additionally measuring the physical Layer element will not include any of the children, since it won't render it. Events that propgate from within the content will not go through the Layer element as well.`
@@ -70,7 +70,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, any> {
         donts={
           <div>
             <ul>
-              <li>{'Don\'t use string refs ( ref=\'root\' ).'}</li>
+              <li>{ 'Don\'t use string refs ( ref=\'root\' ).' }</li>
             </ul>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/demo/pages/LinkPage/LinkPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/LinkPage/LinkPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-let LinkBasicExampleCode = require('./examples/Link.Basic.Example.tsx');
+let LinkBasicExampleCode = require('./examples/Link.Basic.Example.tsx') as string;
 
 export class LinkPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/ListPage/ListPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ListPage/ListPage.tsx
@@ -10,9 +10,9 @@ import { ListMailExample } from './examples/List.Mail.Example';
 import { ListGridExample } from './examples/List.Grid.Example';
 import { createListItems } from '../../utilities/data';
 
-const ListBasicExampleCode = require('./examples/List.Basic.Example.tsx');
-const ListMailExampleCode = require('./examples/List.Mail.Example.tsx');
-const ListGridExampleCode = require('./examples/List.Grid.Example.tsx');
+const ListBasicExampleCode = require('./examples/List.Basic.Example.tsx') as string;
+const ListMailExampleCode = require('./examples/List.Mail.Example.tsx') as string;
+const ListGridExampleCode = require('./examples/List.Grid.Example.tsx') as string;
 
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';

--- a/packages/office-ui-fabric-react/src/demo/pages/MarqueeSelectionPage/MarqueeSelectionPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/MarqueeSelectionPage/MarqueeSelectionPage.tsx
@@ -9,7 +9,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const MarqueeSelectionBasicExampleCode = require('./examples/MarqueeSelection.Basic.Example.tsx');
+const MarqueeSelectionBasicExampleCode = require('./examples/MarqueeSelection.Basic.Example.tsx') as string;
 
 export class MarqueeSelectionPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -21,7 +21,7 @@ export class MarqueeSelectionPage extends React.Component<IComponentDemoPageProp
 
   public render() {
     return (
-       <ComponentPage
+      <ComponentPage
         title='MarqueeSelection'
         componentName='MarqueeSelectionExample'
         exampleCards={

--- a/packages/office-ui-fabric-react/src/demo/pages/MessageBarPage/MessageBarPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/MessageBarPage/MessageBarPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const MessageBarBasicExampleCode = require('./examples/MessageBar.Basic.Example.tsx');
+const MessageBarBasicExampleCode = require('./examples/MessageBar.Basic.Example.tsx') as string;
 
 export class MessageBarPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/NavPage/NavPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/NavPage/NavPage.tsx
@@ -13,10 +13,10 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const NavBasicExampleCode = require('./examples/Nav.Basic.Example.tsx');
-const NavFabricDemoAppExampleCode = require('./examples/Nav.FabricDemoApp.Example.tsx');
-const NavNestedExampleCode = require('./examples/Nav.Nested.Example.tsx');
-const NavByKeysExampleCode = require('./examples/Nav.ByKeys.Example.tsx');
+const NavBasicExampleCode = require('./examples/Nav.Basic.Example.tsx') as string;
+const NavFabricDemoAppExampleCode = require('./examples/Nav.FabricDemoApp.Example.tsx') as string;
+const NavNestedExampleCode = require('./examples/Nav.Nested.Example.tsx') as string;
+const NavByKeysExampleCode = require('./examples/Nav.ByKeys.Example.tsx') as string;
 
 export class NavPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/OverlayPage/OverlayPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/OverlayPage/OverlayPage.tsx
@@ -11,8 +11,8 @@ import { IComponentDemoPageProps } from '../../components/ComponentPage/ICompone
 import { OverlayDarkExample } from './examples/Overlay.Dark.Example';
 import { OverlayLightExample } from './examples/Overlay.Light.Example';
 
-const OverlayLightExampleCode = require('./examples/Overlay.Light.Example.tsx');
-const OverlayDarkExampleCode = require('./examples/Overlay.Dark.Example.tsx');
+const OverlayLightExampleCode = require('./examples/Overlay.Light.Example.tsx') as string;
+const OverlayDarkExampleCode = require('./examples/Overlay.Dark.Example.tsx') as string;
 
 export class OverlayPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/PanelPage/PanelPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PanelPage/PanelPage.tsx
@@ -18,15 +18,15 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const PanelSmallRightExampleCode = require('./examples/Panel.SmallRight.Example.tsx');
-const PanelSmallLeftExampleCode = require('./examples/Panel.SmallLeft.Example.tsx');
-const PanelSmallFluidExampleCode = require('./examples/Panel.SmallFluid.Example.tsx');
-const PanelMediumExampleCode = require('./examples/Panel.Medium.Example.tsx');
-const PanelLargeExampleCode = require('./examples/Panel.Large.Example.tsx');
-const PanelLargeFixedExampleCode = require('./examples/Panel.LargeFixed.Example.tsx');
-const PanelExtraLargeExampleCode = require('./examples/Panel.ExtraLarge.Example.tsx');
-const PanelLightDismissExampleCode = require('./examples/Panel.LightDismiss.Example.tsx');
-const PanelNonModalExampleCode = require('./examples/Panel.NonModal.Example.tsx');
+const PanelSmallRightExampleCode = require('./examples/Panel.SmallRight.Example.tsx') as string;
+const PanelSmallLeftExampleCode = require('./examples/Panel.SmallLeft.Example.tsx') as string;
+const PanelSmallFluidExampleCode = require('./examples/Panel.SmallFluid.Example.tsx') as string;
+const PanelMediumExampleCode = require('./examples/Panel.Medium.Example.tsx') as string;
+const PanelLargeExampleCode = require('./examples/Panel.Large.Example.tsx') as string;
+const PanelLargeFixedExampleCode = require('./examples/Panel.LargeFixed.Example.tsx') as string;
+const PanelExtraLargeExampleCode = require('./examples/Panel.ExtraLarge.Example.tsx') as string;
+const PanelLightDismissExampleCode = require('./examples/Panel.LightDismiss.Example.tsx') as string;
+const PanelNonModalExampleCode = require('./examples/Panel.NonModal.Example.tsx') as string;
 
 export class PanelPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/PeoplePickerPage/PeoplePickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PeoplePickerPage/PeoplePickerPage.tsx
@@ -13,7 +13,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const PeoplePickerTypesExampleCode = require('./examples/PeoplePicker.Types.Example.tsx');
+const PeoplePickerTypesExampleCode = require('./examples/PeoplePicker.Types.Example.tsx') as string;
 
 export class PeoplePickerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -30,7 +30,7 @@ export class PeoplePickerPage extends React.Component<IComponentDemoPageProps, a
         componentName='PeoplePickerExample'
         exampleCards={
           <div>
-            <ExampleCard title='People Pickers' code={PeoplePickerTypesExampleCode}>
+            <ExampleCard title='People Pickers' code={ PeoplePickerTypesExampleCode }>
               <PeoplePickerTypesExample />
             </ExampleCard>
           </div>
@@ -44,8 +44,8 @@ export class PeoplePickerPage extends React.Component<IComponentDemoPageProps, a
             <span> are used to pick recipients.</span>
           </div>
         }
-        route={this._url}
-        isHeaderVisible={this.props.isHeaderVisible}
+        route={ this._url }
+        isHeaderVisible={ this.props.isHeaderVisible }
         related={
           <a href='https://github.com/OfficeDev/office-ui-fabric-js/blob/master/ghdocs/components/PeoplePicker.md'>Fabric JS</a>
         }

--- a/packages/office-ui-fabric-react/src/demo/pages/PersonaPage/PersonaPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PersonaPage/PersonaPage.tsx
@@ -11,8 +11,8 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const PersonaInitialsExampleCode = require('./examples/Persona.Initials.Example.tsx');
-const PersonaBasicExampleCode = require('./examples/Persona.Basic.Example.tsx');
+const PersonaInitialsExampleCode = require('./examples/Persona.Initials.Example.tsx') as string;
+const PersonaBasicExampleCode = require('./examples/Persona.Basic.Example.tsx') as string;
 
 export class PersonaPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/PickersPage/PickersPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PickersPage/PickersPage.tsx
@@ -14,8 +14,8 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const TagPickerExampleCode = require('./examples/TagPicker.Basic.Example.tsx');
-const PickerCustomResultExampleCode = require('./examples/Picker.CustomResult.Example.tsx');
+const TagPickerExampleCode = require('./examples/TagPicker.Basic.Example.tsx') as string;
+const PickerCustomResultExampleCode = require('./examples/Picker.CustomResult.Example.tsx') as string;
 
 export class PickersPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -32,12 +32,12 @@ export class PickersPage extends React.Component<IComponentDemoPageProps, any> {
         componentName='PickersExample'
         exampleCards={
           <div>
-              <ExampleCard title='Tag Picker' code={ TagPickerExampleCode }>
-                <TagPickerBasicExample />
-              </ExampleCard>
-              <ExampleCard title='Custom Picker (Document Picker)' code={ PickerCustomResultExampleCode }>
-                <PickerCustomResultExample />
-              </ExampleCard>
+            <ExampleCard title='Tag Picker' code={ TagPickerExampleCode }>
+              <TagPickerBasicExample />
+            </ExampleCard>
+            <ExampleCard title='Custom Picker (Document Picker)' code={ PickerCustomResultExampleCode }>
+              <PickerCustomResultExample />
+            </ExampleCard>
           </div>
         }
         propertiesTables={

--- a/packages/office-ui-fabric-react/src/demo/pages/PivotPage/PivotPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/PivotPage/PivotPage.tsx
@@ -18,15 +18,15 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const PivotRemoveExampleCode = require('./examples/Pivot.Remove.Example.tsx');
-const PivotBasicExampleCode = require('./examples/Pivot.Basic.Example.tsx');
-const PivotLargeExampleCode = require('./examples/Pivot.Large.Example.tsx');
-const PivotTabsExampleCode = require('./examples/Pivot.Tabs.Example.tsx');
-const PivotTabsLargesExampleCode = require('./examples/Pivot.TabsLarge.Example.tsx');
-const PivotFabricExampleCode = require('./examples/Pivot.Fabric.Example.tsx');
-const PivotOnChangeExampleCode = require('./examples/Pivot.OnChange.Example.tsx');
-const PivotIconCountExampleCode = require('./examples/Pivot.IconCount.Example.tsx');
-const PivotOverrideExampleCode = require('./examples/Pivot.Override.Example.tsx');
+const PivotRemoveExampleCode = require('./examples/Pivot.Remove.Example.tsx') as string;
+const PivotBasicExampleCode = require('./examples/Pivot.Basic.Example.tsx') as string;
+const PivotLargeExampleCode = require('./examples/Pivot.Large.Example.tsx') as string;
+const PivotTabsExampleCode = require('./examples/Pivot.Tabs.Example.tsx') as string;
+const PivotTabsLargesExampleCode = require('./examples/Pivot.TabsLarge.Example.tsx') as string;
+const PivotFabricExampleCode = require('./examples/Pivot.Fabric.Example.tsx') as string;
+const PivotOnChangeExampleCode = require('./examples/Pivot.OnChange.Example.tsx') as string;
+const PivotIconCountExampleCode = require('./examples/Pivot.IconCount.Example.tsx') as string;
+const PivotOverrideExampleCode = require('./examples/Pivot.Override.Example.tsx') as string;
 
 export class PivotPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/ProgressIndicatorPage/ProgressIndicatorPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ProgressIndicatorPage/ProgressIndicatorPage.tsx
@@ -9,7 +9,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 import { ProgressIndicatorBasicExample } from './examples/ProgressIndicator.Basic.Example';
-const ProgressIndicatorBasicExampleCode = require('./examples/ProgressIndicator.Basic.Example.tsx');
+const ProgressIndicatorBasicExampleCode = require('./examples/ProgressIndicator.Basic.Example.tsx') as string;
 
 export class ProgressIndicatorPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;
@@ -21,7 +21,7 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
 
   public render() {
     return (
-     <ComponentPage
+      <ComponentPage
         title='ProgressIndicator'
         componentName='ProgressIndicatorExample'
         exampleCards={
@@ -30,7 +30,7 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
           </ExampleCard>
         }
         propertiesTables={
-            <PropertiesTableSet componentName='ProgressIndicator' />
+          <PropertiesTableSet componentName='ProgressIndicator' />
         }
         overview={
           <div>
@@ -66,10 +66,10 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
         dos={
           <div>
             <ul>
-            <li>Use a ProgressIndicator when the total units to completion is known</li>
-            <li>Display operation description</li>
-            <li>Show text above and/or below the bar</li>
-            <li>Combine steps of a single operation into one bar</li>
+              <li>Use a ProgressIndicator when the total units to completion is known</li>
+              <li>Display operation description</li>
+              <li>Show text above and/or below the bar</li>
+              <li>Combine steps of a single operation into one bar</li>
             </ul>
           </div>
         }
@@ -87,7 +87,7 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
           <a href='https://github.com/OfficeDev/office-ui-fabric-js/blob/master/ghdocs/components/ProgressIndicator.md'>Fabric JS</a>
         }
         route={ this._url }
-         isHeaderVisible={ this.props.isHeaderVisible }>
+        isHeaderVisible={ this.props.isHeaderVisible }>
       </ComponentPage>
     );
   }

--- a/packages/office-ui-fabric-react/src/demo/pages/RatingPage/RatingPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/RatingPage/RatingPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const RatingBasicExampleCode = require('./examples/Rating.Basic.Example.tsx');
+const RatingBasicExampleCode = require('./examples/Rating.Basic.Example.tsx') as string;
 
 export class RatingPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/SearchBoxPage/SearchBoxPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/SearchBoxPage/SearchBoxPage.tsx
@@ -11,8 +11,8 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const SearchBoxSmallExampleCode = require('./examples/SearchBox.Small.Example.tsx');
-const SearchBoxFullSizeExampleCode = require('./examples/SearchBox.FullSize.Example.tsx');
+const SearchBoxSmallExampleCode = require('./examples/SearchBox.Small.Example.tsx') as string;
+const SearchBoxFullSizeExampleCode = require('./examples/SearchBox.FullSize.Example.tsx') as string;
 
 export class SearchBoxPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/SelectionPage/SelectionPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/SelectionPage/SelectionPage.tsx
@@ -9,7 +9,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const SelectionBasicExampleCode = require('./examples/Selection.Basic.Example.tsx');
+const SelectionBasicExampleCode = require('./examples/Selection.Basic.Example.tsx') as string;
 
 export class SelectionPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/SliderPage/SliderPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/SliderPage/SliderPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const SliderBasicExampleCode = require('./examples/Slider.Basic.Example.tsx');
+const SliderBasicExampleCode = require('./examples/Slider.Basic.Example.tsx') as string;
 
 export class SliderPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/SpinnerPage/SpinnerPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/SpinnerPage/SpinnerPage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const SpinnerBasicExampleCode = require('./examples/Spinner.Basic.Example.tsx');
+const SpinnerBasicExampleCode = require('./examples/Spinner.Basic.Example.tsx') as string;
 
 export class SpinnerPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/TeachingBubblePage/TeachingBubblePage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/TeachingBubblePage/TeachingBubblePage.tsx
@@ -15,9 +15,9 @@ import { TeachingBubbleIllustrationExample } from './examples/TeachingBubble.Ill
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 
-const TeachingBubbleBasicExampleCode = require('./examples/TeachingBubble.Basic.Example.tsx');
-const TeachingBubbleCondensedExampleCode = require('./examples/TeachingBubble.Condensed.Example.tsx');
-const TeachingBubbleIllustrationExampleCode = require('./examples/TeachingBubble.Basic.Example.tsx');
+const TeachingBubbleBasicExampleCode = require('./examples/TeachingBubble.Basic.Example.tsx') as string;
+const TeachingBubbleCondensedExampleCode = require('./examples/TeachingBubble.Condensed.Example.tsx') as string;
+const TeachingBubbleIllustrationExampleCode = require('./examples/TeachingBubble.Basic.Example.tsx') as string;
 
 export class TeachingBubblePage extends React.Component<any, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/TextFieldPage/TextFieldPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/TextFieldPage/TextFieldPage.tsx
@@ -11,8 +11,8 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const TextFieldBasicExampleCode = require('./examples/TextField.Basic.Example.tsx');
-const TextFieldErrorMessageExampleCode = require('./examples/TextField.ErrorMessage.Example.tsx');
+const TextFieldBasicExampleCode = require('./examples/TextField.Basic.Example.tsx') as string;
+const TextFieldErrorMessageExampleCode = require('./examples/TextField.ErrorMessage.Example.tsx') as string;
 
 export class TextFieldPage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/ThemePage/ThemePage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/ThemePage/ThemePage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { loadTheme, ITheme } from '@microsoft/load-themed-styles';
-let Highlight = require('react-highlight');
+let Highlight = require('react-highlight') as any;
 import { defaultTheme } from './defaultTheme';
 import {
   Callout,
@@ -16,7 +16,7 @@ const ThemeCodeExample = require('./ThemeCodeExample.txt');
 export class ThemePage extends React.Component<any, any> {
 
   public refs: {
-    [ key: string ]: React.ReactInstance;
+    [key: string]: React.ReactInstance;
     list: DetailsList;
   };
 
@@ -56,7 +56,7 @@ export class ThemePage extends React.Component<any, any> {
             items={ colors }
             selectionMode={ SelectionMode.none }
             layoutMode={ LayoutMode.fixedColumns }
-            columns={[
+            columns={ [
               {
                 key: 'name',
                 name: 'Name',
@@ -82,22 +82,22 @@ export class ThemePage extends React.Component<any, any> {
                 fieldName: 'description',
                 minWidth: 90
               }
-            ]}
+            ] }
           />
 
           { colorPickerProps && (
-          <Callout
-            isBeakVisible={ false }
-            gapSpace={ 10 }
-            targetElement={ colorPickerProps.targetElement }
-            onDismiss={ this._onPickerDismiss }>
+            <Callout
+              isBeakVisible={ false }
+              gapSpace={ 10 }
+              targetElement={ colorPickerProps.targetElement }
+              onDismiss={ this._onPickerDismiss }>
 
-            <ColorPicker
-              color={ colorPickerProps.value }
-              onColorChanged={ this._onColorChanged.bind(this, colorPickerProps.index) }
-            />
+              <ColorPicker
+                color={ colorPickerProps.value }
+                onColorChanged={ this._onColorChanged.bind(this, colorPickerProps.index) }
+              />
 
-          </Callout>
+            </Callout>
           ) }
 
         </div>

--- a/packages/office-ui-fabric-react/src/demo/pages/TogglePage/TogglePage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/TogglePage/TogglePage.tsx
@@ -10,7 +10,7 @@ import { getPageRouteFromState } from '../../utilities/pageroute';
 import { AppState } from '../../components/App/AppState';
 import { IComponentDemoPageProps } from '../../components/ComponentPage/IComponentDemoPageProps';
 
-const ToggleBasicExampleCode = require('./examples/Toggle.Basic.Example.tsx');
+const ToggleBasicExampleCode = require('./examples/Toggle.Basic.Example.tsx') as string;
 
 export class TogglePage extends React.Component<IComponentDemoPageProps, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/src/demo/pages/TooltipPage/TooltipPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/TooltipPage/TooltipPage.tsx
@@ -16,8 +16,8 @@ import { AppState } from '../../components/App/AppState';
 
 import './TooltipPage.scss';
 
-const TooltipBasicExampleCode = require('./examples/Tooltip.Basic.Example.tsx');
-const TooltipBottomExampleCode = require('./examples/Tooltip.Bottom.Example.tsx');
+const TooltipBasicExampleCode = require('./examples/Tooltip.Basic.Example.tsx') as string;
+const TooltipBottomExampleCode = require('./examples/Tooltip.Bottom.Example.tsx') as string;
 
 export class TooltipPage extends React.Component<any, any> {
   private _url: string;

--- a/packages/office-ui-fabric-react/tsconfig.json
+++ b/packages/office-ui-fabric-react/tsconfig.json
@@ -11,8 +11,7 @@
     "types": [
       "chai",
       "mocha",
-      "node",
-      "webpack"
+      "webpack-env"
     ]
   },
   "exclude": [


### PR DESCRIPTION
This change simply removes the node typings and replaces with `@types/webpack-env` which enables my next couple of PRs to use require.ensure in places.
