### PR TITLE
Fixing exception thrown on Panel.tsx

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -263,12 +263,14 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> {
 
   private _updateFooterPosition() {
     let _content = this._content;
-    let height = _content.clientHeight;
-    let innerHeight = _content.scrollHeight;
+    if (_content) {
+      let height = _content.clientHeight;
+      let innerHeight = _content.scrollHeight;
 
-    this.setState({
-      isFooterSticky: height < innerHeight ? true : false
-    });
+      this.setState({
+        isFooterSticky: height < innerHeight ? true : false
+      });
+    }
   }
 
   private _onPanelClick() {


### PR DESCRIPTION
If the props are changed on Panel.tsx, but the content has never been set, there is an exception in `_updateFooterPosition` due to `this._content` being undefined. Added a check for the existence of `_content` before trying to set the footer position.

#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
