### PR TITLE
Dialog/Panel: add onDismissed dialog event handler

### DIFF
--- a/common/changes/scriby-dialog-on-dismissed_2017-01-31-19-40.json
+++ b/common/changes/scriby-dialog-on-dismissed_2017-01-31-19-40.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Dialog/Panel: new `onDismissed` callback added to be called when the dismiss animation is complete.",
+      "comment": "Dialog: new `onDismissed` callback added to be called when the dismiss animation is complete.",
       "type": "minor"
     }
   ],

--- a/common/changes/scriby-dialog-on-dismissed_2017-01-31-19-40.json
+++ b/common/changes/scriby-dialog-on-dismissed_2017-01-31-19-40.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Dialog: Call onDismissed callback function when dialog close animation finishes.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "email": "chscribn@microsoft.com"

--- a/common/changes/scriby-dialog-on-dismissed_2017-01-31-19-40.json
+++ b/common/changes/scriby-dialog-on-dismissed_2017-01-31-19-40.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Dialog: Call onDismissed callback function when dialog close animation finishes.",
+      "comment": "Dialog/Panel: new `onDismissed` callback added to be called when the dismiss animation is complete.",
       "type": "minor"
     }
   ],

--- a/common/changes/scriby-dialog-on-dismissed_2017-01-31-19-40.json
+++ b/common/changes/scriby-dialog-on-dismissed_2017-01-31-19-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dialog: Call onDismissed callback function when dialog close animation finishes.",
+      "type": "patch"
+    }
+  ],
+  "email": "chscribn@microsoft.com"
+}

--- a/common/changes/scriby-panel-on-dismissed_2017-01-31-19-40.json
+++ b/common/changes/scriby-panel-on-dismissed_2017-01-31-19-40.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Panel: Call onDismissed callback function when panel close animation finishes.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "email": "chscribn@microsoft.com"

--- a/common/changes/scriby-panel-on-dismissed_2017-01-31-19-40.json
+++ b/common/changes/scriby-panel-on-dismissed_2017-01-31-19-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Call onDismissed callback function when panel close animation finishes.",
+      "type": "patch"
+    }
+  ],
+  "email": "chscribn@microsoft.com"
+}

