### PR TITLE
Fix RTL bug in ChoiceField

### DIFF
--- a/common/changes/choice-group-rtl-fix_2017-03-30-05-16.json
+++ b/common/changes/choice-group-rtl-fix_2017-03-30-05-16.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "Fix RTL bug in ChoiceField"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -294,10 +294,10 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
       overflow-y: hidden;
 
       @include ms-font-m;
-    }
 
-    :global(.ms-Label) {
-      padding: 0;
+      :global(.ms-Label) {
+        padding: 0;
+      }
     }
 
     &::before {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [ ] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Making .ms-Label style in Choice-field image/icon more specific as it is overridden by plain choice-field RTL padding-left.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
