### PR TITLE
Adding componentRef support, BaseComponent warnings, and initial Customizer component.

### DIFF
--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -42,7 +42,7 @@
     "source-map-loader": "0.1.5",
     "tslint": "^3.15.1",
     "tslint-microsoft-contrib": "^2.0.9",
-    "typescript": "^2.1.5",
+    "typescript": "^2.2.2",
     "vinyl-ftp": "0.4.5",
     "webpack-bundle-analyzer": "^2.2.1"
   },

--- a/apps/todo-app/package.json
+++ b/apps/todo-app/package.json
@@ -28,6 +28,6 @@
     "office-ui-fabric-react": ">=2.10.5 <3.0.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "typescript": "^2.0.6"
+    "typescript": "^2.2.2"
   }
 }

--- a/common/changes/general-updates_2017-04-04-00-01.json
+++ b/common/changes/general-updates_2017-04-04-00-01.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "In components which expose a public API such as `Dropdown` which implements `IDropdown`, to access the exact interface we've exposed a `componentRef` property on all components. This property replaces typical `ref={ c => this._component = c }` usage, as componentRef is guaranteed to access the public contract of the component regardless of the higher-order component or decorator wrapping it. If you are accessing the public API of a component, replace your `ref` usage with `componentRef`.",
+      "type": "minor"
+    },
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "BaseComponent: added support for resolving `componentRef` automatically. Also added `_warnDeprecations` and `_warnMutualExclusion` helpers for warning on misuse.",
+      "type": "minor"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/common/npm-shrinkwrap.json
+++ b/common/npm-shrinkwrap.json
@@ -5,14 +5,7 @@
     "@microsoft/api-extractor": {
       "version": "2.0.0",
       "from": "@microsoft/api-extractor@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-2.0.0.tgz",
-      "dependencies": {
-        "typescript": {
-          "version": "2.2.1",
-          "from": "typescript@>=2.2.1-0 <3.0.0-0",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-2.0.0.tgz"
     },
     "@microsoft/gulp-core-build": {
       "version": "2.4.3",
@@ -161,11 +154,6 @@
           "version": "4.0.1",
           "from": "tslint-microsoft-contrib@>=4.0.0 <4.1.0",
           "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-4.0.1.tgz"
-        },
-        "typescript": {
-          "version": "2.2.1",
-          "from": "typescript@>=2.2.1 <2.3.0",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz"
         }
       }
     },
@@ -274,14 +262,14 @@
       "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz"
     },
     "@types/cheerio": {
-      "version": "0.22.0",
+      "version": "0.22.1",
       "from": "@types/cheerio@*",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.0.tgz"
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.1.tgz"
     },
     "@types/enzyme": {
-      "version": "2.7.6",
+      "version": "2.7.7",
       "from": "@types/enzyme@>=2.7.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-2.7.6.tgz"
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-2.7.7.tgz"
     },
     "@types/es6-collections": {
       "version": "0.5.29",
@@ -339,9 +327,9 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz"
     },
     "@types/react": {
-      "version": "15.0.20",
+      "version": "15.0.21",
       "from": "@types/react@>=15.0.16 <16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.0.20.tgz"
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.0.21.tgz"
     },
     "@types/react-addons-test-utils": {
       "version": "0.14.17",
@@ -389,9 +377,9 @@
       "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz"
     },
     "@uifabric/utilities": {
-      "version": "1.3.0",
-      "from": "@uifabric/utilities@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-1.3.0.tgz"
+      "version": "1.4.0",
+      "from": "@uifabric/utilities@1.4.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-1.4.0.tgz"
     },
     "abbrev": {
       "version": "1.0.9",
@@ -757,9 +745,9 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz",
       "dependencies": {
         "camelcase": {
-          "version": "4.0.0",
+          "version": "4.1.0",
           "from": "camelcase@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -814,9 +802,9 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
     },
     "browserify-sign": {
-      "version": "4.0.0",
+      "version": "4.0.4",
       "from": "browserify-sign@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz"
     },
     "browserify-zlib": {
       "version": "0.1.4",
@@ -891,9 +879,9 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.5.3.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000640",
+      "version": "1.0.30000649",
       "from": "caniuse-db@>=1.0.30000488 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000640.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000649.tgz"
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -1233,9 +1221,9 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
     },
     "convert-source-map": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "convert-source-map@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
     },
     "cookie": {
       "version": "0.3.1",
@@ -1722,9 +1710,9 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz"
     },
     "electron-to-chromium": {
-      "version": "1.2.8",
+      "version": "1.3.2",
       "from": "electron-to-chromium@>=1.2.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.2.8.tgz"
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.2.tgz"
     },
     "elliptic": {
       "version": "6.4.0",
@@ -1815,9 +1803,9 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "enzyme": {
-      "version": "2.7.1",
+      "version": "2.8.0",
       "from": "enzyme@>=2.7.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.8.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -2095,9 +2083,9 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
     },
     "fbjs": {
-      "version": "0.8.11",
+      "version": "0.8.12",
       "from": "fbjs@>=0.8.4 <0.9.0",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.11.tgz",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -3352,9 +3340,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "interpret@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.2.tgz"
     },
     "invariant": {
       "version": "2.2.2",
@@ -3367,9 +3355,9 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "ipaddr.js": {
-      "version": "1.2.0",
-      "from": "ipaddr.js@1.2.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz"
+      "version": "1.3.0",
+      "from": "ipaddr.js@1.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
     },
     "irregular-plurals": {
       "version": "1.2.0",
@@ -3891,9 +3879,9 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
     },
     "latest-version": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "from": "latest-version@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz"
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -4472,14 +4460,14 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.0.3.tgz"
     },
     "method-override": {
-      "version": "2.3.7",
+      "version": "2.3.8",
       "from": "method-override@>=2.3.5 <2.4.0",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.8.tgz",
       "dependencies": {
         "debug": {
-          "version": "2.3.3",
-          "from": "debug@2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+          "version": "2.6.3",
+          "from": "debug@2.6.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz"
         }
       }
     },
@@ -4726,9 +4714,9 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.0.2.tgz"
     },
     "node-sass": {
-      "version": "4.5.1",
+      "version": "4.5.2",
       "from": "node-sass@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.2.tgz",
       "dependencies": {
         "gaze": {
           "version": "1.1.2",
@@ -4763,9 +4751,9 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz"
     },
     "normalize-path": {
-      "version": "2.0.1",
+      "version": "2.1.1",
       "from": "normalize-path@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -4870,9 +4858,9 @@
       "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-5.1.0.tgz"
     },
     "office-ui-fabric-react": {
-      "version": "2.7.1",
+      "version": "2.10.5",
       "from": "office-ui-fabric-react@>=2.7.1-0 <3.0.0-0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-2.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-2.10.5.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
@@ -4998,9 +4986,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "package-json": {
-      "version": "3.1.0",
-      "from": "package-json@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-3.1.0.tgz"
+      "version": "4.0.0",
+      "from": "package-json@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.0.tgz"
     },
     "pako": {
       "version": "0.2.9",
@@ -5481,9 +5469,9 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "proxy-addr": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "from": "proxy-addr@>=1.1.3 <1.2.0",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz"
     },
     "prr": {
       "version": "0.0.0",
@@ -5566,9 +5554,9 @@
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz"
     },
     "rc": {
-      "version": "1.1.7",
+      "version": "1.2.0",
       "from": "rc@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz"
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.0.tgz"
     },
     "react": {
       "version": "15.4.2",
@@ -5712,6 +5700,11 @@
       "version": "0.1.5",
       "from": "regjsparser@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+    },
+    "remove-trailing-separator": {
+      "version": "1.0.1",
+      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -5869,11 +5862,6 @@
           "version": "3.1.2",
           "from": "supports-color@3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-        },
-        "typescript": {
-          "version": "2.2.1",
-          "from": "typescript@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz"
         }
       }
     },
@@ -5958,11 +5946,6 @@
           "version": "3.1.2",
           "from": "supports-color@3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-        },
-        "typescript": {
-          "version": "2.2.1",
-          "from": "typescript@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz"
         }
       }
     },
@@ -6014,9 +5997,9 @@
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.3.tgz",
       "dependencies": {
         "async": {
-          "version": "2.1.5",
+          "version": "2.3.0",
           "from": "async@>=2.1.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz"
         },
         "loader-utils": {
           "version": "1.1.0",
@@ -6845,9 +6828,9 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
     },
     "type-is": {
-      "version": "1.6.14",
+      "version": "1.6.15",
       "from": "type-is@>=1.6.14 <1.7.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
@@ -6855,9 +6838,9 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "typescript": {
-      "version": "2.1.6",
-      "from": "typescript@>=2.1.0 <2.2.0",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.1.6.tgz"
+      "version": "2.2.2",
+      "from": "typescript@>=2.2.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.2.tgz"
     },
     "ua-parser-js": {
       "version": "0.7.12",
@@ -6865,9 +6848,9 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "uglify-js": {
-      "version": "2.8.16",
+      "version": "2.8.21",
       "from": "uglify-js@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.16.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.21.tgz",
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -6994,9 +6977,9 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "useragent": {
-      "version": "2.1.12",
+      "version": "2.1.13",
       "from": "useragent@>=2.1.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz",
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
@@ -7033,9 +7016,9 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
     },
     "v8flags": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "v8flags@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.12.tgz"
     },
     "vali-date": {
       "version": "1.0.0",
@@ -7196,9 +7179,9 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
         },
         "async": {
-          "version": "2.1.5",
+          "version": "2.3.0",
           "from": "async@>=2.1.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz"
         },
         "camelcase": {
           "version": "3.0.0",

--- a/common/temp_modules/rush-example-app-base/package.json
+++ b/common/temp_modules/rush-example-app-base/package.json
@@ -22,12 +22,12 @@
     "source-map-loader": "0.1.5",
     "tslint": "^3.15.1",
     "tslint-microsoft-contrib": "^2.0.9",
-    "typescript": "~2.1.0",
+    "typescript": "^2.2.2",
     "highlight.js": "^9.9.0",
     "office-ui-fabric-core": ">=5.0.0 <6.0.0",
     "office-ui-fabric-react": ">=2.7.1-0 <3.0.0-0"
   },
   "rushDependencies": {
-    "@uifabric/utilities": "1.3.0"
+    "@uifabric/utilities": "1.4.0"
   }
 }

--- a/common/temp_modules/rush-example-component/package.json
+++ b/common/temp_modules/rush-example-component/package.json
@@ -27,14 +27,14 @@
     "sass-loader": "^6.0.3",
     "style-loader": "^0.13.2",
     "ts-loader": "^2.0.1",
-    "typescript": "^2.2.1",
+    "typescript": "^2.2.2",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.1",
     "webpack-notifier": "^1.5.0"
   },
   "rushDependencies": {
-    "@uifabric/example-app-base": "^1.3.2",
-    "@uifabric/utilities": "^1.3.0",
-    "office-ui-fabric-react": ">=2.7.1-0 <3.0.0-0"
+    "@uifabric/example-app-base": "^1.3.4",
+    "@uifabric/utilities": "^1.4.0",
+    "office-ui-fabric-react": "2.10.5"
   }
 }

--- a/common/temp_modules/rush-fabric-website/package.json
+++ b/common/temp_modules/rush-fabric-website/package.json
@@ -30,7 +30,7 @@
     "source-map-loader": "0.1.5",
     "tslint": "^3.15.1",
     "tslint-microsoft-contrib": "^2.0.9",
-    "typescript": "^2.1.5",
+    "typescript": "^2.2.2",
     "vinyl-ftp": "0.4.5",
     "webpack-bundle-analyzer": "^2.2.1",
     "color-functions": "1.1.0",
@@ -39,8 +39,8 @@
     "office-ui-fabric-core": "5.1.0"
   },
   "rushDependencies": {
-    "@uifabric/example-app-base": "^1.3.2",
-    "office-ui-fabric-react": ">=2.7.1-0 <3.0.0-0",
-    "@uifabric/utilities": ">=1.2.0 <2.0.0"
+    "@uifabric/example-app-base": "^1.3.4",
+    "office-ui-fabric-react": "2.10.5",
+    "@uifabric/utilities": ">=1.3.0 <2.0.0"
   }
 }

