### PR TITLE
Remove lineheight and using flexbox to position dialog

### DIFF
--- a/common/changes/dialog-lineheight-removal_2017-03-31-18-35.json
+++ b/common/changes/dialog-lineheight-removal_2017-03-31-18-35.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dialog: Removed IE9 lineheight hacks so that lineheight wouldn't affect internal components",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.scss
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.scss
@@ -11,20 +11,14 @@ $Dialog-lgHeader-backgroundColor: $ms-color-themePrimary;
 $Dialog-default-min-width: 288px;
 $Dialog-default-max-width: 340px;
 
-// Mixin for IE9 specific styles
-@mixin dialogPositioningIE9Fallback {
-  vertical-align: middle;
-  display: inline-block;
-}
-
 .root {
   @include ms-baseFont;
   background-color: transparent;
   position: fixed;
   height: 100%;
   width:  100%;
-  top:  0;
-  @include left(0);
+  align-items: center;
+  justify-content: center;
   display: none; // Hidden by default
 
   :global(.ms-Button.ms-Button--compound) {
@@ -41,31 +35,14 @@ $Dialog-default-max-width: 340px;
 
 // State: The dialog is open
 .root.isOpen {
-  display: block;
-}
-
-// Fallback for IE9 when dialog is open
-.root.isOpen {
-  display: block;
-  line-height: 100vh;
-  text-align: center;
-
-  &::before {
-    @include dialogPositioningIE9Fallback();
-    content: "";
-    height: 100%;
-    width: 0;
-  }
+  display: flex;
 }
 
 // The actual dialog element
 .main {
-  @include dialogPositioningIE9Fallback();
   @include drop-shadow();
   background-color: $ms-color-white;
   box-sizing: border-box;
-  line-height: 1.35;
-  margin: auto;
   width: $Dialog-default-min-width;
   position: relative;
   @include text-align(left);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1384
- [x] Include a change request file if publishing <!-- see notes below -->

#### Description of changes

Removed unnecessary lineheights that were used for some IE9 hacks, and redid the dialog layout using flexbox.