### PR TITLE
add aria-sort to column header of detailsList

### DIFF
--- a/common/changes/fix-detailsListAria_2017-02-24-07-03.json
+++ b/common/changes/fix-detailsListAria_2017-02-24-07-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "move aria-sort attr of detailsList headerColum to the right place",
+      "type": "patch"
+    }
+  ],
+  "email": "ssivam@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -135,7 +135,10 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
           { GroupSpacer({ count: groupNestingDepth - 1 }) }
           { columns.map((column, columnIndex) => (
             <div key={ column.key } className='ms-DetailsHeader-cellSizeWrapper'>
-              <div className='ms-DetailsHeader-cellWrapper' role='columnheader'>
+              <div
+                className='ms-DetailsHeader-cellWrapper'
+                role='columnheader'
+                aria-sort={ column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none' }>
                 <button
                   key={ column.fieldName }
                   disabled={ column.columnActionsMode === ColumnActionsMode.disabled }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #970
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] bugfix

#### Description of changes

I an earlier [PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/1027), I removed aria-sort from button as it was not supposed to be there. now adding it back to the right place.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
