### PR TITLE
TextField: Fix duplicate onChanged triggers

### DIFF
--- a/common/changes/textfield-multipletrigger_2017-03-15-11-01.json
+++ b/common/changes/textfield-multipletrigger_2017-03-15-11-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: Fix for multiple onChanged calls",
+      "type": "patch"
+    }
+  ],
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -340,9 +340,11 @@ describe('TextField', () => {
     const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
 
     ReactTestUtils.Simulate.input(inputDOM, mockEvent('value change'));
+    ReactTestUtils.Simulate.change(inputDOM, mockEvent('value change'));
     expect(callCount).to.equal(1);
 
     ReactTestUtils.Simulate.input(inputDOM, mockEvent(''));
+    ReactTestUtils.Simulate.change(inputDOM, mockEvent(''));
     expect(callCount).to.equal(2);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -48,6 +48,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
   private _delayedValidate: (value: string) => void;
   private _isMounted: boolean;
   private _lastValidation: number;
+  private _latestValue;
   private _latestValidateValue;
   private _isDescriptionAvailable: boolean;
   private _textElement: HTMLInputElement | HTMLTextAreaElement;
@@ -97,6 +98,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         onBeforeChange(newProps.value);
       }
 
+      this._latestValue = newProps.value;
       this.setState({
         value: newProps.value,
         errorMessage: ''
@@ -282,9 +284,13 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
   private _onInputChange(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>): void {
     const element: HTMLInputElement = event.target as HTMLInputElement;
     const value: string = element.value;
-    if (value === this.state.value) {
+
+    // HACK: skip validation given both onInput and onChange are attached
+    // https://github.com/OfficeDev/office-ui-fabric-react/issues/824
+    if (value === this._latestValue) {
       return;
     }
+    this._latestValue = value;
 
     this.setState({
       value: value,

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -285,8 +285,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     const element: HTMLInputElement = event.target as HTMLInputElement;
     const value: string = element.value;
 
-    // HACK: skip validation given both onInput and onChange are attached
-    // https://github.com/OfficeDev/office-ui-fabric-react/issues/824
+    // Avoid doing unnecessary work when the value has not changed.
     if (value === this._latestValue) {
       return;
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1270 
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] bugfix
  - [x] Includes tests
- [ ] Documentation update

#### Description of changes
TextField uses both onChange and onInput handlers internally due to IE10 document mode issue for sharepoint. Having both handlers we should skip validation and setState for one of the calls. Currently it checks latest value with `this.state.value` which may not be the updated since setState call is async in React. 

Using internal variable to match against last latest value.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
