### PR TITLE
Fix issues with Drag/Drop in Details List after refresh

### DIFF
--- a/common/changes/details-list-drag-drop_2017-02-16-21-48.json
+++ b/common/changes/details-list-drag-drop_2017-02-16-21-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed issues with drag/drop after item refresh.",
+      "type": "minor"
+    }
+  ],
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -81,7 +81,7 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
   constrainMode?: ConstrainMode;
 
   /** Event names and corresponding callbacks that will be registered to rendered row elements. */
-  rowElementEventMap?: [{ eventName: string, callback: (context: IDragDropContext, event?: any) => void }];
+  rowElementEventMap?: { eventName: string, callback: (context: IDragDropContext, event?: any) => void }[];
 
   /** Callback for when the details list has been updated. Useful for telemetry tracking externally. */
   onDidUpdate?: (detailsList?: DetailsList) => any;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
@@ -42,7 +42,7 @@ export interface IGroupedListProps extends React.Props<GroupedList> {
   dragDropHelper?: IDragDropHelper;
 
   /** Event names and corresponding callbacks that will be registered to groups and rendered elements */
-  eventsToRegister?: [{ eventName: string, callback: (context: IDragDropContext, event?: any) => void }];
+  eventsToRegister?: { eventName: string, callback: (context: IDragDropContext, event?: any) => void }[];
 
   /** Optional override properties to render groups. */
   groupProps?: IGroupRenderProps;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -32,6 +32,7 @@ import {
 } from './../../utilities/dragdrop/interfaces';
 import { assign, css } from '../../Utilities';
 import { IViewport } from '../../utilities/decorators/withViewport';
+import { IDisposable } from '@uifabric/utilities';
 
 export interface IGroupedListSectionProps extends React.Props<GroupedListSection> {
   /** Map of callback functions related to drag and drop functionality. */
@@ -41,7 +42,7 @@ export interface IGroupedListSectionProps extends React.Props<GroupedListSection
   dragDropHelper?: IDragDropHelper;
 
   /** Event names and corresponding callbacks that will be registered to the group and the rendered elements */
-  eventsToRegister?: [{ eventName: string, callback: (context: IDragDropContext, event?: any) => void }];
+  eventsToRegister?: { eventName: string, callback: (context: IDragDropContext, event?: any) => void }[];
 
   /** Information to pass in to the group footer. */
   footerProps?: IGroupDividerProps;
@@ -107,7 +108,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
   private _subGroups: {
     [key: string]: GroupedListSection;
   };
-  private _dragDropKey: string;
+  private _dragDropSubscription: IDisposable;
 
   constructor(props: IGroupedListSectionProps) {
     super(props);
@@ -125,7 +126,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
     let { dragDropHelper, selection } = this.props;
 
     if (dragDropHelper) {
-      dragDropHelper.subscribe(this.refs.root, this._events, this._getGroupDragDropOptions());
+      this._dragDropSubscription = dragDropHelper.subscribe(this.refs.root, this._events, this._getGroupDragDropOptions());
     }
 
     if (selection) {
@@ -134,10 +135,23 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
   }
 
   public componentWillUnmount() {
-    let { dragDropHelper } = this.props;
+    if (this._dragDropSubscription) {
+      this._dragDropSubscription.dispose();
+    }
+  }
 
-    if (dragDropHelper) {
-      dragDropHelper.unsubscribe(this.refs.root, this._dragDropKey);
+  public componentDidUpdate(previousProps: IGroupedListSectionProps) {
+    if (this.props.group !== previousProps.group ||
+      this.props.groupIndex !== previousProps.groupIndex ||
+      this.props.dragDropHelper !== previousProps.dragDropHelper) {
+      if (this._dragDropSubscription) {
+        this._dragDropSubscription.dispose();
+        delete this._dragDropSubscription;
+      }
+
+      if (this.props.dragDropHelper) {
+        this._dragDropSubscription = this.props.dragDropHelper.subscribe(this.refs.root, this._events, this._getGroupDragDropOptions());
+      }
     }
   }
 
@@ -321,13 +335,11 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
   @autobind
   private _getGroupDragDropOptions(): IDragDropOptions {
     let { group, groupIndex, dragDropEvents, eventsToRegister } = this.props;
-    this._dragDropKey = 'group-' + (group ? group.key : String(groupIndex));
     let options = {
-      key: this._dragDropKey,
       eventMap: eventsToRegister,
       selectionIndex: -1,
       context: { data: group, index: groupIndex, isGroup: true },
-      canDrag: () => { return false; }, // cannot drag groups
+      canDrag: () => false, // cannot drag groups
       canDrop: dragDropEvents.canDrop,
       onDragStart: null,
       updateDropState: this._updateDroppingState

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/DragDropHelper.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/DragDropHelper.tsx
@@ -5,7 +5,8 @@ import {
   IDragDropHelper,
   IDragDropTarget,
   IDragDropOptions,
-  IDragDropEvent
+  IDragDropEvent,
+  IDragDropContext
 } from './interfaces';
 import { ISelection } from '../../utilities/selection/interfaces';
 
@@ -31,11 +32,13 @@ export class DragDropHelper implements IDragDropHelper {
   private _selection: ISelection;
   private _activeTargets: { [key: string]: IDragDropTarget };
   private _events: EventGroup;
+  private _lastId: number;
 
   constructor(params: IDragDropHelperParams) {
     this._selection = params.selection;
     this._dragEnterCounts = {};
     this._activeTargets = {};
+    this._lastId = 0;
 
     this._events = new EventGroup(this);
     // clear drag data when mouse up, use capture event to ensure it will be run
@@ -47,68 +50,130 @@ export class DragDropHelper implements IDragDropHelper {
     this._events.dispose();
   }
 
-  public subscribe(root: HTMLElement, events: EventGroup, dragDropOptions: IDragDropOptions) {
+  public subscribe(root: HTMLElement, events: EventGroup, dragDropOptions: IDragDropOptions): {
+    dispose(): void;
+  } {
+    const key = `${++this._lastId}`;
+
+    const handlers: {
+      callback: (context: IDragDropContext, event?: any) => void;
+      eventName: string;
+    }[] = [];
+
+    let onDragLeave: (event: DragEvent) => void;
+    let onDragEnter: (event: DragEvent) => void;
+    let onDragEnd: (event: DragEvent) => void;
+    let onDrop: (event: DragEvent) => void;
+    let onMouseDown: (event: MouseEvent) => void;
+
+    let isDraggable: boolean;
+    let isDroppable: boolean;
+
     if (dragDropOptions && root) {
-      let { key, eventMap, context, updateDropState } = dragDropOptions;
-      let dragDropTarget = { root: root, options: dragDropOptions };
-      let isDraggable = this._isDraggable(dragDropTarget);
-      let isDroppable = this._isDroppable(dragDropTarget);
+      const {
+        eventMap,
+        context,
+        updateDropState
+      } = dragDropOptions;
+
+      const dragDropTarget: IDragDropTarget = {
+        root: root,
+        options: dragDropOptions,
+        key: key
+      };
+
+      isDraggable = this._isDraggable(dragDropTarget);
+      isDroppable = this._isDroppable(dragDropTarget);
 
       if (isDraggable || isDroppable) {
         this._activeTargets[key] = dragDropTarget;
 
         if (eventMap) {
-          for (let event of eventMap) {
-            this._events.on(root, event.eventName, event.callback.bind(null, context));
+          for (const event of eventMap) {
+            const handler = {
+              callback: event.callback.bind(null, context),
+              eventName: event.eventName
+            };
+
+            handlers.push(handler);
+
+            this._events.on(root, handler.eventName, handler.callback);
           }
         }
       }
 
       if (isDroppable) {
+        onDragLeave = (event: DragEvent) => {
+          if (!(event as IDragDropEvent).isHandled) {
+            (event as IDragDropEvent).isHandled = true;
+            this._dragEnterCounts[key]--;
+            if (this._dragEnterCounts[key] === 0) {
+              updateDropState(false /* isDropping */, event);
+            }
+          }
+        };
+
+        onDragEnter = (event: DragEvent) => {
+          event.preventDefault(); // needed for IE
+          if (!(event as IDragDropEvent).isHandled) {
+            (event as IDragDropEvent).isHandled = true;
+            this._dragEnterCounts[key]++;
+            if (this._dragEnterCounts[key] === 1) {
+              updateDropState(true /* isDropping */, event);
+            }
+          }
+        };
+
+        onDragEnd = (event: DragEvent) => {
+          this._dragEnterCounts[key] = 0;
+          updateDropState(false /* isDropping */, event);
+        };
+
+        onDrop = (event: DragEvent) => {
+          this._dragEnterCounts[key] = 0;
+          updateDropState(false /* isDropping */, event);
+        };
+
         this._dragEnterCounts[key] = 0;
+
         // dragenter and dragleave will be fired when hover to the child element
         // but we only want to change state when enter or leave the current element
         // use the count to ensure it.
-        events.onAll(root, {
-          'dragenter': (event: DragEvent) => {
-            event.preventDefault(); // needed for IE
-            if (!(event as IDragDropEvent).isHandled) {
-              (event as IDragDropEvent).isHandled = true;
-              this._dragEnterCounts[key]++;
-              if (this._dragEnterCounts[key] === 1) {
-                updateDropState(true /* isDropping */, event);
-              }
-            }
-          },
-          'dragleave': (event: DragEvent) => {
-            if (!(event as IDragDropEvent).isHandled) {
-              (event as IDragDropEvent).isHandled = true;
-              this._dragEnterCounts[key]--;
-              if (this._dragEnterCounts[key] === 0) {
-                updateDropState(false /* isDropping */, event);
-              }
-            }
-          },
-          'dragend': (event: DragEvent) => {
-            this._dragEnterCounts[key] = 0;
-            updateDropState(false /* isDropping */, event);
-          },
-          'drop': (event: DragEvent) => {
-            this._dragEnterCounts[key] = 0;
-            updateDropState(false /* isDropping */, event);
-          }
-        });
+        events.on(root, 'dragenter', onDragEnter);
+        events.on(root, 'dragleave', onDragLeave);
+        events.on(root, 'dragend', onDragEnd);
+        events.on(root, 'drop', onDrop);
       }
 
       if (isDraggable) {
-        events.on(root, 'mousedown', this._onMouseDown.bind(this, dragDropTarget));
+        onMouseDown = this._onMouseDown.bind(this, dragDropTarget);
+
+        events.on(root, 'mousedown', onMouseDown);
       }
     }
-  }
 
-  public unsubscribe(root: HTMLElement, key: string) {
-    delete this._activeTargets[key];
-    this._events.off(root);
+    return {
+      dispose: () => {
+        delete this._activeTargets[key];
+
+        if (root) {
+          for (const handler of handlers) {
+            this._events.off(root, handler.eventName, handler.callback);
+          }
+
+          if (isDroppable) {
+            events.off(root, 'dragenter', onDragEnter);
+            events.off(root, 'dragleave', onDragLeave);
+            events.off(root, 'dragend', onDragEnd);
+            events.off(root, 'drop', onDrop);
+          }
+
+          if (isDraggable) {
+            events.off(root, 'mousedown', onMouseDown);
+          }
+        }
+      }
+    };
   }
 
   /**
@@ -162,7 +227,7 @@ export class DragDropHelper implements IDragDropHelper {
       return;
     }
 
-    let { root, options } = target;
+    let { root, options, key } = target;
     if (this._isDragging) {
       if (this._isDroppable(target)) {
         // we can have nested drop targets in the DOM, like a folder inside a group. In that case, when we drag into
@@ -170,7 +235,7 @@ export class DragDropHelper implements IDragDropHelper {
         // outer target too, and we need to prevent the outer one from taking over.
         // So, check if the last dropTarget is not a child of the current.
         if (this._dragData.dropTarget &&
-          this._dragData.dropTarget.options.key !== options.key &&
+          this._dragData.dropTarget.key !== key &&
           !this._isChild(root, this._dragData.dropTarget.root)) {
           EventGroup.raise(this._dragData.dropTarget.root, 'dragleave');
           this._dragData.dropTarget = null;
@@ -203,7 +268,7 @@ export class DragDropHelper implements IDragDropHelper {
    */
   private _onMouseLeave(target: IDragDropTarget, event: MouseEvent) {
     if (this._isDragging) {
-      if (this._dragData && this._dragData.dropTarget && this._dragData.dropTarget.options.key === target.options.key) {
+      if (this._dragData && this._dragData.dropTarget && this._dragData.dropTarget.key === target.key) {
         EventGroup.raise(target.root, 'dragleave');
         this._dragData.dropTarget = null;
       }

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
@@ -3,8 +3,10 @@ import { EventGroup } from '../../Utilities';
 
 export interface IDragDropHelper {
   subscribe: (root: HTMLElement, events: EventGroup, options: IDragDropOptions) => {
+    key: string;
     dispose: () => void;
   };
+  unsubscribe: (root: HTMLElement, key: string) => void;
   dispose: () => void;
 }
 
@@ -30,6 +32,7 @@ export interface IDragDropTarget {
 }
 
 export interface IDragDropOptions {
+  key?: string;
   eventMap?: { eventName: string, callback: (context: IDragDropContext, event?: any) => void }[];
   selectionIndex: number;
   context: IDragDropContext;

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { EventGroup } from '../../Utilities';
 
 export interface IDragDropHelper {
-  subscribe: (root: HTMLElement, events: EventGroup, options: IDragDropOptions) => void;
-  unsubscribe: (root: HTMLElement, key: string) => void;
+  subscribe: (root: HTMLElement, events: EventGroup, options: IDragDropOptions) => {
+    dispose: () => void;
+  };
   dispose: () => void;
 }
 
@@ -25,11 +26,11 @@ export interface IDragDropContext {
 export interface IDragDropTarget {
   root: React.ReactInstance;
   options: IDragDropOptions;
+  key: string;
 }
 
 export interface IDragDropOptions {
-  key: string;
-  eventMap?: [{ eventName: string, callback: (context: IDragDropContext, event?: any) => void }];
+  eventMap?: { eventName: string, callback: (context: IDragDropContext, event?: any) => void }[];
   selectionIndex: number;
   context: IDragDropContext;
   updateDropState: (isDropping: boolean, event: DragEvent) => void;


### PR DESCRIPTION
#### Description of changes

This PR fixes an issue with `DragDropHelper`, wherein after refreshing the contents of a list, items below the inserted items could not be used to start a drag.  
This was occurring because the inserted `DetailsRow` entries were overriding the subscriptions for later items since they were re-using the keys for later (now moved) rows. Later rows were never re-updating with new subscriptions, so they were never checking the correct `itemIndex` for selection state and failing to start a drag.

This PR switches `DragDropHelper` to use an `IDisposable` pattern for subscriptions, assigning a new unique `key` every time. Whenever the `item` or `itemIndex` updates, the `DetailsRow` unsubscribes and resubscribes to the current `DragDropHelper`, ensuring that it stays up to date with the correct source `item` and `itemIndex`.

This PR also fixes some internal issues with `DragDropHelper`, properly handling event subscription lifetimes per-handler, rather than assuming they are always managed as a block.

#### Focus areas to test

Drag-and-drop scenarios in `DetailsRow`, notably after inserting items into the list.

#### Breaking changes

This PR changes the interfaces used for `DragDropHelper`, so any dependent projects will need to update to accommodate those changes. Code which exclusively depends on `DetailsRow` will be unaffected.