### PR TITLE
Fix capitalization of sample branded icon HTML

### DIFF
--- a/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
@@ -156,7 +156,7 @@ export class BrandIconsPage extends React.Component<any, any> {
         <CodeBlock language='html' isLightTheme={ true }>
           {
             `// Sample code for displaying an Excel 96x96px Icon
-<div class="ms-BrandIcon--Icon96 ms-BrandIcon--Excel"></div>
+<div class="ms-BrandIcon--icon96 ms-BrandIcon--excel"></div>
 `
           }
         </CodeBlock>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1413
- [ ] Include a change request file if publishing <!-- see notes below -->
- [x] Bugfix
- [x] Documentation update

#### Description of changes

Simple fix for capitalization of BrandIcon sample HTML on [Brand Icons page](https://dev.office.com/fabric#/styles/brand-icons) of Fabric website.
