### PR TITLE
Dropdown: update selectedIndex when options change

### DIFF
--- a/common/changes/dropdown_2017-02-08-22-19.json
+++ b/common/changes/dropdown_2017-02-08-22-19.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: update selectedIndex when options change",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "aditima@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -54,7 +54,8 @@ export class Dropdown extends BaseComponent<IDropdownProps, IDropdownState> {
   }
 
   public componentWillReceiveProps(newProps: IDropdownProps) {
-    if (newProps.selectedKey !== this.props.selectedKey) {
+    if (newProps.selectedKey !== this.props.selectedKey ||
+      newProps.options !== this.props.options) {
       this.setState({
         selectedIndex: this._getSelectedIndex(newProps.options, newProps.selectedKey)
       });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Need to recalculate the selectedIndex when the options props change.

