### PR TITLE
Providing a Button solution for issue #1329

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -87,8 +87,8 @@ export class BaseButton extends BaseComponent<IButtonProps, IBaseButtonState> im
         className: css(
           styles.root,
           this.props.className,
-          this.classNames.base,
-          this.classNames.variant,
+          this.props.useOnlyHashedClassNames ? '' : this.classNames.base,
+          this.props.useOnlyHashedClassNames ? '' : this.classNames.variant,
           this.classNames.root,
           {
             'disabled': disabled,
@@ -129,7 +129,7 @@ export class BaseButton extends BaseComponent<IButtonProps, IBaseButtonState> im
     return React.createElement(
       tag,
       buttonProps,
-      React.createElement('div', { className: css(this.classNames.base + '-flexContainer', styles.flexContainer, this.classNames.flexContainer) },
+      React.createElement('div', { className: css(`${this.composeCssForNonHashedProperties('-flexContainer')}`, styles.flexContainer, this.classNames.flexContainer) },
         this.onRenderIcon(),
         this.onRenderLabel(),
         this.onRenderDescription(),
@@ -144,7 +144,7 @@ export class BaseButton extends BaseComponent<IButtonProps, IBaseButtonState> im
     const { icon } = this.props;
 
     return icon && (
-      <span className={ css(`${this.classNames.base}-icon`, this.classNames.icon) }>
+      <span className={ css(`${this.composeCssForNonHashedProperties('-icon')}`, this.classNames.icon) }>
         <i className={ `ms-Icon ms-Icon--${icon}` } />
       </span>
     );
@@ -159,7 +159,7 @@ export class BaseButton extends BaseComponent<IButtonProps, IBaseButtonState> im
     }
 
     return text && (
-      <span className={ css(`${this.classNames.base}-label`, this.classNames.label) } id={ this._labelId } >
+      <span className={ css(`${this.composeCssForNonHashedProperties('-label')}`, this.classNames.label) } id={ this._labelId } >
         { text }
       </span>
     );
@@ -184,7 +184,7 @@ export class BaseButton extends BaseComponent<IButtonProps, IBaseButtonState> im
     // In other cases it will not be displayed.
     return description ? (
       <span
-        className={ css(`${this.classNames.base}-description`, this.classNames.description) }
+        className={ css(`${this.composeCssForNonHashedProperties('-description')}`, this.classNames.description) }
         id={ this._descriptionId }
       >
         { description }
@@ -204,6 +204,15 @@ export class BaseButton extends BaseComponent<IButtonProps, IBaseButtonState> im
     ) : (
         null
       );
+  }
+
+  private composeCssForNonHashedProperties(appendToBase: string) {
+    if (this.props.useOnlyHashedClassNames) {
+      return "";
+    }
+    else {
+      return `${this.classNames.base}${appendToBase}`;
+    }
   }
 
   @autobind

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -77,6 +77,12 @@ export interface IButtonProps extends React.HTMLProps<HTMLButtonElement | HTMLAn
   description?: string;
 
   /**
+   * Use only hashed class names.
+   * Drops any class like ms-Button*
+   */
+  useOnlyHashedClassNames?: boolean;
+
+  /**
    * The type of button to render.
    * @defaultvalue ButtonType.default
    * @deprecated


### PR DESCRIPTION

Providing a Button solution for issue #1329

When having building your own component that is integrated in webpages that also use Fabric UI we are getting into collision madness.

This provides a possible an easy solution to disable collisions, while there is not the full solution in place. By making it possible to avoid customization through non-hashed classes.

#### Focus areas to test

Everything should work as before. But when provided the boolean value, ms-Button-* classes should go away.