--- a/common/temp_modules/rush-office-ui-fabric-react/package.json
+++ b/common/temp_modules/rush-office-ui-fabric-react/package.json
@@ -41,7 +41,7 @@
     "ts-loader": "^2.0.1",
     "tslint": "^3.15.1",
     "tslint-microsoft-contrib": "^2.0.9",
-    "typescript": "^2.2.1",
+    "typescript": "^2.2.2",
     "vinyl-ftp": "0.4.5",
     "webpack": "^2.2.1",
     "webpack-bundle-analyzer": "^2.2.1",
@@ -50,7 +50,7 @@
     "webpack-split-by-path": "0.0.10"
   },
   "rushDependencies": {
-    "@uifabric/example-app-base": ">=1.1.0-0 <2.0.0-0",
-    "@uifabric/utilities": ">=1.2.0-0 <2.0.0-0"
+    "@uifabric/example-app-base": "1.3.4",
+    "@uifabric/utilities": "1.4.0"
   }
 }

--- a/common/temp_modules/rush-todo-app/package.json
+++ b/common/temp_modules/rush-todo-app/package.json
@@ -19,9 +19,9 @@
     "office-ui-fabric-core": ">=5.1.0 <6.0.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "typescript": "^2.0.6"
+    "typescript": "^2.2.2"
   },
   "rushDependencies": {
-    "office-ui-fabric-react": ">=2.7.1 <3.0.0"
+    "office-ui-fabric-react": ">=2.10.5 <3.0.0"
   }
 }

--- a/common/temp_modules/rush-utilities/package.json
+++ b/common/temp_modules/rush-utilities/package.json
@@ -22,6 +22,6 @@
     "source-map-loader": "0.1.5",
     "tslint": "^3.15.1",
     "tslint-microsoft-contrib": "^2.0.9",
-    "typescript": "~2.1.0"
+    "typescript": "^2.2.2"
   }
 }

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -34,7 +34,7 @@
     "source-map-loader": "0.1.5",
     "tslint": "^3.15.1",
     "tslint-microsoft-contrib": "^2.0.9",
