### PR TITLE
Adding alertdialog role for confirmation dialog

### DIFF
--- a/common/changes/alert-dialog_2017-02-20-10-12.json
+++ b/common/changes/alert-dialog_2017-02-20-10-12.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dialog: Accessibility fix for confirmation dialogs",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
@@ -112,7 +112,7 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
       return (
         <Layer onLayerDidMount={ onLayerMounted || onLayerDidMount }>
           <Popup
-            role='dialog'
+            role={ isBlocking ? 'alertdialog' : 'dialog' }
             ariaLabelledBy={ title ? id + '-title' : '' }
             ariaDescribedBy={ subText ? id + '-subText' : '' }
             onDismiss={ onDismiss }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] bugfix,
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes
Modal dialogs which requires immediate user attention should have role='alertdialog'. Using isBlocking prop as an indication to set the role.
https://www.w3.org/TR/wai-aria-practices-1.1/#alertdialog 

#### Focus areas to test
<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
