### PR TITLE
CSS modules: Buttons and Links

### DIFF
--- a/common/changes/component-css-button_2017-02-18-02-10.json
+++ b/common/changes/component-css-button_2017-02-18-02-10.json
@@ -4,6 +4,11 @@
       "packageName": "office-ui-fabric-react",
       "comment": "Button variants: the styles are now scoped within css modules. All class names that were previously on buttons still remain unchanged, but the styles have moved into a type safe hashed class name. This allows 2 different versions of any Button variant to live on the same page without having rules collide. The style rules for the variants were also tweaked. Content is now aligned using flexbox, which means more consistent centering when injecting inline, inline-block, or block elements. Second, all line-heights were removed and content now correctly centers within buttons, so if you change the height of the container (e.g. you make CommandButtons render in 36px instead of 40px) things will center correctly.",
       "type": "minor"
+    },
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Link: the styles are now scoped within css modules. All class names that were previously on buttons still remain unchanged, but the styles have moved into a type safe hashed class name.",
+      "type": "minor"
     }
   ],
   "email": "dzearing@microsoft.com"

--- a/common/changes/component-css-button_2017-02-18-02-10.json
+++ b/common/changes/component-css-button_2017-02-18-02-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button variants: the styles are now scoped within css modules. All class names that were previously on buttons still remain unchanged, but the styles have moved into a type safe hashed class name. This allows 2 different versions of any Button variant to live on the same page without having rules collide. The style rules for the variants were also tweaked. Content is now aligned using flexbox, which means more consistent centering when injecting inline, inline-block, or block elements. Second, all line-heights were removed and content now correctly centers within buttons, so if you change the height of the container (e.g. you make CommandButtons render in 36px instead of 40px) things will center correctly.",
+      "type": "minor"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_focusBorder.scss
+++ b/packages/office-ui-fabric-react/src/common/_focusBorder.scss
@@ -14,7 +14,7 @@
     position: relative;
   }
 
