### PR TITLE
DetailsHeader: fix iconClassName to be pushed into Icon correctly, add iconName.

### DIFF
--- a/common/changes/fix-header_2017-03-17-16-38.json
+++ b/common/changes/fix-header_2017-03-17-16-38.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: header sizing fixed (was a css selector tweak that caused the issue.) Also added `iconName` to IColumn to specify an iconName like \"Mail\". The `iconClassName` property is still preserved, but is piped into the className of the Icon component.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -38,7 +38,9 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
 
 button.cell {
   @include ms-font-s;
+}
 
+.cell {
   background: transparent;
   color: $disabledForegroundColor;
   @include focus-border();
@@ -80,6 +82,7 @@ button.cell {
   &.cellIsSizer {
     position: absolute;
     width: 16px;
+
     @include margin-left(-10px);
     cursor: ew-resize;
     bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -185,8 +185,9 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                   <Icon className={ styles.nearIcon } iconName='GroupedDescending' />
                 ) }
 
+                /* Note: due to backwards compat, we are locking this to the old "" */
                 { column.iconClassName && (
-                  <Icon className={ styles.nearIcon } iconName={ column.iconClassName as any } />
+                  <Icon className={ css(styles.nearIcon, column.iconClassName) } iconName={ column.iconName } />
                 ) }
 
                 { column.name }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -185,7 +185,6 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                   <Icon className={ styles.nearIcon } iconName='GroupedDescending' />
                 ) }
 
-                /* Note: due to backwards compat, we are locking this to the old "" */
                 { column.iconClassName && (
                   <Icon className={ css(styles.nearIcon, column.iconClassName) } iconName={ column.iconName } />
                 ) }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -206,7 +206,12 @@ export interface IColumn {
   columnActionsMode?: ColumnActionsMode;
 
   /**
-   * Icon name to show in addition to the text.
+   * Optional iconName to use for the column header.
+   */
+  iconName?: string;
+
+  /**
+   * Class name to add to the Icon component.
    */
   iconClassName?: string;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -9,6 +9,7 @@ import {
   IDragDropEvents,
   IDragDropContext,
 } from './../../utilities/dragdrop/index';
+import { IconName } from '../../Icon';
 import {
   IGroup,
   IGroupRenderProps
@@ -208,7 +209,7 @@ export interface IColumn {
   /**
    * Optional iconName to use for the column header.
    */
-  iconName?: string;
+  iconName?: IconName;
 
   /**
    * Class name to add to the Icon component.

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.Props.ts
@@ -3,7 +3,7 @@ import { IconName } from './IconName';
 import { IconType } from './IconType';
 import { IImageProps } from '../Image/Image.Props';
 export interface IIconProps extends React.HTMLProps<HTMLElement> {
-  iconName: IconName;
+  iconName?: IconName;
   iconType?: IconType;
   imageProps?: IImageProps;
 }

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -13,6 +13,7 @@ import {
 
 export const Icon: (props: IIconProps) => JSX.Element = (props: IIconProps) => {
   let customIcon = props.iconName === 'None';
+  let iconClassName = props.iconName ? ('ms-Icon--' + props.iconName) : '';
 
   if (props.iconType === IconType.Image) {
     let containerClassName = css('ms-Icon', 'ms-Icon-imageContainer', styles.imageContainer, props.className);
@@ -23,7 +24,7 @@ export const Icon: (props: IIconProps) => JSX.Element = (props: IIconProps) => {
       </div>
     );
   } else {
-    let className = css('ms-Icon', customIcon ? '' : ('ms-Icon--' + props.iconName), props.className);
+    let className = css('ms-Icon', customIcon ? '' : iconClassName, props.className);
 
     return <i { ...getNativeProps(props, htmlElementProperties) } className={ className } />;
   }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement
- [X] Documentation update

#### Description of changes

IColumn has an `iconClassName` property, which was getting pushed into Icon as the iconName. This is incorrect; it should be pushed into the className, but in addition, we can expose iconName.

Also made Icon's `iconName` optional and made it gracefully handle blank/undefined iconName values in the case one isn't passed.

