### PR TITLE
SCSS imports now transpile correctly for AMD.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,6 @@
     "**/.DS_Store": true,
     "**/bower_components": true,
     "**/coverage": true,
-    "**/lib-amd": true,
     "**/*.scss.ts": true
   },
   // Configure glob patterns for excluding files and folders in searches. Inherits all glob patterns from the file.exclude setting.

--- a/apps/fabric-website/src/components/CodeBlock/CodeBlock.tsx
+++ b/apps/fabric-website/src/components/CodeBlock/CodeBlock.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-const styles: any = require('./CodeBlock.module.scss');
+import styles = require('./CodeBlock.module.scss');
 
 const Highlight = require('react-highlight');
 

--- a/apps/fabric-website/src/components/ColorTable/ColorTable.tsx
+++ b/apps/fabric-website/src/components/ColorTable/ColorTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-const styles: any = require('./ColorTable.module.scss');
+import styles = require('./ColorTable.module.scss');
 
 export interface IColorTableProps {
   /**

--- a/apps/fabric-website/src/components/IconGrid/IconGrid.tsx
+++ b/apps/fabric-website/src/components/IconGrid/IconGrid.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
-const styles: any = require('./IconGrid.module.scss');
+import styles = require('./IconGrid.module.scss');
 
 export interface IIconGridProps {
   /**

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-const styles: any = require('./Nav.module.scss');
+import styles = require('./Nav.module.scss');
 import {
   INavProps,
   INavPage

--- a/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
+++ b/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css, BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
-const styles: any = require('./PageHeader.module.scss');
+import styles = require('./PageHeader.module.scss');
 import { getPageRouteFromState } from '../../utilities/pageroute';
 import { PageHeaderLink } from '../../components/PageHeaderLink/PageHeaderLink';
 

--- a/apps/fabric-website/src/components/Table/Table.tsx
+++ b/apps/fabric-website/src/components/Table/Table.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AnimationCell } from './AnimationCell/AnimationCell';
-const styles: any = require('./Table.module.scss');
+import styles = require('./Table.module.scss');
 
 export interface ITableProps {
   content: any;

--- a/apps/fabric-website/src/pages/BlogPage/BlogPage.tsx
+++ b/apps/fabric-website/src/pages/BlogPage/BlogPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PageHeader } from '../../components/PageHeader/PageHeader';
 import { BlogItem } from './BlogItem';
-const styles: any = require('./BlogPage.module.scss');
+import styles = require('./BlogPage.module.scss');
 
 const blogData = require('json!../../data/blog-posts.json');
 

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -4,7 +4,7 @@ import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { PageHeader } from '../../components/PageHeader/PageHeader';
 
 const diagramStyles: any = require('./GetStartedPage.diagram.module.scss');
-const styles: any = require('./GetStartedPage.module.scss');
+import styles = require('./GetStartedPage.module.scss');
 
 export class GetStartedPage extends React.Component<any, any> {
   public render() {

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-const styles: any = require('./HomePage.module.scss');
+import styles = require('./HomePage.module.scss');
 
 const packageData = require('json!../../../package.json');
 

--- a/apps/fabric-website/src/pages/Interstitials/AngularJSPage.tsx
+++ b/apps/fabric-website/src/pages/Interstitials/AngularJSPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-const styles: any = require('./Interstitials.module.scss');
+import styles = require('./Interstitials.module.scss');
 
 export class AngularJSPage extends React.Component<any, any> {
   public render() {

--- a/apps/fabric-website/src/pages/Interstitials/FabricIOSPage.tsx
+++ b/apps/fabric-website/src/pages/Interstitials/FabricIOSPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-const styles: any = require('./Interstitials.module.scss');
+import styles = require('./Interstitials.module.scss');
 
 export class FabricIOSPage extends React.Component<any, any> {
   public render() {

--- a/apps/fabric-website/src/pages/Interstitials/FabricJSPage.tsx
+++ b/apps/fabric-website/src/pages/Interstitials/FabricJSPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-const styles: any = require('./Interstitials.module.scss');
+import styles = require('./Interstitials.module.scss');
 
 export class FabricJSPage extends React.Component<any, any> {
   public render() {

--- a/apps/fabric-website/src/pages/Overviews/ComponentsPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/ComponentsPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { PageHeader } from '../../components/PageHeader/PageHeader';
-const styles: any = require('./Overviews.module.scss');
+import styles = require('./Overviews.module.scss');
 
 export class ComponentsPage extends React.Component<any, any> {
   public render() {

--- a/apps/fabric-website/src/pages/Overviews/StylesPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/StylesPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { PageHeader } from '../../components/PageHeader/PageHeader';
-const styles: any = require('./Overviews.module.scss');
+import styles = require('./Overviews.module.scss');
 
 export class StylesPage extends React.Component<any, any> {
   public render() {

--- a/apps/fabric-website/src/pages/ResourcesPage/ResourcesPage.tsx
+++ b/apps/fabric-website/src/pages/ResourcesPage/ResourcesPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { PageHeader } from '../../components/PageHeader/PageHeader';
-const styles: any = require('./ResourcesPage.module.scss');
+import styles = require('./ResourcesPage.module.scss');
 
 export class ResourcesPage extends React.Component<any, any> {
   public render() {

--- a/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../../components/CodeBlock/CodeBlock';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 import { Table } from '../../../components/Table/Table';
 import { IconGrid } from '../../../components/IconGrid/IconGrid';
-const styles: any = require('./BrandIconsPage.module.scss');
+import styles = require('./BrandIconsPage.module.scss');
 const pageStyles: any = require('../../PageStyles.module.scss');
 
 const svgResolutionData = require('json!../../../data/brand-icons-svg-resolutions.json');

--- a/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ColorTable } from '../../../components/ColorTable/ColorTable';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 import { Table } from '../../../components/Table/Table';
-const styles: any = require('./ColorsPage.module.scss');
+import styles = require('./ColorsPage.module.scss');
 const pageStyles: any = require('../../PageStyles.module.scss');
 import { baseURL } from '../../../appConfig';
 

--- a/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { CodeBlock } from '../../../components/CodeBlock/CodeBlock';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 import { Table } from '../../../components/Table/Table';
-const styles: any = require('./LayoutPage.module.scss');
+import styles = require('./LayoutPage.module.scss');
 const pageStyles: any = require('../../PageStyles.module.scss');
 
 const visibilityData = require('json!../../../data/layout-visibility.json');

--- a/apps/fabric-website/src/pages/Styles/LocalizationPage/LocalizationPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/LocalizationPage/LocalizationPage.tsx
@@ -3,7 +3,7 @@ import { CodeBlock } from '../../../components/CodeBlock/CodeBlock';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 import { Table } from '../../../components/Table/Table';
 const pageStyles: any = require('../../PageStyles.module.scss');
-const styles: any = require('./LocalizationPage.module.scss');
+import styles = require('./LocalizationPage.module.scss');
 
 const directionalIconsData = require('json!../../../data/directional-icons.json');
 const localizedFontsData = require('json!../../../data/localized-fonts.json');

--- a/apps/todo-app/gulpfile.js
+++ b/apps/todo-app/gulpfile.js
@@ -9,6 +9,12 @@ build.karma.isEnabled = () => false;
 /* Configure TypeScript 2.0. */
 build.typescript.setConfig({ typescript: require('typescript') });
 
+// Use css modules.
+build.sass.setConfig({
+  useCSSModules: true,
+  moduleExportName: ''
+});
+
 // Set up a "rushBuild" subTask that will spawn rush build
 let fs = require('fs');
 let spawn = require('child_process').spawn;

--- a/apps/todo-app/src/components/Todo.tsx
+++ b/apps/todo-app/src/components/Todo.tsx
@@ -6,7 +6,7 @@ import { ITodoProps, ITodoState, ITodoItem, ITodoItemProps } from '../types/inde
 import TodoForm from './TodoForm';
 import TodoTabs from './TodoTabs';
 
-const styles: any = require('./Todo.module.scss');
+import styles = require('./Todo.module.scss');
 import strings from './../strings';
 
 /**

--- a/apps/todo-app/src/components/Todo.tsx
+++ b/apps/todo-app/src/components/Todo.tsx
@@ -7,7 +7,7 @@ import TodoForm from './TodoForm';
 import TodoTabs from './TodoTabs';
 
 import styles = require('./Todo.module.scss');
-import strings from './../strings';
+import strings from '../strings';
 
 /**
  * Todo component is the top level react component of this web part.
@@ -42,12 +42,12 @@ export default class Todo extends React.Component<ITodoProps, ITodoState> {
         </div>
         <TodoForm
           onSubmit={ this.props.dataProvider.createItem }
-          />
+        />
         <TodoTabs
           items={ this.state.items }
           onToggleComplete={ this.props.dataProvider.toggleComplete }
           onDeleteItem={ this.props.dataProvider.deleteItem }
-          />
+        />
         { this._renderFetchingTasksSpinner() }
       </div>
     );

--- a/apps/todo-app/src/components/TodoForm.tsx
+++ b/apps/todo-app/src/components/TodoForm.tsx
@@ -3,7 +3,7 @@ import { autobind } from 'office-ui-fabric-react/lib/Utilities';
 import { Button, ButtonType } from 'office-ui-fabric-react/lib/Button';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { ITodoFormProps, ITodoFormState } from '../types/index';
-const styles: any = require('./Todo.module.scss');
+import styles = require('./Todo.module.scss');
 import strings from './../strings';
 
 /**

--- a/apps/todo-app/src/components/TodoItem.tsx
+++ b/apps/todo-app/src/components/TodoItem.tsx
@@ -6,7 +6,7 @@ import { DocumentCardActivity } from 'office-ui-fabric-react/lib/DocumentCard';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { ITodoItem, ITodoItemProps } from '../types/index';
 
-const styles: any = require('./Todo.module.scss');
+import styles = require('./Todo.module.scss');
 import strings from './../strings';
 
 /**

--- a/apps/todo-app/src/components/TodoTabs.tsx
+++ b/apps/todo-app/src/components/TodoTabs.tsx
@@ -11,7 +11,7 @@ import { KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
 import TodoItem from './TodoItem';
 import { ITodoItem, ITodoItemProps, ITodoTabsProps } from '../types/index';
 
-const styles: any = require('./Todo.module.scss');
+import styles = require('./Todo.module.scss');
 import strings from './../strings';
 
 /**

--- a/common/changes/fix-amd-modules_2017-03-29-17-25.json
+++ b/common/changes/fix-amd-modules_2017-03-29-17-25.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Chaning scss imports to use typescript `import` instead of `require` so that lib-amd build actually imports via AMD require and not commonjs require.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "Chaning scss imports to use typescript `import` instead of `require` so that lib-amd build actually imports via AMD require and not commonjs require.",
+      "packageName": "@uifabric/example-app-base",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/example-component/gulpfile.js
+++ b/packages/example-component/gulpfile.js
@@ -13,6 +13,12 @@ let rules = Object.assign(
 );
 build.tslint.setConfig({ lintConfig: { rules } });
 
+// Use css modules.
+build.sass.setConfig({
+  useCSSModules: true,
+  moduleExportName: ''
+});
+
 // Custom build steps.
 build.task('tslint', build.tslint);
 

--- a/packages/example-component/src/ExampleComponent.tsx
+++ b/packages/example-component/src/ExampleComponent.tsx
@@ -17,7 +17,7 @@ import {
 import { IExampleComponentProps } from './ExampleComponent.Props';
 
 /* tslint:disable:no-any */
-const styles: any = require('./ExampleComponent.scss');
+import styles = require('./ExampleComponent.scss');
 /* tslint:enable:no-any */
 
 /**

--- a/packages/office-ui-fabric-react/.vscode/settings.json
+++ b/packages/office-ui-fabric-react/.vscode/settings.json
@@ -16,7 +16,6 @@
     "**/.DS_Store": true,
     "**/bower_components": true,
     "**/coverage": true,
-    "**/lib-amd": true,
     "**/*.scss.ts": true
   },
   // Configure glob patterns for excluding files and folders in searches. Inherits all glob patterns from the file.exclude setting.

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -12,7 +12,7 @@ import { Link } from '../../Link';
 import { IBreadcrumbProps, IBreadcrumbItem } from './Breadcrumb.Props';
 import { DirectionalHint } from '../../common/DirectionalHint';
 
