### PR TITLE
Adds readOnly prop to TextField component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Fabric React is a responsive, mobile-first collection of robust components desig
 
 Before you get started, make sure you have [node.js](https://nodejs.org/), [gulp](http://gulpjs.com/), and [git](https://git-scm.com/) installed. To view the documentation including examples, contracts, component status, and to add functionality or fix issues locally, you can:
 
-1. `git clone https://github.com/OfficeDev/office-ui-fabric-react.git`
-2. `npm install`
-3. `npm start`
+1. Fork this repo.
+1. Clone your fork (i.e. `git clone https://github.com/[your-username]/office-ui-fabric-react.git`).
+2. Run `npm install` to install dependencies.
+3. Run `npm start` to compile and start the demo app.
 
 This will run `gulp serve` from the office-ui-fabric-react package folder, which will open a web browser with the example page. You can make changes to the code which will automatically build and refresh the page using live-reload.
 
@@ -69,7 +70,7 @@ If you need to render Fabric components on the server side in a node environment
 
 ```ts
 import { configureLoadStyles } from '@microsoft/load-themed-styles';
- 
+
 // Store registered styles in a variable used later for injection.
 let _allStyles = '';
 
@@ -77,13 +78,13 @@ let _allStyles = '';
 configureLoadStyles((styles: string) => {
   _allStyles += styles;
 });
- 
+
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
-import { Button } from 'office-ui-fabric-react/lib/Button'; 
- 
+import { Button } from 'office-ui-fabric-react/lib/Button';
+
 let body = ReactDOMServer.renderToString(<Button>hello</Button>);
- 
+
 console.log(
   `
   <html>

--- a/common/changes/textfield-readOnly_2017-04-06-19-48.json
+++ b/common/changes/textfield-readOnly_2017-04-06-19-48.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds \"readOnly\" prop to TextField component.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "email": "joem@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.Props.ts
@@ -40,6 +40,12 @@ export interface ITextFieldProps extends React.HTMLProps<HTMLInputElement | HTML
   resizable?: boolean;
 
   /**
+   * Whether or not the component is readonly.
+   * @default false
+   */
+  readOnly?: boolean;
+
+  /**
    * Whether or not to auto adjust textField height. Applies only to multiline textfield.
    * @default false
    */

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -33,6 +33,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     resizable: true,
     autoAdjustHeight: false,
     underlined: false,
+    readOnly: false,
     onChanged: () => { /* noop */ },
     onBeforeChange: () => { /* noop */ },
     onNotifyValidationResult: () => { /* noop */ },

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Basic.Example.tsx
@@ -14,6 +14,8 @@ export class TextFieldBasicExample extends React.Component<any, any> {
         <TextField label='Multiline TextField Unresizable' multiline resizable={ false } />
         <TextField label='Multiline TextField with auto adjust height' multiline autoAdjustHeight />
         <TextField label='Underlined TextField' underlined />
+        <TextField label='Readonly TextField' readOnly value={ `The value of this TextField is readonly.` } />
+        <TextField label='Multiline Readonly TextField' multiline readOnly value={ `The value of this TextField is readonly.` } />
       </div>
     );
   }

--- a/packages/utilities/src/properties.ts
+++ b/packages/utilities/src/properties.ts
@@ -206,9 +206,12 @@ export const buttonProperties = htmlElementProperties.concat([
 
 export const divProperties = htmlElementProperties.concat(['align', 'noWrap']);
 
-export const inputProperties = buttonProperties;
+export const inputProperties = htmlElementProperties.concat([
+  'disabled',
+  'readonly'
+]);
 
-export const textAreaProperties = buttonProperties;
+export const textAreaProperties = inputProperties;
 
 export const imageProperties = divProperties;
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing
- [X] New enhancement
  - [X] Includes examples
- [X] Documentation update

#### Description of changes

* This PR adds a new optional prop, `readOnly`, to the `TextField` component. If specified (and `true`), the inner `input` element will be readonly. It's implemented similarly as the `disabled` prop.
* Also edits the README slightly to let contributors know they need to fork to create a PR, because its current state led me to believe I can clone this repo directly and create a branch.

#### Focus areas to test

* If `readOnly` is specified (and `true`), verify that the value of the TextField cannot be changed.
* If `readOnly` isn't specified (or is specified and `false`), verify that the value of the TextField can be changed.

