### PR TITLE
DocumentCard: Personas now look correct.

### DIFF
--- a/common/changes/doccard-fix_2017-03-30-20-21.json
+++ b/common/changes/doccard-fix_2017-03-30-20-21.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DocumentCard: Personas rendered within look correct.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
@@ -120,7 +120,7 @@ $ms-DocumentCardActions-verticalPadding: 4px;
 
 /** Activity **/
 $ms-DocumentCardActivity-horizontalPadding: 16px;
-$ms-DocumentCardActivity-imageSize: 25px;
+$ms-DocumentCardActivity-imageSize: 24px;
 $ms-DocumentCardActivity-verticalPadding: 8px;
 $ms-DocumentCardActivity-personaTextGutter: 8px;
 
@@ -141,6 +141,7 @@ $ms-DocumentCardActivity-personaTextGutter: 8px;
 
 .avatars {
   @include margin-left(-2px); // Avatars sit outside of the usual padding for visual balance
+  height: 32px;
 }
 
 .avatar {
@@ -148,8 +149,8 @@ $ms-DocumentCardActivity-personaTextGutter: 8px;
   vertical-align: top;
   position: relative;
   text-align: center;
-  width: 24px;
-  height: 24px;
+  width: $ms-DocumentCardActivity-imageSize;
+  height: $ms-DocumentCardActivity-imageSize;
 
   &:after {
     content: '';

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
@@ -144,32 +144,23 @@ $ms-DocumentCardActivity-personaTextGutter: 8px;
 }
 
 .avatar {
-  border: 2px solid #fafafa; // Match the background of the card
-  border-radius: 50%;
-  height: $ms-DocumentCardActivity-imageSize;
-  width: $ms-DocumentCardActivity-imageSize;
   display: inline-block;
+  vertical-align: top;
   position: relative;
-  overflow: hidden;
   text-align: center;
+  width: 24px;
+  height: 24px;
 
-  :global(.ms-Persona-initials) {
-    height: $ms-DocumentCardActivity-imageSize;
-    line-height: $ms-DocumentCardActivity-imageSize;
-    font-size: $ms-font-size-s;
-  }
-
-  img {
-    width: 100%;
-    height: 100%;
+  &:after {
+    content: '';
+    position: absolute;
+    left: -1px;
+    top: -1px;
+    right: -1px;
+    bottom: -1px;
+    border: 2px solid #fafafa; // Match the background of the card
     border-radius: 50%;
   }
-}
-
-.avatarInitials {
-  background: $ms-color-themePrimary;
-  color: $ms-color-white;
-  font-weight: 100;
 }
 
 .activityDetails {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.tsx
@@ -42,7 +42,7 @@ export class DocumentCardActivity extends React.Component<IDocumentCardActivityP
           imageUrl={ person.profileImageSrc }
           initialsColor={ person.initialsColor }
           role='persentation'
-          size={ PersonaSize.extraSmall }
+          size={ PersonaSize.extraExtraSmall }
         />
 
       </div>


### PR DESCRIPTION
A recent change regressed visuals of the Personas rendered within DocumentCard. Bring them back up to par.

Now looks like this:

![image](https://cloud.githubusercontent.com/assets/1110944/24524665/4711de38-154c-11e7-8b3f-b60e4fa2957a.png)
