### PR TITLE
#1334 -- CommandBar: Fixes ugly focus border when clicked (Chrome/Mac)

### DIFF
--- a/common/changes/1334_CommandBarBrokenStyles_2017-03-23-23-19.json
+++ b/common/changes/1334_CommandBarBrokenStyles_2017-03-23-23-19.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes ugly focus border when clicked (Chrome/Mac)",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "v-algemb@microsoft.com"
+}

--- a/common/changes/1334_CommandBarBrokenStyles_2017-03-23-23-19.json
+++ b/common/changes/1334_CommandBarBrokenStyles_2017-03-23-23-19.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fixes ugly focus border when clicked (Chrome/Mac)",
+      "comment": "CommandBar: Fixes ugly focus border when clicked (Chrome/Mac)",
       "type": "patch"
     },
     {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
@@ -88,6 +88,7 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
 }
 
 @mixin CommandBarItem-text {
+  @include focus-border(2px);
   @include ms-font-m;
   color: $ms-color-neutralPrimary;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #1334
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

 Fixes ugly focus border when clicked (Chrome/Mac)

#### Focus areas to test

CommandBar

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
