### PR TITLE
Callout: Adding class to body

### DIFF
--- a/common/changes/callout-body-class_2017-03-14-16-24.json
+++ b/common/changes/callout-body-class_2017-03-14-16-24.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout: Adding 'ms-Callout__Body--open' class to the body tag.",
+      "type": "minor"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "ihor3000@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -18,6 +18,7 @@ import { getRelativePositions, IPositionInfo, IPositionProps, getMaxHeight } fro
 import { Popup } from '../../Popup';
 import styles from './Callout.scss';
 
+const BODY_CLASS = 'ms-Callout__Body--open';
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 const OFF_SCREEN_STYLE = { opacity: 0 };
 const BORDER_WIDTH: number = 1;
@@ -81,6 +82,11 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
   }
   public componentDidMount() {
     this._onComponentDidMount();
+    document.body.classList.add(BODY_CLASS);
+  }
+
+  public componentWillUnmount() {
+    document.body.classList.remove(BODY_CLASS);
   }
 
   public render() {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [ ] Include a change request file if publishing <!-- see notes below -->
- [x] New feature
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Now **Callout** is adding `ms-Callout__Body--open` class to the `body` tag. You can use this to remove scrolling on the the body while the **Callout** is open.

```css
/* Remove scroll on the body when Callout is open */
.ms-Callout__Body--open {
    overflow: hidden;
}
```

Inspired by [react-modal](https://github.com/reactjs/react-modal#body-class).