-const styles: any = require('./Breadcrumb.scss');
+import styles = require('./Breadcrumb.scss');
 
 export interface IBreadcrumbState {
   isOverflowOpen: boolean;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -12,7 +12,7 @@ import {
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { ContextualMenu, IContextualMenuProps } from '../../ContextualMenu';
 import { IButtonProps, IButton } from './Button.Props';
-const styles: any = require('./BaseButton.scss');
+import styles = require('./BaseButton.scss');
 
 export interface IBaseButtonClassNames {
   base: string;

--- a/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.tsx
@@ -1,5 +1,5 @@
 import { BaseButton } from '../BaseButton';
-const styles: any = require('./CommandButton.scss');
+import styles = require('./CommandButton.scss');
 
 export class CommandButton extends BaseButton {
   protected classNames = {

--- a/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.tsx
@@ -1,5 +1,5 @@
 import { BaseButton } from '../BaseButton';
-const styles: any = require('./CompoundButton.scss');
+import styles = require('./CompoundButton.scss');
 
 export class CompoundButton extends BaseButton {
   protected classNames = {

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.tsx
@@ -1,5 +1,5 @@
 import { BaseButton } from '../BaseButton';
-const styles: any = require('./DefaultButton.scss');
+import styles = require('./DefaultButton.scss');
 
 export class DefaultButton extends BaseButton {
   protected classNames = {

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.tsx
@@ -1,5 +1,5 @@
 import { BaseButton } from '../BaseButton';
-const styles: any = require('./IconButton.scss');
+import styles = require('./IconButton.scss');
 
 export class IconButton extends BaseButton {
   protected classNames = {

--- a/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.tsx
@@ -1,5 +1,5 @@
 import { BaseButton } from '../BaseButton';
-const styles: any = require('./PrimaryButton.scss');
+import styles = require('./PrimaryButton.scss');
 
 export class PrimaryButton extends BaseButton {
   protected classNames = {

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -9,7 +9,7 @@ import {
   BaseComponent,
   KeyCodes
 } from '../../Utilities';
-const styles: any = require('./Calendar.scss');
+import styles = require('./Calendar.scss');
 
 export interface ICalendarState {
   /** The currently focused date in the calendar, but not necessarily selected */

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -21,7 +21,7 @@ import {
   isInDateRangeArray
 } from '../../utilities/dateMath/DateMath';
 
-const styles: any = require('./Calendar.scss');
+import styles = require('./Calendar.scss');
 
 const DAYS_IN_WEEK = 7;
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -7,7 +7,7 @@ import {
 import { ICalendarStrings } from './Calendar.Props';
 import { FocusZone } from '../../FocusZone';
 import { addYears, setMonth } from '../../utilities/dateMath/DateMath';
-const styles: any = require('./Calendar.scss');
+import styles = require('./Calendar.scss');
 
 export interface ICalendarMonthProps {
   navigatedDate: Date;

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../Utilities';
 import { getRelativePositions, IPositionInfo, IPositionProps, getMaxHeight } from '../../utilities/positioning';
 import { Popup } from '../../Popup';
-const styles: any = require('./Callout.scss');
+import styles = require('./Callout.scss');
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 const OFF_SCREEN_STYLE = { opacity: 0 };

--- a/packages/office-ui-fabric-react/src/components/Check/Check.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from '../../Utilities';
-const styles: any = require('./Check.scss');
+import styles = require('./Check.scss');
 
 export interface ICheckProps extends React.Props<Check> {
   /**

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -9,7 +9,7 @@ import {
   ICheckbox,
   ICheckboxProps
 } from './Checkbox.Props';
-const styles: any = require('./Checkbox.scss');
+import styles = require('./Checkbox.scss');
 
 export interface ICheckboxState {
   /** Is true when the control has focus. */

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -8,7 +8,7 @@ import {
   getId,
   BaseComponent
 } from '../../Utilities';
-const styles: any = require('./ChoiceGroup.scss');
+import styles = require('./ChoiceGroup.scss');
 
 export interface IChoiceGroupState {
   keyChecked: string | number;

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
@@ -32,14 +32,14 @@ export class ChoiceGroupImageExample extends React.Component<any, IChoiceGroupIm
             {
               key: 'bar',
               imageSrc: './images/choicegroup-bar-unselected.png',
-              selectedImageSrc: 'dist/choicegroup-bar-selected.png',
+              selectedImageSrc: './images/choicegroup-bar-selected.png',
               imageSize: { width: 32, height: 32 },
               text: 'Bar chart'
             },
             {
               key: 'pie',
               imageSrc: './images/choicegroup-pie-unselected.png',
-              selectedImageSrc: 'dist/choicegroup-pie-selected.png',
+              selectedImageSrc: './images/choicegroup-pie-selected.png',
               imageSize: { width: 32, height: 32 },
               text: 'Pie chart'
             }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -12,7 +12,7 @@ import {
   updateH,
   updateSV
 } from './colors';
-const styles: any = require('./ColorPicker.scss');
+import styles = require('./ColorPicker.scss');
 
 export interface IColorPickerState {
   isOpen: boolean;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle.tsx
@@ -12,7 +12,7 @@ import {
   getFullColorString,
   hsv2hex
 } from './colors';
-const styles: any = require('./ColorPicker.scss');
+import styles = require('./ColorPicker.scss');
 
 export interface IColorRectangleProps {
   color: IColor;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider.tsx
@@ -4,7 +4,7 @@ import {
   autobind,
   css
 } from '../../Utilities';
-const styles: any = require('./ColorPicker.scss');
+import styles = require('./ColorPicker.scss');
 
 export interface IColorSliderProps {
   minValue?: number;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -17,7 +17,7 @@ import {
   IconName,
   IIconProps
 } from '../../Icon';
-const styles: any = require('./CommandBar.scss');
+import styles = require('./CommandBar.scss');
 
 const OVERFLOW_KEY = 'overflow';
 const OVERFLOW_WIDTH = 41.5;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -21,7 +21,7 @@ import {
   Icon,
   IIconProps
 } from '../../Icon';
-const styles: any = require('./ContextualMenu.scss');
+import styles = require('./ContextualMenu.scss');
 
 export interface IContextualMenuState {
   expandedMenuItemKey?: string;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -15,7 +15,7 @@ import {
   KeyCodes,
   css
 } from '../../Utilities';
-const styles: any = require('./DatePicker.scss');
+import styles = require('./DatePicker.scss');
 
 export interface IDatePickerState {
   /** The currently focused date in the drop down, but not necessarily selected */

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -12,7 +12,7 @@ import { Icon } from '../../Icon';
 import { Layer } from '../../Layer';
 import { GroupSpacer } from '../GroupedList/GroupSpacer';
 import { ISelection, SelectionMode, SELECTION_CHANGE } from '../../utilities/selection/interfaces';
-const styles: any = require('./DetailsHeader.scss');
+import styles = require('./DetailsHeader.scss');
 
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 const MOUSEMOVE_PRIMARY_BUTTON = 1; // for mouse move event we are using ev.buttons property, 1 means left button

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -30,7 +30,7 @@ import {
   SelectionZone
 } from '../../utilities/selection/index';
 import { DragDropHelper } from '../../utilities/dragdrop/DragDropHelper';
-const styles: any = require('./DetailsList.scss');
+import styles = require('./DetailsList.scss');
 
 export interface IDetailsListState {
   lastWidth?: number;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -17,7 +17,7 @@ import {
   IDragDropOptions,
 } from './../../utilities/dragdrop/interfaces';
 import { IViewport } from '../../utilities/decorators/withViewport';
-const styles: any = require('./DetailsRow.scss');
+import styles = require('./DetailsRow.scss');
 import { IDisposable } from '@uifabric/utilities';
 
 export interface IDetailsRowProps extends React.Props<DetailsRow> {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 import { css } from '../../Utilities';
 import { Check } from '../../Check';
-const styles: any = require('./DetailsRow.scss');
+import styles = require('./DetailsRow.scss');
 
 export interface IDetailsRowCheckProps {
   selected?: boolean;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IColumn } from './DetailsList.Props';
 import { css } from '../../Utilities';
-const styles: any = require('./DetailsRow.scss');
+import styles = require('./DetailsRow.scss');
 
 export interface IDetailsRowFieldsProps {
   item: any;

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
@@ -12,7 +12,7 @@ import { Button, ButtonType } from '../../Button';
 import { DialogFooter } from './DialogFooter';
 import { Popup } from '../Popup/index';
 import { withResponsiveMode, ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
-const styles: any = require('./Dialog.scss');
+import styles = require('./Dialog.scss');
 
 // @TODO - need to change this to a panel whenever the breakpoint is under medium (verify the spec)
 

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from '../../Utilities';
-const styles: any = require('./Dialog.scss');
+import styles = require('./Dialog.scss');
 
 export class DialogFooter extends React.Component<any, any> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
@@ -5,7 +5,7 @@ import {
   css,
   KeyCodes
 } from '../../Utilities';
-const styles: any = require('./DocumentCard.scss');
+import styles = require('./DocumentCard.scss');
 
 export class DocumentCard extends React.Component<IDocumentCardProps, any> {
   public static defaultProps: IDocumentCardProps = {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActions.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActions.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { css } from '../../Utilities';
 import { IDocumentCardActionsProps } from './DocumentCard.Props';
 import { Button, ButtonType } from '../../Button';
-const styles: any = require('./DocumentCard.scss');
+import styles = require('./DocumentCard.scss');
 
 export class DocumentCardActions extends React.Component<IDocumentCardActionsProps, any> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { css } from '../../Utilities';
 import { IDocumentCardActivityProps, IDocumentCardActivityPerson } from './DocumentCard.Props';
 import { Persona, PersonaSize } from '../Persona';
-const styles: any = require('./DocumentCard.scss');
+import styles = require('./DocumentCard.scss');
 
 export class DocumentCardActivity extends React.Component<IDocumentCardActivityProps, any> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css } from '../../Utilities';
 import { IDocumentCardLocationProps } from './DocumentCard.Props';
-const styles: any = require('./DocumentCard.scss');
+import styles = require('./DocumentCard.scss');
 
 export class DocumentCardLocation extends React.Component<IDocumentCardLocationProps, any> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -5,7 +5,7 @@ import {
   autobind,
   css
 } from '../../Utilities';
-const styles: any = require('./DocumentCard.scss');
+import styles = require('./DocumentCard.scss');
 
 const LIST_ITEM_COUNT = 3;
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardTitle.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardTitle.tsx
@@ -8,7 +8,7 @@ import {
   css
 } from '../../Utilities';
 import { IDocumentCardTitleProps } from './DocumentCard.Props';
-const styles: any = require('./DocumentCard.scss');
+import styles = require('./DocumentCard.scss');
 
 export interface IDocumentCardTitleState {
   truncatedTitleFirstPiece?: string;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -16,7 +16,7 @@ import {
   findIndex,
   getId
 } from '../../Utilities';
-const styles: any = require('./Dropdown.scss');
+import styles = require('./Dropdown.scss');
 
 // Internal only props iterface to support mixing in responsive mode
 export interface IDropdownInternalProps extends IDropdownProps, IWithResponsiveModeState {

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.tsx
@@ -21,7 +21,7 @@ import {
   Persona,
   PersonaSize
 } from '../../Persona';
-const styles: any = require('./Facepile.scss');
+import styles = require('./Facepile.scss');
 
 export class Facepile extends React.Component<IFacepileProps, {}> {
   public static defaultProps: IFacepileProps = {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.tsx
@@ -7,7 +7,7 @@ import {
 import { Link } from '../../Link';
 import { IGroupDividerProps } from './GroupedList.Props';
 import { GroupSpacer } from './GroupSpacer';
-const styles: any = require('./GroupFooter.scss');
+import styles = require('./GroupFooter.scss');
 
 export class GroupFooter extends BaseComponent<IGroupDividerProps, {}> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.tsx
@@ -10,7 +10,7 @@ import { Icon } from '../../Icon';
 import { GroupSpacer } from './GroupSpacer';
 import { Spinner } from '../../Spinner';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
-const styles: any = require('./GroupHeader.scss');
+import styles = require('./GroupHeader.scss');
 
 export interface IGroupHeaderState {
   isCollapsed: boolean;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupSpacer.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupSpacer.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {
   css
 } from '../../Utilities';
-const styles: any = require('./GroupSpacer.scss');
+import styles = require('./GroupSpacer.scss');
 
 export interface IGroupSpacerProps {
   count: number;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -19,7 +19,7 @@ import {
 import {
   SelectionMode
 } from '../../utilities/selection/index';
-const styles: any = require('./GroupedList.scss');
+import styles = require('./GroupedList.scss');
 
 export interface IGroupedListState {
   lastWidth?: number;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -33,7 +33,7 @@ import {
 } from './../../utilities/dragdrop/interfaces';
 import { assign, css } from '../../Utilities';
 import { IViewport } from '../../utilities/decorators/withViewport';
-const styles: any = require('./GroupedList.scss');
+import styles = require('./GroupedList.scss');
 import { IDisposable } from '@uifabric/utilities';
 
 export interface IGroupedListSectionProps extends React.Props<GroupedListSection> {

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 /* tslint:disable */
 import * as React from 'react';
-const styles: any = require('./Icon.scss')
+import styles = require('./Icon.scss')
 /* tslint:enable */
 import { IIconProps } from './Icon.Props';
 import { IconType } from './IconType';

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../Utilities';
 import { IImageProps, ImageFit, ImageLoadState } from './Image.Props';
 
-const styles: any = require('./Image.scss');
+import styles = require('./Image.scss');
 
 export interface IImageState {
   loadState?: ImageLoadState;

--- a/packages/office-ui-fabric-react/src/components/Label/Label.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css, divProperties, getNativeProps } from '../../Utilities';
 import { ILabelProps } from './Label.Props';
-const styles: any = require('./Label.scss');
+import styles = require('./Label.scss');
 
 export class Label extends React.Component<ILabelProps, any> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
@@ -6,7 +6,7 @@ import * as ReactDOM from 'react-dom';
 import { Fabric } from '../../Fabric';
 import { ILayerProps } from './Layer.Props';
 import { css, BaseComponent, getDocument, setVirtualParent } from '../../Utilities';
-const styles: any = require('./Layer.scss');
+import styles = require('./Layer.scss');
 
 let _layersByHostId: { [hostId: string]: Layer[] } = {};
 

--- a/packages/office-ui-fabric-react/src/components/Link/Link.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.tsx
@@ -8,7 +8,7 @@ import {
   getNativeProps
 } from '../../Utilities';
 import { ILink, ILinkProps } from './Link.Props';
-const styles: any = require('./Link.scss');
+import styles = require('./Link.scss');
 
 interface IMyScreen extends Screen {
   left: number;

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -11,7 +11,7 @@ import {
   getRTL
 } from '../../Utilities';
 import { IMarqueeSelectionProps } from './MarqueeSelection.Props';
-const styles: any = require('./MarqueeSelection.scss');
+import styles = require('./MarqueeSelection.scss');
 
 export interface IMarqueeSelectionState {
   dragOrigin?: IPoint;

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../Utilities';
 import { Button, ButtonType } from '../../Button';
 import { IMessageBarProps, MessageBarType } from './MessageBar.Props';
-const styles: any = require('./MessageBar.scss');
+import styles = require('./MessageBar.scss');
 
 export interface IMessageBarState {
   labelId?: string;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -5,7 +5,7 @@ import {
 } from '../../Utilities';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { CommandButton } from '../../Button';
-const styles: any = require('./Nav.scss');
+import styles = require('./Nav.scss');
 
 import {
   INav,

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../Utilities';
 import { IOverlayProps } from './Overlay.Props';
 
-const styles: any = require('./Overlay.scss');
+import styles = require('./Overlay.scss');
 
 export class Overlay extends React.Component<IOverlayProps, {}> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -15,7 +15,7 @@ import { Layer } from '../Layer/Layer';
 import { Overlay } from '../../Overlay';
 import { Popup } from '../../Popup';
 import { IconButton } from '../../Button';
-const styles: any = require('./Panel.scss');
+import styles = require('./Panel.scss');
 
 export interface IPanelState {
   isFooterSticky?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
@@ -5,7 +5,7 @@ import { Persona } from './Persona';
 import { PersonaInitialsColor } from './Persona.Props';
 import { shallow } from 'enzyme';
 import * as chai from 'chai';
-const styles: any = require('./Persona.scss');
+import styles = require('./Persona.scss');
 
 const { expect } = chai;
 

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -20,7 +20,7 @@ import {
   PERSONA_PRESENCE,
   PERSONA_SIZE
 } from './PersonaConsts';
-const styles: any = require('./Persona.scss');
+import styles = require('./Persona.scss');
 
 // The RGB color swatches
 const COLOR_SWATCHES_LOOKUP: PersonaInitialsColor[] = [

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -12,7 +12,7 @@ import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { PivotItem } from './PivotItem';
 import { PivotLinkFormat } from './Pivot.Props';
 import { PivotLinkSize } from './Pivot.Props';
-const styles: any = require('./Pivot.scss');
+import styles = require('./Pivot.scss');
 
 /**
  *  Usage:

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -7,7 +7,7 @@ import {
   css
 } from '../../Utilities';
 import { IProgressIndicatorProps } from './ProgressIndicator.Props';
-const styles: any = require('./ProgressIndicator.scss');
+import styles = require('./ProgressIndicator.scss');
 
 // if the percentComplete is near 0, don't animate it.
 // This prevents animations on reset to 0 scenarios

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.tsx
@@ -5,7 +5,7 @@ import {
   getId
 } from '../../Utilities';
 import { IRatingProps, RatingSize } from './Rating.Props';
-const styles: any = require('./Rating.scss');
+import styles = require('./Rating.scss');
 
 export interface IRatingState {
   rating: number;

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -10,7 +10,7 @@ import {
   KeyCodes
 } from '../../Utilities';
 import './SearchBox.scss';
-const styles: any = require('./SearchBox.scss');
+import styles = require('./SearchBox.scss');
 
 export interface ISearchBoxState {
   value?: string;

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../Utilities';
 import { ISliderProps, ISlider } from './Slider.Props';
 import { Label } from '../../Label';
-const styles: any = require('./Slider.scss');
+import styles = require('./Slider.scss');
 
 export interface ISliderState {
   value?: number;

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css } from '../../Utilities';
 import { ISpinnerProps, SpinnerType, SpinnerSize } from './Spinner.Props';
-const styles: any = require('./Spinner.scss');
+import styles = require('./Spinner.scss');
 
 export class Spinner extends React.Component<ISpinnerProps, any> {
   public static defaultProps: ISpinnerProps = {

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.tsx
@@ -6,7 +6,7 @@ import { TeachingBubbleContent } from './TeachingBubbleContent';
 import { ITeachingBubbleProps } from './TeachingBubble.Props';
 import { Callout } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
-const styles: any = require('./TeachingBubble.scss');
+import styles = require('./TeachingBubble.scss');
 
 export interface ITeachingBubbleState {
   isTeachingBubbleVisible?: boolean;

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.tsx
@@ -10,7 +10,7 @@ import { ITeachingBubbleProps } from './TeachingBubble.Props';
 import { ITeachingBubbleState } from './TeachingBubble';
 import { Button, ButtonType } from '../../Button';
 import { Image, ImageFit } from '../../Image';
-const styles: any = require('./TeachingBubble.scss');
+import styles = require('./TeachingBubble.scss');
 
 export class TeachingBubbleContent extends BaseComponent<ITeachingBubbleProps, ITeachingBubbleState> {
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -10,7 +10,7 @@ import {
   inputProperties,
   textAreaProperties
 } from '../../Utilities';
-const styles: any = require('./TextField.scss');
+import styles = require('./TextField.scss');
 
 export interface ITextFieldState {
   value?: string;

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../Utilities';
 import { IToggleProps } from './Toggle.Props';
 import { Label } from '../../Label';
-const styles: any = require('./Toggle.scss');
+import styles = require('./Toggle.scss');
 
 export interface IToggleState {
   isChecked: boolean;

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
@@ -10,7 +10,7 @@ import {
 import { ITooltipProps, TooltipDelay } from './Tooltip.Props';
 import { Callout } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
-const styles: any = require('./Tooltip.scss');
+import styles = require('./Tooltip.scss');
 
 export class Tooltip extends BaseComponent<ITooltipProps, any> {
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -12,7 +12,7 @@ import {
 import { ITooltipHostProps } from './TooltipHost.Props';
 import { Tooltip } from './Tooltip';
 import { TooltipDelay } from './Tooltip.Props';
-const styles: any = require('./Tooltip.scss');
+import styles = require('./Tooltip.scss');
 
 export interface ITooltipHostState {
   isTooltipVisible?: boolean;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -15,7 +15,7 @@ import { SuggestionsController } from './Suggestions/SuggestionsController';
 import { IBasePickerProps } from './BasePicker.Props';
 import { BaseAutoFill } from './AutoFill/BaseAutoFill';
 import { IPickerItemProps } from './PickerItem.Props';
-const styles: any = require('./BasePicker.scss');
+import styles = require('./BasePicker.scss');
 
 export interface IBasePickerState {
   items?: any;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -5,7 +5,7 @@ import { css } from '../../../../Utilities';
 import { Persona, PersonaSize, PersonaPresence } from '../../../../Persona';
 import { IPeoplePickerItemProps } from './PeoplePickerItem.Props';
 import { IconButton } from '../../../../Button';
-const styles: any = require('./PickerItemsDefault.scss');
+import styles = require('./PickerItemsDefault.scss');
 
 export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element = (peoplePickerItemProps: IPeoplePickerItemProps) => {
   let {

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
@@ -7,7 +7,7 @@ import { Persona, PersonaPresence } from '../../../../Persona';
 import { ContextualMenu, DirectionalHint } from '../../../../ContextualMenu';
 import { IconButton } from '../../../../Button';
 import { FocusZone } from '../../../../FocusZone';
-const styles: any = require('./PickerItemsDefault.scss');
+import styles = require('./PickerItemsDefault.scss');
 
 export interface IPeoplePickerItemState {
   contextualMenuVisible: boolean;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 /* tslint:enable */
 import { css } from '../../../../Utilities';
 import { Persona, PersonaSize, IPersonaProps, PersonaPresence } from '../../../../Persona';
-const styles: any = require('../PeoplePicker.scss');
+import styles = require('../PeoplePicker.scss');
 
 export const SuggestionItemNormal: (persona: IPersonaProps) => JSX.Element = (personaProps: IPersonaProps) => {
   return (

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -6,7 +6,7 @@ import {
 import { CommandButton } from '../../../Button';
 import { Spinner } from '../../../Spinner';
 import { ISuggestionItemProps, ISuggestionsProps } from './Suggestions.Props';
-const styles: any = require('./Suggestions.scss');
+import styles = require('./Suggestions.scss');
 
 export class SuggestionsItem<T> extends React.Component<ISuggestionItemProps<T>, {}> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { css } from '../../../Utilities';
 import { IPickerItemProps } from '../PickerItem.Props';
 import { ITag } from './TagPicker';
-const styles: any = require('./TagItem.scss');
+import styles = require('./TagItem.scss');
 
 export const TagItem = (props: IPickerItemProps<ITag>) => (
   <div


### PR DESCRIPTION
In the build updates, I changed scss imports to use `require`, which when sent through TypeScript transpiling, will not generate the correct AMD imports for the AMD build.

Changed all `require` usage to `import` fixes this:

Before, generated lib-amd\...\Breadcrumb.js :
```js
var styles = require("./Breadcrumb.scss");
```
After:
```js
define(["require", "exports", "react", "../../Utilities", "../../FocusZone", "../../ContextualMenu", "../../Link", "../../common/DirectionalHint", "./Breadcrumb.scss"], function (require, exports, React, Utilities_1, FocusZone_1, ContextualMenu_1, Link_1, DirectionalHint_1, styles) {
```