--- a/common/changes/scriby-panel-on-dismissed_2017-01-31-19-40.json
+++ b/common/changes/scriby-panel-on-dismissed_2017-01-31-19-40.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Panel: Call onDismissed callback function when panel close animation finishes.",
+      "comment": "Panel: new `onDismissed` callback added to be called when the dismiss animation is complete.",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
@@ -24,12 +24,12 @@ export interface IDialogProps extends React.Props<Dialog>, IWithResponsiveModeSt
   isDarkOverlay?: boolean;
 
   /**
-  * A callback function for when the Dialog is dismissed from the close button or light dismiss.
+  * A callback function for when the Dialog is dismissed from the close button or light dismiss, before the animation completes.
   */
   onDismiss?: (ev?: React.MouseEvent<HTMLButtonElement>) => any;
 
   /**
-   * A callback function which is called after the Dialog is dismissed.
+   * A callback function which is called after the Dialog is dismissed and the animation is complete.
    */
   onDismissed?: () => any;
 

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
@@ -29,6 +29,11 @@ export interface IDialogProps extends React.Props<Dialog>, IWithResponsiveModeSt
   onDismiss?: (ev?: React.MouseEvent<HTMLButtonElement>) => any;
 
   /**
+   * A callback function which is called after the Dialog is dismissed.
+   */
+  onDismissed?: () => any;
+
+  /**
   * The title text to display at the top of the dialog.
   */
   title?: string;

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
@@ -1,0 +1,39 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
+import * as ReactDOM from 'react-dom';
+
+let { expect } = chai;
+
+import { Dialog } from './Dialog';
+
+describe('Dialog', () => {
+  afterEach(() => {
+    [].forEach.call(document.querySelectorAll('body > div'), div => div.parentNode.removeChild(div));
+
+    expect(document.querySelector('.ms-Dialog')).to.be.null;
+  });
+
+  it('Fires dismissed after closing', () => {
+    let dismissedCalled = false;
+
+    const handleDismissed = () => {
+      dismissedCalled = true;
+    };
+
+    const div = document.createElement('div');
+    ReactDOM.render(<Dialog isOpen={true} onDismissed={handleDismissed} />, div);
+      ReactDOM.render(<Dialog isOpen={false} onDismissed={handleDismissed} />, div);
+      const event = document.createEvent('CustomEvent'); // AnimationEvent is not supported by PhantomJS
+      event.initCustomEvent('animationend', true, true, {});
+      (event as any).animationName = 'fadeOut';
+
+      const dialog = document.querySelector('.ms-Dialog');
+      expect(dialog).not.to.be.null;
+
+      dialog.dispatchEvent(event);
+
+      expect(dismissedCalled).to.be.true;
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
@@ -206,8 +206,8 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
       });
 
       // Call the onDismiss callback
-      if (this.props.onDismiss) {
-        this.props.onDismiss();
+      if (this.props.onDismissed) {
+        this.props.onDismissed();
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
@@ -33,12 +33,12 @@ export interface IPanelProps extends React.Props<Panel> {
   headerText?: string;
 
   /**
-  * A callback function for when the panel is closed.
+  * A callback function for when the panel is closed, before the animation completes.
   */
   onDismiss?: () => void;
 
   /**
-   * A callback function which is called after the Panel is dismissed.
+   * A callback function which is called after the Panel is dismissed and the animation is complete.
    */
   onDismissed?: () => void;
 

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
@@ -33,9 +33,14 @@ export interface IPanelProps extends React.Props<Panel> {
   headerText?: string;
 
   /**
-  * Event handler for when the panel is closed.
+  * A callback function for when the panel is closed.
   */
   onDismiss?: () => void;
+
+  /**
+   * A callback function which is called after the Panel is dismissed.
+   */
+  onDismissed?: () => void;
 
   /**
   * Additional styling options.

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
@@ -1,0 +1,39 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
+import * as ReactDOM from 'react-dom';
+
+let { expect } = chai;
+
+import { Panel } from './Panel';
+
+describe('Panel', () => {
+  afterEach(() => {
+    [].forEach.call(document.querySelectorAll('body > div'), div => div.parentNode.removeChild(div));
+
+    expect(document.querySelector('.ms-Panel')).to.be.null;
+  });
+
+  it('Fires dismissed after closing', () => {
+    let dismissedCalled = false;
+
+    const handleDismissed = () => {
+      dismissedCalled = true;
+    };
+
+    const div = document.createElement('div');
+    ReactDOM.render(<Panel isOpen={true} onDismissed={handleDismissed} />, div);
+    ReactDOM.render(<Panel isOpen={false} onDismissed={handleDismissed} />, div);
+    const event = document.createEvent('CustomEvent'); // AnimationEvent is not supported by PhantomJS
+    event.initCustomEvent('animationend', true, true, {});
+    (event as any).animationName = 'fadeOut';
+
+    const panel = document.querySelector('.ms-Panel');
+    expect(panel).not.to.be.null;
+
+    panel.dispatchEvent(event);
+
+    expect(dismissedCalled).to.be.true;
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -198,8 +198,8 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
         isAnimatingClose: false
       });
 
-      if (this.props.onDismiss) {
-        this.props.onDismiss();
+      if (this.props.onDismissed) {
+        this.props.onDismissed();
       }
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update

#### Description of changes

When a dialog is closed, it calls the onDismiss handler. When the dialog closing animation finishes, it calls the onDismiss handler again. It's difficult to distinguish whether the dialog has just begun closing or is done closing.

In this PR, I added an onDismissed callback which is called when the dialog is done being dismissed.

#### Focus areas to test

Dialog opening / closing. I didn't see any automated tests in this repo. Did I miss that or are there no tests?
