### PR TITLE
Updated panel title to use correct lineheight

### DIFF
--- a/common/changes/master_2017-03-23-19-07.json
+++ b/common/changes/master_2017-03-23-19-07.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Title text updated with correct lineheight and removed overflow styles",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.scss
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.scss
@@ -268,8 +268,6 @@ $CommandBarHeight: 40px;
 .headerText {
   @include ms-font-xl;
   color: $ms-color-neutralPrimary;
-  line-height: 1;
+  line-height: 32px;
   margin: 0;
-  text-overflow: ellipsis;
-  overflow: hidden;
 }


### PR DESCRIPTION
As per design, updated panel title to use correct lineheight. Remove unnecessary overflow styles
