### PR TITLE
Tayoun/commandbar items onrender

### DIFF
--- a/common/changes/tayoun-commandbar-items-onrender_2017-03-12-02-46.json
+++ b/common/changes/tayoun-commandbar-items-onrender_2017-03-12-02-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding support for IContextualMenuItem onRender in CommadBar",
+      "type": "patch"
+    }
+  ],
+  "email": "tayoun@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -174,8 +174,7 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
       { (() => {
         if (item.onRender) {
           return item.onRender(item);
-        }
-        else if (item.onClick || hasSubmenuItems(item)) {
+        } else if (item.onClick || hasSubmenuItems(item)) {
           return <button
             { ...getNativeProps(item, buttonProperties) }
             id={ this._id + item.key }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -172,7 +172,10 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
 
     return <div className={ css('ms-CommandBarItem', styles.item, item.className) } key={ itemKey } ref={ itemKey }>
       { (() => {
-        if (item.onClick || hasSubmenuItems(item)) {
+        if (item.onRender) {
+          return item.onRender(item);
+        }
+        else if (item.onClick || hasSubmenuItems(item)) {
           return <button
             { ...getNativeProps(item, buttonProperties) }
             id={ this._id + item.key }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ X ] New feature, bugfix, or enhancement
- [ ] Includes tests
- [ ] Documentation update

#### Description of changes
Adding support for IContextualMenuItem onRender in CommadBar. This will enable support for a menu item to render items other than a div or button, such as a SearchBox. This is necessary with the deprecation of the built in SearchBox.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
