### PR TITLE
Breadcrumb: Fix for keyboard activation of breadcrumb items

### DIFF
--- a/apps/fabric-examples/src/pages/BreadcrumbPage/examples/Breadcrumb.Basic.Example.tsx
+++ b/apps/fabric-examples/src/pages/BreadcrumbPage/examples/Breadcrumb.Basic.Example.tsx
@@ -13,21 +13,33 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
 
   public render() {
     return (
-      <Breadcrumb
-        items={ [
-          {text: 'Files', 'key': 'Files', onClick: this._onBreadcrumbItemClicked},
-          {text: 'This is folder 1', 'key': 'f1', onClick: this._onBreadcrumbItemClicked},
-          {text: 'This is folder 2', 'key': 'f2', onClick: this._onBreadcrumbItemClicked},
-          {text: 'This is folder 3', 'key': 'f3', onClick: this._onBreadcrumbItemClicked},
-          {text: 'This is folder 4', 'key': 'f4', onClick: this._onBreadcrumbItemClicked},
-          {text: 'This is folder 5', 'key': 'f5', onClick: this._onBreadcrumbItemClicked},
-        ] }
-        maxDisplayedItems={ 3 } />
+      <div>
+        <Breadcrumb
+          items={ [
+            { text: 'Files', 'key': 'Files', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 1', 'key': 'f1', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 2', 'key': 'f2', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 3', 'key': 'f3', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 4', 'key': 'f4', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 5', 'key': 'f5', onClick: this._onBreadcrumbItemClicked },
+          ] }
+          maxDisplayedItems={ 3 } />
+        <Breadcrumb
+          items={ [
+            { text: 'Files', 'key': 'Files', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is link 1', 'key': 'l1', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is link 2', 'key': 'l2', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is link 3', 'key': 'l3', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is link 4', 'key': 'l4', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is link 5', 'key': 'l5', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked },
+          ] }
+          maxDisplayedItems={ 3 } />
+      </div>
     );
   }
 
   private _onBreadcrumbItemClicked(ev: React.MouseEvent<HTMLElement>, item: IBreadcrumbItem) {
-    console.log(`Breadcrumb item with key "${ item.key }" has been clicked.`);
+    console.log(`Breadcrumb item with key "${item.key}" has been clicked.`);
   }
 
 }

--- a/common/changes/breadcrumb-fixes_2017-02-08-17-57.json
+++ b/common/changes/breadcrumb-fixes_2017-02-08-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Breadcrumb: Fixed keyboard activation of items",
+      "type": "patch"
+    }
+  ],
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.scss
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.scss
@@ -46,10 +46,6 @@ $Breadcrumb-itemMaxWidth-sm: 116px;
     }
   }
 
-  .ms-Breadcrumb-itemLink {
-    @include focus-border;
-  }
-
   .ms-Breadcrumb-item,
   .ms-Breadcrumb-itemLink {
     @include ms-font-xl;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.scss
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.scss
@@ -87,6 +87,7 @@ $Breadcrumb-itemMaxWidth-sm: 116px;
 .ms-Link.ms-Breadcrumb-itemLink {
   &:hover {
     background-color: $selectedHoverBackgroundColor;
+    color: initial;
     cursor: pointer;
   }
 

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.scss
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.scss
@@ -84,7 +84,7 @@ $Breadcrumb-itemMaxWidth-sm: 116px;
   }
 }
 
-.ms-Breadcrumb-itemLink {
+.ms-Link.ms-Breadcrumb-itemLink {
   &:hover {
     background-color: $selectedHoverBackgroundColor;
     cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../Utilities';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { ContextualMenu } from '../../ContextualMenu';
+import { Link } from '../../Link';
 import { IBreadcrumbProps, IBreadcrumbItem } from './Breadcrumb.Props';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import './Breadcrumb.scss';
@@ -113,16 +114,16 @@ export class Breadcrumb extends BaseComponent<IBreadcrumbProps, IBreadcrumbState
 
   private _renderItem(item: IBreadcrumbItem) {
     if (item.onClick || item.href) {
-      return (<a className='ms-Breadcrumb-itemLink'
-              onClick={ this._onBreadcrumbClicked.bind(this, item) }
-              href={ item.href ? item.href : null }
-              role={ item.onClick ? 'button' : 'link' }>
-              { item.text }
-            </a>);
+      return <Link
+        className='ms-Breadcrumb-itemLink'
+        href={ item.href }
+        onClick={ this._onBreadcrumbClicked.bind(this, item) }>
+        { item.text }
+      </Link>
     } else {
       return (<span className='ms-Breadcrumb-item'>
-              { item.text }
-            </span>);
+        { item.text }
+      </span>);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Link/Link.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.tsx
@@ -26,7 +26,6 @@ export class Link extends BaseComponent<ILinkProps, any> implements ILink {
     return (
       href ? (
         <a
-          role='link'
           { ...getNativeProps(this.props, anchorProperties) }
           className={ css('ms-Link', className, {
             'is-disabled': disabled
@@ -34,19 +33,18 @@ export class Link extends BaseComponent<ILinkProps, any> implements ILink {
           onClick={ this._onClick }
           ref={ this._resolveRef('_link') }
           target={ this.props.target }
-          >
+        >
           { children }
         </a>
       ) : (
           <button
-            role='button'
             { ...getNativeProps(this.props, buttonProperties) }
             className={ css('ms-Link', className, {
               'is-disabled': disabled
             }) }
             onClick={ this._onClick }
             ref={ this._resolveRef('_link') }
-            >
+          >
             { children }
           </button>
         ));


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #969 
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] bugfix
  - [ ] Includes tests
- [x] Documentation update

#### Description of changes
Issue:
Breadcrumb items are renders as anchor element. In case it doesn't attaches href to the item, the onClick is not triggered from keyboard 'Enter' press. This is default behavior provided by browsers for anchors without href.

Fix:
Using <Link> component to render breadcrumb so that onClick is triggered even with keyboard. This ensures that if href is not available the item is rendered as a button.
Other minor fixes:
- Link element uses explicit role attribute for button and link which is not required.


#### Focus areas to test
- No regression in breadcrumb styles - focus, hover
- onClick is fired correctly using keyboard or mouse

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
