### PR TITLE
Removing TypeScript files from lib folder in published package

### DIFF
--- a/apps/fabric-website/webpack.site.config.js
+++ b/apps/fabric-website/webpack.site.config.js
@@ -57,6 +57,7 @@ function createConfig(isProduction, publicPath) {
 
     resolve: {
       alias: {
+        'office-ui-fabric-react/src': path.join(__dirname, 'node_modules/office-ui-fabric-react/src'),
         'office-ui-fabric-react/lib': path.join(__dirname, 'node_modules/office-ui-fabric-react/lib')
       },
       extensions: ['', '.js']

--- a/common/changes/example-imports_2017-04-03-18-26.json
+++ b/common/changes/example-imports_2017-04-03-18-26.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removing TypeScript files from being binplaced within the lib folder.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/.npmignore
+++ b/packages/office-ui-fabric-react/.npmignore
@@ -18,7 +18,9 @@ index.html
 jsconfig.json
 karma.config.js
 node_modules
-src
+src/**/*
+!src/**/*.Props.ts
+!src/**/*.Example.tsx
 tsconfig.json
 tsd.json
 tslint.json

--- a/packages/office-ui-fabric-react/gulpfile.js
+++ b/packages/office-ui-fabric-react/gulpfile.js
@@ -52,10 +52,6 @@ build.postCopy.setConfig({
     ],
     [path.join(distFolder, 'css')]: [
       'node_modules/office-ui-fabric-core/dist/css/*.*'
-    ],
-    [libFolder]: [
-      'src/**/*.Example.tsx',
-      'src/**/*.Props.ts'
     ]
   }
 });

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-ui-fabric-react",
-  "version": "2.10.5",
+  "version": "3.0.0-beta-6-3",
   "description": "Reusable React components for building experiences for Office 365.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-ui-fabric-react",
-  "version": "3.0.0-beta-6-3",
+  "version": "2.10.5",
   "description": "Reusable React components for building experiences for Office 365.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/BreadcrumbPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/BreadcrumbPage.tsx
