### PR TITLE
CommandBar: Render <a> element if item has Href prop

### DIFF
--- a/common/changes/leddie24-commandbar-href_2017-01-27-23-38.json
+++ b/common/changes/leddie24-commandbar-href_2017-01-27-23-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Render link element if item has href prop",
+      "type": "patch"
+    }
+  ],
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
@@ -126,6 +126,11 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
   @include CommandBarItem-text;
   cursor: pointer;
 
+  .ms-CommandBar-linkText {
+    display: inline-block;
+    vertical-align: top;
+  }
+
   &:hover,
   &.is-expanded {
     @media screen and (-ms-high-contrast: active) {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -154,7 +154,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
 
   private _renderItemInCommandBar(item: IContextualMenuItem, index: number, expandedMenuItemKey: string, isFarItem?: boolean) {
     const itemKey = item.key || String(index);
-    const className = css(item.onClick ? 'ms-CommandBarItem-link' : 'ms-CommandBarItem-text', !item.name && 'ms-CommandBarItem--noName');
+    const className = css(item.onClick || item.href ? 'ms-CommandBarItem-link' : 'ms-CommandBarItem-text', !item.name && 'ms-CommandBarItem--noName');
     const classNameValue = css(className, { 'is-expanded': (expandedMenuItemKey === item.key) });
     let hasIcon = !!item.icon || !!item.iconProps;
 
@@ -186,7 +186,21 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
             aria-haspopup={ hasSubmenuItems(item) }
             >
             { (hasIcon) ? this._renderIcon(item) : (null) }
-            <span className='ms-CommandBarItem-commandText ms-font-m ms-font-weight-regular' aria-hidden='true' role='presentation'>{ item.name }</span>
+            { (() => {
+              if (item.href) {
+                return (<a className={ classNameValue }
+                        href={ item.href }
+                        role='link'>
+                        { item.name }
+                      </a>);
+              } else {
+                return (<span className={ classNameValue }
+                  aria-hidden='true'
+                  role='presentation'>
+                  { item.name }
+                  </span>);
+              }
+            })() }
           </div>;
         }
       })() }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -185,15 +185,18 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
             data-command-key={ index }
             aria-haspopup={ hasSubmenuItems(item) }
             >
-            { (hasIcon) ? this._renderIcon(item) : (null) }
             { (() => {
               if (item.href) {
                 return (<a className={ classNameValue }
                         href={ item.href }
                         role='link'>
-                        { item.name }
+                        { (hasIcon) ? this._renderIcon(item) : (null) }
+                        <span className='ms-CommandBar-linkText'
+                              aria-hidden='true'
+                              role='presentation'>{ item.name }</span>
                       </a>);
               } else {
+                { (hasIcon) ? this._renderIcon(item) : (null) }
                 return (<span className={ classNameValue }
                   aria-hidden='true'
                   role='presentation'>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #856 
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement

#### Description of changes

Fix CommandBar to render <a> element if item has href prop

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