-  :global .ms-Fabric.is-focusVisible &:focus:after {
+  :global(.ms-Fabric.is-focusVisible) &:focus:after {
     // Wrap the parent element with $padding pixels.
     content: '';
     position: absolute;
@@ -33,7 +33,7 @@
 
 // When focus is set using the keyboard, apply an outline.
 @mixin focus-outline {
-  :global .ms-Fabric.is-focusVisible &:focus {
+  :global(.ms-Fabric.is-focusVisible) &:focus {
     outline: 1px solid $focusedBorderColor;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.scss
@@ -1,0 +1,7 @@
+.flexContainer {
+  display: flex;
+  height: 100%;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -11,18 +11,26 @@ import {
 import { IButtonProps, IButton } from './Button.Props';
 import styles from './BaseButton.scss';
 
+export interface IBaseButtonClassNames {
+  base: string;
+  variant: string;
+  isDisabled: string;
+  isEnabled: string;
+  description?: string;
+  flexContainer?: string;
+  icon?: string;
+  label?: string;
+  root?: string;
+};
+
 export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButton {
 
-  /**
-   * _baseClassName can be overridden by subclasses to provide a unique class prefix to the class name used for
-   * sub parts of the render template.
-   */
-  protected _baseClassName = 'ms-Button';
-
-  /**
-   * _variantClassName can be overridden by subclasses to add an extra default class name to the root element.
-   */
-  protected _variantClassName = '';
+  protected classNames: IBaseButtonClassNames = {
+    base: 'ms-Button',
+    variant: '',
+    isEnabled: '',
+    isDisabled: ''
+  };
 
   private _buttonElement: HTMLButtonElement;
   private _labelId: string;
@@ -65,7 +73,16 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
     let buttonProps = assign(
       nativeProps,
       {
-        className: this.getRootClassName(),
+        className: css(
+          this.props.className,
+          this.classNames.base,
+          this.classNames.variant,
+          this.classNames.root,
+          {
+            'disabled': disabled,
+            [this.classNames.isDisabled]: disabled,
+            [this.classNames.isEnabled]: !disabled
+          }),
         ref: this._resolveRef('_buttonElement'),
         'disabled': disabled,
         'aria-label': ariaLabel,
@@ -84,26 +101,11 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
     }
   }
 
-  protected getRootClassName(): string {
-    return css(
-      this.props.className,
-      this._baseClassName,
-      this._variantClassName,
-      {
-        'disabled': this.props.disabled
-      }
-    );
-  }
-
-  protected getFlexContainerClassName(): string {
-    return styles.flexContainer;
-  }
-
   protected onRenderContent(tag: any, buttonProps: IButtonProps): JSX.Element {
     return React.createElement(
       tag,
       buttonProps,
-      React.createElement('div', { className: this.getFlexContainerClassName() },
+      React.createElement('div', { className: css(styles.flexContainer, this.classNames.flexContainer) },
         this.onRenderIcon(),
         this.onRenderLabel(),
         this.onRenderDescription(),
@@ -112,24 +114,16 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
       ));
   }
 
-  protected getIconClassName(): string {
-    return '';
-  }
-
   protected onRenderIcon() {
     let { icon } = this.props;
 
     return icon ? (
-      <span className={ css(`${this._baseClassName}-icon`, this.getIconClassName()) }>
+      <span className={ css(`${this.classNames.base}-icon`, this.classNames.icon) }>
         <i className={ `ms-Icon ms-Icon--${icon}` } />
       </span>
     ) : (
         null
       );
-  }
-
-  protected getLabelClassName(): string {
-    return '';
   }
 
   protected onRenderLabel() {
@@ -141,7 +135,7 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
     }
 
     return label ? (
-      <span className={ css(`${this._baseClassName}-label`, this.getLabelClassName()) } id={ this._labelId } >
+      <span className={ css(`${this.classNames.base}-label`, this.classNames.label) } id={ this._labelId } >
         { label }
       </span>
     ) : (null);
@@ -166,7 +160,12 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
     // ms-Button-description is only shown when the button type is compound.
     // In other cases it will not be displayed.
     return description ? (
-      <span className={ `${this._baseClassName}-description` } id={ this._descriptionId }>{ description }</span>
+      <span
+        className={ css(`${this.classNames.base}-description`, this.classNames.description) }
+        id={ this._descriptionId }
+      >
+        { description }
+      </span>
     ) : (
         null
       );

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -9,6 +9,7 @@ import {
   anchorProperties
 } from '../../Utilities';
 import { IButtonProps, IButton } from './Button.Props';
+import styles from './BaseButton.scss';
 
 export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButton {
 
@@ -36,7 +37,7 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
   }
 
   public render(): JSX.Element {
-    const { className, description, ariaLabel, ariaDescription, href, disabled } = this.props;
+    const { description, ariaLabel, ariaDescription, href, disabled } = this.props;
     const { _ariaDescriptionId, _labelId, _descriptionId } = this;
     const renderAsAnchor: boolean = !!href;
     const tag = renderAsAnchor ? 'a' : 'button';
@@ -64,16 +65,13 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
     let buttonProps = assign(
       nativeProps,
       {
-        className: css(
-          className,
-          this._baseClassName,
-          this._variantClassName,
-          { 'disabled': disabled }
-        ),
+        className: this.getRootClassName(),
         ref: this._resolveRef('_buttonElement'),
+        'disabled': disabled,
         'aria-label': ariaLabel,
         'aria-labelledby': ariaLabel ? null : _labelId,
-        'aria-describedby': ariaDescribedBy
+        'aria-describedby': ariaDescribedBy,
+        'aria-disabled': disabled
       }
     );
 
@@ -86,28 +84,52 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
     }
   }
 
-  protected onRenderContent(tag, buttonProps): JSX.Element {
+  protected getRootClassName(): string {
+    return css(
+      this.props.className,
+      this._baseClassName,
+      this._variantClassName,
+      {
+        'disabled': this.props.disabled
+      }
+    );
+  }
+
+  protected getFlexContainerClassName(): string {
+    return styles.flexContainer;
+  }
+
+  protected onRenderContent(tag: any, buttonProps: IButtonProps): JSX.Element {
     return React.createElement(
       tag,
       buttonProps,
-      this.onRenderIcon(),
-      this.onRenderLabel(),
-      this.onRenderDescription(),
-      this.onRenderAriaDescription(),
-      this.onRenderChildren()
-    );
+      React.createElement('div', { className: this.getFlexContainerClassName() },
+        this.onRenderIcon(),
+        this.onRenderLabel(),
+        this.onRenderDescription(),
+        this.onRenderAriaDescription(),
+        this.onRenderChildren()
+      ));
+  }
+
+  protected getIconClassName(): string {
+    return '';
   }
 
   protected onRenderIcon() {
     let { icon } = this.props;
 
     return icon ? (
-      <span className={ `${this._baseClassName}-icon` }>
+      <span className={ css(`${this._baseClassName}-icon`, this.getIconClassName()) }>
         <i className={ `ms-Icon ms-Icon--${icon}` } />
       </span>
     ) : (
         null
       );
+  }
+
+  protected getLabelClassName(): string {
+    return '';
   }
 
   protected onRenderLabel() {
@@ -119,7 +141,7 @@ export class BaseButton extends BaseComponent<IButtonProps, {}> implements IButt
     }
 
     return label ? (
-      <span className={ `${this._baseClassName}-label` } id={ this._labelId } >
+      <span className={ css(`${this._baseClassName}-label`, this.getLabelClassName()) } id={ this._labelId } >
         { label }
       </span>
     ) : (null);

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonCore/ButtonCore.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonCore/ButtonCore.scss
@@ -8,101 +8,49 @@
 @import '../../../common/common';
 @import './ButtonCoreVars';
 
-:global {
+@mixin button-core-root-styles {
+  @include focus-border();
+  @include ms-font-m;
 
-  .ms-Button {
-    @include focus-border();
-    @include ms-font-m;
-    user-select: none;
+  user-select: none;
+  border-width: 0;
+  text-decoration: none;
+  text-align: center;
+  cursor: pointer;
+  display: inline-block;
+  padding: $button-core-default-padding;
 
-    border-width: 0;
-    text-decoration: none;
-    text-align: center;
-    cursor: pointer;
-    display: inline-block;
-    padding: $button-core-default-padding;
-
-    @media screen and (-ms-high-contrast: active) {
-      color: $ms-color-contrastBlackSelected;
-      border-color: $ms-color-contrastBlackSelected;
-    }
-
-    @media screen and (-ms-high-contrast: black-on-white) {
-      color: $ms-color-contrastWhiteSelected;
-      border-color: $ms-color-contrastWhiteSelected;
-    }
+  @media screen and (-ms-high-contrast: active) {
+    color: $ms-color-contrastBlackSelected;
+    border-color: $ms-color-contrastBlackSelected;
   }
 
-  .ms-Button-icon {
-    margin: 0 4px;
-    width: 16px;
-    vertical-align: top;
-    display: inline-block;
+  @media screen and (-ms-high-contrast: black-on-white) {
+    color: $ms-color-contrastWhiteSelected;
+    border-color: $ms-color-contrastWhiteSelected;
   }
+}
 
-  .ms-Button-label {
-    margin: 0 4px;
-    vertical-align: top;
-    display: inline-block;
-  }
+@mixin button-core-icon-styles {
+  margin: 0 4px;
+  width: 16px;
+  height: 16px;
+  text-align: center;
+  vertical-align: middle;
+}
 
-  // TODO: Remove Hero Styles once fully deprecated
+@mixin button-core-label-styles {
+  margin: 0 4px;
+}
 
-  //== Modifier: Hero button
-  //
-  .ms-Button--hero {
-    background-color: transparent;
-    border: 0;
-    height: auto;
+@mixin button-core-disabled {
+  background-color: $ms-color-neutralLighter;
+  color: $ms-color-neutralTertiary;
+  cursor: default;
+  pointer-events: none;
 
-    .ms-Button-icon {
-      color: $ms-color-themePrimary;
-      display: inline-block;
-      @include margin-right(8px);
-      padding-top: 5px;
-      font-size: $ms-icon-size-l;
-      line-height: 1; // FireFox vertical offset
-    }
-
-    .ms-Button-label {
-      color: $ms-color-themePrimary;
-      font-size: $ms-font-size-xl;
-      font-weight: $ms-font-weight-light;
-      vertical-align: top;
-    }
-
-    &:hover,
-    &:focus {
-      background-color: transparent;
-
-      .ms-Button-icon {
-        color: $ms-color-themeDark;
-      }
-
-      .ms-Button-label {
-        color: $ms-color-themeDarker;
-      }
-    }
-
-    &:active {
-      .ms-Button-icon {
-        color: $ms-color-themePrimary;
-      }
-
-      .ms-Button-label {
-        color: $ms-color-themePrimary;
-      }
-    }
-
-    &:disabled,
-    &.is-disabled {
-      .ms-Button-icon {
-        color: $ms-color-neutralTertiaryAlt;
-      }
-
-      .ms-Button-label {
-        color: $ms-color-neutralTertiary;
-      }
-    }
+  &:hover,
+  &:focus {
+    outline: 0;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonCore/ButtonCore.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonCore/ButtonCore.scss
@@ -35,12 +35,14 @@
   margin: 0 4px;
   width: 16px;
   height: 16px;
+  line-height: 16px;
   text-align: center;
   vertical-align: middle;
 }
 
 @mixin button-core-label-styles {
   margin: 0 4px;
+  line-height: 100%;
 }
 
 @mixin button-core-disabled {

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonCore/ButtonCoreVars.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonCore/ButtonCoreVars.scss
@@ -2,15 +2,3 @@ $button-core-default-height: 32px;
 $button-core-default-minWidth: 80px;
 $button-core-default-padding: 0 16px;
 
-@mixin core-button-disabled {
-  background-color: $ms-color-neutralLighter;
-  border-color: $ms-color-neutralLighter;
-  cursor: default;
-  pointer-events: none;
-  color: $ms-color-neutralTertiary;
-
-  &:hover,
-  &:focus {
-    outline: 0;
-  }
-}

--- a/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.scss
@@ -1,5 +1,3 @@
-@import '../../../common/common';
-
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
 //
@@ -7,65 +5,41 @@
 // --------------------------------------------------
 // Command Button styles
 
+@import '../../../common/common';
+@import '../ButtonCore/ButtonCore';
+@import '../ButtonCore/ButtonCoreVars';
+
 $button-commandButtonHeight: 40px;
 
-:global {
-  
-  .ms-Button.ms-Button--command {
-    @include text-align(left);
+.root {
+  @include button-core-root-styles;
 
-    background-color: transparent;
-    border: none;
-    padding: 0 4px;
+  background-color: transparent;
+  padding: 0 4px;
+  height: $button-commandButtonHeight;
+}
 
-    .ms-Button-label,
-    .ms-Button-icon {
-      height: $button-commandButtonHeight;
-      line-height: $button-commandButtonHeight;
-    }
+.label {
+  @include button-core-label-styles;
+}
 
-    .ms-Button-label {
-      @include ms-font-m;
-      font-weight: $ms-font-weight-regular;
-      color: $ms-color-neutralPrimary;
-    }
+.icon {
+  @include button-core-icon-styles;
+}
 
-    .ms-Button-icon {
-      vertical-align: top;
-      color: $ms-color-themePrimary;
-      display: inline-block;
-      font-size: $ms-icon-size-m;
-      position: relative;
-    }
+.isEnabled {
 
-    &:hover,
-    &:focus {
-      background-color: transparent;
-
-      &,
-      .ms-Button-icon,
-      .ms-Button-label {
-        color: $ms-color-themeDarker;
-      }
-    }
-
-    &:active {
-      &,
-      .ms-Button-icon,
-      .ms-Button-label {
-        color: $ms-color-themePrimary;
-      }
-    }
-
-    &:disabled,
-    &.disabled {
-      background-color: transparent;
-
-      .ms-Button-icon,
-      .ms-Button-label {
-        color: $ms-color-neutralTertiaryAlt;
-      }
-    }
+  &:hover {
+    color: $ms-color-themeDarker;
   }
 
+  &:active {
+    color: $ms-color-themePrimary;
+  }
 }
+
+.isDisabled {
+  @include button-core-disabled;
+  background-color: transparent;
+}
+

--- a/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.scss
@@ -17,6 +17,7 @@ $button-commandButtonHeight: 40px;
   background-color: transparent;
   padding: 0 4px;
   height: $button-commandButtonHeight;
+  color: $ms-color-neutralPrimary;
 }
 
 .label {
@@ -34,6 +35,10 @@ $button-commandButtonHeight: 40px;
   }
 
   &:active {
+    color: $ms-color-themePrimary;
+  }
+
+  .icon {
     color: $ms-color-themePrimary;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.tsx
@@ -1,11 +1,16 @@
 import { BaseButton } from '../BaseButton';
-import './CommandButton.scss';
-import '../ButtonCore/ButtonCore.scss';
+import styles from './CommandButton.scss';
 
 export class CommandButton extends BaseButton {
-  protected _variantClassName = 'ms-Button--command';
+  protected classNames = {
+    base: 'ms-Button',
+    variant: 'ms-Button--default',
+    icon: styles.icon,
+    isDisabled: styles.isDisabled,
+    isEnabled: styles.isEnabled,
+    label: styles.label,
+    root: styles.root
+  };
 
-  protected onRenderDescription() {
-    return null;
-  }
+  protected onRenderDescription() { return null; }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.scss
@@ -1,5 +1,3 @@
-@import '../../../common/common';
-
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
 
 //
@@ -7,73 +5,75 @@
 // --------------------------------------------------
 // Compound Button styles
 
-:global {
-  .ms-Button.ms-Button--compound {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: stretch;
+@import '../../../common/common';
+@import '../ButtonCore/ButtonCore';
+@import '../ButtonCore/ButtonCoreVars';
 
-    width: 100%;
-    max-width: 280px;
-    min-height: 72px;
+.root {
+  @include button-core-root-styles;
 
-    padding: 16px 20px;
-    background: $ms-color-neutralLighter;
+  padding: 16px 20px;
+  background-color: $ms-color-neutralLighter;
+  color: $ms-color-neutralSecondary;
 
-    @include text-align(left);
+  min-width: $button-core-default-minWidth;
+  max-width: 280px;
 
-    .ms-Button-label {
-      @include ms-font-m;
-      display: block;
-      font-weight: $ms-font-weight-semibold;
-      color: $ms-color-black;
-      margin: 0 0 2px;
+  min-height: 72px;
+}
+
+.flexContainer {
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+
+  @include text-align(left);
+
+  min-width: 100%;
+  height: auto;
+}
+
+
+.label {
+  @include button-core-label-styles;
+
+  font-weight: $ms-font-weight-semibold;
+  color: $ms-color-black;
+  margin: 0 0 5px;
+}
+
+.description {
+  @include ms-font-s;
+  color: $ms-color-neutralSecondary;
+  line-height: 100%;
+}
+
+.isEnabled {
+
+  &:hover {
+    background-color: $ms-color-neutralLight;
+
+    .description {
+      color: $ms-color-neutralDark;
     }
+  }
 
-    .ms-Button-description {
-      @include ms-font-s;
-      color: $ms-color-neutralSecondary;
-      display: block;
+  &:active {
+    background-color: $ms-color-themePrimary;
+    color: $ms-color-white;
+
+    .label,
+    .description {
+      color: inherit;
     }
+  }
+}
 
-    &:hover {
-      background-color: $ms-color-neutralLight;
-      border-color: $ms-color-neutralLight;
+.isDisabled {
+  @include button-core-disabled;
 
-      .ms-Button-description {
-        color: $ms-color-neutralDark;
-      }
-    }
-
-    &:focus {
-      border-color: $ms-color-themePrimary;
-      background-color: $ms-color-neutralLighter;
-
-      .ms-Button-label {
-        color: $ms-color-neutralPrimary;
-      }
-
-      .ms-Button-description {
-        color: $ms-color-neutralSecondary;
-      }
-    }
-
-    &:active {
-      background-color: $ms-color-themePrimary;
-
-      .ms-Button-description,
-      .ms-Button-label {
-        color: $ms-color-white;
-      }
-    }
-
-    &:disabled,
-    &.disabled {
-      .ms-Button-label,
-      .ms-Button-description {
-        color: $ms-color-neutralTertiary;
-      }
-    }
+  .label,
+  .description {
+    color: inherit;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.tsx
@@ -1,11 +1,17 @@
+import { css } from '../../../Utilities';
 import { BaseButton } from '../BaseButton';
-import './CompoundButton.scss';
-import '../ButtonCore/ButtonCore.scss';
+import styles from './CompoundButton.scss';
 
 export class CompoundButton extends BaseButton {
-  protected _variantClassName = 'ms-Button--compound';
-
-  protected onRenderIcon() {
-    return null;
-  }
+  protected classNames = {
+    base: 'ms-Button',
+    variant: 'ms-Button--compound',
+    description: styles.description,
+    flexContainer: styles.flexContainer,
+    icon: null,
+    isDisabled: styles.isDisabled,
+    isEnabled: styles.isEnabled,
+    label: styles.label,
+    root: styles.root
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.scss
@@ -1,4 +1,5 @@
 @import '../../../common/common';
+@import '../ButtonCore/ButtonCore';
 @import '../ButtonCore/ButtonCoreVars';
 
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
@@ -8,56 +9,51 @@
 // --------------------------------------------------
 // Default Button styles
 
-:global {
-  .ms-Button.ms-Button--default {
-    background-color: $ms-color-neutralLighter;
-    border: 1px solid $ms-color-neutralLighter;
-    min-width: $button-core-default-minWidth;
-    color: $ms-color-neutralPrimary;
+.root {
+  @include button-core-root-styles;
 
-    .ms-Button-label,
-    .ms-Button-icon {
-      height: $button-core-default-height;
-      line-height: $button-core-default-height;
-    }
+  background-color: $ms-color-neutralLighter;
+  color: $ms-color-neutralPrimary;
 
-    &:hover {
-      background-color: $ms-color-neutralLight;
-      border-color: $ms-color-neutralLight;
-      color: $ms-color-black;
-    }
+  min-width: $button-core-default-minWidth;
+  height: $button-core-default-height;
 
-    &:focus {
-      background-color: $ms-color-neutralLight;
-      border-color: $ms-color-neutralLighter;
-      outline: 1px solid transparent;
-      color: $ms-color-black;
+  font-weight: $ms-font-weight-semibold;
+  font-size: $ms-font-size-m;
+}
 
-    }
+.label {
+  @include button-core-label-styles;
+}
 
-    &:active {
-      background-color: $ms-color-themePrimary;
-      border-color: $ms-color-themePrimary;
-      color: $ms-color-white;
-    }
+.icon {
+  @include button-core-icon-styles;
+}
 
-    .ms-Button-label {
-      font-weight: $ms-font-weight-semibold;
-      font-size: $ms-font-size-m;
-    }
+.isActive {
 
-    &:disabled, &.disabled {
-      @include core-button-disabled;
-    }
+  &:hover {
+    background-color: $ms-color-neutralLight;
+    color: $ms-color-black;
   }
 
-  .ms-Fabric.is-focusVisible .ms-Button {
-    &:focus {
-      color: $ms-color-black;
+  &:active {
+    background-color: $ms-color-themePrimary;
+    color: $ms-color-white;
+  }
+}
 
-      &:before {
-        border-color: $ms-color-themePrimary;
-      }
+.isDisabled {
+  @include button-core-disabled;
+}
+
+
+:global(.ms-Fabric.is-focusVisible) .root {
+  &:focus {
+    color: $ms-color-black;
+
+    &:before {
+      border-color: $ms-color-themePrimary;
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.scss
@@ -1,13 +1,12 @@
-@import '../../../common/common';
-@import '../ButtonCore/ButtonCore';
-@import '../ButtonCore/ButtonCoreVars';
-
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
-
 //
 // Office UI Fabric
 // --------------------------------------------------
 // Default Button styles
+
+@import '../../../common/common';
+@import '../ButtonCore/ButtonCore';
+@import '../ButtonCore/ButtonCoreVars';
 
 .root {
   @include button-core-root-styles;
@@ -30,7 +29,7 @@
   @include button-core-icon-styles;
 }
 
-.isActive {
+.isEnabled {
 
   &:hover {
     background-color: $ms-color-neutralLight;
@@ -47,13 +46,3 @@
   @include button-core-disabled;
 }
 
-
-:global(.ms-Fabric.is-focusVisible) .root {
-  &:focus {
-    color: $ms-color-black;
-
-    &:before {
-      border-color: $ms-color-themePrimary;
-    }
-  }
-}

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.tsx
@@ -3,23 +3,15 @@ import { BaseButton } from '../BaseButton';
 import styles from './DefaultButton.scss';
 
 export class DefaultButton extends BaseButton {
-  protected getRootClassName() {
-    let { disabled } = this.props;
-
-    return css(
-      super.getRootClassName(),
-      'ms-Button--default',
-      styles.root,
-      {
-        [styles.isActive]: !disabled,
-        [styles.isDisabled]: disabled
-      });
-  }
-
-  protected getIconClassName() { return styles.icon; }
-
-  protected getLabelClassName() { return styles.label; }
+  protected classNames = {
+    base: 'ms-Button',
+    variant: 'ms-Button--default',
+    icon: styles.icon,
+    isDisabled: styles.isDisabled,
+    isEnabled: styles.isEnabled,
+    label: styles.label,
+    root: styles.root
+  };
 
   protected onRenderDescription() { return null; }
-
 }

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.tsx
@@ -1,11 +1,25 @@
+import { css } from '../../../Utilities';
 import { BaseButton } from '../BaseButton';
-import './DefaultButton.scss';
-import '../ButtonCore/ButtonCore.scss';
+import styles from './DefaultButton.scss';
 
 export class DefaultButton extends BaseButton {
-  protected _variantClassName = 'ms-Button--default';
+  protected getRootClassName() {
+    let { disabled } = this.props;
 
-  protected onRenderDescription() {
-    return null;
+    return css(
+      super.getRootClassName(),
+      'ms-Button--default',
+      styles.root,
+      {
+        [styles.isActive]: !disabled,
+        [styles.isDisabled]: disabled
+      });
   }
+
+  protected getIconClassName() { return styles.icon; }
+
+  protected getLabelClassName() { return styles.label; }
+
+  protected onRenderDescription() { return null; }
+
 }

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.scss
@@ -1,50 +1,53 @@
-@import '../../../common/common';
-@import '../ButtonCore/ButtonCoreVars';
-
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
+
 //
 // Office UI Fabric
 // --------------------------------------------------
 // Icon Button styles
 
-:global {
+@import '../../../common/common';
+@import '../ButtonCore/ButtonCore';
+@import '../ButtonCore/ButtonCoreVars';
 
-  .ms-Button.ms-Button--icon {
-    @include focus-border(0px);
-    background-color: transparent;
-    color: $ms-color-neutralSecondary;
-    padding: 0 4px;
-    font-size: $ms-icon-size-m;
+$button-iconButtonSize: 40px;
 
-    .ms-Button-label,
-    .ms-Button-icon {
-      height: $button-core-default-height;
-      line-height: $button-core-default-height;
-    }
+.root {
+  @include button-core-root-styles;
 
-    &:hover,
-    &:active {
-      background-color: transparent;
-      color: $ms-color-neutralPrimary;
-    }
+  background-color: transparent;
+  padding: 0 4px;
 
-    &:focus {
-      background-color: transparent;
-    }
+  width: $button-iconButtonSize;
+  height: $button-iconButtonSize;
 
-    &.disabled,
-    &:disabled {
-      color: $ms-color-neutralTertiaryAlt;
-      background-color: transparent;
-    }
+  color: $ms-color-neutralSecondary;
+  font-size: $ms-icon-size-m;
+}
 
-    @media screen and (-ms-high-contrast: active) {
-      color: $ms-color-yellowLight;
-    }
+.icon {
+  @include button-core-icon-styles;
+}
 
-    @media screen and (-ms-high-contrast: black-on-white) {
-      color: $ms-color-blueMid;
-    }
+.isEnabled {
+
+  &:hover {
+    color: $ms-color-themeDarker;
   }
 
+  &:active {
+    color: $ms-color-themePrimary;
+  }
+}
+
+.isDisabled {
+  @include button-core-disabled;
+  background-color: transparent;
+
+  @media screen and (-ms-high-contrast: active) {
+    color: $ms-color-yellowLight;
+  }
+
+  @media screen and (-ms-high-contrast: black-on-white) {
+    color: $ms-color-blueMid;
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.tsx
@@ -1,19 +1,17 @@
 import { BaseButton } from '../BaseButton';
-import './IconButton.scss';
-import '../ButtonCore/ButtonCore.scss';
+import styles from './IconButton.scss';
 
 export class IconButton extends BaseButton {
-  protected _variantClassName = 'ms-Button--icon';
+  protected classNames = {
+    base: 'ms-Button',
+    variant: 'ms-Button--icon',
+    icon: styles.icon,
+    isDisabled: styles.isDisabled,
+    isEnabled: styles.isEnabled,
+    root: styles.root
+  };
 
-  protected onRenderLabel() {
-    return null;
-  }
-
-  protected onRenderDescription() {
-    return null;
-  }
-
-  protected onRenderChildren() {
-    return null;
-  }
+  protected onRenderLabel() { return null; }
+  protected onRenderDescription() { return null; }
+  protected onRenderChildren() { return null; }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.scss
@@ -1,13 +1,12 @@
-@import '../../../common/common';
-@import '../ButtonCore/ButtonCore';
-@import '../ButtonCore/ButtonCoreVars';
-
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
-
 //
 // Office UI Fabric
 // --------------------------------------------------
 // Default Button styles
+
+@import '../../../common/common';
+@import '../ButtonCore/ButtonCore';
+@import '../ButtonCore/ButtonCoreVars';
 
 .root {
   @include button-core-root-styles;
@@ -31,7 +30,7 @@
   @include button-core-icon-styles;
 }
 
-.isActive {
+.isEnabled {
 
   &:hover {
     background-color: $ms-color-themeDark;
@@ -45,14 +44,4 @@
 
 .isDisabled {
   @include button-core-disabled;
-}
-
-.ms-Fabric.is-focusVisible .ms-Button--primary {
-  &:focus {
-    color: $ms-color-white;
-
-    &:before {
-      border-color: $ms-color-themeLighter;
-    }
-  }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.scss
@@ -1,4 +1,5 @@
 @import '../../../common/common';
+@import '../ButtonCore/ButtonCore';
 @import '../ButtonCore/ButtonCoreVars';
 
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
@@ -6,56 +7,52 @@
 //
 // Office UI Fabric
 // --------------------------------------------------
-// Primary Button styles
+// Default Button styles
 
-:global {
+.root {
+  @include button-core-root-styles;
+  @include focus-border(1px, $ms-color-white);
 
-  .ms-Button.ms-Button--primary {
-    @include focus-border(1px, $ms-color-white);
+  background-color: $ms-color-themePrimary;
+  color: $ms-color-white;
 
-    min-width: $button-core-default-minWidth;
-    background-color: $ms-color-themePrimary;
-    border-color: $ms-color-themePrimary;
-    color: $ms-color-white;
+  min-width: $button-core-default-minWidth;
+  height: $button-core-default-height;
 
-    .ms-Button-label,
-    .ms-Button-icon {
-      height: $button-core-default-height;
-      line-height: $button-core-default-height;
-    }
+  font-weight: $ms-font-weight-semibold;
+  font-size: $ms-font-size-m;
+}
 
-    .ms-Button-label {
-      font-weight: $ms-font-weight-semibold;
-      font-size: $ms-font-size-m;
-    }
+.label {
+  @include button-core-label-styles;
+}
 
-    &:hover {
-      background-color: $ms-color-themeDark;
-      border-color: $ms-color-themeDark;
-    }
+.icon {
+  @include button-core-icon-styles;
+}
 
-    &:focus {
-      background-color: $ms-color-themeDark;
-      border-color: $ms-color-themePrimary;
-    }
+.isActive {
 
-    &:active {
-      background-color: $ms-color-themePrimary;
-      border-color: $ms-color-themePrimary;
-    }
-
-    &:disabled, &.disabled {
-      @include core-button-disabled;
-    }
+  &:hover {
+    background-color: $ms-color-themeDark;
   }
 
-  .ms-Fabric.is-focusVisible .ms-Button--primary {
-    &:focus {
-      color: $ms-color-white;
+  &:active {
+    background-color: $ms-color-themePrimary;
+    color: $ms-color-white;
+  }
+}
 
-      &:before {
-        border-color: $ms-color-themeLighter;
-      }
+.isDisabled {
+  @include button-core-disabled;
+}
+
+.ms-Fabric.is-focusVisible .ms-Button--primary {
+  &:focus {
+    color: $ms-color-white;
+
+    &:before {
+      border-color: $ms-color-themeLighter;
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.tsx
@@ -3,22 +3,16 @@ import { BaseButton } from '../BaseButton';
 import styles from './PrimaryButton.scss';
 
 export class PrimaryButton extends BaseButton {
-  protected getRootClassName() {
-    let { disabled } = this.props;
-
-    return css(
-      super.getRootClassName(),
-      'ms-Button--primary',
-      styles.root,
-      {
-        [styles.isActive]: !disabled,
-        [styles.isDisabled]: disabled
-      });
-  }
-
-  protected getIconClassName() { return styles.icon; }
-
-  protected getLabelClassName() { return styles.label; }
+  protected classNames = {
+    base: 'ms-Button',
+    variant: 'ms-Button--primary',
+    icon: styles.icon,
+    isDisabled: styles.isDisabled,
+    isEnabled: styles.isEnabled,
+    label: styles.label,
+    root: styles.root
+  };
 
   protected onRenderDescription() { return null; }
+
 }

--- a/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.tsx
@@ -1,11 +1,24 @@
+import { css } from '../../../Utilities';
 import { BaseButton } from '../BaseButton';
-import './PrimaryButton.scss';
-import '../ButtonCore/ButtonCore.scss';
+import styles from './PrimaryButton.scss';
 
 export class PrimaryButton extends BaseButton {
-  protected _variantClassName = 'ms-Button--primary';
+  protected getRootClassName() {
+    let { disabled } = this.props;
 
-  protected onRenderDescription() {
-    return null;
+    return css(
+      super.getRootClassName(),
+      'ms-Button--primary',
+      styles.root,
+      {
+        [styles.isActive]: !disabled,
+        [styles.isDisabled]: disabled
+      });
   }
+
+  protected getIconClassName() { return styles.icon; }
+
+  protected getLabelClassName() { return styles.label; }
+
+  protected onRenderDescription() { return null; }
 }

--- a/packages/office-ui-fabric-react/src/components/Link/Link.scss
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.scss
@@ -1,48 +1,48 @@
 @import '../../common/common';
 
-:global {
-  .ms-Link {
-    @include ms-baseFont;
+// Element: ms-Link root component
+.root {
+  @include ms-baseFont;
+  color: $ms-color-themePrimary;
+  margin: 0;
+  overflow: inherit;
+  padding: 0;
+  text-overflow: inherit;
+}
+
+// State: The button is not disabled.
+:not(.isDisabled) {
+  &:hover,
+  &:focus {
+    color: $ms-color-themeDarker;
+  }
+
+  &:active {
     color: $ms-color-themePrimary;
-    margin: 0;
-    overflow: inherit;
-    padding: 0;
-    text-overflow: inherit;
-
-    // State: The button is not disabled.
-    &:not(.is-disabled) {
-      &:hover,
-      &:focus {
-        color: $ms-color-themeDarker;
-      }
-
-      &:active {
-        color: $ms-color-themePrimary;
-      }
-    }
-
-    // State: The button is disabled.
-    &.is-disabled {
-      color: $ms-color-neutralTertiary;
-      pointer-events: none;
-      cursor: default;
-    }
   }
+}
 
-  // Link implemented as a button.
-  button.ms-Link {
-    @include focus-border;
-    @include text-align(left);
-    background: none;
-    border: none;
-    cursor: pointer;
-    display: inline;
-    font-size: inherit; // Ensure that we inherit font size, rather than the browser's default.
-  }
+// State: The button is disabled.
+.isDisabled {
+  color: $ms-color-neutralTertiary;
+  pointer-events: none;
+  cursor: default;
+}
 
-  // Link implemented as an anchor.
-  a.ms-Link {
-    @include focus-outline;
-    text-decoration: none;
-  }
+
+// Link implemented as a button.
+button.root {
+  @include focus-border;
+  @include text-align(left);
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: inline;
+  font-size: inherit; // Ensure that we inherit font size, rather than the browser's default.
+}
+
+// Link implemented as an anchor.
+a.root {
+  @include focus-outline;
+  text-decoration: none;
 }

--- a/packages/office-ui-fabric-react/src/components/Link/Link.scss
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.scss
@@ -11,7 +11,7 @@
 }
 
 // State: The button is not disabled.
-:not(.isDisabled) {
+.isEnabled {
   &:hover,
   &:focus {
     color: $ms-color-themeDarker;

--- a/packages/office-ui-fabric-react/src/components/Link/Link.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.tsx
@@ -8,7 +8,7 @@ import {
   getNativeProps
 } from '../../Utilities';
 import { ILink, ILinkProps } from './Link.Props';
-import './Link.scss';
+import styles from './Link.scss';
 
 interface IMyScreen extends Screen {
   left: number;
@@ -27,8 +27,9 @@ export class Link extends BaseComponent<ILinkProps, any> implements ILink {
       href ? (
         <a
           { ...getNativeProps(this.props, anchorProperties) }
-          className={ css('ms-Link', className, {
-            'is-disabled': disabled
+          className={ css('ms-Link', styles.root, className, {
+            'is-disabled': disabled,
+            [styles.isDisabled]: disabled
           }) }
           onClick={ this._onClick }
           ref={ this._resolveRef('_link') }
@@ -39,8 +40,9 @@ export class Link extends BaseComponent<ILinkProps, any> implements ILink {
       ) : (
           <button
             { ...getNativeProps(this.props, buttonProperties) }
-            className={ css('ms-Link', className, {
-              'is-disabled': disabled
+            className={ css('ms-Link', styles.root, className, {
+              'is-disabled': disabled,
+              [styles.isDisabled]: disabled
             }) }
             onClick={ this._onClick }
             ref={ this._resolveRef('_link') }

--- a/packages/office-ui-fabric-react/src/components/Link/Link.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.tsx
@@ -29,7 +29,8 @@ export class Link extends BaseComponent<ILinkProps, any> implements ILink {
           { ...getNativeProps(this.props, anchorProperties) }
           className={ css('ms-Link', styles.root, className, {
             'is-disabled': disabled,
-            [styles.isDisabled]: disabled
+            [styles.isDisabled]: disabled,
+            [styles.isEnabled]: !disabled
           }) }
           onClick={ this._onClick }
           ref={ this._resolveRef('_link') }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement

#### Description of changes

##### Link and Button variants

First, all style definitions have been moved within css modules scoped class names. All class names that were previously on buttons still remain unchanged, so no customizations should be affected. This allows 2 different versions of any Button variant to live on the same page without having rules collide.

In order to make this change I've needed to try and flatten some of the rules to reduce the specificity and nesting.

We also found that the way content was being centered within buttons using inline-block and line-heights was too rigid and caused unexpected issues for partners downstream.

To adjust for thesse issues, the style rules for the variants were also tweaked. Content is now aligned using flexbox, which means more consistent centering when injecting inline, inline-block, or block elements. Second, all line-heights were removed and content now correctly centers within buttons, so if you change the height of the container (e.g. you make CommandButtons render in 36px instead of 40px) things will center correctly.

I've also noticed that IconButton had some colors for hover/active/disabled styling that were not entirely consistent with CommandButton. I've modified some of the rules to make it as consistent as possible.