@@ -8,7 +8,9 @@ import {
 
 import { BreadcrumbBasicExample } from './examples/Breadcrumb.Basic.Example';
 
-const BreadcrumbBasicExampleCode = require('!raw-loader!./examples/Breadcrumb.Basic.Example.tsx') as string;
+const BreadcrumbBasicExampleCode = require(
+  '!raw-loader!office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx'
+) as string;
 
 export class BreadcrumbPage extends React.Component<IComponentDemoPageProps, any> {
   public render() {
@@ -26,7 +28,7 @@ export class BreadcrumbPage extends React.Component<IComponentDemoPageProps, any
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!./Breadcrumb.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonPage.tsx
@@ -17,14 +17,14 @@ import { ButtonScreenReaderExample } from './examples/Button.ScreenReader.Exampl
 import { IButtonDemoPageState } from './examples/IButtonDemoPageState';
 import './examples/Button.Basic.Example.scss';
 
-const ButtonDefaultExampleCode = require('!raw-loader!./examples/Button.Default.Example.tsx') as string;
-const ButtonPrimaryExampleCode = require('!raw-loader!./examples/Button.Primary.Example.tsx') as string;
-const ButtonCompoundExampleCode = require('!raw-loader!./examples/Button.Compound.Example.tsx') as string;
-const ButtonCommandExampleCode = require('!raw-loader!./examples/Button.Command.Example.tsx') as string;
-const ButtonIconExampleCode = require('!raw-loader!./examples/Button.Icon.Example.tsx') as string;
-const ButtonAnchorExampleCode = require('!raw-loader!./examples/Button.Anchor.Example.tsx') as string;
-const ButtonScreenReaderExampleCode = require('!raw-loader!./examples/Button.ScreenReader.Example.tsx') as string;
-const ButtonContextualMenuExampleCode = require('!raw-loader!./examples/Button.ContextualMenu.Example.tsx') as string;
+const ButtonDefaultExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Button/examples/Button.Default.Example.tsx') as string;
+const ButtonPrimaryExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Button/examples/Button.Primary.Example.tsx') as string;
+const ButtonCompoundExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Button/examples/Button.Compound.Example.tsx') as string;
+const ButtonCommandExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Button/examples/Button.Command.Example.tsx') as string;
+const ButtonIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Button/examples/Button.Icon.Example.tsx') as string;
+const ButtonAnchorExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Button/examples/Button.Anchor.Example.tsx') as string;
+const ButtonScreenReaderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Button/examples/Button.ScreenReader.Example.tsx') as string;
+const ButtonContextualMenuExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx') as string;
 
 export class ButtonPage extends React.Component<IComponentDemoPageProps, IButtonDemoPageState> {
   constructor() {
@@ -72,7 +72,7 @@ export class ButtonPage extends React.Component<IComponentDemoPageProps, IButton
           <div>
             <PropertiesTableSet
               sources={ [
-                require<string>('!raw-loader!office-ui-fabric-react/lib/components/Button/Button.Props.ts')
+                require<string>('!raw-loader!office-ui-fabric-react/src/components/Button/Button.Props.ts')
               ] }
             />
             <p>Besides the above properties, the <code>Button</code> component accepts all properties that the React <code>button</code> and <code>a</code> components accept.</p>

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarPage.tsx
@@ -9,8 +9,8 @@ import { DateRangeType } from 'office-ui-fabric-react/lib/Calendar';
 import { CalendarButtonExample } from './examples/Calendar.Button.Example';
 import { CalendarInlineExample } from './examples/Calendar.Inline.Example';
 
-const CalendarButtonExampleCode = require('!raw-loader!./examples/Calendar.Button.Example.tsx') as string;
-const CalendarInlineExampleCode = require('!raw-loader!./examples/Calendar.Inline.Example.tsx') as string;
+const CalendarButtonExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx') as string;
+const CalendarInlineExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx') as string;
 
 export class CalendarPage extends React.Component<IComponentDemoPageProps, any> {
   public render() {
@@ -44,7 +44,7 @@ export class CalendarPage extends React.Component<IComponentDemoPageProps, any> 
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Calendar/Calendar.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutPage.tsx
@@ -12,10 +12,10 @@ import { CalloutNestedExample } from './examples/Callout.Nested.Example';
 import { CalloutDirectionalExample } from './examples/Callout.Directional.Example';
 import { CalloutCoverExample } from './examples/Callout.Cover.Example';
 
-const CalloutBasicExampleCode = require('!raw-loader!./examples/Callout.Basic.Example.tsx') as string;
-const CalloutNestedExampleCode = require('!raw-loader!./examples/Callout.Nested.Example.tsx') as string;
-const CalloutDirectionalExampleCode = require('!raw-loader!./examples/Callout.Directional.Example.tsx') as string;
-const CalloutCoverExampleCode = require('!raw-loader!./examples/Callout.Cover.Example.tsx') as string;
+const CalloutBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.Basic.Example.tsx') as string;
+const CalloutNestedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.Nested.Example.tsx') as string;
+const CalloutDirectionalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.Directional.Example.tsx') as string;
+const CalloutCoverExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.Cover.Example.tsx') as string;
 
 export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
   public render() {
@@ -45,7 +45,7 @@ export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
           <div>
             <PropertiesTableSet
               sources={ [
-                require<string>('!raw-loader!office-ui-fabric-react/lib/components/Callout/Callout.Props.ts')
+                require<string>('!raw-loader!office-ui-fabric-react/src/components/Callout/Callout.Props.ts')
               ] }
             />
             <p>Besides the above properties, the <code>Callout</code> component accepts all properties that the React <code>button</code> and <code>a</code> components accept.</p>

--- a/packages/office-ui-fabric-react/src/components/Checkbox/CheckboxPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/CheckboxPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { CheckboxBasicExample } from './examples/Checkbox.Basic.Example';
 
-const CheckboxBasicExampleCode = require('!raw-loader!./examples/Checkbox.Basic.Example.tsx') as string;
+const CheckboxBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Basic.Example.tsx') as string;
 
 export class CheckboxPage extends React.Component<IComponentDemoPageProps, any> {
   public render() {
@@ -23,7 +23,7 @@ export class CheckboxPage extends React.Component<IComponentDemoPageProps, any> 
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Checkbox/Checkbox.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupPage.tsx
@@ -9,9 +9,9 @@ import { ChoiceGroupBasicExample } from './examples/ChoiceGroup.Basic.Example';
 import { ChoiceGroupImageExample } from './examples/ChoiceGroup.Image.Example';
 import { ChoiceGroupIconExample } from './examples/ChoiceGroup.Icon.Example';
 
-const ChoiceGroupBasicExampleCode = require('!raw-loader!./examples/ChoiceGroup.Basic.Example.tsx') as string;
-const ChoiceGroupImageExampleCode = require('!raw-loader!./examples/ChoiceGroup.Image.Example.tsx') as string;
-const ChoiceGroupIconExampleCode = require('!raw-loader!./examples/ChoiceGroup.Icon.Example.tsx') as string;
+const ChoiceGroupBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Basic.Example.tsx') as string;
+const ChoiceGroupImageExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx') as string;
+const ChoiceGroupIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx') as string;
 
 export class ChoiceGroupPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -35,7 +35,7 @@ export class ChoiceGroupPage extends React.Component<IComponentDemoPageProps, {}
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/ChoiceGroup/ChoiceGroup.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPickerPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { ColorPickerBasicExample } from './examples/ColorPicker.Basic.Example';
 
-const ColorPickerBasicExampleCode = require('!raw-loader!./examples/ColorPicker.Basic.Example.tsx') as string;
+const ColorPickerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx') as string;
 
 export class ColorPickerPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -25,7 +25,7 @@ export class ColorPickerPage extends React.Component<IComponentDemoPageProps, {}
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/ColorPicker/ColorPicker.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/ColorPicker/ColorPicker.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBarPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBarPage.tsx
@@ -9,8 +9,8 @@ import { items, farItems } from './examples/data';
 import { CommandBarBasicExample } from './examples/CommandBar.Basic.Example';
 import { CommandBarNonFocusableItemsExample } from './examples/CommandBar.NonFocusable.Example';
 
-const CommandBarBasicExampleCode = require('!raw-loader!./examples/CommandBar.Basic.Example.tsx') as string;
-const CommandBarNoFocusableItemsExampleCode = require('!raw-loader!./examples/CommandBar.NonFocusable.Example.tsx') as string;
+const CommandBarBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx') as string;
+const CommandBarNoFocusableItemsExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.NonFocusable.Example.tsx') as string;
 
 export class CommandBarPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -33,8 +33,8 @@ export class CommandBarPage extends React.Component<IComponentDemoPageProps, {}>
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/CommandBar/CommandBar.Props.ts'),
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/ContextualMenu/ContextualMenu.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts'),
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
@@ -11,11 +11,11 @@ import { ContextualMenuDirectionalExample } from './examples/ContextualMenu.Dire
 import { ContextualMenuCustomizationExample } from './examples/ContextualMenu.Customization.Example';
 import { ContextualMenuHeaderExample } from './examples/ContextualMenu.Header.Example';
 
-const ContextualMenuBasicExampleCode = require('!raw-loader!./examples/ContextualMenu.Basic.Example.tsx') as string;
-const ContextualMenuCheckmarksExampleCode = require('!raw-loader!./examples/ContextualMenu.Checkmarks.Example.tsx') as string;
-const ContextualMenuDirectionalExampleCode = require('!raw-loader!./examples/ContextualMenu.Directional.Example.tsx') as string;
-const ContextualMenuCustomizationExampleCode = require('!raw-loader!./examples/ContextualMenu.Customization.Example.tsx') as string;
-const ContextualMenuHeaderExampleCode = require('!raw-loader!./examples/ContextualMenu.Header.Example.tsx') as string;
+const ContextualMenuBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx') as string;
+const ContextualMenuCheckmarksExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx') as string;
+const ContextualMenuDirectionalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx') as string;
+const ContextualMenuCustomizationExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx') as string;
+const ContextualMenuHeaderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx') as string;
 
 export class ContextualMenuPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -45,8 +45,8 @@ export class ContextualMenuPage extends React.Component<IComponentDemoPageProps,
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/ContextualMenu/ContextualMenu.Props.ts'),
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Callout/Callout.Props.ts'),
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts'),
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Callout/Callout.Props.ts'),
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePickerPage.tsx
@@ -9,9 +9,9 @@ import { DatePickerBasicExample } from './examples/DatePicker.Basic.Example';
 import { DatePickerRequiredExample } from './examples/DatePicker.Required.Example';
 import { DatePickerInputExample } from './examples/DatePicker.Input.Example';
 
-const DatePickerBasicExampleCode = require('!raw-loader!./examples/DatePicker.Basic.Example.tsx') as string;
-const DatePickerRequiredExampleCode = require('!raw-loader!./examples/DatePicker.Required.Example.tsx') as string;
-const DatePickerInputExampleCode = require('!raw-loader!./examples/DatePicker.Input.Example.tsx') as string;
+const DatePickerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx') as string;
+const DatePickerRequiredExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx') as string;
+const DatePickerInputExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx') as string;
 
 export class DatePickerPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -35,7 +35,7 @@ export class DatePickerPage extends React.Component<IComponentDemoPageProps, {}>
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/DatePicker/DatePicker.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/DatePicker/DatePicker.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsListPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsListPage.tsx
@@ -7,25 +7,25 @@ import {
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 import { DetailsListBasicExample } from './examples/DetailsList.Basic.Example';
-const DetailsListBasicExampleCode = require('!raw-loader!./examples/DetailsList.Basic.Example.tsx') as string;
+const DetailsListBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx') as string;
 
 import { DetailsListCustomColumnsExample } from './examples/DetailsList.CustomColumns.Example';
-const DetailsListCustomColumnsExampleCode = require('!raw-loader!./examples/DetailsList.CustomColumns.Example.tsx') as string;
+const DetailsListCustomColumnsExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx') as string;
 
 import { DetailsListCustomRowsExample } from './examples/DetailsList.CustomRows.Example';
-const DetailsListCustomRowsExampleCode = require('!raw-loader!./examples/DetailsList.CustomRows.Example.tsx') as string;
+const DetailsListCustomRowsExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx') as string;
 
 import { DetailsListCustomGroupHeadersExample } from './examples/DetailsList.CustomGroupHeaders.Example';
-const DetailsListCustomGroupHeadersExampleCode = require('!raw-loader!./examples/DetailsList.CustomGroupHeaders.Example.tsx') as string;
+const DetailsListCustomGroupHeadersExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx') as string;
 
 import { DetailsListAdvancedExample } from './examples/DetailsList.Advanced.Example';
-const DetailsListAdvancedExampleCode = require('!raw-loader!./examples/DetailsList.Advanced.Example.tsx') as string;
+const DetailsListAdvancedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx') as string;
 
 import { DetailsListGroupedExample } from './examples/DetailsList.Grouped.Example';
-const DetailsListGroupedExampleCode = require('!raw-loader!./examples/DetailsList.Grouped.Example.tsx') as string;
+const DetailsListGroupedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx') as string;
 
 import { DetailsListDragDropExample } from './examples/DetailsList.DragDrop.Example';
-const DetailsListDragDropExampleCode = require('!raw-loader!./examples/DetailsList.DragDrop.Example.tsx') as string;
+const DetailsListDragDropExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx') as string;
 
 export class DetailsListPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -61,7 +61,7 @@ export class DetailsListPage extends React.Component<IComponentDemoPageProps, {}
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/DetailsList/DetailsList.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogPage.tsx
@@ -10,10 +10,10 @@ import { DialogLargeHeaderExample } from './examples/Dialog.LargeHeader.Example'
 import { DialogCloseExample } from './examples/Dialog.Close.Example';
 import { DialogBlockingExample } from './examples/Dialog.Blocking.Example';
 
-const DialogBasicExampleCode = require('!raw-loader!./examples/Dialog.Basic.Example.tsx') as string;
-const DialogLargeHeaderExampleCode = require('!raw-loader!./examples/Dialog.LargeHeader.Example.tsx') as string;
-const DialogCloseExampleCode = require('!raw-loader!./examples/Dialog.Close.Example.tsx') as string;
-const DialogBlockingExampleCode = require('!raw-loader!./examples/Dialog.Blocking.Example.tsx') as string;
+const DialogBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx') as string;
+const DialogLargeHeaderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dialog/examples/Dialog.LargeHeader.Example.tsx') as string;
+const DialogCloseExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dialog/examples/Dialog.Close.Example.tsx') as string;
+const DialogBlockingExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dialog/examples/Dialog.Blocking.Example.tsx') as string;
 
 export class DialogPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -49,7 +49,7 @@ export class DialogPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Dialog/Dialog.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPage.tsx
@@ -9,9 +9,9 @@ import { DocumentCardBasicExample } from './examples/DocumentCard.Basic.Example'
 import { DocumentCardCompleteExample } from './examples/DocumentCard.Complete.Example';
 import { DocumentCardCompactExample } from './examples/DocumentCard.Compact.Example';
 
-const DocumentCardBasicExampleCode = require('!raw-loader!./examples/DocumentCard.Basic.Example.tsx') as string;
-const DocumentCardCompleteExampleCode = require('!raw-loader!./examples/DocumentCard.Complete.Example.tsx') as string;
-const DocumentCardCompactExampleCode = require('!raw-loader!./examples/DocumentCard.Compact.Example.tsx') as string;
+const DocumentCardBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx') as string;
+const DocumentCardCompleteExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx') as string;
+const DocumentCardCompactExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx') as string;
 
 export class DocumentCardPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -44,7 +44,7 @@ export class DocumentCardPage extends React.Component<IComponentDemoPageProps, {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/DocumentCard/DocumentCard.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/DropdownPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/DropdownPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { DropdownBasicExample } from './examples/Dropdown.Basic.Example';
 
-const DropdownBasicExampleCode = require('!raw-loader!./examples/Dropdown.Basic.Example.tsx') as string;
+const DropdownBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx') as string;
 
 export class DropdownPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -23,7 +23,7 @@ export class DropdownPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Dropdown/Dropdown.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Facepile/FacepilePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/FacepilePage.tsx
@@ -9,9 +9,9 @@ import { FacepileAddFaceExample } from './examples/Facepile.AddFace.Example';
 import { FacepileBasicExample } from './examples/Facepile.Basic.Example';
 import { FacepileOverflowExample } from './examples/Facepile.Overflow.Example';
 
-const FacepileAddFaceExampleCode = require('!raw-loader!./examples/Facepile.AddFace.Example.tsx') as string;
-const FacepileBasicExampleCode = require('!raw-loader!./examples/Facepile.Basic.Example.tsx') as string;
-const FacepileOverflowExampleCode = require('!raw-loader!./examples/Facepile.Overflow.Example.tsx') as string;
+const FacepileAddFaceExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Facepile/examples/Facepile.AddFace.Example.tsx') as string;
+const FacepileBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx') as string;
+const FacepileOverflowExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Facepile/examples/Facepile.Overflow.Example.tsx') as string;
 
 export class FacepilePage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -35,7 +35,7 @@ export class FacepilePage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Facepile/Facepile.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZonePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZonePage.tsx
@@ -9,16 +9,16 @@ import {
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 import FocusTrapZoneBoxExample from './examples/FocusTrapZone.Box.Example';
-let FocusTrapZoneBoxExampleCode = require('!raw-loader!./examples/FocusTrapZone.Box.Example.tsx') as string;
+let FocusTrapZoneBoxExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Example.tsx') as string;
 
 import FocusTrapZoneBoxExampleWithFocusableItem from './examples/FocusTrapZone.Box.FocusOnCustomElement.Example';
-let FocusTrapZoneBoxExampleWithFocusableItemCode = require('!raw-loader!./examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx') as string;
+let FocusTrapZoneBoxExampleWithFocusableItemCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx') as string;
 
 import FocusTrapZoneBoxClickExample from './examples/FocusTrapZone.Box.Click.Example';
-let FocusTrapZoneBoxClickExampleCode = require('!raw-loader!./examples/FocusTrapZone.Box.Click.Example.tsx') as string;
+let FocusTrapZoneBoxClickExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Click.Example.tsx') as string;
 
 import FocusTrapZoneNestedExample from './examples/FocusTrapZone.Nested.Example';
-let FocusTrapZoneNestedExampleCode = require('!raw-loader!./examples/FocusTrapZone.Nested.Example.tsx') as string;
+let FocusTrapZoneNestedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx') as string;
 
 export class FocusTrapZonePage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -45,7 +45,7 @@ export class FocusTrapZonePage extends React.Component<IComponentDemoPageProps, 
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/FocusTrapZone/FocusTrapZone.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZonePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZonePage.tsx
@@ -9,9 +9,9 @@ import { FocusZonePhotosExample } from './examples/FocusZone.Photos.Example';
 import { FocusZoneListExample } from './examples/FocusZone.List.Example';
 import { FocusZoneDisabledExample } from './examples/FocusZone.Disabled.Example';
 
-const FocusZonePhotosExampleCode = require('!raw-loader!./examples/FocusZone.Photos.Example.tsx') as string;
-const FocusZoneListExampleCode = require('!raw-loader!./examples/FocusZone.List.Example.tsx') as string;
-const FocusZoneDisabledExampleCode = require('!raw-loader!./examples/FocusZone.Disabled.Example.tsx') as string;
+const FocusZonePhotosExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Photos.Example.tsx') as string;
+const FocusZoneListExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx') as string;
+const FocusZoneDisabledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Disabled.Example.tsx') as string;
 
 export class FocusZonePage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -35,7 +35,7 @@ export class FocusZonePage extends React.Component<IComponentDemoPageProps, {}> 
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/FocusZone/FocusZone.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListPage.tsx
@@ -8,8 +8,8 @@ import {
 import { GroupedListBasicExample } from './examples/GroupedList.Basic.Example';
 import { GroupedListCustomExample } from './examples/GroupedList.Custom.Example';
 
-const GroupedListBasicExampleCode = require('!raw-loader!./examples/GroupedList.Basic.Example.tsx') as string;
-const GroupedListCustomExampleCode = require('!raw-loader!./examples/GroupedList.Custom.Example.tsx') as string;
+const GroupedListBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Basic.Example.tsx') as string;
+const GroupedListCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.tsx') as string;
 
 export class GroupedListPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -30,7 +30,7 @@ export class GroupedListPage extends React.Component<IComponentDemoPageProps, {}
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/GroupedList/GroupedList.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Icon/IconPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/IconPage.tsx
@@ -9,9 +9,9 @@ import { IconBasicExample } from './examples/Icon.Basic.Example';
 import { IconColorExample } from './examples/Icon.Color.Example';
 import { IconImageSheetExample } from './examples/Icon.ImageSheet.Example';
 
-const IconBasicExampleCode = require('!raw-loader!./examples/Icon.Basic.Example.tsx') as string;
-const IconColorExampleCode = require('!raw-loader!./examples/Icon.Color.Example.tsx') as string;
-const IconImageSheetExampleCode = require('!raw-loader!./examples/Icon.ImageSheet.Example.tsx') as string;
+const IconBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Icon/examples/Icon.Basic.Example.tsx') as string;
+const IconColorExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Icon/examples/Icon.Color.Example.tsx') as string;
+const IconImageSheetExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Icon/examples/Icon.ImageSheet.Example.tsx') as string;
 
 export class IconPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -35,7 +35,7 @@ export class IconPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Icon/Icon.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Icon/Icon.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Image/ImagePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/ImagePage.tsx
@@ -13,12 +13,12 @@ import { ImageCoverExample } from './examples/Image.Cover.Example';
 import { ImageNoneExample } from './examples/Image.None.Example';
 import { ImageMaximizeFrameExample } from './examples/Image.MaximizeFrame.Example';
 
-const ImageDefaultExampleCode = require('!raw-loader!./examples/Image.Default.Example.tsx') as string;
-const ImageCenterExampleCode = require('!raw-loader!./examples/Image.Center.Example.tsx') as string;
-const ImageContainExampleCode = require('!raw-loader!./examples/Image.Contain.Example.tsx') as string;
-const ImageCoverExampleCode = require('!raw-loader!./examples/Image.Cover.Example.tsx') as string;
-const ImageNoneExampleCode = require('!raw-loader!./examples/Image.None.Example.tsx') as string;
-const ImageMaximizeFrameExampleCode = require('!raw-loader!./examples/Image.MaximizeFrame.Example.tsx') as string;
+const ImageDefaultExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.Default.Example.tsx') as string;
+const ImageCenterExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.Center.Example.tsx') as string;
+const ImageContainExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.Contain.Example.tsx') as string;
+const ImageCoverExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.Cover.Example.tsx') as string;
+const ImageNoneExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.None.Example.tsx') as string;
+const ImageMaximizeFrameExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.MaximizeFrame.Example.tsx') as string;
 
 export class ImagePage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -51,7 +51,7 @@ export class ImagePage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Image/Image.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Image/Image.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Label/LabelPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/LabelPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { LabelBasicExample } from './examples/Label.Basic.Example';
 
-const LabelBasicExampleCode = require('!raw-loader!./examples/Label.Basic.Example.tsx') as string;
+const LabelBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Label/examples/Label.Basic.Example.tsx') as string;
 
 export class LabelPage extends React.Component<IComponentDemoPageProps, any> {
   public render() {
@@ -23,7 +23,7 @@ export class LabelPage extends React.Component<IComponentDemoPageProps, any> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Label/Label.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Label/Label.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerPage.tsx
@@ -9,8 +9,8 @@ import {
 import { LayerBasicExample } from './examples/Layer.Basic.Example';
 import { LayerHostedExample } from './examples/Layer.Hosted.Example';
 
-const LayerBasicExampleCode = require('!raw-loader!./examples/Layer.Basic.Example.tsx') as string;
-const LayerHostedExampleCode = require('!raw-loader!./examples/Layer.Hosted.Example.tsx') as string;
+const LayerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Basic.Example.tsx') as string;
+const LayerHostedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Hosted.Example.tsx') as string;
 
 export class LayerPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -31,7 +31,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Layer/Layer.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Layer/Layer.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Link/LinkPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/LinkPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { LinkBasicExample } from './examples/Link.Basic.Example';
 
-let LinkBasicExampleCode = require('!raw-loader!./examples/Link.Basic.Example.tsx') as string;
+let LinkBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Link/examples/Link.Basic.Example.tsx') as string;
 
 export class LinkPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -23,7 +23,7 @@ export class LinkPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Link/Link.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Link/Link.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/List/ListPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/ListPage.tsx
@@ -11,10 +11,10 @@ import { ListGridExample } from './examples/List.Grid.Example';
 import { ListScrollingExample } from './examples/List.Scrolling.Example';
 import { createListItems } from '@uifabric/example-app-base';
 
-const ListBasicExampleCode = require('!raw-loader!./examples/List.Basic.Example.tsx') as string;
-const ListMailExampleCode = require('!raw-loader!./examples/List.Mail.Example.tsx') as string;
-const ListGridExampleCode = require('!raw-loader!./examples/List.Grid.Example.tsx') as string;
-const ListScrollingExampleCode = require('!raw-loader!./examples/List.Scrolling.Example.tsx') as string;
+const ListBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx') as string;
+const ListMailExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/List/examples/List.Mail.Example.tsx') as string;
+const ListGridExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx') as string;
+const ListScrollingExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.tsx') as string;
 
 let _cachedItems;
 
@@ -49,7 +49,7 @@ export class ListPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/List/List.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/List/List.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelectionPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelectionPage.tsx
@@ -7,7 +7,7 @@ import {
 
 import { MarqueeSelectionBasicExample } from './examples/MarqueeSelection.Basic.Example';
 
-const MarqueeSelectionBasicExampleCode = require('!raw-loader!./examples/MarqueeSelection.Basic.Example.tsx') as string;
+const MarqueeSelectionBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.tsx') as string;
 
 export class MarqueeSelectionPage extends React.Component<IComponentDemoPageProps, any> {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBarPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBarPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { MessageBarBasicExample } from './examples/MessageBar.Basic.Example';
 
-const MessageBarBasicExampleCode = require('!raw-loader!./examples/MessageBar.Basic.Example.tsx') as string;
+const MessageBarBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx') as string;
 
 export class MessageBarPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -25,7 +25,7 @@ export class MessageBarPage extends React.Component<IComponentDemoPageProps, {}>
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/MessageBar/MessageBar.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Nav/NavPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/NavPage.tsx
@@ -10,10 +10,10 @@ import { NavFabricDemoAppExample } from './examples/Nav.FabricDemoApp.Example';
 import { NavNestedExample } from './examples/Nav.Nested.Example';
 import { NavByKeysExample } from './examples/Nav.ByKeys.Example';
 
-const NavBasicExampleCode = require('!raw-loader!./examples/Nav.Basic.Example.tsx') as string;
-const NavFabricDemoAppExampleCode = require('!raw-loader!./examples/Nav.FabricDemoApp.Example.tsx') as string;
-const NavNestedExampleCode = require('!raw-loader!./examples/Nav.Nested.Example.tsx') as string;
-const NavByKeysExampleCode = require('!raw-loader!./examples/Nav.ByKeys.Example.tsx') as string;
+const NavBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx') as string;
+const NavFabricDemoAppExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Nav/examples/Nav.FabricDemoApp.Example.tsx') as string;
+const NavNestedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Nav/examples/Nav.Nested.Example.tsx') as string;
+const NavByKeysExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Nav/examples/Nav.ByKeys.Example.tsx') as string;
 
 export class NavPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -40,7 +40,7 @@ export class NavPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Nav/Nav.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Nav/Nav.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Overlay/OverlayPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Overlay/OverlayPage.tsx
@@ -8,8 +8,8 @@ import {
 import { OverlayDarkExample } from './examples/Overlay.Dark.Example';
 import { OverlayLightExample } from './examples/Overlay.Light.Example';
 
-const OverlayLightExampleCode = require('!raw-loader!./examples/Overlay.Light.Example.tsx') as string;
-const OverlayDarkExampleCode = require('!raw-loader!./examples/Overlay.Dark.Example.tsx') as string;
+const OverlayLightExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Overlay/examples/Overlay.Light.Example.tsx') as string;
+const OverlayDarkExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Overlay/examples/Overlay.Dark.Example.tsx') as string;
 
 export class OverlayPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -30,7 +30,7 @@ export class OverlayPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Overlay/Overlay.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Overlay/Overlay.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Panel/PanelPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/PanelPage.tsx
@@ -15,15 +15,15 @@ import { PanelExtraLargeExample } from './examples/Panel.ExtraLarge.Example';
 import { PanelLightDismissExample } from './examples/Panel.LightDismiss.Example';
 import { PanelNonModalExample } from './examples/Panel.NonModal.Example';
 
-const PanelSmallRightExampleCode = require('!raw-loader!./examples/Panel.SmallRight.Example.tsx') as string;
-const PanelSmallLeftExampleCode = require('!raw-loader!./examples/Panel.SmallLeft.Example.tsx') as string;
-const PanelSmallFluidExampleCode = require('!raw-loader!./examples/Panel.SmallFluid.Example.tsx') as string;
-const PanelMediumExampleCode = require('!raw-loader!./examples/Panel.Medium.Example.tsx') as string;
-const PanelLargeExampleCode = require('!raw-loader!./examples/Panel.Large.Example.tsx') as string;
-const PanelLargeFixedExampleCode = require('!raw-loader!./examples/Panel.LargeFixed.Example.tsx') as string;
-const PanelExtraLargeExampleCode = require('!raw-loader!./examples/Panel.ExtraLarge.Example.tsx') as string;
-const PanelLightDismissExampleCode = require('!raw-loader!./examples/Panel.LightDismiss.Example.tsx') as string;
-const PanelNonModalExampleCode = require('!raw-loader!./examples/Panel.NonModal.Example.tsx') as string;
+const PanelSmallRightExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.SmallRight.Example.tsx') as string;
+const PanelSmallLeftExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.SmallLeft.Example.tsx') as string;
+const PanelSmallFluidExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.SmallFluid.Example.tsx') as string;
+const PanelMediumExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Medium.Example.tsx') as string;
+const PanelLargeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Large.Example.tsx') as string;
+const PanelLargeFixedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.LargeFixed.Example.tsx') as string;
+const PanelExtraLargeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.ExtraLarge.Example.tsx') as string;
+const PanelLightDismissExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismiss.Example.tsx') as string;
+const PanelNonModalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.NonModal.Example.tsx') as string;
 
 export class PanelPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -65,7 +65,7 @@ export class PanelPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Panel/Panel.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Panel/Panel.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPage.tsx
@@ -9,9 +9,9 @@ import { PersonaInitialsExample } from './examples/Persona.Initials.Example';
 import { PersonaBasicExample } from './examples/Persona.Basic.Example';
 import { PersonaCustomRenderExample } from './examples/Persona.CustomRender.Example';
 
-const PersonaInitialsExampleCode = require('!raw-loader!./examples/Persona.Initials.Example.tsx') as string;
-const PersonaBasicExampleCode = require('!raw-loader!./examples/Persona.Basic.Example.tsx') as string;
-const PersonaCustomRenderExampleCode = require('!raw-loader!./examples/Persona.CustomRender.Example.tsx') as string;
+const PersonaInitialsExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Persona/examples/Persona.Initials.Example.tsx') as string;
+const PersonaBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx') as string;
+const PersonaCustomRenderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Persona/examples/Persona.CustomRender.Example.tsx') as string;
 
 export class PersonaPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -35,7 +35,7 @@ export class PersonaPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Persona/Persona.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Persona/Persona.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotPage.tsx
@@ -15,15 +15,15 @@ import { PivotOnChangeExample } from './examples/Pivot.OnChange.Example';
 import { PivotRemoveExample } from './examples/Pivot.Remove.Example';
 import { PivotOverrideExample } from './examples/Pivot.Override.Example';
 
-const PivotRemoveExampleCode = require('!raw-loader!./examples/Pivot.Remove.Example.tsx') as string;
-const PivotBasicExampleCode = require('!raw-loader!./examples/Pivot.Basic.Example.tsx') as string;
-const PivotLargeExampleCode = require('!raw-loader!./examples/Pivot.Large.Example.tsx') as string;
-const PivotTabsExampleCode = require('!raw-loader!./examples/Pivot.Tabs.Example.tsx') as string;
-const PivotTabsLargesExampleCode = require('!raw-loader!./examples/Pivot.TabsLarge.Example.tsx') as string;
-const PivotFabricExampleCode = require('!raw-loader!./examples/Pivot.Fabric.Example.tsx') as string;
-const PivotOnChangeExampleCode = require('!raw-loader!./examples/Pivot.OnChange.Example.tsx') as string;
-const PivotIconCountExampleCode = require('!raw-loader!./examples/Pivot.IconCount.Example.tsx') as string;
-const PivotOverrideExampleCode = require('!raw-loader!./examples/Pivot.Override.Example.tsx') as string;
+const PivotRemoveExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Remove.Example.tsx') as string;
+const PivotBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx') as string;
+const PivotLargeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Large.Example.tsx') as string;
+const PivotTabsExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Tabs.Example.tsx') as string;
+const PivotTabsLargesExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.TabsLarge.Example.tsx') as string;
+const PivotFabricExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Fabric.Example.tsx') as string;
+const PivotOnChangeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.OnChange.Example.tsx') as string;
+const PivotIconCountExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx') as string;
+const PivotOverrideExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Override.Example.tsx') as string;
 
 export class PivotPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -65,8 +65,7 @@ export class PivotPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Pivot/Pivot.Props.ts'),
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Pivot/PivotItem.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Pivot/Pivot.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicatorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicatorPage.tsx
@@ -6,7 +6,7 @@ import {
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 import { ProgressIndicatorBasicExample } from './examples/ProgressIndicator.Basic.Example';
-const ProgressIndicatorBasicExampleCode = require('!raw-loader!./examples/ProgressIndicator.Basic.Example.tsx') as string;
+const ProgressIndicatorBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ProgressIndicator/examples/ProgressIndicator.Basic.Example.tsx') as string;
 
 export class ProgressIndicatorPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -22,7 +22,7 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/ProgressIndicator/ProgressIndicator.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Rating/RatingPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/RatingPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { RatingBasicExample } from './examples/Rating.Basic.Example';
 
-const RatingBasicExampleCode = require('!raw-loader!./examples/Rating.Basic.Example.tsx') as string;
+const RatingBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx') as string;
 
 export class RatingPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -23,7 +23,7 @@ export class RatingPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Rating/Rating.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Rating/Rating.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
@@ -8,8 +8,8 @@ import {
 import { SearchBoxSmallExample } from './examples/SearchBox.Small.Example';
 import { SearchBoxFullSizeExample } from './examples/SearchBox.FullSize.Example';
 
-const SearchBoxSmallExampleCode = require('!raw-loader!./examples/SearchBox.Small.Example.tsx') as string;
-const SearchBoxFullSizeExampleCode = require('!raw-loader!./examples/SearchBox.FullSize.Example.tsx') as string;
+const SearchBoxSmallExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx') as string;
+const SearchBoxFullSizeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.FullSize.Example.tsx') as string;
 
 export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -30,7 +30,7 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> 
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/SearchBox/SearchBox.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Slider/SliderPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/SliderPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { SliderBasicExample } from './examples/Slider.Basic.Example';
 
-const SliderBasicExampleCode = require('!raw-loader!./examples/Slider.Basic.Example.tsx') as string;
+const SliderBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Slider/examples/Slider.Basic.Example.tsx') as string;
 
 export class SliderPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -23,7 +23,7 @@ export class SliderPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Slider/Slider.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Slider/Slider.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Spinner/SpinnerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/SpinnerPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { SpinnerBasicExample } from './examples/Spinner.Basic.Example';
 
-const SpinnerBasicExampleCode = require('!raw-loader!./examples/Spinner.Basic.Example.tsx') as string;
+const SpinnerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Spinner/examples/Spinner.Basic.Example.tsx') as string;
 
 export class SpinnerPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -25,7 +25,7 @@ export class SpinnerPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Spinner/Spinner.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Spinner/Spinner.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubblePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubblePage.tsx
@@ -10,9 +10,9 @@ import { TeachingBubbleBasicExample } from './examples/TeachingBubble.Basic.Exam
 import { TeachingBubbleCondensedExample } from './examples/TeachingBubble.Condensed.Example';
 import { TeachingBubbleIllustrationExample } from './examples/TeachingBubble.Illustration.Example';
 
-const TeachingBubbleBasicExampleCode = require('!raw-loader!./examples/TeachingBubble.Basic.Example.tsx') as string;
-const TeachingBubbleCondensedExampleCode = require('!raw-loader!./examples/TeachingBubble.Condensed.Example.tsx') as string;
-const TeachingBubbleIllustrationExampleCode = require('!raw-loader!./examples/TeachingBubble.Basic.Example.tsx') as string;
+const TeachingBubbleBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Basic.Example.tsx') as string;
+const TeachingBubbleCondensedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Condensed.Example.tsx') as string;
+const TeachingBubbleIllustrationExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Basic.Example.tsx') as string;
 
 export class TeachingBubblePage extends React.Component<any, any> {
   public render() {
@@ -36,7 +36,7 @@ export class TeachingBubblePage extends React.Component<any, any> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/TeachingBubble/TeachingBubble.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextFieldPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextFieldPage.tsx
@@ -8,8 +8,8 @@ import {
 import { TextFieldBasicExample } from './examples/TextField.Basic.Example';
 import { TextFieldErrorMessageExample } from './examples/TextField.ErrorMessage.Example';
 
-const TextFieldBasicExampleCode = require('!raw-loader!./examples/TextField.Basic.Example.tsx') as string;
-const TextFieldErrorMessageExampleCode = require('!raw-loader!./examples/TextField.ErrorMessage.Example.tsx') as string;
+const TextFieldBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Basic.Example.tsx') as string;
+const TextFieldErrorMessageExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.ErrorMessage.Example.tsx') as string;
 
 export class TextFieldPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -30,7 +30,7 @@ export class TextFieldPage extends React.Component<IComponentDemoPageProps, {}> 
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/TextField/TextField.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/TextField/TextField.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Theme/ThemePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Theme/ThemePage.tsx
@@ -8,7 +8,7 @@ import { SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 import { ColorPicker } from 'office-ui-fabric-react/lib/ColorPicker';
 import './ThemePage.scss';
 
-const ThemeCodeExample = require('!raw-loader!./examples/ThemeCode.Example');
+const ThemeCodeExample = require('!raw-loader!office-ui-fabric-react/src/components/Theme/examples/ThemeCode.Example.tsx');
 
 export class ThemePage extends React.Component<any, any> {
 

--- a/packages/office-ui-fabric-react/src/components/Toggle/TogglePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/TogglePage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@uifabric/example-app-base';
 import { ToggleBasicExample } from './examples/Toggle.Basic.Example';
 
-const ToggleBasicExampleCode = require('!raw-loader!./examples/Toggle.Basic.Example.tsx') as string;
+const ToggleBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx') as string;
 
 export class TogglePage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -23,7 +23,7 @@ export class TogglePage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Toggle/Toggle.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
@@ -11,8 +11,8 @@ import { TooltipBasicExample } from './examples/Tooltip.Basic.Example';
 
 import './TooltipPage.scss';
 
-const TooltipBasicExampleCode = require('!raw-loader!./examples/Tooltip.Basic.Example.tsx') as string;
-const TooltipBottomExampleCode = require('!raw-loader!./examples/Tooltip.Bottom.Example.tsx') as string;
+const TooltipBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx') as string;
+const TooltipBottomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Bottom.Example.tsx') as string;
 
 export class TooltipPage extends React.Component<any, any> {
   public render() {
@@ -34,7 +34,7 @@ export class TooltipPage extends React.Component<any, any> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/Tooltip/Tooltip.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@uifabric/example-app-base';
 import { PeoplePickerTypesExample } from './examples/PeoplePicker.Types.Example';
 
-const PeoplePickerTypesExampleCode = require('!raw-loader!./examples/PeoplePicker.Types.Example.tsx') as string;
+const PeoplePickerTypesExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx') as string;
 
 export class PeoplePickerPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -26,7 +26,7 @@ export class PeoplePickerPage extends React.Component<IComponentDemoPageProps, {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/pickers/BasePicker.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/pickers/PickersPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PickersPage.tsx
@@ -9,8 +9,8 @@ import {
 import { PickerCustomResultExample } from './examples/Picker.CustomResult.Example';
 import { TagPickerBasicExample } from './examples/TagPicker.Basic.Example';
 
-const TagPickerExampleCode = require('!raw-loader!./examples/TagPicker.Basic.Example.tsx') as string;
-const PickerCustomResultExampleCode = require('!raw-loader!./examples/Picker.CustomResult.Example.tsx') as string;
+const TagPickerExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx') as string;
+const PickerCustomResultExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx') as string;
 
 export class PickersPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -31,7 +31,7 @@ export class PickersPage extends React.Component<IComponentDemoPageProps, {}> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/lib/components/pickers/BasePicker.Props.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionPage.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionPage.tsx
@@ -7,7 +7,7 @@ import {
 
 import { SelectionBasicExample } from './examples/Selection.Basic.Example';
 
-const SelectionBasicExampleCode = require('!raw-loader!./examples/Selection.Basic.Example.tsx') as string;
+const SelectionBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx') as string;
 
 export class SelectionPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {

--- a/packages/office-ui-fabric-react/webpack.serve.config.js
+++ b/packages/office-ui-fabric-react/webpack.serve.config.js
@@ -18,6 +18,7 @@ module.exports = {
 
   resolve: {
     alias: {
+      'office-ui-fabric-react/src': path.join(__dirname, 'src'),
       'office-ui-fabric-react/lib': path.join(__dirname, 'src'),
       'Props.ts.js': 'Props',
       'Example.tsx.js': 'Example'


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #1397 
- [X] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Removing the binplace step which is causing ts files to show up in lib, which breaks webpack configs which prioritize ts files over js files.

Including Props and Example files in npm package (by excluding them in the ignore file.)

Updating all imports to pull examples and props raw text from the /src files.

