### PR TITLE
Fix a logic check issue in function isElementTabbable of focus.ts

### DIFF
--- a/common/changes/luh-fix-issue-1098_2017-02-23-14-13.json
+++ b/common/changes/luh-fix-issue-1098_2017-02-23-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Fix a logic check issue in function isElementTabbable of focus.ts",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "email": "luh@microsoft.com"
+}

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -175,8 +175,9 @@ export function isElementTabbable(element: HTMLElement): boolean {
       (element.tagName === 'TEXTAREA') ||
       (tabIndex >= 0) ||
       (element.getAttribute && (
-        isFocusableAttribute === 'true') ||
-        element.getAttribute('role') === 'button')
+        isFocusableAttribute === 'true' ||
+        element.getAttribute('role') === 'button'
+      ))
     ));
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1098 
- [x] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

function isElementTabbable(element: HTMLElement) of focus.ts will raise error "Uncaught TypeError: element.getAttribute is not a function" when element is document. This is caused by the logic error in focus.ts at line 177 - 179. The change is to fix this issue. 

#### Focus areas to test

FocusZone
