### PR TITLE
People Picker: Add render overrides

### DIFF
--- a/apps/fabric-examples/src/pages/PersonaPage/PersonaPage.tsx
+++ b/apps/fabric-examples/src/pages/PersonaPage/PersonaPage.tsx
@@ -7,9 +7,11 @@ import {
 } from '@uifabric/example-app-base';
 import { PersonaInitialsExample } from './examples/Persona.Initials.Example';
 import { PersonaBasicExample } from './examples/Persona.Basic.Example';
+import { PersonaCustomRenderExample } from './examples/Persona.CustomRender.Example';
 
 const PersonaInitialsExampleCode = require('./examples/Persona.Initials.Example.tsx') as string;
 const PersonaBasicExampleCode = require('./examples/Persona.Basic.Example.tsx') as string;
+const PersonaCustomRenderExampleCode = require('./examples/Persona.CustomRender.Example.tsx') as string;
 
 export class PersonaPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -24,6 +26,9 @@ export class PersonaPage extends React.Component<IComponentDemoPageProps, {}> {
             </ExampleCard>
             <ExampleCard title='Persona in initials' code={ PersonaInitialsExampleCode }>
               <PersonaInitialsExample />
+            </ExampleCard>
+            <ExampleCard title='Rendering custom persona text' code={ PersonaCustomRenderExampleCode }>
+              <PersonaCustomRenderExample />
             </ExampleCard>
           </div>
         }

--- a/apps/fabric-examples/src/pages/PersonaPage/examples/Persona.CustomRender.Example.tsx
+++ b/apps/fabric-examples/src/pages/PersonaPage/examples/Persona.CustomRender.Example.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import {
+  autobind,
+  css
+} from 'office-ui-fabric-react/lib/Utilities';
+import {
+  IPersonaProps,
+  Persona,
+  PersonaSize,
+  PersonaPresence
+} from 'office-ui-fabric-react/lib/Persona';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import './PersonaExample.scss';
+
+const examplePersona = {
+  imageUrl: './images/persona-female.png',
+  imageInitials: 'AL',
+  primaryText: 'Annie Lindqvist',
+  secondaryText: 'Software Engineer',
+  tertiaryText: 'In a meeting',
+  optionalText: 'Available at 4:00pm'
+};
+
+export class PersonaCustomRenderExample extends React.Component<React.Props<PersonaCustomRenderExample>, any> {
+  constructor() {
+    super();
+  }
+
+  public render() {
+    return (
+      <div>
+        <Persona
+          { ...examplePersona }
+          size={ PersonaSize.large }
+          presence={ PersonaPresence.offline }
+          onRenderSecondaryText={ this._onRenderSecondaryText }
+        />
+      </div>
+    );
+  }
+
+  @autobind
+  private _onRenderSecondaryText(props: IPersonaProps): JSX.Element {
+    return (
+      <div>
+        <Icon iconName={ 'Suitcase' } className={ 'ms-JobIconExample' } />
+        { props.secondaryText }
+      </div>
+    );
+  }
+}

--- a/apps/fabric-examples/src/pages/PersonaPage/examples/PersonaExample.scss
+++ b/apps/fabric-examples/src/pages/PersonaPage/examples/PersonaExample.scss
@@ -1,0 +1,3 @@
+.ms-JobIconExample {
+  margin-right: 5px;
+}

