### PR TITLE
Returned enum to original order, added explicit numbers as well

### DIFF
--- a/apps/fabric-website/src/utilities/parser/Interfaces.ts
+++ b/apps/fabric-website/src/utilities/parser/Interfaces.ts
@@ -26,5 +26,6 @@ export interface IPropertiesTableProps {
 }
 
 export enum PropertyType {
-  enum, interface
+  enum = 0,
+  interface = 1
 }

--- a/common/changes/button-enum-order-hotfix_2017-02-03-18-23.json
+++ b/common/changes/button-enum-order-hotfix_2017-02-03-18-23.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updated all enums to use explicit numbers",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "email": "micahgodbolt@gmail.com"
+}

--- a/common/changes/button-enum-order-hotfix_2017-02-03-18-23.json
+++ b/common/changes/button-enum-order-hotfix_2017-02-03-18-23.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Updated all enums to use explicit numbers",
-      "type": "patch"
+      "type": "minor"
     },
     {
       "comment": "",

--- a/packages/office-ui-fabric-react/src/common/DirectionalHint.ts
+++ b/packages/office-ui-fabric-react/src/common/DirectionalHint.ts
@@ -2,70 +2,70 @@ export enum DirectionalHint {
   /**
    * Appear above the target element, with the left edges of the callout and target aligning.
    */
-  topLeftEdge,
+  topLeftEdge = 0,
 
   /**
    * Appear above the target element, with the centers of the callout and target aligning.
    */
-  topCenter,
+  topCenter = 1,
 
   /**
    * Appear above the target element, with the right edges of the callout and target aligning.
    */
-  topRightEdge,
+  topRightEdge = 2,
 
   /**
    * Appear above the target element, aligning with the target element such that the callout tends toward the center of the screen.
    */
-  topAutoEdge,
+  topAutoEdge = 3,
 
   /**
    * Appear below the target element, with the left edges of the callout and target aligning.
    */
-  bottomLeftEdge,
+  bottomLeftEdge = 4,
 
   /**
    * Appear below the target element, with the centers of the callout and target aligning.
    */
-  bottomCenter,
+  bottomCenter = 5,
 
   /**
    * Appear below the target element, with the right edges of the callout and target aligning.
    */
-  bottomRightEdge,
+  bottomRightEdge = 6,
 
   /**
    * Appear below the target element, aligning with the target element such that the callout tends toward the center of the screen.
    */
-  bottomAutoEdge,
+  bottomAutoEdge = 7,
 
   /**
    * Appear to the left of the target element, with the top edges of the callout and target aligning.
    */
-  leftTopEdge,
+  leftTopEdge = 8,
 
   /**
    * Appear to the left of the target element, with the centers of the callout and target aligning.
    */
-  leftCenter,
+  leftCenter = 9,
 
   /**
    * Appear to the left of the target element, with the bottom edges of the callout and target aligning.
    */
-  leftBottomEdge,
+  leftBottomEdge = 10,
 
   /**
    * Appear to the right of the target element, with the top edges of the callout and target aligning.
    */
-  rightTopEdge,
+  rightTopEdge = 11,
 
   /**
    * Appear to the right of the target element, with the centers of the callout and target aligning.
    */
-  rightCenter,
+  rightCenter = 12,
 
   /**
    * Appear to the right of the target element, with the bottom edges of the callout and target aligning.
    */
-  rightBottomEdge
+  rightBottomEdge = 13
 }

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -70,9 +70,9 @@ export interface IButtonProps extends React.HTMLProps<HTMLButtonElement | HTMLAn
 
 export enum ElementType {
   /** <button> element. */
-  button,
+  button = 0,
   /** <a> element. */
-  anchor
+  anchor = 1
 }
 
 export enum ButtonType {

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -76,12 +76,11 @@ export enum ElementType {
 }
 
 export enum ButtonType {
-  default,
-  normal,
-  primary,
-  hero,
-  compound,
-  command,
-  icon,
-  clean
+  normal = 0,
+  primary = 1,
+  hero = 2,
+  compound = 3,
+  command = 4,
+  icon = 5,
+  default = 6
 }

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
@@ -48,13 +48,13 @@ export interface ICalendarProps extends React.Props<Calendar> {
 }
 
 export enum DayOfWeek {
-  Sunday,
-  Monday,
-  Tuesday,
-  Wednesday,
-  Thursday,
-  Friday,
-  Saturday
+  Sunday = 0,
+  Monday = 1,
+  Tuesday = 2,
+  Wednesday = 3,
+  Thursday = 4,
+  Friday = 5,
+  Saturday = 6
 }
 
 export interface ICalendarStrings {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -10,9 +10,9 @@ import {
 export { DirectionalHint } from '../../common/DirectionalHint';
 
 export enum ContextualMenuItemType {
-  Normal,
-  Divider,
-  Header
+  Normal = 0,
+  Divider = 1,
+  Header = 2
 }
 
 export interface IContextualMenuProps extends React.Props<ContextualMenu> {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -36,9 +36,9 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
 }
 
 export enum SelectAllVisibility {
-  none,
-  hidden,
-  visible
+  none = 0,
+  hidden = 1,
+  visible = 2
 }
 
 export interface IDetailsHeaderState {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -282,55 +282,55 @@ export enum ColumnActionsMode {
   /**
    * Renders the column header as disabled.
    */
-  disabled,
+  disabled = 0,
 
   /**
    * Renders the column header is clickable.
    */
-  clickable,
+  clickable = 1,
 
   /**
    * Renders the column header ias clickable and displays the dropdown cheveron.
    */
-  hasDropdown
+  hasDropdown = 2
 }
 
 export enum ConstrainMode {
   /** If specified, lets the content grow which allows the page to manage scrolling. */
-  unconstrained,
+  unconstrained = 0,
 
   /**
    * If specified, constrains the list to the given layout space.
    */
-  horizontalConstrained
+  horizontalConstrained = 1
 }
 
 export enum DetailsListLayoutMode {
   /**
    * Lets the user resize columns and makes not attempt to fit them.
    */
-  fixedColumns,
+  fixedColumns = 0,
 
   /**
    * Manages which columns are visible, tries to size them according to their min/max rules and drops
    * off columns that can't fit and have isCollapsable set.
    */
-  justified
+  justified = 1
 }
 
 export enum CheckboxVisibility {
   /**
    * Visible on hover.
    */
-  onHover,
+  onHover = 0,
 
   /**
    * Visible always.
    */
-  always,
+  always = 1,
 
   /**
    * Hide checkboxes.
    */
-  hidden
+  hidden = 2
 }

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
@@ -83,9 +83,9 @@ export interface IDialogProps extends React.Props<Dialog>, IWithResponsiveModeSt
 
 export enum DialogType {
   /** Standard dialog */
-  normal,
+  normal = 0,
   /** Dialog with large header banner */
-  largeHeader,
+  largeHeader = 1,
   /** Dialog with an 'x' close button in the upper-right corner */
-  close
+  close = 2
 }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
@@ -43,11 +43,11 @@ export enum DocumentCardType {
   /**
    * Standard DocumentCard.
    */
-  normal,
+  normal = 0,
   /**
    * Compact layout. Displays the preview beside the details, rather than above.
    */
-  compact
+  compact = 1
 }
 
 export interface IDocumentCardPreviewProps extends React.Props<DocumentCardPreview> {

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts
@@ -91,11 +91,11 @@ export interface IFacepilePersona extends React.HTMLProps<HTMLButtonElement | HT
 
 export enum OverflowButtonType {
   /** No overflow */
-  none,
+  none = 0,
   /** +1 overflow icon */
-  descriptive,
+  descriptive = 1,
   /** More overflow icon */
-  more,
+  more = 2,
   /** Chevron overflow icon */
-  downArrow
+  downArrow = 3
 }

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
@@ -89,11 +89,11 @@ export interface IFocusZoneProps extends React.Props<FocusZone> {
 
 export enum FocusZoneDirection {
   /** Only react to up/down arrows. */
-  vertical,
+  vertical = 0,
 
   /** Only react to left/right arrows. */
-  horizontal,
+  horizontal = 1,
 
   /** React to all arrows. */
-  bidirectional
+  bidirectional = 2
 }

--- a/packages/office-ui-fabric-react/src/components/Icon/IconType.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/IconType.ts
@@ -1,5 +1,5 @@
 // Please keep alphabetized
 export enum IconType {
-  Default,
-  Image
+  Default = 0,
+  Image = 1
 }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -42,46 +42,46 @@ export enum ImageFit {
   /**
    * The image is not scaled. The image is centered and cropped within the content box.
    */
-  center,
+  center = 0,
 
   /**
    * The image is scaled to maintain its aspect ratio while being fully contained within the frame. The image will
    * be centered horizontally and vertically within the frame. The space in the top and bottom or in the sides of
    * the frame will be empty depending on the difference in aspect ratio between the image and the frame.
    */
-  contain,
+  contain = 1,
 
   /**
    * The image is scaled to maintain its aspect ratio while filling the frame. Portions of the image will be cropped from
    * the top and bottom, or from the sides, depending on the difference in aspect ratio between the image and the frame.
    */
-  cover,
+  cover = 2,
 
   /**
    * Neither the image nor the frame are scaled. If their sizes do not match, the image will either be cropped or the
    * frame will have empty space.
    */
-  none
+  none = 3
 }
 
 export enum ImageLoadState {
   /**
    * The image has not yet been loaded, and there is no error yet.
    */
-  notLoaded,
+  notLoaded = 0,
 
   /**
    * The image has been loaded successfully.
    */
-  loaded,
+  loaded = 1,
 
   /**
    * An error has been encountered while loading the image.
    */
-  error,
+  error = 2,
 
   /**
    * The image was not successfully loaded due to an error.
    */
-  errorLoaded
+  errorLoaded = 3
 }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -16,8 +16,8 @@ export interface IImageState {
 }
 
 export enum CoverStyle {
-  landscape,
-  portrait
+  landscape = 0,
+  portrait = 1
 }
 
 export const CoverStyleMap = {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts
@@ -40,20 +40,20 @@ export interface IMessageBarProps extends React.HTMLProps<HTMLElement> {
 
 export enum MessageBarType {
   /** Info styled MessageBar */
-  info,
+  info = 0,
   /** Error styled MessageBar */
-  error,
+  error = 1,
   /** Blocked styled MessageBar */
-  blocked,
+  blocked = 2,
   /** SevereWarning styled MessageBar */
-  severeWarning,
+  severeWarning = 3,
   /** Success styled MessageBar */
-  success,
+  success = 4,
   /** Warning styled MessageBar */
-  warning,
+  warning = 5,
   /**
    * @deprecated
    * Deprecated at v0.48.0, to be removed at >= v1.0.0. Use 'blocked' instead.
    */
-  remove
+  remove = 6
 }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
@@ -97,7 +97,7 @@ export enum PanelType {
    * XLarge: <unused>
    * XXLarge: <unused>
    */
-  smallFluid,
+  smallFluid = 0,
 
   /**
    * Renders the panel in 'small' mode, anchored to the far side (right in LTR mode), and has a fixed width.
@@ -107,7 +107,7 @@ export enum PanelType {
    * XLarge: 340px width, 32px Left/Right padding
    * XXLarge: 340px width, 40px Left/Right padding
    */
-  smallFixedFar,
+  smallFixedFar = 1,
 
   /**
    * Renders the panel in 'small' mode, anchored to the near side (left in LTR mode), and has a fixed width.
@@ -117,7 +117,7 @@ export enum PanelType {
    * XLarge: 272px width, 32px Left/Right padding
    * XXLarge: 272px width, 32px Left/Right padding
    */
-  smallFixedNear,
+  smallFixedNear = 2,
 
   /**
    * Renders the panel in 'medium' mode, anchored to the far side (right in LTR mode).
@@ -127,7 +127,7 @@ export enum PanelType {
    * XLarge: 644px width, 32px Left/Right padding
    * XXLarge: 643px width, 40px Left/Right padding
    */
-  medium,
+  medium = 3,
 
   /**
    * Renders the panel in 'large' mode, anchored to the far side (right in LTR mode), and is fluid at XXX-Large breakpoint.
@@ -138,7 +138,7 @@ export enum PanelType {
    * XXLarge: 48px fixed left margin, 32px Left/Right padding
    * XXXLarge: 48px fixed left margin, (no redlines for padding, assuming previous breakpoint)
    */
-  large,
+  large = 4,
 
   /**
    * Renders the panel in 'large' mode, anchored to the far side (right in LTR mode), and is fixed at XXX-Large breakpoint.
@@ -149,7 +149,7 @@ export enum PanelType {
    * XXLarge: 48px fixed left margin, 32px Left/Right padding
    * XXXLarge: 940px width, (no redlines for padding, assuming previous breakpoint)
    */
-  largeFixed,
+  largeFixed = 5,
 
   /**
    * Renders the panel in 'extra large' mode, anchored to the far side (right in LTR mode).
@@ -160,5 +160,5 @@ export enum PanelType {
    * XXLarge: 176px fixed left margin, 40px Left/Right padding
    * XXXLarge: 176px fixed left margin, 40px Left/Right padding
    */
-  extraLarge
+  extraLarge = 6
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
@@ -68,39 +68,39 @@ export interface IPersonaProps extends React.HTMLProps<Persona> {
 }
 
 export enum PersonaSize {
-  tiny,
-  extraExtraSmall,
-  extraSmall,
-  small,
-  regular,
-  large,
-  extraLarge
+  tiny = 0,
+  extraExtraSmall = 1,
+  extraSmall = 2,
+  small = 3,
+  regular = 4,
+  large = 5,
+  extraLarge = 6
 }
 
 export enum PersonaPresence {
-  none,
-  offline,
-  online,
-  away,
-  dnd,
-  blocked,
-  busy
+  none = 0,
+  offline = 1,
+  online = 2,
+  away = 3,
+  dnd = 4,
+  blocked = 5,
+  busy = 6
 }
 
 export enum PersonaInitialsColor {
-  lightBlue,
-  blue,
-  darkBlue,
-  teal,
-  lightGreen,
-  green,
-  darkGreen,
-  lightPink,
-  pink,
-  magenta,
-  purple,
-  black,
-  orange,
-  red,
-  darkRed
+  lightBlue = 0,
+  blue = 1,
+  darkBlue = 2,
+  teal = 3,
+  lightGreen = 4,
+  green = 5,
+  darkGreen = 6,
+  lightPink = 7,
+  pink = 8,
+  magenta = 9,
+  purple = 10,
+  black = 11,
+  orange = 12,
+  red = 13,
+  darkRed = 14
 }

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.Props.ts
@@ -46,12 +46,12 @@ export enum PivotLinkFormat {
   /**
    * Display Pivot Links as links
    */
-  links,
+  links = 0,
 
   /**
    * Display Pivot Links as Tabs
    */
-  tabs
+  tabs = 1
 }
 
 export enum PivotLinkSize {
@@ -59,10 +59,10 @@ export enum PivotLinkSize {
   /**
    * Display Link using normal font size
    */
-  normal,
+  normal = 0,
 
   /**
    * Display links using large font size
    */
-  large
+  large = 1
 }

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.Props.ts
@@ -46,6 +46,6 @@ export interface IRatingProps extends React.HTMLProps<HTMLElement> {
 }
 
 export enum RatingSize {
-  Small,
-  Large
+  Small = 0,
+  Large = 1
 }

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
@@ -18,8 +18,8 @@ export interface ISliderState {
 }
 
 export enum ValuePosition {
-  Previous,
-  Next
+  Previous = 0,
+  Next = 1
 }
 
 export class Slider extends BaseComponent<ISliderProps, ISliderState> implements ISlider {

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.Props.ts
@@ -20,6 +20,6 @@ export interface ISpinnerProps extends React.Props<Spinner> {
 }
 
 export enum SpinnerType {
-  normal,
-  large
+  normal = 0,
+  large = 1
 }

--- a/packages/office-ui-fabric-react/src/components/Spinner/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/components/Spinner/interfaces.ts
@@ -1,4 +1,4 @@
 export enum SpinnerType {
-  normal,
-  large
+  normal = 0,
+  large = 1
 }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
@@ -37,6 +37,6 @@ export interface ITooltipProps extends React.HTMLProps<HTMLDivElement | Tooltip>
 }
 
 export enum TooltipDelay {
-  zero,
-  medium
+  zero = 0,
+  medium = 1
 }

--- a/packages/office-ui-fabric-react/src/demo/components/App/AppState.ts
+++ b/packages/office-ui-fabric-react/src/demo/components/App/AppState.ts
@@ -2,10 +2,10 @@ import { INavLink, INavLinkGroup } from '../../../components/Nav/index';
 import { DetailsListBasicExample } from '../../pages/DetailsListPage/examples/DetailsList.Basic.Example';
 
 export enum ExampleStatus {
-  placeholder,
-  started,
-  beta,
-  release
+  placeholder = 0,
+  started = 1,
+  beta = 2,
+  release = 3
 }
 
 export interface IAppLink extends INavLink {

--- a/packages/office-ui-fabric-react/src/demo/components/PropertiesTable/PropertiesTable.tsx
+++ b/packages/office-ui-fabric-react/src/demo/components/PropertiesTable/PropertiesTable.tsx
@@ -39,7 +39,8 @@ export interface IPropertiesTableProps {
 }
 
 export enum PropertyType {
-  enum, interface
+  enum = 0,
+  interface = 1
 }
 
 const DEFAULT_COLUMNS: IColumn[] = [

--- a/packages/office-ui-fabric-react/src/demo/pages/FacepilePage/examples/Facepile.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/demo/pages/FacepilePage/examples/Facepile.Basic.Example.tsx
@@ -13,7 +13,7 @@ import './Facepile.Examples.scss';
 
 export enum ExtraDataType {
   none = 0,
-  name
+  name = 1
 }
 
 export interface IFacepileBasicExampleState {

--- a/packages/office-ui-fabric-react/src/utilities/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning.ts
@@ -7,10 +7,10 @@ import {
 } from '../Utilities';
 
 export enum RectangleEdge {
-  top,
-  bottom,
-  left,
-  right
+  top = 0,
+  bottom = 1,
+  left = 2,
+  right = 3
 }
 
 let SLIDE_ANIMATIONS: { [key: number]: string; } = {

--- a/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
@@ -5,9 +5,9 @@ export interface IObjectWithKey {
 export const SELECTION_CHANGE = 'change';
 
 export enum SelectionMode {
-  none,
-  single,
-  multiple
+  none = 0,
+  single = 1,
+  multiple = 2
 }
 
 export interface ISelection {


### PR DESCRIPTION

 From Pete Gonzalaz del Solar

>For public API, the convention is that enums must have hardcoded values:
 
enum Fruit {
  Apple = 0,
  Banana = 1,
  Coconut = 2
}
 
You can reorder the items, but you must not reassign the numbers (without breaking SemVer).  It might be a good idea to revert that change, since it’s likely to break other people.


Returned enum to original order, made explicit number values (so we CAN reorder if needed) and removed clean, as it was only used in an old PR
