### PR TITLE
CommandBar: no longer throws nullref in menu dismiss case.

### DIFF
--- a/common/changes/commandbar-fix_2017-01-31-16-28.json
+++ b/common/changes/commandbar-fix_2017-01-31-16-28.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: no longer throws nullref in dismiss handling.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -121,7 +121,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
                   aria-label={ this.props.elipisisAriaLabel || '' }
                   aria-haspopup={ true }
                   data-automation-id='commandBarOverflow'
-                  >
+                >
                   <i className='ms-CommandBarItem-overflow ms-Icon ms-Icon--More' />
                 </button>
               </div>
@@ -142,7 +142,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
             targetElement={ contextualMenuTarget }
             labelElementId={ expandedMenuId }
             onDismiss={ this._onContextMenuDismiss }
-            />
+          />
           ) : (null) }
       </div>
     );
@@ -170,7 +170,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
             aria-haspopup={ hasSubmenuItems(item) }
             role='menuitem'
             aria-label={ item.ariaLabel || item.name }
-            >
+          >
             { (hasIcon) ? this._renderIcon(item) : (null) }
             { (!!item.name) && <span className='ms-CommandBarItem-commandText'>{ item.name }</span> }
             { hasSubmenuItems(item) ? (
@@ -184,7 +184,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
             className={ classNameValue }
             data-command-key={ index }
             aria-haspopup={ hasSubmenuItems(item) }
-            >
+          >
             { (hasIcon) ? this._renderIcon(item) : (null) }
             <span className='ms-CommandBarItem-commandText ms-font-m ms-font-weight-regular' aria-hidden='true' role='presentation'>{ item.name }</span>
           </div>;
@@ -317,9 +317,12 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
   @autobind
   private _onContextMenuDismiss(ev?: any) {
     if (!ev || !ev.relatedTarget || !this.refs.commandSurface.contains(ev.relatedTarget as HTMLElement)) {
-      if (this.state.contextualMenuProps.onDismiss) {
+      let { contextualMenuProps } = this.state;
+
+      if (contextualMenuProps && contextualMenuProps.onDismiss) {
         this.state.contextualMenuProps.onDismiss(ev);
       }
+
       this.setState({
         expandedMenuItemKey: null,
         contextualMenuProps: null,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #916
- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Null ref introduced in this change by @MLoughry:

https://github.com/OfficeDev/office-ui-fabric-react/commit/52065a816e1a6661d61a76729971bb271459a503 

Adding a null check to make the code more resilient.

