### PR TITLE
Make panel top padding on by default and disable via specific prop

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -184,6 +184,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           isLightDismiss={ true }
           onDismissed={ this._onDismiss }
           hasCloseButton={ false }
+          hasTopPadding={ false }
         >
           { onRenderList(props, this._onRenderList) }
         </Panel>

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
@@ -15,6 +15,12 @@ export interface IPanelProps extends React.Props<Panel> {
   hasCloseButton?: boolean;
 
   /**
+  * Has top padding needed to show the close button
+  * @default true
+  */
+  hasTopPadding?: boolean;
+
+  /**
   * Whether the panel can be light dismissed.
   * @default false
   */

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.scss
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.scss
@@ -204,7 +204,7 @@ $CommandBarHeight: 40px;
 }
 
 // Scrollable content area
-.contentInner {
+.inner {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -213,7 +213,7 @@ $CommandBarHeight: 40px;
   padding: 0 16px 20px;
   overflow-y: auto;
 
-  .rootHasCloseButton & {
+  &.innerHasTopPadding {
     top: $CommandBarHeight;
   }
 

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -39,6 +39,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
     isOpen: false,
     isBlocking: true,
     hasCloseButton: true,
+    hasTopPadding: true,
     type: PanelType.smallFixedFar,
   };
 
@@ -82,6 +83,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
       className = '',
       type,
       hasCloseButton,
+      hasTopPadding,
       isLightDismiss,
       isBlocking,
       headerText,
@@ -155,8 +157,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
                 ['ms-Panel--md ' + styles.rootIsMedium]: type === PanelType.medium,
                 ['ms-Panel--lg ' + styles.rootIsLarge]: type === PanelType.large || type === PanelType.largeFixed,
                 ['ms-Panel--fixed ' + styles.rootIsFixed]: type === PanelType.largeFixed,
-                ['ms-Panel--xl ' + styles.rootIsXLarge]: type === PanelType.extraLarge,
-                ['ms-Panel--hasCloseButton ' + styles.rootHasCloseButton]: hasCloseButton
+                ['ms-Panel--xl ' + styles.rootIsXLarge]: type === PanelType.extraLarge
               })
             }
           >
@@ -182,7 +183,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
                 { pendingCommandBarContent }
                 { closeButton }
               </div>
-              <div className={ css('ms-Panel-contentInner', styles.contentInner) }>
+              <div className={ css('ms-Panel-contentInner', styles.inner, hasTopPadding && styles.innerHasTopPadding) }>
                 { header }
                 <div className={ css('ms-Panel-content') }>
                   { children }


### PR DESCRIPTION
I made the assumption that if a panel didn't have a close button, that it wouldn't want the top padding used to push content down below the close button....

Wrong assumption...

So, removing the padding isn't tied to `hasCloseButton` but rather a unique prop called `hasTopPadding`. 

This prop is already used in dropdown (in mobile view) as well as will be used in dialog (in mobile). So makes sense for this to not be some manual css override. 