### PR TITLE
Changes to Checkbox Props and ChoiceGroup Props to support StrictNullChecks

### DIFF
--- a/common/changes/lahuey-StrictNullCheckFixes_2017-02-09-22-21.json
+++ b/common/changes/lahuey-StrictNullCheckFixes_2017-02-09-22-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Changes to Checkbox Props and ChoiceGroup Props to support StrictNullChecks",
+      "type": "minor"
+    }
+  ],
+  "email": "lahuey@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
@@ -14,7 +14,7 @@ export interface ICheckbox {
 /**
  * Checkbox properties.
  */
-export interface ICheckboxProps extends React.HTMLProps<HTMLElement> {
+export interface ICheckboxProps extends React.HTMLProps<HTMLElement | HTMLInputElement> {
   /**
    * Additional class name to provide on the root element, in addition to the ms-Checkbox class.
    */
@@ -45,7 +45,7 @@ export interface ICheckboxProps extends React.HTMLProps<HTMLElement> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (ev?: React.FormEvent<HTMLElement>, checked?: boolean) => void;
+  onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => void;
 
   /**
    * Optional input props that will be mixed into the input element, *before* other props are applied. This allows
@@ -53,5 +53,5 @@ export interface ICheckboxProps extends React.HTMLProps<HTMLElement> {
    * Note that if you provide, for example, "disabled" as well as "inputProps.disabled", the former will take
    * precedence over the later.
    */
-  inputProps?: React.HTMLProps<HTMLElement>;
+  inputProps?: React.HTMLProps<HTMLElement | HTMLInputElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
@@ -45,7 +45,7 @@ export interface ICheckboxProps extends React.HTMLProps<HTMLElement> {
   /**
    * Callback that is called when the checked value has changed.
    */
-  onChange?: (ev?: React.FormEvent<HTMLInputElement>, checked?: boolean) => void;
+  onChange?: (ev?: React.FormEvent<HTMLElement>, checked?: boolean) => void;
 
   /**
    * Optional input props that will be mixed into the input element, *before* other props are applied. This allows
@@ -53,5 +53,5 @@ export interface ICheckboxProps extends React.HTMLProps<HTMLElement> {
    * Note that if you provide, for example, "disabled" as well as "inputProps.disabled", the former will take
    * precedence over the later.
    */
-  inputProps?: React.HTMLProps<HTMLInputElement>;
+  inputProps?: React.HTMLProps<HTMLElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement> {
+export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement | HTMLInputElement> {
   /**
    * The options for the choice group.
    */
@@ -10,12 +10,12 @@ export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement> {
    * @deprecated
    * Deprecated and will be removed by 07/17/2017 Use 'onChange' instead.
    */
-  onChanged?: (option: IChoiceGroupOption, evt?: React.FormEvent<HTMLElement>) => void;
+  onChanged?: (option: IChoiceGroupOption, evt?: React.FormEvent<HTMLElement | HTMLInputElement>) => void;
 
   /**
    * A callback for receiving a notification when the choice has been changed.
    */
-  onChange?: (ev?: React.FormEvent<HTMLElement>, option?: IChoiceGroupOption) => void;
+  onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, option?: IChoiceGroupOption) => void;
 
   /**
    * Descriptive label for the choice group.

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -10,12 +10,12 @@ export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement> {
    * @deprecated
    * Deprecated and will be removed by 07/17/2017 Use 'onChange' instead.
    */
-  onChanged?: (option: IChoiceGroupOption, evt?: React.FormEvent<HTMLInputElement>) => void;
+  onChanged?: (option: IChoiceGroupOption, evt?: React.FormEvent<HTMLElement>) => void;
 
   /**
    * A callback for receiving a notification when the choice has been changed.
    */
-  onChange?: (ev?: React.FormEvent<HTMLInputElement>, option?: IChoiceGroupOption) => void;
+  onChange?: (ev?: React.FormEvent<HTMLElement>, option?: IChoiceGroupOption) => void;
 
   /**
    * Descriptive label for the choice group.


### PR DESCRIPTION
…in strictNullChecks mode

#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [ ] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->

In strictNullChecks mode, having a mismatch generic typing between the extended interface type HTMLElement and a member function's event callback typing HTMLInputElement causes a compiler error. The solution would be to keep the generic typing consistent throughout the class.