### PR TITLE
Introducing scoped css to Button variants.

### DIFF
--- a/packages/office-ui-fabric-react/src/common/_common.scss
+++ b/packages/office-ui-fabric-react/src/common/_common.scss
@@ -3,4 +3,4 @@
 @import './themeOverrides';
 @import './focusBorder';
 @import './semanticColorVariables';
-
+@import './scope';

--- a/packages/office-ui-fabric-react/src/common/_scope.scss
+++ b/packages/office-ui-fabric-react/src/common/_scope.scss
@@ -1,0 +1,8 @@
+// Variable is set during gulp task as comma seperated list. i.e. 5,1,0
+$ms-fabric-scope-class: '.msfr1';
+
+@mixin scope-fabric {
+  #{$ms-fabric-scope-class} {
+    @content;
+  }
+}

--- a/packages/office-ui-fabric-react/src/common/scope.ts
+++ b/packages/office-ui-fabric-react/src/common/scope.ts
@@ -1,0 +1,1 @@
+export const scopeClassName = 'msfr1';

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { scopeClassName } from '../../common/scope';
 import {
   BaseComponent,
   css,
@@ -65,6 +66,7 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
       nativeProps,
       {
         className: css(
+          scopeClassName,
           className,
           this._baseClassName,
           this._variantClassName,

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonCore/ButtonCore.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonCore/ButtonCore.scss
@@ -8,112 +8,114 @@
 @import '../../../common/common';
 @import './ButtonCoreVars';
 
-.ms-Button {
-  @include focus-border();
-  @include ms-font-m;
-  user-select: none;
+@include scope-fabric {
+  &.ms-Button {
+    @include focus-border();
+    @include ms-font-m;
+    user-select: none;
 
-  border-width: 0;
-  text-decoration: none;
-  text-align: center;
-  cursor: pointer;
-  display: inline-block;
-  padding: $button-core-default-padding;
+    border-width: 0;
+    text-decoration: none;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    padding: $button-core-default-padding;
 
-  @media screen and (-ms-high-contrast: active) {
-    color: $ms-color-contrastBlackSelected;
-    border-color: $ms-color-contrastBlackSelected;
-  }
+    @media screen and (-ms-high-contrast: active) {
+      color: $ms-color-contrastBlackSelected;
+      border-color: $ms-color-contrastBlackSelected;
+    }
 
-  @media screen and (-ms-high-contrast: black-on-white) {
-    color: $ms-color-contrastWhiteSelected;
-    border-color: $ms-color-contrastWhiteSelected;
-  }
+    @media screen and (-ms-high-contrast: black-on-white) {
+      color: $ms-color-contrastWhiteSelected;
+      border-color: $ms-color-contrastWhiteSelected;
+    }
 
-  &:disabled,
-  &.disabled {
-    background-color: $ms-color-neutralLighter;
-    border-color: $ms-color-neutralLighter;
-    cursor: default;
-    pointer-events: none;
-    color: $ms-color-neutralTertiary;
+    &:disabled,
+    &.disabled {
+      background-color: $ms-color-neutralLighter;
+      border-color: $ms-color-neutralLighter;
+      cursor: default;
+      pointer-events: none;
+      color: $ms-color-neutralTertiary;
 
-    &:hover,
-    &:focus {
-      outline: 0;
+      &:hover,
+      &:focus {
+        outline: 0;
+      }
     }
   }
-}
-
-.ms-Button-icon {
-  margin: 0 4px;
-  width: 16px;
-  vertical-align: top;
-  display: inline-block;
-}
-
-.ms-Button-label {
-  margin: 0 4px;
-  vertical-align: top;
-  display: inline-block;
-}
-
-// TODO: Remove Hero Styles once fully deprecated
-
-//== Modifier: Hero button
-//
-.ms-Button--hero {
-  background-color: transparent;
-  border: 0;
-  height: auto;
 
   .ms-Button-icon {
-    color: $ms-color-themePrimary;
+    margin: 0 4px;
+    width: 16px;
+    vertical-align: top;
     display: inline-block;
-    @include margin-right(8px);
-    padding-top: 5px;
-    font-size: $ms-icon-size-l;
-    line-height: 1; // FireFox vertical offset
   }
 
   .ms-Button-label {
-    color: $ms-color-themePrimary;
-    font-size: $ms-font-size-xl;
-    font-weight: $ms-font-weight-light;
+    margin: 0 4px;
     vertical-align: top;
+    display: inline-block;
   }
 
-  &:hover,
-  &:focus {
+  // TODO: Remove Hero Styles once fully deprecated
+
+  //== Modifier: Hero button
+  //
+  .ms-Button--hero {
     background-color: transparent;
+    border: 0;
+    height: auto;
 
-    .ms-Button-icon {
-      color: $ms-color-themeDark;
-    }
-
-    .ms-Button-label {
-      color: $ms-color-themeDarker;
-    }
-  }
-
-  &:active {
     .ms-Button-icon {
       color: $ms-color-themePrimary;
+      display: inline-block;
+      @include margin-right(8px);
+      padding-top: 5px;
+      font-size: $ms-icon-size-l;
+      line-height: 1; // FireFox vertical offset
     }
 
     .ms-Button-label {
       color: $ms-color-themePrimary;
-    }
-  }
-
-  &:disabled,
-  &.is-disabled {
-    .ms-Button-icon {
-      color: $ms-color-neutralTertiaryAlt;
+      font-size: $ms-font-size-xl;
+      font-weight: $ms-font-weight-light;
+      vertical-align: top;
     }
 
-    .ms-Button-label {
-      color: $ms-color-neutralTertiary;
+    &:hover,
+    &:focus {
+      background-color: transparent;
+
+      .ms-Button-icon {
+        color: $ms-color-themeDark;
+      }
+
+      .ms-Button-label {
+        color: $ms-color-themeDarker;
+      }
+    }
+
+    &:active {
+      .ms-Button-icon {
+        color: $ms-color-themePrimary;
+      }
+
+      .ms-Button-label {
+        color: $ms-color-themePrimary;
+      }
+    }
+
+    &:disabled,
+    &.is-disabled {
+      .ms-Button-icon {
+        color: $ms-color-neutralTertiaryAlt;
+      }
+
+      .ms-Button-label {
+        color: $ms-color-neutralTertiary;
+      }
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.scss
@@ -9,61 +9,64 @@
 
 $button-commandButtonHeight: 40px;
 
-.ms-Button--command {
-  @include text-align(left);
+@include scope-fabric {
 
-  background-color: transparent;
-  border: none;
-  padding: 0 4px;
+  &.ms-Button--command {
+    @include text-align(left);
 
-  &,
-  .ms-Button-label,
-  .ms-Button-icon {
-    height: $button-commandButtonHeight;
-    line-height: $button-commandButtonHeight;
-  }
-
-  .ms-Button-label {
-    @include ms-font-m;
-    font-weight: $ms-font-weight-regular;
-    color: $ms-color-neutralPrimary;
-  }
-
-  .ms-Button-icon {
-    vertical-align: top;
-    color: $ms-color-themePrimary;
-    display: inline-block;
-    font-size: $ms-icon-size-m;
-    position: relative;
-  }
-
-  &:hover,
-  &:focus {
     background-color: transparent;
+    border: none;
+    padding: 0 4px;
 
     &,
-    .ms-Button-icon,
-    .ms-Button-label {
-      color: $ms-color-themeDarker;
+    .ms-Button-label,
+    .ms-Button-icon {
+      height: $button-commandButtonHeight;
+      line-height: $button-commandButtonHeight;
     }
-  }
 
-  &:active {
-    &,
-    .ms-Button-icon,
     .ms-Button-label {
+      @include ms-font-m;
+      font-weight: $ms-font-weight-regular;
+      color: $ms-color-neutralPrimary;
+    }
+
+    .ms-Button-icon {
+      vertical-align: top;
       color: $ms-color-themePrimary;
+      display: inline-block;
+      font-size: $ms-icon-size-m;
+      position: relative;
     }
-  }
 
-  &:disabled,
-  &.is-disabled {
-    background-color: transparent;
+    &:hover,
+    &:focus {
+      background-color: transparent;
 
-    &,
-    .ms-Button-icon,
-    .ms-Button-label {
-      color: $ms-color-neutralTertiaryAlt;
+      &,
+      .ms-Button-icon,
+      .ms-Button-label {
+        color: $ms-color-themeDarker;
+      }
+    }
+
+    &:active {
+      &,
+      .ms-Button-icon,
+      .ms-Button-label {
+        color: $ms-color-themePrimary;
+      }
+    }
+
+    &:disabled,
+    &.disabled {
+      background-color: transparent;
+
+      &,
+      .ms-Button-icon,
+      .ms-Button-label {
+        color: $ms-color-neutralTertiaryAlt;
+      }
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.scss
@@ -7,71 +7,73 @@
 // --------------------------------------------------
 // Compound Button styles
 
-.ms-Button--compound {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: stretch;
+@include scope-fabric {
+  &.ms-Button--compound {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
 
-  width: 100%;
-  max-width: 280px;
-  min-height: 72px;
+    width: 100%;
+    max-width: 280px;
+    min-height: 72px;
 
-  padding: 16px 20px;
-  background: $ms-color-neutralLighter;
+    padding: 16px 20px;
+    background: $ms-color-neutralLighter;
 
-  @include text-align(left);
-
-  .ms-Button-label {
-    @include ms-font-m;
-    display: block;
-    font-weight: $ms-font-weight-semibold;
-    color: $ms-color-black;
-    margin: 0 0 2px;
-  }
-
-  .ms-Button-description {
-    @include ms-font-s;
-    color: $ms-color-neutralSecondary;
-    display: block;
-  }
-
-  &:hover {
-    background-color: $ms-color-neutralLight;
-    border-color: $ms-color-neutralLight;
-
-    .ms-Button-description {
-      color: $ms-color-neutralDark;
-    }
-  }
-
-  &:focus {
-    border-color: $ms-color-themePrimary;
-    background-color: $ms-color-neutralLighter;
+    @include text-align(left);
 
     .ms-Button-label {
-      color: $ms-color-neutralPrimary;
+      @include ms-font-m;
+      display: block;
+      font-weight: $ms-font-weight-semibold;
+      color: $ms-color-black;
+      margin: 0 0 2px;
     }
 
     .ms-Button-description {
+      @include ms-font-s;
       color: $ms-color-neutralSecondary;
+      display: block;
     }
-  }
 
-  &:active {
-    background-color: $ms-color-themePrimary;
+    &:hover {
+      background-color: $ms-color-neutralLight;
+      border-color: $ms-color-neutralLight;
 
-    .ms-Button-description,
-    .ms-Button-label {
-      color: $ms-color-white;
+      .ms-Button-description {
+        color: $ms-color-neutralDark;
+      }
     }
-  }
 
-  &:disabled,
-  &.disabled {
-    .ms-Button-label,
-    .ms-Button-description {
-      color: $ms-color-neutralTertiary;
+    &:focus {
+      border-color: $ms-color-themePrimary;
+      background-color: $ms-color-neutralLighter;
+
+      .ms-Button-label {
+        color: $ms-color-neutralPrimary;
+      }
+
+      .ms-Button-description {
+        color: $ms-color-neutralSecondary;
+      }
+    }
+
+    &:active {
+      background-color: $ms-color-themePrimary;
+
+      .ms-Button-description,
+      .ms-Button-label {
+        color: $ms-color-white;
+      }
+    }
+
+    &:disabled,
+    &.disabled {
+      .ms-Button-label,
+      .ms-Button-description {
+        color: $ms-color-neutralTertiary;
+      }
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.scss
@@ -7,52 +7,54 @@
 // Office UI Fabric
 // --------------------------------------------------
 // Default Button styles
+@include scope-fabric {
 
-.ms-Button--default {
-  background-color: $ms-color-neutralLighter;
-  border: 1px solid $ms-color-neutralLighter;
-  min-width: $button-core-default-minWidth;
-  color: $ms-color-neutralPrimary;
+  &.ms-Button--default {
+    background-color: $ms-color-neutralLighter;
+    border: 1px solid $ms-color-neutralLighter;
+    min-width: $button-core-default-minWidth;
+    color: $ms-color-neutralPrimary;
 
-  &,
-  .ms-Button-label,
-  .ms-Button-icon {
-    height: $button-core-default-height;
-    line-height: $button-core-default-height;
-  }
+    &,
+    .ms-Button-label,
+    .ms-Button-icon {
+      height: $button-core-default-height;
+      line-height: $button-core-default-height;
+    }
 
-  &:hover {
-    background-color: $ms-color-neutralLight;
-    border-color: $ms-color-neutralLight;
-    color: $ms-color-black;
-  }
+    &:hover {
+      background-color: $ms-color-neutralLight;
+      border-color: $ms-color-neutralLight;
+      color: $ms-color-black;
+    }
 
-  &:focus {
-    background-color: $ms-color-neutralLight;
-    border-color: $ms-color-neutralLighter;
-    outline: 1px solid transparent;
-    color: $ms-color-black;
+    &:focus {
+      background-color: $ms-color-neutralLight;
+      border-color: $ms-color-neutralLighter;
+      outline: 1px solid transparent;
+      color: $ms-color-black;
 
-  }
+    }
 
-  &:active {
-    background-color: $ms-color-themePrimary;
-    border-color: $ms-color-themePrimary;
-    color: $ms-color-white;
-  }
-
-  .ms-Button-label {
-    font-weight: $ms-font-weight-semibold;
-    font-size: $ms-font-size-m;
-  }
-}
-
-.ms-Fabric.is-focusVisible .ms-Button {
-  &:focus {
-    color: $ms-color-black;
-
-    &:before {
+    &:active {
+      background-color: $ms-color-themePrimary;
       border-color: $ms-color-themePrimary;
+      color: $ms-color-white;
+    }
+
+    .ms-Button-label {
+      font-weight: $ms-font-weight-semibold;
+      font-size: $ms-font-size-m;
+    }
+  }
+
+  .ms-Fabric.is-focusVisible .ms-Button {
+    &:focus {
+      color: $ms-color-black;
+
+      &:before {
+        border-color: $ms-color-themePrimary;
+      }
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.scss
@@ -7,41 +7,44 @@
 // --------------------------------------------------
 // Icon Button styles
 
-.ms-Button--icon {
-  @include focus-border(0px);
-  background-color: transparent;
-  color: $ms-color-neutralSecondary;
-  padding: 0 4px;
-  font-size: $ms-icon-size-m;
+@include scope-fabric {
 
-  .ms-Button,
-  .ms-Button-label,
-  .ms-Button-icon {
-    height: $button-core-default-height;
-    line-height: $button-core-default-height;
-  }
-
-  &:hover,
-  &:active {
+  &.ms-Button--icon {
+    @include focus-border(0px);
     background-color: transparent;
-    color: $ms-color-neutralPrimary;
-  }
+    color: $ms-color-neutralSecondary;
+    padding: 0 4px;
+    font-size: $ms-icon-size-m;
 
-  &:focus {
-    background-color: transparent;
-  }
+    .ms-Button,
+    .ms-Button-label,
+    .ms-Button-icon {
+      height: $button-core-default-height;
+      line-height: $button-core-default-height;
+    }
 
-  &.is-disabled,
-  &:disabled {
-    color: $ms-color-neutralTertiaryAlt;
-    background-color: transparent;
-  }
+    &:hover,
+    &:active {
+      background-color: transparent;
+      color: $ms-color-neutralPrimary;
+    }
 
-  @media screen and (-ms-high-contrast: active) {
-    color: $ms-color-yellowLight;
-  }
+    &:focus {
+      background-color: transparent;
+    }
 
-  @media screen and (-ms-high-contrast: black-on-white) {
-    color: $ms-color-blueMid;
+    &.is-disabled,
+    &:disabled {
+      color: $ms-color-neutralTertiaryAlt;
+      background-color: transparent;
+    }
+
+    @media screen and (-ms-high-contrast: active) {
+      color: $ms-color-yellowLight;
+    }
+
+    @media screen and (-ms-high-contrast: black-on-white) {
+      color: $ms-color-blueMid;
+    }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.scss
@@ -7,50 +7,52 @@
 // Office UI Fabric
 // --------------------------------------------------
 // Primary Button styles
+@include scope-fabric {
 
-.ms-Button--primary {
-  @include focus-border(1px, $ms-color-white);
+  &.ms-Button--primary {
+    @include focus-border(1px, $ms-color-white);
 
-  min-width: $button-core-default-minWidth;
-  background-color: $ms-color-themePrimary;
-  border-color: $ms-color-themePrimary;
-  color: $ms-color-white;
-
-  &,
-  .ms-Button-label,
-  .ms-Button-icon {
-    height: $button-core-default-height;
-    line-height: $button-core-default-height;
-  }
-
-  .ms-Button-label {
-    font-weight: $ms-font-weight-semibold;
-    font-size: $ms-font-size-m;
-  }
-
-  &:hover {
-    background-color: $ms-color-themeDark;
-    border-color: $ms-color-themeDark;
-  }
-
-  &:focus {
-    background-color: $ms-color-themeDark;
-    border-color: $ms-color-themePrimary;
-  }
-
-  &:active {
+    min-width: $button-core-default-minWidth;
     background-color: $ms-color-themePrimary;
     border-color: $ms-color-themePrimary;
-  }
-
-}
-
-.ms-Fabric.is-focusVisible .ms-Button--primary {
-  &:focus {
     color: $ms-color-white;
 
-    &:before {
-      border-color: $ms-color-themeLighter;
+    &,
+    .ms-Button-label,
+    .ms-Button-icon {
+      height: $button-core-default-height;
+      line-height: $button-core-default-height;
+    }
+
+    .ms-Button-label {
+      font-weight: $ms-font-weight-semibold;
+      font-size: $ms-font-size-m;
+    }
+
+    &:hover {
+      background-color: $ms-color-themeDark;
+      border-color: $ms-color-themeDark;
+    }
+
+    &:focus {
+      background-color: $ms-color-themeDark;
+      border-color: $ms-color-themePrimary;
+    }
+
+    &:active {
+      background-color: $ms-color-themePrimary;
+      border-color: $ms-color-themePrimary;
+    }
+
+  }
+
+  .ms-Fabric.is-focusVisible .ms-Button--primary {
+    &:focus {
+      color: $ms-color-white;
+
+      &:before {
+        border-color: $ms-color-themeLighter;
+      }
     }
   }
 }


### PR DESCRIPTION
This change updates how the css rules target the components. I have only updated the `Button` variants to use this to limit the review.

# Problem

Two different projects embed different versions of the `Button`. The css rules collide with each other; one sets display to `inline`, while the other sets to `inline-block`.

# Potential fixes

* CSS modules; ensures all rules are hashed, but makes it near impossible to override things.

* Inline styles; no possibility of css collisions, reduces friction with SSR injection, has a lot of benefits in cleaning up the styling story, but throws away pseudoselector usage like `:hover`, `:active`, `:visited`, `:before`, `:after` or requires hacky workarounds to make them work.

* Scoped css; define a global classname that gets added to the root of each component. Scope selectors within. Adds some bulk to selectors, but still possible to override styles.

# Proposed solution

Going with scoped css is probably the most straightforward and least impacting solution. It is still possible to add custom classnames to target overrides. However I'm not sure; selector specificity is just frustrating. Here's where we are:

OLD rules with no namespacing, last one wins:
```css
.ms-Button { display: inline; }
.ms-Button { display: inline-block; }
```

NEW rule, they can live side by side:
```css
.msfr1.ms-Button { display: inline; }
.msfr2.ms-Button { display: inline-block; }
```

Customized rules like this can still work but are still prone to load order issues:
```css
.ms-Button.myCustomButton {
  background: red;
}
```

This particular one is troublesome. Looking for thoughts on this.
