### PR TITLE
Image: Assume images are portraits until proven otherwise

### DIFF
--- a/common/changes/unbreak-visible-image-mount-size_2017-03-02-06-40.json
+++ b/common/changes/unbreak-visible-image-mount-size_2017-03-02-06-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Assume images are portraits until proven otherwise",
+      "type": "patch"
+    }
+  ],
+  "email": "asmundg@big-oil.org"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -42,6 +42,9 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
 
   private static _svgRegex = /\.svg$/i;
 
+  // Make an initial assumption about the image layout until we can
+  // check the rendered element. The value here only takes effect when
+  // shouldStartVisible is true.
   private _coverStyle: CoverStyle = CoverStyle.portrait;
   private _imageElement: HTMLImageElement;
   private _frameElement: HTMLDivElement;

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -42,7 +42,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
 
   private static _svgRegex = /\.svg$/i;
 
-  private _coverStyle: CoverStyle;
+  private _coverStyle: CoverStyle = CoverStyle.portrait;
   private _imageElement: HTMLImageElement;
   private _frameElement: HTMLDivElement;
 
@@ -93,7 +93,7 @@ export class Image extends BaseComponent<IImageProps, IImageState> {
           key={ KEY_PREFIX + this.props.src || '' }
           className={
             css('ms-Image-image',
-              (coverStyle !== undefined) && CoverStyleMap[coverStyle],
+              CoverStyleMap[coverStyle],
               (imageFit !== undefined) && ImageFitMap[imageFit], {
                 'is-fadeIn': shouldFadeIn,
                 'is-notLoaded': !loaded,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1165
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] bugfix
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Assume images are portrait until the onLoad event has fired. This stops us from rendering unscaled images when shouldStartVisible is in use. When shouldStartVisible is false, this has no effect, as we don't render the image until after onLoad.

#### Focus areas to test

Persona, Image.
