### PR TITLE
Add support for custom option rendering to Dropdown

### DIFF
--- a/common/changes/enhanceDropdownOptionRender_2017_01-26-23-30.json
+++ b/common/changes/enhanceDropdownOptionRender_2017_01-26-23-30.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "dropdown: Add support for custom option renderer.",
+      "comment": "Dropdown: now supports a custom option renderer.",
       "type": "patch"
     }
   ],

--- a/common/changes/enhanceDropdownOptionRender_2017_01-26-23-30.json
+++ b/common/changes/enhanceDropdownOptionRender_2017_01-26-23-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "dropdown: Add support for custom option renderer.",
+      "type": "patch"
+    }
+  ],
+  "email": "sferg@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
@@ -37,9 +37,14 @@ export interface IDropdownProps {
   onChanged?: (option: IDropdownOption, index?: number) => void;
 
   /**
-   * Optional custom renderer for the dropdown item
+   * Optional custom renderer for the selected dropdown item
    */
   onRenderItem?: IRenderFunction<IDropdownOption>;
+
+  /**
+   * Optional custom renderer for the dropdown options
+   */
+  onRenderOption?: IRenderFunction<IDropdownOption>;
 
   /**
    * Whether or not the Dropdown is disabled.

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -66,7 +66,7 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
 
   public render() {
     let id = this._id;
-    let { className, label, options, disabled, isDisabled, onRenderItem = this._onRenderItem } = this.props;
+    let { className, label, options, disabled, isDisabled, onRenderItem = this._onRenderItem, onRenderOption = this._onRenderOption } = this.props;
     let { isOpen, selectedIndex } = this.state;
     let selectedOption = options[selectedIndex];
 
@@ -96,13 +96,13 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
           aria-label={ label }
           aria-describedby={ id + '-option' }
           aria-activedescendant={ selectedIndex >= 0 ? (this._id + '-list' + selectedIndex) : (this._id + '-list') }
-          >
+        >
           <span
             id={ id + '-option' }
             className='ms-Dropdown-title'
             key={ selectedIndex }
             aria-atomic={ true }
-            >
+          >
             { selectedOption ? onRenderItem(selectedOption, this._onRenderItem) : '' }
           </span>
           <i className='ms-Dropdown-caretDown ms-Icon ms-Icon--ChevronDown'></i>
@@ -117,12 +117,12 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
             directionalHint={ DirectionalHint.bottomLeftEdge }
             onDismiss={ this._onDismiss }
             onPositioned={ this._onPositioned }
-            >
+          >
             <FocusZone
               ref={ this._resolveRef('_focusZone') }
               direction={ FocusZoneDirection.vertical }
               defaultActiveElement={ '#' + id + '-list' + selectedIndex }
-              >
+            >
               <ul ref={ (c: HTMLElement) => this._optionList = c }
                 id={ id + '-list' }
                 style={ { width: this._dropDown.clientWidth - 2 } }
@@ -141,8 +141,8 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
                     role='option'
                     aria-selected={ selectedIndex === index ? 'true' : 'false' }
                     aria-label={ option.text }
-                    >
-                    { option.text }
+                  >
+                    { onRenderOption(option, this._onRenderOption) }
                   </li>
                 )) }
               </ul>
@@ -179,6 +179,11 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
 
   @autobind
   private _onRenderItem(item: IDropdownOption): JSX.Element {
+    return <span>{ item.text }</span>;
+  }
+
+  @autobind
+  private _onRenderOption(item: IDropdownOption): JSX.Element {
     return <span>{ item.text }</span>;
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ X] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ X] Documentation update

#### Description of changes

Dropdown has a custom selected item renderer, but it does not have a custom option renderer.  I would like to add a custom option renderer so that I can render options as something more than just text.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
