### PR TITLE
Image: allow loading of SVGs in IE, which does not provide a naturalWidth/Height

### DIFF
--- a/common/changes/dagoff-Image2_2017-01-31-23-22.json
+++ b/common/changes/dagoff-Image2_2017-01-31-23-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Image: Does not handle loaded event correctly in Edge for SVG files",
+      "type": "patch"
+    }
+  ],
+  "email": "dagoff@microsoft.com"
+}

--- a/common/changes/dagoff-Image2_2017-01-31-23-22.json
+++ b/common/changes/dagoff-Image2_2017-01-31-23-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Image: Does not handle loaded event correctly in Edge for SVG files",
+      "comment": "Image: Now correctly loads SVG images in Edge.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
@@ -80,6 +80,8 @@ export interface IDocumentCardPreviewImage {
   previewImageSrc?: string;
 
   /**
+   * @deprecated
+   * Deprecated at v1.3.6, to be removed at >= v2.0.0.
    * Path to the image to display if the preview image won't load.
    */
   errorImageSrc?: string;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -47,7 +47,6 @@ export class DocumentCardPreview extends React.Component<IDocumentCardPreviewPro
         height={ height }
         imageFit={ imageFit }
         src={ previewImage.previewImageSrc }
-        errorSrc={ previewImage.errorImageSrc }
         role='presentation' alt='' />
     );
 

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -19,7 +19,10 @@ export interface IImageProps extends React.HTMLProps<HTMLImageElement> {
   imageFit?: ImageFit;
 
   /**
-   * Image source to display if an error occurs loading the image indicated by src.
+   * @deprecated
+   * Deprecated at v1.3.6, to be removed at >= v2.0.0.
+   * To replace the src in case of errors, use onLoadingStateChange instead and rerender the Image with a 
+   * difference src.
    */
   errorSrc?: string;
 
@@ -81,8 +84,10 @@ export enum ImageLoadState {
   error,
 
   /**
-   * The src provided did not load correctly, so an attempt to load from errorSrc was made
-   * and it was successful.
+   * @deprecated
+   * Deprecated at v1.3.6, to be removed at >= v2.0.0.
+   * To replace the src in case of errors, use onLoadingStateChange instead and rerender the Image with a 
+   * difference src.
    */
   errorLoaded
 }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -29,8 +29,8 @@ export interface IImageProps extends React.HTMLProps<HTMLImageElement> {
   maximizeFrame?: boolean;
 
   /**
-   * Optional callback method for when the image load state has changes
-   * The 'loadState' parameter indicates the current state of the Image
+   * Optional callback method for when the image load state has changed.
+   * The 'loadState' parameter indicates the current state of the Image.
    */
   onLoadingStateChange?: (loadState: ImageLoadState) => void;
 }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -81,7 +81,8 @@ export enum ImageLoadState {
   error,
 
   /**
-   * The image was not successfully loaded due to an error.
+   * The src provided did not load correctly, so an attempt to load from errorSrc was made
+   * and it was successful.
    */
   errorLoaded
 }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-addons-test-utils';
 
-
 let { expect } = chai;
 
 import { Image } from './Image';

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -7,7 +7,7 @@ import * as ReactTestUtils from 'react-addons-test-utils';
 
 import 'es6-promise';
 
-let { expect, assert } = chai;
+let { expect } = chai;
 
 import { Image } from './Image';
 import { ImageFit, ImageLoadState } from './Image.Props';

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -5,10 +5,12 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-addons-test-utils';
 
-let { expect } = chai;
+import 'es6-promise';
+
+let { expect, assert } = chai;
 
 import { Image } from './Image';
-import { ImageFit } from './Image.Props';
+import { ImageFit, ImageLoadState } from './Image.Props';
 
 /* tslint:disable:no-unused-variable */
 const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
@@ -31,6 +33,15 @@ describe('Image', () => {
 
   it('can cover a portrait (tall) frame with a square image', (done) => {
     let root = document.createElement('div');
+    let onLoadingStateChange = (loadState: ImageLoadState) => {
+      if (loadState === ImageLoadState.loaded) {
+        let image = document.querySelector('.ms-Image.is-portraitFrame .ms-Image-image');
+        try {
+          expect(image.className).to.contain('ms-Image-image--landscape');
+        } catch (e) { done(e); }
+        done();
+      }
+    };
     document.body.appendChild(root);
     ReactDOM.render<HTMLDivElement>(
       <Image
@@ -39,19 +50,22 @@ describe('Image', () => {
         height={ 3 }
         imageFit={ ImageFit.cover }
         className='is-portraitFrame'
+        onLoadingStateChange={ onLoadingStateChange }
         />, root
     );
-
-    let image = document.querySelector('.ms-Image.is-portraitFrame .ms-Image-image');
-    try {
-      expect(image.className).to.contain('ms-Image-image--landscape');
-    } catch (e) { done(e); }
-
-    done();
   });
 
   it('can cover a landscape (wide) frame with a square image', (done) => {
     let root = document.createElement('div');
+    let onLoadingStateChange = (loadState: ImageLoadState) => {
+      if (loadState === ImageLoadState.loaded) {
+        let image = document.querySelector('.ms-Image.is-landscapeFrame .ms-Image-image');
+        try {
+          expect(image.className).to.contain('ms-Image-image--portrait');
+        } catch (e) { done(e); }
+        done();
+      }
+    };
     document.body.appendChild(root);
     ReactDOM.render<HTMLDivElement>(
       <Image
@@ -60,19 +74,22 @@ describe('Image', () => {
         height={ 1 }
         imageFit={ ImageFit.cover }
         className='is-landscapeFrame'
+        onLoadingStateChange={ onLoadingStateChange }
         />, root
     );
-
-    let image = document.querySelector('.ms-Image.is-landscapeFrame .ms-Image-image');
-    try {
-      expect(image.className).to.contain('ms-Image-image--portrait');
-    } catch (e) { done(e); }
-
-    done();
   });
 
   it('can cover a landscape (wide) parent element with a square image', (done) => {
     let root = document.createElement('div');
+    let onLoadingStateChange = (loadState: ImageLoadState) => {
+      if (loadState === ImageLoadState.loaded) {
+        let image = document.querySelector('.ms-Image.is-frameMaximizedPortrait .ms-Image-image');
+        try {
+          expect(image.className).to.contain('ms-Image-image--portrait');
+        } catch (e) { done(e); }
+        done();
+      }
+    };
     document.body.appendChild(root);
     ReactDOM.render<HTMLDivElement>(
       <div style={ { width: '20px', height: '10px' } }>
@@ -81,20 +98,23 @@ describe('Image', () => {
           imageFit={ ImageFit.cover }
           maximizeFrame
           src={ testImage1x1 }
+          onLoadingStateChange={ onLoadingStateChange }
           />
       </div>, root
     );
-
-    let image = document.querySelector('.ms-Image.is-frameMaximizedPortrait .ms-Image-image');
-    try {
-      expect(image.className).to.contain('ms-Image-image--portrait');
-    } catch (e) { done(e); }
-
-    done();
   });
 
   it('can cover a portrait (tall) parent element with a square image', (done) => {
     let root = document.createElement('div');
+    let onLoadingStateChange = (loadState: ImageLoadState) => {
+      if (loadState === ImageLoadState.loaded) {
+        let image = document.querySelector('.ms-Image.is-frameMaximizedLandscape .ms-Image-image');
+        try {
+          expect(image.className).to.contain('ms-Image-image--landscape');
+        } catch (e) { done(e); }
+        done();
+      }
+    };
     document.body.appendChild(root);
     ReactDOM.render<HTMLDivElement>(
       <div style={ { width: '10px', height: '20px' } }>
@@ -102,17 +122,11 @@ describe('Image', () => {
           src={ testImage1x1 }
           imageFit={ ImageFit.cover }
           className='is-frameMaximizedLandscape'
+          onLoadingStateChange={ onLoadingStateChange }
           maximizeFrame
           />
       </div>, root
     );
-
-    let image = document.querySelector('.ms-Image.is-frameMaximizedLandscape .ms-Image-image');
-    try {
-      expect(image.className).to.contain('ms-Image-image--landscape');
-    } catch (e) { done(e); }
-
-    done();
   });
 
 });

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-addons-test-utils';
 
-import 'es6-promise';
 
 let { expect } = chai;
 
@@ -16,6 +15,7 @@ import { ImageFit, ImageLoadState } from './Image.Props';
 const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 const testImage1x2 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWP4////fyYGBgYGAB32A/+PRyXoAAAAAElFTkSuQmCC';
 const testImage2x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAAEUlEQVQImWP8////fwYGBgYAGfgD/hEzDhoAAAAASUVORK5CYII=';
+const brokenImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 /* tslint:enable:no-unused-variable */
 
 describe('Image', () => {
@@ -129,4 +129,14 @@ describe('Image', () => {
     );
   });
 
+  it('allows onError events to be attached', (done) => {
+    ReactTestUtils.renderIntoDocument(
+      <Image
+        src={ brokenImage }
+        onError={ () => {
+          done();
+        } }
+        />
+    );
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -39,6 +39,8 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     shouldFadeIn: true
   };
 
+  private static _svgRegex = /\.svg$/i;
+
   private _coverStyle: CoverStyle;
   private _imageElement: HTMLImageElement;
   private _frameElement: HTMLDivElement;
@@ -127,7 +129,13 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
   private _evaluateImage(): boolean {
     let { src } = this.props;
     let { loadState } = this.state;
-    let isLoaded = (src && this._imageElement.complete);
+
+    // testing if naturalWidth and naturalHeight are greater than zero is better than checking
+    // .complete, because .complete will also be set to true if the image breaks. However,
+    // for some browsers, SVG images do not have a naturalWidth or naturalHeight, so fall back
+    // to checking .complete for these images.
+    let isLoaded: boolean = src && (this._imageElement.naturalWidth > 0 && this._imageElement.naturalHeight > 0) ||
+      (this._imageElement.complete && Image._svgRegex.test(src));
 
     this._computeCoverStyle(this.props);
 

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -59,7 +59,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
       this.setState({
         loadState: ImageLoadState.notLoaded
       });
-    } else if (this.state.loadState === ImageLoadState.loaded || this.state.loadState === ImageLoadState.errorLoaded) {
+    } else if (this.state.loadState === ImageLoadState.loaded) {
       this._computeCoverStyle(nextProps);
     }
   }
@@ -74,12 +74,10 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
 
   public render() {
     let imageProps = getNativeProps(this.props, imageProperties, ['width', 'height']);
-    let { src, alt, width, height, shouldFadeIn, className, imageFit, errorSrc, role, maximizeFrame} = this.props;
+    let { src, alt, width, height, shouldFadeIn, className, imageFit, role, maximizeFrame} = this.props;
     let { loadState } = this.state;
     let coverStyle = this._coverStyle;
-    let loaded = loadState === ImageLoadState.loaded || loadState === ImageLoadState.errorLoaded;
-    let srcToDisplay: string =
-      (loadState === ImageLoadState.error || loadState === ImageLoadState.errorLoaded) ? errorSrc : src;
+    let loaded = loadState === ImageLoadState.loaded;
 
     // If image dimensions aren't specified, the natural size of the image is used.
     return (
@@ -107,7 +105,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
                 'ms-Image-image--scaleWidthHeight': (imageFit === undefined && !!width && !!height),
               }) }
           ref={ this._resolveRef('_imageElement') }
-          src={ srcToDisplay }
+          src={ src }
           alt={ alt }
           role={ role }
           />
@@ -125,7 +123,9 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     this._computeCoverStyle(this.props);
 
     if (src) {
-      this._setStateToLoadedOrErrorLoaded();
+      this.setState({
+        loadState: ImageLoadState.loaded
+      });
     }
   }
 
@@ -133,7 +133,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     let { src } = this.props;
     let { loadState } = this.state;
 
-    if (loadState === ImageLoadState.notLoaded || loadState === ImageLoadState.error) {
+    if (loadState === ImageLoadState.notLoaded) {
       // testing if naturalWidth and naturalHeight are greater than zero is better than checking
       // .complete, because .complete will also be set to true if the image breaks. However,
       // for some browsers, SVG images do not have a naturalWidth or naturalHeight, so fall back
@@ -143,20 +143,10 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
 
       if (isLoaded) {
         this._computeCoverStyle(this.props);
-        this._setStateToLoadedOrErrorLoaded();
+        this.setState({
+          loadState: ImageLoadState.loaded
+        });
       }
-    }
-  }
-
-  private _setStateToLoadedOrErrorLoaded(): void {
-    if (this.state.loadState === ImageLoadState.notLoaded) {
-      this.setState({
-        loadState: ImageLoadState.loaded
-      });
-    } else if (this.state.loadState === ImageLoadState.error) {
-      this.setState({
-        loadState: ImageLoadState.errorLoaded
-      });
     }
   }
 
@@ -191,10 +181,8 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     if (this.props.onError) {
       this.props.onError(ev);
     }
-    if (this.state.loadState !== ImageLoadState.error && this.state.loadState !== ImageLoadState.errorLoaded) {
-      this.setState({
-        loadState: ImageLoadState.error
-      });
-    }
+    this.setState({
+      loadState: ImageLoadState.error
+    });
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 import {
+  autobind,
   BaseComponent,
   css,
   getNativeProps,
@@ -39,8 +40,6 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     shouldFadeIn: true
   };
 
-  private static _svgRegex = /\.svg$/i;
-
   private _coverStyle: CoverStyle;
   private _imageElement: HTMLImageElement;
   private _frameElement: HTMLDivElement;
@@ -53,32 +52,17 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     };
   }
 
-  public componentDidMount() {
-    if (!this._evaluateImage()) {
-      this._events.on(this._imageElement, 'load', this._evaluateImage);
-      this._events.on(this._imageElement, 'error', this._setError);
-    }
-  }
-
   public componentWillReceiveProps(nextProps: IImageProps) {
     if (nextProps.src !== this.props.src) {
-      this._events.off();
       this.setState({
         loadState: ImageLoadState.notLoaded
       });
-    } else if (this.state.loadState === ImageLoadState.loaded) {
+    } else if (this.state.loadState === ImageLoadState.loaded || this.state.loadState === ImageLoadState.errorLoaded) {
       this._computeCoverStyle(nextProps);
     }
   }
 
   public componentDidUpdate(prevProps: IImageProps, prevState: IImageState) {
-    if (prevProps.src !== this.props.src) {
-      if (!this._evaluateImage()) {
-        this._events.on(this._imageElement, 'load', this._evaluateImage);
-        this._events.on(this._imageElement, 'error', this._setError);
-      }
-    }
-
     if (this.props.onLoadingStateChange
       && prevState.loadState !== this.state.loadState) {
       this.props.onLoadingStateChange(this.state.loadState);
@@ -103,6 +87,8 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
         >
         <img
           { ...imageProps }
+          onLoad={ this._onImageLoaded }
+          onError={ this._onImageError }
           key={ KEY_PREFIX + this.props.src || '' }
           className={
             css('ms-Image-image',
@@ -126,27 +112,24 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     );
   }
 
-  private _evaluateImage(): boolean {
-    let { src } = this.props;
+  @autobind
+  private _onImageLoaded(ev: React.SyntheticEvent<HTMLImageElement>): boolean {
+    let { src, onLoad } = this.props;
     let { loadState } = this.state;
 
-    // testing if naturalWidth and naturalHeight are greater than zero is better than checking
-    // .complete, because .complete will also be set to true if the image breaks. However,
-    // for some browsers, SVG images do not have a naturalWidth or naturalHeight, so fall back
-    // to checking .complete for these images.
-    let isLoaded: boolean = src && (this._imageElement.naturalWidth > 0 && this._imageElement.naturalHeight > 0) ||
-      (this._imageElement.complete && Image._svgRegex.test(src));
+    if (onLoad) {
+      onLoad(ev);
+    }
 
     this._computeCoverStyle(this.props);
 
-    if (isLoaded && loadState !== ImageLoadState.loaded && loadState !== ImageLoadState.errorLoaded) {
-      this._events.off();
-      this.setState({
+    if (src && loadState !== ImageLoadState.loaded && loadState !== ImageLoadState.errorLoaded) {
+        this.setState({
         loadState: loadState === ImageLoadState.error ? ImageLoadState.errorLoaded : ImageLoadState.loaded
       });
     }
 
-    return isLoaded;
+    return !!src;
   }
 
   private _computeCoverStyle(props: IImageProps) {
@@ -175,7 +158,11 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
     }
   }
 
-  private _setError() {
+  @autobind
+  private _onImageError(ev: React.SyntheticEvent<HTMLImageElement>) {
+    if (this.props.onError) {
+      this.props.onError(ev);
+    }
     if (this.state.loadState !== ImageLoadState.error && this.state.loadState !== ImageLoadState.errorLoaded) {
       this.setState({
         loadState: ImageLoadState.error

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -127,7 +127,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
   private _evaluateImage(): boolean {
     let { src } = this.props;
     let { loadState } = this.state;
-    let isLoaded = (src && this._imageElement.naturalWidth > 0 && this._imageElement.naturalHeight > 0);
+    let isLoaded = (src && this._imageElement.complete);
 
     this._computeCoverStyle(this.props);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #913 
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [x] Includes tests
- [x] Documentation update

Change _evaluateImage() to check for image.complete instead of image.naturalHeight and image.naturalWidth being greater than 0, since for SVG images in some browsers, image.naturalHeight and image.naturalWidth will always be 0.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