-    "typescript": "~2.1.0"
+    "typescript": "^2.2.2"
   },
   "peerDependencies": {
     "react": "^0.14 || ^15.0.1-0 || ^16.0.0-0",

--- a/packages/example-component/package.json
+++ b/packages/example-component/package.json
@@ -38,7 +38,7 @@
     "sass-loader": "^6.0.3",
     "style-loader": "^0.13.2",
     "ts-loader": "^2.0.1",
-    "typescript": "^2.2.1",
+    "typescript": "^2.2.2",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.1",
     "webpack-notifier": "^1.5.0"

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -56,7 +56,7 @@
     "ts-loader": "^2.0.1",
     "tslint": "^3.15.1",
     "tslint-microsoft-contrib": "^2.0.9",
-    "typescript": "^2.2.1",
+    "typescript": "^2.2.2",
     "vinyl-ftp": "0.4.5",
     "webpack": "^2.2.1",
     "webpack-bundle-analyzer": "^2.2.1",

--- a/packages/office-ui-fabric-react/src/common/StoreHost.tsx
+++ b/packages/office-ui-fabric-react/src/common/StoreHost.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { StoreSet } from './StoreSet';
+import { BaseComponent } from '../Utilities';
 
 export interface IStoreHostProps extends React.Props<StoreHost> {
   stores?: StoreSet;
@@ -9,7 +10,7 @@ export interface IStoreHostContext {
   stores?: StoreSet;
 }
 
-export class StoreHost extends React.Component<IStoreHostProps, {}> {
+export class StoreHost extends BaseComponent<IStoreHostProps, {}> {
   public static contextTypes = {
     stores: React.PropTypes.object
   };

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.Props.ts
@@ -4,7 +4,16 @@ import * as React from 'react';
 import { Breadcrumb } from './Breadcrumb';
 import { IRenderFunction } from '../../Utilities';
 
+export interface IBreadcrumb {
+
+}
+
 export interface IBreadcrumbProps extends React.Props<Breadcrumb> {
+  /**
+   * Optional callback to access the IBreadcrumb interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IBreadcrumb) => void;
 
   /**
    * Collection of breadcrumbs to render

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -46,7 +46,10 @@ export class BaseButton extends BaseComponent<IButtonProps, IBaseButtonState> im
   private _ariaDescriptionId: string;
 
   constructor(props: IButtonProps, rootClassName: string, deprecationMap: any) {
-    super(props, { 'rootProps': null });
+    super(props);
+
+    this._warnDeprecations({ 'rootProps': null });
+
     this._labelId = getId();
     this._descriptionId = getId();
     this._ariaDescriptionId = getId();

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -13,6 +13,12 @@ export interface IButton {
 
 export interface IButtonProps extends React.HTMLProps<HTMLButtonElement | HTMLAnchorElement | BaseButton | Button> {
   /**
+   * Optional way to fetch the IButton interface. Use this instead of ref, to avoid accessing higher-order component
+   * wrappers rather than the IButton interface.
+   */
+  componentRef?: (component: IButton) => void;
+
+  /**
    * If provided, this component will be rendered as an anchor.
    * @default ElementType.anchor
    */

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -13,8 +13,8 @@ export interface IButton {
 
 export interface IButtonProps extends React.HTMLProps<HTMLButtonElement | HTMLAnchorElement | BaseButton | Button> {
   /**
-   * Optional way to fetch the IButton interface. Use this instead of ref, to avoid accessing higher-order component
-   * wrappers rather than the IButton interface.
+   * Optional callback to access the IButton interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
    */
   componentRef?: (component: IButton) => void;
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
@@ -6,10 +6,16 @@ export { DayOfWeek, DateRangeType }
 
 export interface ICalendar {
   /** Sets focus to the selected date. */
-  focus(): void;
+  focus: () => void;
 }
 
 export interface ICalendarProps extends React.Props<Calendar> {
+  /**
+   * Optional callback to access the ICalendar interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ICalendar) => void;
+
   /**
   * Callback issued when a date is selected
   * @param date - The date the user selected

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   KeyCodes,
   css,
   getRTL
@@ -15,7 +16,7 @@ export interface ICalendarMonthProps {
   onNavigateDate: (date: Date, focusOnNavigatedDay: boolean) => void;
 }
 
-export class CalendarMonth extends React.Component<ICalendarMonthProps, {}> {
+export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
   private _selectMonthCallbacks: (() => void)[];
 
   public constructor(props: ICalendarMonthProps) {

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -7,7 +7,16 @@ import {
   IRectangle
 } from '../../Utilities';
 
+export interface ICallout {
+
+}
+
 export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
+  /**
+   * Optional callback to access the ICallout interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ICallout) => void;
 
   /**
    * The target that the Callout should try to position itself based on.

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -49,7 +49,9 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
   private _target: HTMLElement | MouseEvent;
 
   constructor(props: ICalloutProps) {
-    super(props, { 'beakStyle': 'beakWidth' });
+    super(props);
+
+    this._warnDeprecations({ 'beakStyle': 'beakWidth' });
 
     this._didSetInitialFocus = false;
     this.state = {

--- a/packages/office-ui-fabric-react/src/components/Check/Check.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { css } from '../../Utilities';
+import { BaseComponent, css } from '../../Utilities';
 import styles = require('./Check.scss');
 
 export interface ICheckProps extends React.Props<Check> {
@@ -15,7 +15,7 @@ export interface ICheckProps extends React.Props<Check> {
   isChecked?: boolean;
 }
 
-export class Check extends React.Component<ICheckProps, {}> {
+export class Check extends BaseComponent<ICheckProps, {}> {
   public static defaultProps = {
     isChecked: false
   };

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
@@ -16,8 +16,8 @@ export interface ICheckbox {
  */
 export interface ICheckboxProps extends React.HTMLProps<HTMLElement | HTMLInputElement> {
   /**
-   * Optional way to fetch the IButton interface. Use this instead of ref, to avoid accessing higher-order component
-   * wrappers rather than the IButton interface.
+   * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
    */
   componentRef?: (component: ICheckbox) => void;
 

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
@@ -8,13 +8,19 @@ export interface ICheckbox {
   checked: boolean;
 
   /** Sets focus to the checkbox. */
-  focus(): void;
+  focus: () => void;
 }
 
 /**
  * Checkbox properties.
  */
 export interface ICheckboxProps extends React.HTMLProps<HTMLElement | HTMLInputElement> {
+  /**
+   * Optional way to fetch the IButton interface. Use this instead of ref, to avoid accessing higher-order component
+   * wrappers rather than the IButton interface.
+   */
+  componentRef?: (component: ICheckbox) => void;
+
   /**
    * Additional class name to provide on the root element, in addition to the ms-Checkbox class.
    */

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -29,6 +29,10 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
   constructor(props: ICheckboxProps) {
     super(props);
 
+    this._warnMutuallyExclusive({
+      'checked': 'defaultChecked'
+    });
+
     this._id = getId('checkbox-');
     this.state = {
       isFocused: false,

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -99,7 +99,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
     return this._checkBox ? this._checkBox.checked : false;
   }
 
-  public focus() {
+  public focus(): void {
     if (this._checkBox) {
       this._checkBox.focus();
     }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -1,7 +1,17 @@
 import * as React from 'react';
 import { IIconProps } from '../../Icon';
 
+export interface IChoiceGroup {
+
+}
+
 export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement | HTMLInputElement> {
+  /**
+   * Optional callback to access the IChoiceGroup interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IChoiceGroup) => void;
+
   /**
    * The options for the choice group.
    */

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -27,7 +27,13 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
   private _inputElement: HTMLInputElement;
 
   constructor(props: IChoiceGroupProps, ) {
-    super(props, { ['onChanged']: 'onChange' });
+    super(props);
+
+    this._warnDeprecations({ 'onChanged': 'onChange' });
+
+    this._warnMutuallyExclusive({
+      'selectedKey': 'defaultSelectedKey'
+    });
 
     this.state = {
       keyChecked: (props.defaultSelectedKey === undefined) ?

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { autobind, css } from '../../Utilities';
+import {
+  BaseComponent,
+  autobind,
+  css
+} from '../../Utilities';
 import { IColorPickerProps } from './ColorPicker.Props';
 import { TextField } from '../../TextField';
 import { ColorRectangle } from './ColorRectangle';
@@ -31,7 +35,7 @@ export interface IColor {
   str: string;
 }
 
-export class ColorPicker extends React.Component<IColorPickerProps, IColorPickerState> {
+export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerState> {
   constructor(props: IColorPickerProps) {
     super(props);
 

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  EventGroup,
+  BaseComponent,
   assign,
   autobind,
   css
@@ -28,7 +28,7 @@ export interface IColorPickerState {
   fullColorString?: string;
 }
 
-export class ColorRectangle extends React.Component<IColorRectangleProps, IColorPickerState> {
+export class ColorRectangle extends BaseComponent<IColorRectangleProps, IColorPickerState> {
   public static defaultProps = {
     minSize: 220
   };
@@ -38,14 +38,10 @@ export class ColorRectangle extends React.Component<IColorRectangleProps, IColor
     root: HTMLElement;
   };
 
-  private _events: EventGroup;
-
   constructor(props: IColorRectangleProps) {
     super(props);
 
     let { color } = this.props;
-
-    this._events = new EventGroup(this);
 
     this.state = {
       isAdjusting: false,

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  EventGroup,
+  BaseComponent,
   autobind,
   css
 } from '../../Utilities';
@@ -24,7 +24,7 @@ export interface IColorSliderState {
   currentValue?: number;
 }
 
-export class ColorSlider extends React.Component<IColorSliderProps, IColorSliderState> {
+export class ColorSlider extends BaseComponent<IColorSliderProps, IColorSliderState> {
   public static defaultProps = {
     minValue: 0,
     maxValue: 100,
@@ -37,24 +37,16 @@ export class ColorSlider extends React.Component<IColorSliderProps, IColorSlider
     root: HTMLElement;
   };
 
-  private _events: EventGroup;
-
   constructor(props: IColorSliderProps) {
     super(props);
 
     let { initialValue } = this.props;
-
-    this._events = new EventGroup(this);
 
     this.state = {
       isAdjusting: false,
       origin: null,
       currentValue: initialValue
     };
-  }
-
-  public componentWillUnmount() {
-    this._events.dispose();
   }
 
   public render() {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts
@@ -10,6 +10,12 @@ export interface ICommandBar {
 
 export interface ICommandBarProps extends React.HTMLProps<HTMLDivElement> {
   /**
+   * Optional callback to access the ICommandBar interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ICommandBar) => void;
+
+  /**
    * Whether or not the search box is visible
    * @defaultvalue false
    */

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  EventGroup,
+  BaseComponent,
   autobind,
   buttonProperties,
   css,
@@ -32,7 +32,7 @@ export interface ICommandBarState {
   renderedFarItems?: IContextualMenuItem[];
 }
 
-export class CommandBar extends React.Component<ICommandBarProps, ICommandBarState> implements ICommandBar {
+export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState> implements ICommandBar {
   public static defaultProps = {
     items: [],
     overflowItems: [],
@@ -51,7 +51,6 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
   private _id: string;
   private _overflowWidth: number;
   private _commandItemWidths: { [key: string]: number };
-  private _events: EventGroup;
 
   constructor(props: ICommandBarProps) {
     super(props);
@@ -59,7 +58,6 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
     this.state = this._getStateFromProps(props);
 
     this._id = getId('CommandBar');
-    this._events = new EventGroup(this);
   }
 
   public componentDidMount() {
@@ -67,10 +65,6 @@ export class CommandBar extends React.Component<ICommandBarProps, ICommandBarSta
     this._updateRenderedItems();
 
     this._events.on(window, 'resize', this._updateRenderedItems);
-  }
-
-  public componentWillUnmount() {
-    this._events.dispose();
   }
 
   public componentWillReceiveProps(nextProps: ICommandBarProps) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -15,7 +15,16 @@ export enum ContextualMenuItemType {
   Header = 2
 }
 
+export interface IContextualMenu {
+
+}
+
 export interface IContextualMenuProps extends React.Props<ContextualMenu> {
+  /**
+   * Optional callback to access the IContextualMenu interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IContextualMenu) => void;
 
   /**
    * The target that the ContextualMenu should try to position itself based on.

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.Props.ts
@@ -2,7 +2,17 @@ import * as React from 'react';
 import { DatePicker } from './DatePicker';
 import { DayOfWeek } from '../../Calendar';
 
+export interface IDatePicker {
+
+}
+
 export interface IDatePickerProps extends React.Props<DatePicker> {
+  /**
+   * Optional callback to access the IDatePicker interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IDatePicker) => void;
+
   /**
    * Callback issued when a date is selected
    */

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -27,6 +27,12 @@ export interface IDetailsList {
 }
 
 export interface IDetailsListProps extends React.Props<DetailsList> {
+  /**
+   * Optional callback to access the IDetailsList interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IDetailsList) => void;
+
   /** A key that uniquely identifies the given items. If provided, the selection will be reset when the key changes. */
   setKey?: string;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  EventGroup,
+  BaseComponent,
   KeyCodes,
   assign,
   autobind,
@@ -52,7 +52,7 @@ const DEFAULT_RENDERED_WINDOWS_AHEAD = 2;
 const DEFAULT_RENDERED_WINDOWS_BEHIND = 2;
 
 @withViewport
-export class DetailsList extends React.Component<IDetailsListProps, IDetailsListState> implements IDetailsList {
+export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListState> implements IDetailsList {
   public static defaultProps = {
     layoutMode: DetailsListLayoutMode.justified,
     selectionMode: SelectionMode.multiple,
@@ -71,7 +71,6 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
     selectionZone: SelectionZone
   };
 
-  private _events: EventGroup;
   private _selection: ISelection;
   private _activeRows: { [key: string]: DetailsRow };
   private _dragDropHelper: DragDropHelper;
@@ -108,7 +107,6 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
       isSomeGroupExpanded: props.groupProps && !props.groupProps.isAllGroupsCollapsed
     };
 
-    this._events = new EventGroup(this);
     this._selection = props.selection || new Selection({ onSelectionChanged: null, getKey: props.getKey });
     this._selection.setItems(props.items as IObjectWithKey[], false);
     this._dragDropHelper = props.dragDropEvents ? new DragDropHelper({ selection: this._selection }) : null;
@@ -116,7 +114,6 @@ export class DetailsList extends React.Component<IDetailsListProps, IDetailsList
   }
 
   public componentWillUnmount() {
-    this._events.dispose();
     if (this._dragDropHelper) {
       this._dragDropHelper.dispose();
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  EventGroup,
+  BaseComponent,
   assign,
   css,
   shallowCompare
@@ -58,14 +58,13 @@ export interface IDetailsRowState {
 
 const DEFAULT_DROPPING_CSS_CLASS = 'is-dropping';
 
-export class DetailsRow extends React.Component<IDetailsRowProps, IDetailsRowState> {
+export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState> {
   public refs: {
     [key: string]: React.ReactInstance,
     root: HTMLElement,
     cellMeasurer: HTMLElement
   };
 
-  private _events: EventGroup;
   private _hasSetFocus: boolean;
   private _droppingClassNames: string;
   private _hasMounted: boolean;
@@ -83,7 +82,6 @@ export class DetailsRow extends React.Component<IDetailsRowProps, IDetailsRowSta
 
     this._hasSetFocus = false;
 
-    this._events = new EventGroup(this);
     this._droppingClassNames = '';
     this._updateDroppingState = this._updateDroppingState.bind(this);
   }
@@ -141,8 +139,6 @@ export class DetailsRow extends React.Component<IDetailsRowProps, IDetailsRowSta
   public componentWillUnmount() {
     let { item, onWillUnmount } = this.props;
 
-    this._events.dispose();
-
     // Only call the onWillUnmount callback if we have an item.
     if (onWillUnmount && item) {
       onWillUnmount(this);
@@ -197,7 +193,7 @@ export class DetailsRow extends React.Component<IDetailsRowProps, IDetailsRowSta
         data-selection-index={ itemIndex }
         data-item-index={ itemIndex }
         data-is-draggable={ isDraggable }
-        draggable= { isDraggable }
+        draggable={ isDraggable }
         data-automationid='DetailsRow'
         style={ { minWidth: viewport ? viewport.width : 0 } }
         aria-selected={ isSelected }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IColumn } from './DetailsList.Props';
-import { css } from '../../Utilities';
+import { BaseComponent, css } from '../../Utilities';
 import styles = require('./DetailsRow.scss');
 
 export interface IDetailsRowFieldsProps {
@@ -14,7 +14,7 @@ export interface IDetailsRowFieldsState {
   cellContent: React.ReactNode[];
 }
 
-export class DetailsRowFields extends React.Component<IDetailsRowFieldsProps, IDetailsRowFieldsState> {
+export class DetailsRowFields extends BaseComponent<IDetailsRowFieldsProps, IDetailsRowFieldsState> {
   constructor(props: IDetailsRowFieldsProps) {
     super();
 

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
@@ -4,7 +4,17 @@ import { IButtonProps } from '../Button/Button.Props';
 import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
 import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
 
+export interface IDialog {
+
+}
+
 export interface IDialogProps extends React.Props<Dialog>, IWithResponsiveModeState, IAccessiblePopupProps {
+  /**
+   * Optional callback to access the IDialog interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IDialog) => void;
+
   /**
   * Whether the dialog is displayed.
   * @default false

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { css } from '../../Utilities';
+import { BaseComponent, css } from '../../Utilities';
 import styles = require('./Dialog.scss');
 
-export class DialogFooter extends React.Component<any, any> {
+export class DialogFooter extends BaseComponent<any, any> {
   public render() {
     return (
       <div className={ css('ms-Dialog-actions', styles.actions) }>

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
@@ -9,7 +9,17 @@ import { PersonaInitialsColor } from '../../Persona';
 import { ImageFit } from '../../Image';
 import { IButtonProps } from '../../Button';
 
+export interface IDocumentCard {
+
+}
+
 export interface IDocumentCardProps extends React.Props<DocumentCard> {
+  /**
+   * Optional callback to access the IDocumentCard interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IDocumentCard) => void;
+
   /**
   * The type of DocumentCard to display.
   * @default DocumentCardType.normal

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { IDocumentCardProps, DocumentCardType } from './DocumentCard.Props';
 import {
+  BaseComponent,
+  KeyCodes,
   autobind,
-  css,
-  KeyCodes
+  css
 } from '../../Utilities';
 import styles = require('./DocumentCard.scss');
 
-export class DocumentCard extends React.Component<IDocumentCardProps, any> {
+export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
   public static defaultProps: IDocumentCardProps = {
     type: DocumentCardType.normal
   };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActions.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActions.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { css } from '../../Utilities';
+import { BaseComponent, css } from '../../Utilities';
 import { IDocumentCardActionsProps } from './DocumentCard.Props';
 import { Button, ButtonType } from '../../Button';
 import styles = require('./DocumentCard.scss');
 
-export class DocumentCardActions extends React.Component<IDocumentCardActionsProps, any> {
+export class DocumentCardActions extends BaseComponent<IDocumentCardActionsProps, any> {
   public render() {
     let { actions, views } = this.props;
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { css } from '../../Utilities';
+import { BaseComponent, css } from '../../Utilities';
 import { IDocumentCardActivityProps, IDocumentCardActivityPerson } from './DocumentCard.Props';
 import { Persona, PersonaSize } from '../../Persona';
 import styles = require('./DocumentCard.scss');
 
-export class DocumentCardActivity extends React.Component<IDocumentCardActivityProps, any> {
+export class DocumentCardActivity extends BaseComponent<IDocumentCardActivityProps, any> {
   public render() {
     let { activity, people } = this.props;
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { css } from '../../Utilities';
+import { BaseComponent, css } from '../../Utilities';
 import { IDocumentCardLocationProps } from './DocumentCard.Props';
 import styles = require('./DocumentCard.scss');
 
-export class DocumentCardLocation extends React.Component<IDocumentCardLocationProps, any> {
+export class DocumentCardLocation extends BaseComponent<IDocumentCardLocationProps, any> {
   public render() {
     let { location, locationHref, ariaLabel, onClick } = this.props;
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IDocumentCardPreviewProps, IDocumentCardPreviewImage } from './DocumentCard.Props';
 import { Image } from '../../Image';
 import {
+  BaseComponent,
   autobind,
   css
 } from '../../Utilities';
@@ -9,7 +10,7 @@ import styles = require('./DocumentCard.scss');
 
 const LIST_ITEM_COUNT = 3;
 
-export class DocumentCardPreview extends React.Component<IDocumentCardPreviewProps, any> {
+export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps, any> {
   public render() {
     let { previewImages } = this.props;
     let style, preview;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
@@ -2,7 +2,17 @@ import * as React from 'react';
 import { IRenderFunction } from '../../Utilities';
 import { Dropdown } from './Dropdown';
 
+export interface IDropdown {
+
+}
+
 export interface IDropdownProps extends React.Props<Dropdown> {
+  /**
+   * Optional callback to access the IDropdown interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IDropdown) => void;
+
   /**
    * Descriptive label for the Dropdown
    */

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
@@ -6,7 +6,7 @@ export interface IDropdownProps extends React.Props<Dropdown> {
   /**
    * Descriptive label for the Dropdown
    */
-  label: string;
+  label?: string;
 
   /**
   * Aria Label for the Dropdown for screen reader users.

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -49,7 +49,9 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   private _id: string;
 
   constructor(props?: IDropdownProps) {
-    super(props, {
+    super(props);
+
+    this._warnDeprecations({
       'isDisabled': 'disabled'
     });
 

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  EventGroup,
+  BaseComponent,
   KeyCodes,
   css
 } from '../../Utilities';
@@ -30,13 +30,11 @@ if (typeof (document) === 'object' && document.documentElement && !document.docu
   document.documentElement.setAttribute('dir', 'ltr');
 }
 
-export class Fabric extends React.Component<React.HTMLProps<HTMLDivElement>, IFabricState> {
+export class Fabric extends BaseComponent<React.HTMLProps<HTMLDivElement>, IFabricState> {
   public refs: {
     [key: string]: React.ReactInstance;
     root: HTMLElement;
   };
-
-  private _events: EventGroup;
 
   constructor() {
     super();
@@ -44,17 +42,11 @@ export class Fabric extends React.Component<React.HTMLProps<HTMLDivElement>, IFa
     this.state = {
       isFocusVisible: _lastIsFocusVisible
     };
-
-    this._events = new EventGroup(this);
   }
 
   public componentDidMount() {
     this._events.on(document.body, 'mousedown', this._onMouseDown, true);
     this._events.on(document.body, 'keydown', this._onKeyDown, true);
-  }
-
-  public componentWillUnmount() {
-    this._events.dispose();
   }
 
   public render() {

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts
@@ -7,7 +7,17 @@ import {
   PersonaSize
 } from '../Persona/index';
 
+export interface IFacepile {
+
+}
+
 export interface IFacepileProps extends React.Props<Facepile> {
+  /**
+   * Optional callback to access the IFacepile interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IFacepile) => void;
+
   /**
    * Array of IPersonaProps that define each Persona. Note that the size
    * is fixed at PersonaSize.extraSmall regardless of what is specified.

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   buttonProperties,
   css,
   divProperties,
@@ -23,7 +24,7 @@ import {
 } from '../../Persona';
 import styles = require('./Facepile.scss');
 
-export class Facepile extends React.Component<IFacepileProps, {}> {
+export class Facepile extends BaseComponent<IFacepileProps, {}> {
   public static defaultProps: IFacepileProps = {
     maxDisplayablePersonas: 5,
     personas: [],

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.Props.ts
@@ -9,6 +9,12 @@ export interface IFocusTrapZone {
 
 export interface IFocusTrapZoneProps extends React.HTMLProps<HTMLDivElement> {
   /**
+   * Optional callback to access the IFocusTrapZone interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IFocusTrapZone) => void;
+
+  /**
    * Sets the HTMLElement to focus on when exiting the FocusTrapZone.
    * @default The element.target that triggered the FTZ.
    */
@@ -31,14 +37,14 @@ export interface IFocusTrapZoneProps extends React.HTMLProps<HTMLDivElement> {
    */
   ignoreExternalFocusing?: boolean;
 
-   /**
-   * Indicates whether focus trap zone should force focus inside the focus trap zone
-   * @default true
-   */
+  /**
+  * Indicates whether focus trap zone should force focus inside the focus trap zone
+  * @default true
+  */
   forceFocusInsideTrap?: boolean;
 
-   /**
-   * Indicates the selector for first focusable item
-   */
+  /**
+  * Indicates the selector for first focusable item
+  */
   firstFocusableSelector?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
@@ -26,6 +26,12 @@ export interface IFocusZone {
  */
 export interface IFocusZoneProps extends React.HTMLProps<HTMLElement | FocusZone> {
   /**
+   * Optional callback to access the IFocusZone interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IFocusZone) => void;
+
+  /**
    * Additional class name to provide on the root element, in addition to the ms-FocusZone class.
    */
   className?: string;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -56,7 +56,9 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   private _isInnerZone: boolean;
 
   constructor(props) {
-    super(props, { 'rootProps': null });
+    super(props);
+
+    this._warnDeprecations({ 'rootProps': null });
 
     this._id = getId('FocusZone');
     _allInstances[this._id] = this;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   autobind,
   css
 } from '../../Utilities';
@@ -17,7 +18,7 @@ export interface IGroupHeaderState {
   isLoadingVisible: boolean;
 }
 
-export class GroupHeader extends React.Component<IGroupDividerProps, IGroupHeaderState> {
+export class GroupHeader extends BaseComponent<IGroupDividerProps, IGroupHeaderState> {
   constructor(props: IGroupDividerProps) {
     super(props);
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
@@ -32,6 +32,12 @@ export interface IGroupedList {
 }
 
 export interface IGroupedListProps extends React.Props<GroupedList> {
+  /**
+   * Optional callback to access the IGroupedList interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IGroupedList) => void;
+
   /** Optional class name to add to the root element. */
   className?: string;
 

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -1,6 +1,16 @@
 import * as React from 'react';
 
+export interface IImage {
+
+}
+
 export interface IImageProps extends React.HTMLProps<HTMLImageElement> {
+  /**
+   * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IImage) => void;
+
   /**
    * If true, fades the image in when loaded.
    * @defaultvalue false;

--- a/packages/office-ui-fabric-react/src/components/Label/Label.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.Props.ts
@@ -2,7 +2,17 @@
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 
+export interface ILabel {
+
+}
+
 export interface ILabelProps extends React.HTMLProps<HTMLLabelElement> {
+  /**
+   * Optional callback to access the ILabel interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ILabel) => void;
+
   /**
    * Whether the associated form field is required or not
    * @defaultvalue false

--- a/packages/office-ui-fabric-react/src/components/Label/Label.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { css, divProperties, getNativeProps } from '../../Utilities';
+import { BaseComponent, css, divProperties, getNativeProps } from '../../Utilities';
 import { ILabelProps } from './Label.Props';
 import styles = require('./Label.scss');
 
-export class Label extends React.Component<ILabelProps, any> {
+export class Label extends BaseComponent<ILabelProps, any> {
   public render() {
     let { disabled, required, children, className } = this.props;
 

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.Props.ts
@@ -1,7 +1,17 @@
 import * as React from 'react';
 import { Layer } from './Layer';
 
+export interface ILayer {
+
+}
+
 export interface ILayerProps extends React.HTMLProps<HTMLDivElement | Layer> {
+  /**
+   * Optional callback to access the ILayer interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ILayer) => void;
+
   /** Callback for when the layer is mounted. */
   onLayerMounted?: () => void;
 

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
@@ -32,8 +32,9 @@ export class Layer extends BaseComponent<ILayerProps, {}> {
   }
 
   constructor(props: ILayerProps) {
-    super(props, {
-      // Make sure to deprecate old properties.
+    super(props);
+
+    this._warnDeprecations({
       'onLayerMounted': 'onLayerDidMount'
     });
 

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.Props.ts
@@ -1,6 +1,16 @@
 import * as React from 'react';
 
+export interface ILayerHost {
+
+}
+
 export interface ILayerHostProps extends React.HTMLProps<HTMLElement> {
+  /**
+   * Optional callback to access the ILayerHost interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ILayerHost) => void;
+
   /**
    * Defines the id for the layer host that Layers can target (using the hostId property.)
    */

--- a/packages/office-ui-fabric-react/src/components/Link/Link.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.Props.ts
@@ -10,6 +10,12 @@ export interface ILink {
 
 export interface ILinkProps extends React.HTMLProps<HTMLAnchorElement | HTMLButtonElement | HTMLElement | Link> {
   /**
+   * Optional callback to access the ILink interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ILink) => void;
+
+  /**
    * Whether the link is disabled
    */
   disabled?: boolean;

--- a/packages/office-ui-fabric-react/src/components/List/List.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.Props.ts
@@ -2,7 +2,17 @@ import * as React from 'react';
 import { IRectangle } from '../../Utilities';
 import { List } from './List';
 
+export interface IList {
+
+}
+
 export interface IListProps extends React.HTMLProps<List | HTMLDivElement> {
+  /**
+   * Optional callback to access the IList interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IList) => void;
+
   /** Optional classname to append to root list. */
   className?: string;
 

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.Props.ts
@@ -2,7 +2,17 @@ import * as React from 'react';
 import { ISelection } from '../../utilities/selection/interfaces';
 import { MarqueeSelection } from './MarqueeSelection';
 
+export interface IMarqueeSelection {
+
+}
+
 export interface IMarqueeSelectionProps extends React.Props<MarqueeSelection> {
+  /**
+   * Optional callback to access the IMarqueeSelection interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IMarqueeSelection) => void;
+
   /**
    * The selection object to interact with when updating selection changes.
    */

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts
@@ -1,6 +1,15 @@
 import * as React from 'react';
 
+export interface IMessageBar {
+
+}
+
 export interface IMessageBarProps extends React.HTMLProps<HTMLElement> {
+  /**
+   * Optional callback to access the IMessageBar interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IMessageBar) => void;
 
   /**
    * The type of MessageBar to render.
@@ -32,9 +41,9 @@ export interface IMessageBarProps extends React.HTMLProps<HTMLElement> {
    */
   isMultiline?: boolean;
 
-   /**
-   * Aria label on dismiss button if onDismiss is defined.
-   */
+  /**
+  * Aria label on dismiss button if onDismiss is defined.
+  */
   dismissButtonAriaLabel?: string;
 }
 

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   DelayedRender,
   css,
   getId
@@ -13,7 +14,7 @@ export interface IMessageBarState {
   showContent?: boolean;
 }
 
-export class MessageBar extends React.Component<IMessageBarProps, IMessageBarState> {
+export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState> {
 
   public static defaultProps: IMessageBarProps = {
     messageBarType: MessageBarType.info,

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
@@ -12,6 +12,12 @@ export interface INav {
 
 export interface INavProps {
   /**
+   * Optional callback to access the INav interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: INav) => void;
+
+  /**
    * A collection of link groups to display in the navigation bar
    */
   groups: INavLinkGroup[];

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   css,
   getRTL
 } from '../../Utilities';
@@ -30,7 +31,7 @@ export interface INavState {
   selectedKey?: string;
 }
 
-export class Nav extends React.Component<INavProps, INavState> implements INav {
+export class Nav extends BaseComponent<INavProps, INavState> implements INav {
 
   public static defaultProps: INavProps = {
     groups: null,

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.Props.ts
@@ -1,6 +1,16 @@
 import * as React from 'react';
 
+export interface IOverlay {
+
+}
+
 export interface IOverlayProps extends React.HTMLProps<HTMLElement> {
+  /**
+   * Optional callback to access the IOverlay interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IOverlay) => void;
+
   /**
    * Whether to use the dark-themed overlay.
    * @defaultvalue false

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   css,
   getNativeProps,
   divProperties,
@@ -10,7 +11,7 @@ import { IOverlayProps } from './Overlay.Props';
 
 import styles = require('./Overlay.scss');
 
-export class Overlay extends React.Component<IOverlayProps, {}> {
+export class Overlay extends BaseComponent<IOverlayProps, {}> {
 
   public componentDidMount() {
     disableBodyScroll();

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
@@ -3,7 +3,15 @@ import { Panel } from './Panel';
 import { IRenderFunction } from '../../Utilities';
 import { ILayerProps } from '../../Layer';
 
+export interface IPanel {
+
+}
 export interface IPanelProps extends React.Props<Panel> {
+  /**
+   * Optional callback to access the IPanel interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IPanel) => void;
 
   /**
   * Whether the panel is displayed.

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
@@ -2,7 +2,17 @@ import * as React from 'react';
 import { IRenderFunction } from '../../Utilities';
 import { Persona } from './Persona';
 
+export interface IPersona {
+
+}
+
 export interface IPersonaProps extends React.HTMLProps<Persona> {
+  /**
+   * Optional callback to access the IPersona interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IPersona) => void;
+
   /**
    * Primary text to display, usually the name of the person.
    */

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   autobind,
   css,
   divProperties,
@@ -47,7 +48,7 @@ export interface IPersonaState {
   isImageLoaded?: boolean;
 }
 
-export class Persona extends React.Component<IPersonaProps, IPersonaState> {
+export class Persona extends BaseComponent<IPersonaProps, IPersonaState> {
   public static defaultProps: IPersonaProps = {
     primaryText: '',
     size: PersonaSize.regular,

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.Props.ts
@@ -3,7 +3,17 @@ import * as React from 'react';
 import { Pivot } from './Pivot';
 import { PivotItem } from './PivotItem';
 
+export interface IPivot {
+
+}
+
 export interface IPivotProps extends React.Props<Pivot> {
+  /**
+   * Optional callback to access the IPivot interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IPivot) => void;
+
   /**
    * The index of the pivot item initially selected.
    *

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   KeyCodes,
   css,
   getId,
@@ -36,7 +37,7 @@ export interface IPivotState {
   selectedTabId: string;
 }
 
-export class Pivot extends React.Component<IPivotProps, IPivotState> {
+export class Pivot extends BaseComponent<IPivotProps, IPivotState> {
   private _keyToIndexMapping: { [key: string]: number };
   private _keyToTabIds: { [key: string]: string };
   private _pivotId: string;

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
+import { BaseComponent } from '../../Utilities';
 import { IPivotItemProps } from './PivotItem.Props';
 
-export class PivotItem extends React.Component<IPivotItemProps, any> {
+export class PivotItem extends BaseComponent<IPivotItemProps, {}> {
 
   public render() {
     return (
       <div>
-        {this.props.children}
+        { this.props.children }
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.Props.ts
@@ -3,7 +3,17 @@ import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 import { Popup } from './Popup';
 
+export interface IPopup {
+
+}
+
 export interface IPopupProps extends React.HTMLProps<Popup> {
+  /**
+   * Optional callback to access the IPopup interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IPopup) => void;
+
   /**
    * Aria role for popup
    */

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.Props.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 export interface IProgressIndicator {
 
 }

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.Props.ts
@@ -1,4 +1,15 @@
+import * as React from 'react';
+
+export interface IProgressIndicator {
+
+}
+
 export interface IProgressIndicatorProps {
+  /**
+   * Optional callback to access the IProgressIndicator interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IProgressIndicator) => void;
 
   /**
    * Class name to apply to the root in addition to ms-ProgressIndicator.

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -22,8 +22,14 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
   };
 
   constructor(props: IProgressIndicatorProps) {
-    super(props, {
+    super(props);
+
+    this._warnDeprecations({
       'title': 'label'
+    });
+
+    this._warnMutuallyExclusive({
+      'selectedKey': 'defaultSelectedKey'
     });
   }
 

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -28,9 +28,6 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
       'title': 'label'
     });
 
-    this._warnMutuallyExclusive({
-      'selectedKey': 'defaultSelectedKey'
-    });
   }
 
   public render() {

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.Props.ts
@@ -1,9 +1,19 @@
 import * as React from 'react';
 
+export interface IRating {
+
+}
+
 /**
  * Rating component props.
  */
 export interface IRatingProps extends React.HTMLProps<HTMLElement> {
+  /**
+   * Optional callback to access the IRating interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IRating) => void;
+
   /**
    * Selected rating, has to be an integer between min and max
    */

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
@@ -1,7 +1,16 @@
 import * as React from 'react';
 import { SearchBox } from './SearchBox';
 
+export interface ISearchBox {
+
+}
+
 export interface ISearchBoxProps extends React.Props<SearchBox> {
+  /**
+   * Optional callback to access the ISearchBox interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ISearchBox) => void;
 
   /**
   * Label text for the SearchBox.

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
@@ -1,9 +1,15 @@
 import * as React from 'react';
 
+export interface ISlider {
+  value: number;
+
+  focus: () => void;
+}
+
 export interface ISliderProps {
   /**
-   * Optional way to fetch the ISlider interface. Use this instead of ref, to avoid accessing higher-order component
-   * wrappers rather than the ISlider interface.
+   * Optional callback to access the ISlider interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
    */
   componentRef?: (component: ISlider) => void;
 
@@ -74,8 +80,3 @@ export interface ISliderProps {
   buttonProps?: React.HTMLProps<HTMLButtonElement>;
 }
 
-export interface ISlider {
-  value: number;
-
-  focus: () => void;
-}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
@@ -79,4 +79,3 @@ export interface ISliderProps {
    */
   buttonProps?: React.HTMLProps<HTMLButtonElement>;
 }
-

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
@@ -2,6 +2,12 @@ import * as React from 'react';
 
 export interface ISliderProps {
   /**
+   * Optional way to fetch the ISlider interface. Use this instead of ref, to avoid accessing higher-order component
+   * wrappers rather than the ISlider interface.
+   */
+  componentRef?: (component: ISlider) => void;
+
+  /**
    * Description label of the Slider
    */
   label?: string;

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
@@ -8,6 +8,7 @@ import * as ReactTestUtils from 'react-addons-test-utils';
 let { expect } = chai;
 
 import { Slider } from './Slider';
+import { ISlider } from './Slider.Props';
 
 describe('Slider', () => {
 
@@ -29,7 +30,7 @@ describe('Slider', () => {
     let component = ReactTestUtils.renderIntoDocument<React.ReactInstance>(
       <Slider
         onChange={ onChange }
-        />
+      />
     );
 
     let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
@@ -79,4 +80,12 @@ describe('Slider', () => {
     }
   });
 
+  it('can read the current value', () => {
+    let slider: ISlider;
+
+    let component = ReactTestUtils.renderIntoDocument(
+      <Slider label='slider' defaultValue={ 12 } min={ 0 } max={ 100 } componentRef={ s => slider = s } />
+    );
+    expect(slider.value).equals(12);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
@@ -44,6 +44,10 @@ export class Slider extends BaseComponent<ISliderProps, ISliderState> implements
   constructor(props?: ISliderProps) {
     super(props);
 
+    this._warnMutuallyExclusive({
+      'value': 'defaultValue'
+    });
+
     this._id = getId('Slider');
 
     let value = props.value || props.defaultValue || props.min;

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.Props.ts
@@ -1,7 +1,16 @@
 import * as React from 'react';
 import { Spinner } from './Spinner';
 
+export interface ISpinner {
+
+}
+
 export interface ISpinnerProps extends React.Props<Spinner> {
+  /**
+   * Optional callback to access the ISpinner interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ISpinner) => void;
 
   /**
    * @deprecated

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { css } from '../../Utilities';
+import { BaseComponent, css } from '../../Utilities';
 import { ISpinnerProps, SpinnerType, SpinnerSize } from './Spinner.Props';
 import styles = require('./Spinner.scss');
 
-export class Spinner extends React.Component<ISpinnerProps, any> {
+export class Spinner extends BaseComponent<ISpinnerProps, any> {
   public static defaultProps: ISpinnerProps = {
     size: SpinnerSize.medium
   };

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.Props.ts
@@ -6,11 +6,21 @@ import { IButtonProps } from '../../Button';
 import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
 import { ICalloutProps } from '../../Callout';
 
+export interface ITeachingBubble {
+
+}
+
 /**
  * TeachingBubble component props.
  */
 
 export interface ITeachingBubbleProps extends React.Props<TeachingBubble | TeachingBubbleContent>, IAccessiblePopupProps {
+  /**
+   * Optional callback to access the ISlider interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ITeachingBubble) => void;
+
   /**
    * Properties to pass through for Callout, reference detail properties in ICalloutProps
    */

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.Props.ts
@@ -1,9 +1,32 @@
 import * as React from 'react';
 
+export interface ITextField {
+  /** Gets the current value of the input. */
+  value: string;
+
+  /** Sets focus to the input. */
+  focus: () => void;
+
+  /** Select the value of the text field. */
+  select: () => void;
+
+  /** Sets the selection start of the text field to a specified value */
+  setSelectionStart: (value: number) => void;
+
+  /** Sets the selection end of the text field to a specified value */
+  setSelectionEnd: (value: number) => void;
+}
+
 /**
  * TextField component props.
  */
 export interface ITextFieldProps extends React.HTMLProps<HTMLInputElement | HTMLTextAreaElement> {
+  /**
+   * Optional callback to access the ITextField interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ITextField) => void;
+
   /**
    * Whether or not the textfield is a multiline textfield.
    * @default false
@@ -134,21 +157,4 @@ export interface ITextFieldProps extends React.HTMLProps<HTMLInputElement | HTML
    * @default true
    */
   validateOnLoad?: boolean;
-}
-
-export interface ITextField {
-  /** Gets the current value of the input. */
-  value: string;
-
-  /** Sets focus to the input. */
-  focus(): void;
-
-  /** Select the value of the text field. */
-  select(): void;
-
-  /** Sets the selection start of the text field to a specified value */
-  setSelectionStart(value: number): void;
-
-  /** Sets the selection end of the text field to a specified value */
-  setSelectionEnd(value: number): void;
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -57,6 +57,10 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
   public constructor(props: ITextFieldProps) {
     super(props);
 
+    this._warnMutuallyExclusive({
+      'value': 'defaultValue'
+    });
+
     this._id = getId('TextField');
     this._descriptionId = getId('TextFieldDescription');
 

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
@@ -1,9 +1,20 @@
 import * as React from 'react';
 import { Toggle } from './Toggle';
+
+export interface IToggle {
+
+}
+
 /**
  * Toggle component props.
  */
 export interface IToggleProps extends React.HTMLProps<HTMLInputElement | Toggle> {
+  /**
+   * Optional callback to access the IToggle interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IToggle) => void;
+
   /**
    * A label for the toggle.
    */

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  BaseComponent,
   autobind,
   css,
   getId,
@@ -14,7 +15,7 @@ export interface IToggleState {
   isChecked: boolean;
 }
 
-export class Toggle extends React.Component<IToggleProps, IToggleState> {
+export class Toggle extends BaseComponent<IToggleProps, IToggleState> {
 
   public static initialProps = {
     label: '',
@@ -27,6 +28,10 @@ export class Toggle extends React.Component<IToggleProps, IToggleState> {
 
   constructor(props: IToggleProps) {
     super();
+
+    this._warnMutuallyExclusive({
+      'checked': 'defaultChecked'
+    });
 
     this.state = {
       isChecked: !!(props.checked || props.defaultChecked)

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
@@ -3,11 +3,20 @@ import { Tooltip } from './Tooltip';
 import { ICalloutProps } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
 
+export interface ITooltip {
+
+}
+
 /**
  * Tooltip component props.
  */
-
 export interface ITooltipProps extends React.HTMLProps<HTMLDivElement | Tooltip> {
+  /**
+   * Optional callback to access the ITooltip interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ITooltip) => void;
+
   /**
    * Properties to pass through for Callout, reference detail properties in ICalloutProps
    */

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
@@ -4,11 +4,20 @@ import { TooltipDelay } from './Tooltip.Props';
 import { ICalloutProps } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
 
+export interface ITooltipHost {
+
+}
+
 /**
  * Tooltip component props.
  */
-
 export interface ITooltipHostProps extends React.HTMLProps<HTMLDivElement | TooltipHost> {
+  /**
+   * Optional callback to access the ITooltipHost interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: ITooltipHost) => void;
+
   /**
    * Additional properties to pass through for Callout, reference detail properties in ICalloutProps
    */

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import * as React from 'react';
 /* tslint:enable */
-import { css } from '../../../../Utilities';
+import { BaseComponent, css } from '../../../../Utilities';
 import { IPeoplePickerItemWithMenuProps } from './PeoplePickerItem.Props';
 import { Persona, PersonaPresence } from '../../../../Persona';
 import { ContextualMenu, DirectionalHint } from '../../../../ContextualMenu';
@@ -13,7 +13,7 @@ export interface IPeoplePickerItemState {
   contextualMenuVisible: boolean;
 }
 
-export class SelectedItemWithMenu extends React.Component<IPeoplePickerItemWithMenuProps, IPeoplePickerItemState> {
+export class SelectedItemWithMenu extends BaseComponent<IPeoplePickerItemWithMenuProps, IPeoplePickerItemState> {
   public refs: {
     [key: string]: any,
     ellipsisRef: HTMLElement

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -8,7 +8,7 @@ import { Spinner } from '../../../Spinner';
 import { ISuggestionItemProps, ISuggestionsProps } from './Suggestions.Props';
 import styles = require('./Suggestions.scss');
 
-export class SuggestionsItem<T> extends React.Component<ISuggestionItemProps<T>, {}> {
+export class SuggestionsItem<T> extends BaseComponent<ISuggestionItemProps<T>, {}> {
   public render() {
     let {
       suggestionModel,

--- a/packages/office-ui-fabric-react/src/utilities/decorators/BaseDecorator.ts
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/BaseDecorator.ts
@@ -6,7 +6,10 @@ import {
 } from '../../Utilities';
 
 export class BaseDecorator<P, S> extends BaseComponent<P, S> {
+  protected _shouldUpdateComponentRef = false;
+
   protected _composedComponentInstance: React.Component<P, S>;
+
   private _hoisted: string[];
 
   constructor() {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -35,7 +35,7 @@
     "source-map-loader": "0.1.5",
     "tslint": "^3.15.1",
     "tslint-microsoft-contrib": "^2.0.9",
-    "typescript": "~2.1.0"
+    "typescript": "^2.2.2"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -38,16 +38,11 @@ export class BaseComponent<P extends IBaseProps, S> extends React.Component<P, S
    * @param {Object} deprecatedProps The map of deprecated prop names to new names, where the key is the old name and the
    * value is the new name. If a prop is removed rather than renamed, leave the value undefined.
    */
-  constructor(props?: P, deprecationMap?: ISettingsMap<P>) {
+  constructor(props?: P) {
     super(props);
 
     this.props = props;
     this._shouldUpdateComponentRef = true;
-
-    // We should remove the map parameter in a major bump.
-    if (deprecationMap) {
-      this._warnDeprecations(deprecationMap);
-    }
 
     _makeAllSafe(this, BaseComponent.prototype, [
       'componentWillMount',

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { Async } from './Async';
 import { EventGroup } from './EventGroup';
 import { IDisposable } from './IDisposable';
-import { warnDeprecations, warnMutuallyExclusive, IStringMap } from './warn';
+import { warnDeprecations, warnMutuallyExclusive, ISettingsMap } from './warn';
 
-export interface IBaseProps<P> extends React.Props<P> {
+export interface IBaseProps {
   componentRef?: any;
 }
 
-export class BaseComponent<P, S> extends React.Component<P, S> {
+export class BaseComponent<P extends IBaseProps, S> extends React.Component<P, S> {
   /**
    * External consumers should override BaseComponent.onError to hook into error messages that occur from
    * exceptions thrown from within components.
@@ -38,7 +38,7 @@ export class BaseComponent<P, S> extends React.Component<P, S> {
    * @param {Object} deprecatedProps The map of deprecated prop names to new names, where the key is the old name and the
    * value is the new name. If a prop is removed rather than renamed, leave the value undefined.
    */
-  constructor(props?: P, deprecationMap?: IStringMap) {
+  constructor(props?: P, deprecationMap?: ISettingsMap<P>) {
     super(props);
 
     this.props = props;
@@ -62,7 +62,7 @@ export class BaseComponent<P, S> extends React.Component<P, S> {
   }
 
   /** When the component will receive props, make sure the componentRef is updated. */
-  public componentWillReceiveProps(newProps?: any, newContext?: any) {
+  public componentWillReceiveProps(newProps?: P, newContext?: any) {
     this._updateComponentRef(this.props, newProps);
   }
 
@@ -164,7 +164,7 @@ export class BaseComponent<P, S> extends React.Component<P, S> {
   /**
    * Updates the componentRef (by calling it with "this" when necessary.)
    */
-  protected _updateComponentRef(currentProps: IBaseProps<P>, newProps: IBaseProps<P> = {}) {
+  protected _updateComponentRef(currentProps: IBaseProps, newProps: IBaseProps = {}) {
     if (this._shouldUpdateComponentRef &&
       ((!currentProps && newProps.componentRef) ||
         (currentProps && currentProps.componentRef !== newProps.componentRef))) {
@@ -182,12 +182,12 @@ export class BaseComponent<P, S> extends React.Component<P, S> {
    * Warns when a deprecated props are being used.
    *
    * @protected
-   * @param {IStringMap} deprecationMap The map of deprecations, where key is the prop name and the value is
+   * @param {ISettingsMap<P>} deprecationMap The map of deprecations, where key is the prop name and the value is
    * either null or a replacement prop name.
    *
    * @memberOf BaseComponent
    */
-  protected _warnDeprecations(deprecationMap: IStringMap) {
+  protected _warnDeprecations(deprecationMap: ISettingsMap<P>) {
     warnDeprecations(this.className, this.props, deprecationMap);
   }
 
@@ -195,20 +195,12 @@ export class BaseComponent<P, S> extends React.Component<P, S> {
    * Warns when props which are mutually exclusive with each other are both used.
    *
    * @protected
-   * @param {IStringMap} mutuallyExclusiveMap The map of mutually exclusive props.
+   * @param {ISettingsMap<P>} mutuallyExclusiveMap The map of mutually exclusive props.
    *
    * @memberOf BaseComponent
    */
-  protected _warnMutuallyExclusive(mutuallyExclusiveMap: IStringMap) {
+  protected _warnMutuallyExclusive(mutuallyExclusiveMap: ISettingsMap<P>) {
     warnMutuallyExclusive(this.className, this.props, mutuallyExclusiveMap);
-  }
-
-  /**
-   * Standard method for rendering null. Useful to wire up onRender methods to a function ref that
-   * never changes.
-   */
-  protected _onRenderNull(): JSX.Element | null {
-    return null;
   }
 }
 
@@ -255,3 +247,5 @@ BaseComponent.onError = (errorMessage) => {
   console.error(errorMessage);
   throw errorMessage;
 };
+
+export function nullRender() { return null; }

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -35,11 +35,11 @@ export class BaseComponent<P extends IBaseProps, S> extends React.Component<P, S
   /**
    * BaseComponent constructor
    * @param {P} props The props for the component.
-   * @param {Object} deprecatedProps The map of deprecated prop names to new names, where the key is the old name and the
+   * @param {Object} context The context for the component.
    * value is the new name. If a prop is removed rather than renamed, leave the value undefined.
    */
-  constructor(props?: P) {
-    super(props);
+  constructor(props?: P, context?: any) {
+    super(props, context);
 
     this.props = props;
     this._shouldUpdateComponentRef = true;

--- a/packages/utilities/src/Customizer.tsx
+++ b/packages/utilities/src/Customizer.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { BaseComponent } from './BaseComponent';
+import { assign } from './object';
+
+export interface ISettings {
+  [key: string]: any;
+}
+
+export interface ICustomizerProps {
+  settings: ISettings;
+}
+
+export interface ICustomizerState {
+  injectedProps?: ISettings;
+}
+
+/**
+ * The Customizer component allows for default props to be mixed into components which
+ * are decorated with the customizable() decorator. This enables injection scenarios like:
+ *
+ * 1. render svg icons instead of the icon font within all buttons
+ * 2. inject a custom theme object into a component
+ *
+ * Props are provided via the settings prop, which should be a json map where the key is
+ * the name of the customizable component, and the value is are the props to pass in.
+ *
+ * @export
+ * @class Customizer
+ * @extends {BaseComponent<ICustomizerProps, ICustomizerState>}
+ */
+export class Customizer extends BaseComponent<ICustomizerProps, ICustomizerState> {
+  public static contextTypes = {
+    injectedProps: React.PropTypes.object
+  };
+
+  public static childContextTypes = Customizer.contextTypes;
+
+  constructor(props, context) {
+    super(props);
+
+    this.state = this._getInjectedProps(props, context);
+  }
+
+  public getChildContext(): any {
+    return this.state;
+  }
+
+  public componentWillReceiveProps(newProps, newContext) {
+
+    this.setState(this._getInjectedProps(newProps, newContext));
+  }
+
+  public render() {
+    return React.Children.only(this.props.children);
+  }
+
+  private _getInjectedProps(props: ICustomizerProps, context: ICustomizerState) {
+    let { settings: injectedPropsFromSettings = {} as ISettings } = props;
+    let { injectedProps: injectedPropsFromContext = {} as ISettings } = context;
+
+    return {
+      injectedProps: assign({}, injectedPropsFromContext, injectedPropsFromSettings)
+    };
+  }
+}

--- a/packages/utilities/src/customizable.tsx
+++ b/packages/utilities/src/customizable.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+export function customizable<P>(componentName?: string) {
+  return function customizableFactory<P, S>(
+    ComposedComponent: (new (props: P, ...args: any[]) => React.Component<P, S>)
+  ): any {
+    return class ComponentWithInjectedProps extends React.Component<P, {}> {
+      public static contextTypes = {
+        injectedProps: React.PropTypes.object
+      };
+
+      public render() {
+        let defaultProps = ((this.context.injectedProps) ?
+          this.context.injectedProps[componentName] :
+          null) || {};
+
+        return (
+          <ComposedComponent { ...defaultProps } { ...this.props } />
+        );
+      }
+    };
+  };
+}

--- a/packages/utilities/src/warn.test.ts
+++ b/packages/utilities/src/warn.test.ts
@@ -1,0 +1,51 @@
+import {
+  setWarningCallback,
+  warnDeprecations,
+  warnMutuallyExclusive
+} from './warn';
+import { expect } from 'chai';
+
+let _lastWarning: string;
+
+describe('warnDeprecations', () => {
+  beforeEach(() => {
+    _lastWarning = undefined;
+    setWarningCallback(message => _lastWarning = message);
+  });
+
+  afterEach(() => setWarningCallback(undefined));
+
+  it('does not warn when unnecessary', () => {
+    warnDeprecations('Foo', { bar: 1 }, { 'foo': null });
+    expect(_lastWarning).equals(undefined);
+  });
+
+  it('can warn on a deprecated prop', () => {
+    warnDeprecations('Foo', { foo: 1 }, { 'foo': null });
+    expect(_lastWarning).equals(`Foo property 'foo' was used but has been deprecated.`);
+  });
+
+  it('can warn on a deprecated prop with replacement', () => {
+    warnDeprecations('Foo', { foo: 1 }, { 'foo': 'bar' });
+    expect(_lastWarning).equals(`Foo property 'foo' was used but has been deprecated. Use 'bar' instead.`);
+  });
+});
+
+describe('warnMutuallyExclusive', () => {
+  beforeEach(() => {
+    _lastWarning = undefined;
+    setWarningCallback(message => _lastWarning = message);
+  });
+
+  afterEach(() => setWarningCallback(undefined));
+
+  it('does not warn when unnecessary', () => {
+    warnMutuallyExclusive('Foo', { foo: 1 }, { 'foo': 'bar' });
+    expect(_lastWarning).equals(undefined);
+  });
+
+  it('can warn on mutual exlusive props', () => {
+    warnMutuallyExclusive('Foo', { foo: 1, bar: 1 }, { 'foo': 'bar' });
+    expect(_lastWarning).equals(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
+  });
+});

--- a/packages/utilities/src/warn.test.ts
+++ b/packages/utilities/src/warn.test.ts
@@ -16,7 +16,7 @@ describe('warnDeprecations', () => {
   afterEach(() => setWarningCallback(undefined));
 
   it('does not warn when unnecessary', () => {
-    warnDeprecations('Foo', { bar: 1 }, { 'foo': null });
+    warnDeprecations('Foo', { bar: 1 }, { 'foo': null } as any);
     expect(_lastWarning).equals(undefined);
   });
 
@@ -45,7 +45,7 @@ describe('warnMutuallyExclusive', () => {
   });
 
   it('can warn on mutual exlusive props', () => {
-    warnMutuallyExclusive('Foo', { foo: 1, bar: 1 }, { 'foo': 'bar' });
+    warnMutuallyExclusive('Foo', { foo: 1, bar: 1 }, { 'foo': 'bar' } as any);
     expect(_lastWarning).equals(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
   });
 });

--- a/packages/utilities/src/warn.ts
+++ b/packages/utilities/src/warn.ts
@@ -1,0 +1,63 @@
+let _warningCallback = _warn;
+
+export interface IStringMap {
+  [key: string]: string;
+}
+
+/**
+ * Warns when a deprecated props are being used.
+ *
+ * @export
+ * @param {string} componentName The name of the component being used.
+ * @param {Object} props The props passed into the component.
+ * @param {IStringMap} deprecationMap The map of deprecations, where key is the prop name and the value is
+ * either null or a replacement prop name.
+ */
+export function warnDeprecations(
+  componentName: string,
+  props: Object,
+  deprecationMap: IStringMap): void {
+
+  for (const propName in deprecationMap) {
+    if (props && propName in props) {
+      let deprecationMessage = `${componentName} property '${propName}' was used but has been deprecated.`;
+      const replacementPropName = deprecationMap[propName];
+
+      if (replacementPropName) {
+        deprecationMessage += ` Use '${replacementPropName}' instead.`;
+      }
+      _warningCallback(deprecationMessage);
+    }
+  }
+}
+
+export function warnMutuallyExclusive(
+  componentName: string,
+  props: Object,
+  exclusiveMap: IStringMap): void {
+
+  for (const propName in exclusiveMap) {
+    if (props && propName in props && exclusiveMap[propName] in props) {
+      _warningCallback(
+        `${componentName} property '${propName}' is mutually exclusive with '${exclusiveMap[propName]}'. Use one or the other.`
+      );
+    }
+  }
+}
+
+/**
+ * Configures the warning callback. Passing in undefined will reset it to use the default
+ * console.warn function.
+ *
+ * @export
+ * @param {(message) => void} warningCallback
+ */
+export function setWarningCallback(warningCallback: (message) => void): void {
+  _warningCallback = warningCallback === undefined ? _warn : warningCallback;
+}
+
+function _warn(message: string): void {
+  if (console && console.warn) {
+    console.warn(message);
+  }
+}

--- a/packages/utilities/src/warn.ts
+++ b/packages/utilities/src/warn.ts
@@ -1,8 +1,8 @@
 let _warningCallback = _warn;
 
-export interface IStringMap {
-  [key: string]: string;
-}
+export type ISettingsMap<T> = {
+  [P in keyof T]: string;
+};
 
 /**
  * Warns when a deprecated props are being used.
@@ -10,13 +10,13 @@ export interface IStringMap {
  * @export
  * @param {string} componentName The name of the component being used.
  * @param {Object} props The props passed into the component.
- * @param {IStringMap} deprecationMap The map of deprecations, where key is the prop name and the value is
+ * @param {ISettingsMap} deprecationMap The map of deprecations, where key is the prop name and the value is
  * either null or a replacement prop name.
  */
-export function warnDeprecations(
+export function warnDeprecations<P>(
   componentName: string,
-  props: Object,
-  deprecationMap: IStringMap): void {
+  props: P,
+  deprecationMap: ISettingsMap<P>): void {
 
   for (const propName in deprecationMap) {
     if (props && propName in props) {
@@ -31,10 +31,10 @@ export function warnDeprecations(
   }
 }
 
-export function warnMutuallyExclusive(
+export function warnMutuallyExclusive<P>(
   componentName: string,
-  props: Object,
-  exclusiveMap: IStringMap): void {
+  props: P,
+  exclusiveMap: ISettingsMap<P>): void {
 
   for (const propName in exclusiveMap) {
     if (props && propName in props && exclusiveMap[propName] in props) {


### PR DESCRIPTION
Addresses issue: https://github.com/OfficeDev/office-ui-fabric-react/issues/1356

This change is a subset of a much larger change, but this includes the important updates which are more general:

* In components which are wrapped in a decorator or HOC, the "ref" ends up pointing to the wrong component, hiding all public methods (like `focus()`.) In order to access the actual "ref", I'm adding support for resolving `componentRef` to the `BaseComponent`. This lets us pass through the callback to an inner component in decorator/HOC patterns. If you use BaseComponent as a base class, it will by default resolve it for you; you simply expose it in your Props definition. If you would like to avoid this being done because the inner component is doing it, you can set the protected `_shouldUpdateComponentRef` bool to false which will bypass resolution at that component layer.
* Added the `Customizer` component and `customizable` decorator for injection. These helpers will enable us to inject new default props into components without requiring every individual component to be subclassed.
* Deprecation maps should no longer be passed into the `BaseComponent` constructor. Instead you can use `BaseComponent` protected helpers `_warnDeprecations` and `_warnMutuallyExclusive` which will console.warn when deprecated things are being used.