--- a/common/changes/add-people-picker-override_2017-03-13-10-20.json
+++ b/common/changes/add-people-picker-override_2017-03-13-10-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "PeoplePicker: Add rendering overrides",
+      "type": "minor"
+    }
+  ],
+  "email": "hross@hross.net"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
@@ -9,6 +9,11 @@ export interface IPersonaProps extends React.HTMLProps<Persona> {
   primaryText?: string;
 
   /**
+   * Optional custom renderer for the primary text.
+   */
+  onRenderPrimaryText?: IRenderFunction<IPersonaProps>;
+
+  /**
    * Decides the size of the control.
    * @defaultvalue PersonaSize.regular
    */
@@ -60,14 +65,29 @@ export interface IPersonaProps extends React.HTMLProps<Persona> {
   secondaryText?: string;
 
   /**
+   * Optional custom renderer for the secondary text.
+   */
+  onRenderSecondaryText?: IRenderFunction<IPersonaProps>;
+
+  /**
    * Tertiary text to display, usually the status of the user.
    */
   tertiaryText?: string;
 
   /**
+   * Optional custom renderer for the tertiary text.
+   */
+  onRenderTertiaryText?: IRenderFunction<IPersonaProps>;
+
+  /**
    * Optional text to display, usually a custom message set.
    */
   optionalText?: string;
+
+  /**
+   * Optional custom renderer for the optional text.
+   */
+  onRenderOptionalText?: IRenderFunction<IPersonaProps>;
 
   /**
    * Whether to not render persona details, and just render the persona image/initials.

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -5,7 +5,8 @@ import {
   divProperties,
   getInitials,
   getNativeProps,
-  getRTL
+  getRTL,
+  IRenderFunction
 } from '../../Utilities';
 import { Image, ImageFit, ImageLoadState } from '../../Image';
 import {
@@ -75,6 +76,10 @@ export class Persona extends React.Component<IPersonaProps, IPersonaState> {
       hidePersonaDetails,
       imageShouldFadeIn,
       onRenderInitials = this._onRenderInitials,
+      onRenderPrimaryText,
+      onRenderSecondaryText,
+      onRenderTertiaryText,
+      onRenderOptionalText,
       imageShouldStartVisible
     } = this.props;
 
@@ -106,12 +111,22 @@ export class Persona extends React.Component<IPersonaProps, IPersonaState> {
 
     let divProps = getNativeProps(this.props, divProperties);
     let personaDetails = <div className={ css('ms-Persona-details', styles.details) }>
-      <div className={ css('ms-Persona-primaryText', styles.primaryText) }>{ primaryText }</div>
-      { secondaryText ? (
-        <div className={ css('ms-Persona-secondaryText', styles.secondaryText) }>{ secondaryText }</div>
-      ) : (null) }
-      <div className={ css('ms-Persona-tertiaryText', styles.tertiaryText) }>{ tertiaryText }</div>
-      <div className={ css('ms-Persona-optionalText', styles.optionalText) }>{ optionalText }</div>
+      { this._renderElement(
+        this.props.primaryText,
+        css('ms-Persona-primaryText', styles.primaryText),
+        onRenderPrimaryText) }
+      { this._renderElement(
+        this.props.secondaryText,
+        css('ms-Persona-secondaryText', styles.secondaryText),
+        onRenderSecondaryText) }
+      { this._renderElement(
+        this.props.tertiaryText,
+        css('ms-Persona-tertiaryText', styles.tertiaryText),
+        onRenderTertiaryText) }
+      { this._renderElement(
+        this.props.optionalText,
+        css('ms-Persona-optionalText', styles.optionalText),
+        onRenderOptionalText) }
       { this.props.children }
     </div>;
 
@@ -148,6 +163,15 @@ export class Persona extends React.Component<IPersonaProps, IPersonaState> {
         ) }
         { presenceElement }
         { (!hidePersonaDetails || (size === PersonaSize.tiny)) && personaDetails }
+      </div>
+    );
+  }
+
+  @autobind
+  private _renderElement(text: string, className: string, render?: IRenderFunction<IPersonaProps>): JSX.Element {
+    return (
+      <div className={ className }>
+        { render ? render(this.props) : text }
       </div>
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1200
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement
- [x] Documentation update

#### Description of changes

Added overrides to the PeoplePicker so you can change the rendered text. This could be useful for showing icons (as in the added example) or to change screen reader text (as in the referenced issue).