### PR TITLE
Image: Check cache availability before rendering images as initially hidden

### DIFF
--- a/common/changes/image-cache_2017-02-21-09-17.json
+++ b/common/changes/image-cache_2017-02-21-09-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add cache check when mounting or changing Image",
+      "type": "patch"
+    }
+  ],
+  "email": "asmundg@big-oil.org"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1041
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Before assuming that there is a delay before an image can be shown, check if it exists in local cache. If it does, make the image visible immediately, instead of hiding it until the onLoad event.

This removes the textboy flicker when mounting Personas with cached profile images.

#### Focus areas to test

Persona, Image. See http://codepen.io/asmundg/pen/YNoaRG.
