### PR TITLE
MessageBar - Show dismiss action for single line messages.

### DIFF
--- a/common/changes/message-bar-dismiss_2017-02-14-01-33.json
+++ b/common/changes/message-bar-dismiss_2017-02-14-01-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: now allows dismiss action for single line messages.",
+      "type": "patch"
+    }
+  ],
+  "email": "jdh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.test.tsx
@@ -1,0 +1,49 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+import * as ReactDOM from 'react-dom';
+import * as ReactTestUtils from 'react-addons-test-utils';
+
+let { expect } = chai;
+
+import { MessageBar } from './MessageBar';
+import { MessageBarType } from './MessageBar.Props';
+
+describe('MessageBar', () => {
+  var noop = () => { };
+  function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
+    const component = ReactTestUtils.renderIntoDocument(element);
+    const renderedDOM: Element = ReactDOM.findDOMNode(component as React.ReactInstance);
+    return renderedDOM as HTMLElement;
+  }
+
+  describe('dismiss', () => {
+    describe('single-line', () => {
+      it('is present when onDismiss exists', () => {
+        const renderedDOM: HTMLElement = renderIntoDocument(<MessageBar onDismiss={ noop } isMultiline={ false } />);
+        let dismissElement = renderedDOM.querySelector('.ms-MessageBar-dismissal');
+        expect(dismissElement).to.not.be.null;
+      });
+
+      it('is not present when onDismiss is missing', () => {
+        const renderedDOM: HTMLElement = renderIntoDocument(<MessageBar isMultiline={ false } />);
+        let dismissElement = renderedDOM.querySelector('.ms-MessageBar-dismissal');
+        expect(dismissElement).to.be.null;
+      });
+    });
+
+    describe('multi-line', () => {
+      it('is present when onDismiss exists', () => {
+        const renderedDOM: HTMLElement = renderIntoDocument(<MessageBar onDismiss={ noop } isMultiline={ true } />);
+        let dismissElement = renderedDOM.querySelector('.ms-MessageBar-dismissal');
+        expect(dismissElement).to.not.be.null;
+      });
+
+      it('is not present when onDismiss is missing', () => {
+        const renderedDOM: HTMLElement = renderIntoDocument(<MessageBar isMultiline={ true } />);
+        let dismissElement = renderedDOM.querySelector('.ms-MessageBar-dismissal');
+        expect(dismissElement).to.be.null;
+      });
+    });
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -55,13 +55,20 @@ export class MessageBar extends React.Component<IMessageBarProps, IMessageBarSta
   }
 
   private _getActionsDiv(): JSX.Element {
-    if (this.props.actions) {
-      return this.props.isMultiline ?
-        <div className='ms-MessageBar-actions'> { this.props.actions } </div> :
-        <div className='ms-MessageBar-actionsOneline'>
+    if (this.props.isMultiline) {
+      if (this.props.actions) {
+        return <div className='ms-MessageBar-actions'>
+          { this.props.actions }
+        </div>;
+      }
+    }
+    else {
+      if (this.props.actions || (this.props.onDismiss != null)) {
+        return <div className='ms-MessageBar-actionsOneline'>
           { this._getDismissDiv() }
           { this.props.actions }
         </div>;
+      }
     }
     return null;
   }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -63,7 +63,7 @@ export class MessageBar extends React.Component<IMessageBarProps, IMessageBarSta
       }
     }
     else {
-      if (this.props.actions || (this.props.onDismiss != null)) {
+      if (this.props.actions || this.props.onDismiss) {
         return <div className='ms-MessageBar-actionsOneline'>
           { this._getDismissDiv() }
           { this.props.actions }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #995

- [ ] New feature, *bugfix*, or enhancement
  - [ ] Includes tests: _Yes_
- [ ] Documentation update: _No_

#### Description of changes

MessageBar renders a dismiss button if `onDismiss` is provided, even if no actions are present.

