### PR TITLE
#1128 -- Fixes missing truncation in IE 11 for Persona text

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -229,6 +229,7 @@ $ms-Persona-presenceSizeXl: 28px;
 .details {
   @include padding(0, 24px, 0, 12px);
   min-width: 0;
+  width: 100%;
   @include text-align(left);
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1128 
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Allows Person text fields to expand and trigger truncation in IE 11

#### Focus areas to test

Largest Persona option in narrow browser

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
