### PR TITLE
Command Bar: Allow for dynamic menus

### DIFF
--- a/common/changes/commandbar-allow-dynamic-menus_2017-01-27-23-06.json
+++ b/common/changes/commandbar-allow-dynamic-menus_2017-01-27-23-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Command Bar: context menus stay open after update if the open menu is still in the new props. Also, propagates most properties from subMenuProps to opened ContextualMenus",
+      "type": "patch"
+    }
+  ],
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.test.tsx
@@ -78,4 +78,167 @@ describe('CommandBar', () => {
 
     expect(document.querySelector('.SubMenuClass')).to.exist;
   });
+
+  it('keeps menu open after update if item is still present', () => {
+    let renderContainer = document.createElement('div');
+    document.body.appendChild(renderContainer);
+
+    try {
+      let items: IContextualMenuItem[] = [
+        {
+          name: 'TestText 1',
+          key: 'TestKey1',
+          subMenuProps: {
+            items: [
+              {
+                name: 'SubmenuText 1',
+                key: 'SubmenuKey1',
+                className: 'SubMenuClass'
+              }
+            ]
+          }
+        },
+      ];
+
+      let renderedContent = ReactDOM.render(
+        <CommandBar
+          items={ items }
+          />,
+        renderContainer
+      ) as React.Component<CommandBar, {}>;
+
+      let menuItem = (ReactDOM.findDOMNode(renderedContent) as HTMLElement).querySelector('button') as HTMLButtonElement;
+      ReactTestUtils.Simulate.click(menuItem);
+
+      // Make sure the menu is open before the re-render
+      expect(document.querySelector('.SubMenuClass')).to.exist;
+
+      // Update the props, and re-render
+      items.push({
+        name: 'Test Key 2',
+        key: 'TestKey2'
+      });
+
+      renderedContent = ReactDOM.render(
+        <CommandBar
+          items={ items }
+          />,
+        renderContainer
+      ) as React.Component<CommandBar, {}>;
+
+      // Make sure the menu is still open after the re-render
+      expect(document.querySelector('.SubMenuClass')).to.exist;
+    } finally {
+      ReactDOM.unmountComponentAtNode(renderContainer);
+      document.body.removeChild(renderContainer);
+    }
+  });
+
+  it('closes menu after update if item is not longer present', () => {
+    let renderContainer = document.createElement('div');
+    document.body.appendChild(renderContainer);
+
+    try {
+      let items: IContextualMenuItem[] = [
+        {
+          name: 'TestText 1',
+          key: 'TestKey1',
+          subMenuProps: {
+            items: [
+              {
+                name: 'SubmenuText 1',
+                key: 'SubmenuKey1',
+                className: 'SubMenuClass'
+              }
+            ]
+          }
+        },
+      ];
+
+      let renderedContent = ReactDOM.render(
+        <CommandBar
+          items={ items }
+          />,
+        renderContainer
+      ) as React.Component<CommandBar, {}>;
+
+      let menuItem = (ReactDOM.findDOMNode(renderedContent) as HTMLElement).querySelector('button') as HTMLButtonElement;
+      ReactTestUtils.Simulate.click(menuItem);
+
+      // Make sure the menu is open before the re-render
+      expect(document.querySelector('.SubMenuClass')).to.exist;
+
+      // Update the props, and re-render
+      items = [{
+        name: 'Test Key 2',
+        key: 'TestKey2'
+      }];
+
+      renderedContent = ReactDOM.render(
+        <CommandBar
+          items={ items }
+          />,
+        renderContainer
+      ) as React.Component<CommandBar, {}>;
+
+      // Make sure the menu is still open after the re-render
+      expect(document.querySelector('.SubMenuClass')).not.to.exist;
+    } finally {
+      ReactDOM.unmountComponentAtNode(renderContainer);
+      document.body.removeChild(renderContainer);
+    }
+  });
+
+  it('updates menu after update if item is still present', () => {
+    let renderContainer = document.createElement('div');
+    document.body.appendChild(renderContainer);
+
+    try {
+      let items: IContextualMenuItem[] = [
+        {
+          name: 'TestText 1',
+          key: 'TestKey1',
+          subMenuProps: {
+            items: [
+              {
+                name: 'SubmenuText 1',
+                key: 'SubmenuKey1',
+                className: 'SubMenuClass'
+              }
+            ]
+          }
+        },
+      ];
+
+      let renderedContent = ReactDOM.render(
+        <CommandBar
+          items={ items }
+          />,
+        renderContainer
+      ) as React.Component<CommandBar, {}>;
+
+      let menuItem = (ReactDOM.findDOMNode(renderedContent) as HTMLElement).querySelector('button') as HTMLButtonElement;
+      ReactTestUtils.Simulate.click(menuItem);
+
+      // Make sure the menu is open before the re-render
+      expect(document.querySelector('.SubMenuClass')).to.exist;
+
+      // Update the props, and re-render
+      items[0].subMenuProps.items[0].className = 'SubMenuClassUpdate';
+
+      renderedContent = ReactDOM.render(
+        <CommandBar
+          items={ items }
+          />,
+        renderContainer
+      ) as React.Component<CommandBar, {}>;
+
+      // Make sure the menu is still open after the re-render
+      expect(document.querySelector('.SubMenuClass')).not.to.exist;
+      expect(document.querySelector('.SubMenuClassUpdate')).to.exist;
+    } finally {
+      ReactDOM.unmountComponentAtNode(renderContainer);
+      document.body.removeChild(renderContainer);
+    }
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #902 
- [x] Include a change request file if publishing
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests

#### Description of changes

This PR covers two changes to `CommandBar` and its menus

 - If an item's menu is opened when a React update happens, we try to maintain the state of which menu is open if the opened item is in the new properties (judging by the `key` value). This allows dynamic updates to context menu content without causing the menu to close.
- We propagate most properties from `subMenuProps` (all but `labelElementId` and `targetElement`) to the resulting `ContextualMenu`, allowing for more customization and the ability to react to it closing.

#### Focus areas to test

CommandBar menus