### PR TITLE
 Dropdown: Improve screenreader accessibility

### DIFF
--- a/common/changes/bugfix-dropdownscreenreader_2017-04-10-17-23.json
+++ b/common/changes/bugfix-dropdownscreenreader_2017-04-10-17-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Improve screen-reader accessibility.",
+      "type": "patch"
+    }
+  ],
+  "email": "clewolff@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -138,7 +138,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
               onRenderTitle(selectedOption, this._onRenderTitle)
             ) }
           </span>
-          <i className={ css('ms-Dropdown-caretDown ms-Icon ms-Icon--ChevronDown', styles.caretDown) }></i>
+          <i className={ css('ms-Dropdown-caretDown ms-Icon ms-Icon--ChevronDown', styles.caretDown) } role='presentation' aria-hidden='true'></i>
         </div>
         { isOpen && (
           onRenderContainer(this.props, this._onRenderContainer)


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1452
- [x] Include a change request file if publishing
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

When the dropdown is selected and we navigate via screen-reader keys (capslock + right arrow), we land on the caret icon which just announces "group". This is a confusing experience for screen reader users. This pull request marks the caret icon as hidden so that it gets excluded from the screen reader.

#### Focus areas to test

Test steps (verified manually on Dropdown.Basic.Example):
1) Open test site in Edge, turn on Narrator, navigate to the dropdown. Press capslock + right arrow.
2) Verify that caret "group" is not announced.