### PR TITLE
CommandBar: Remove aria-disabled="true" for disabled command bar items

### DIFF
--- a/common/changes/v-edwliu-revert-aria-disabled-commandbutton_2017-04-11-17-05.json
+++ b/common/changes/v-edwliu-revert-aria-disabled-commandbutton_2017-04-11-17-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Remove aria-disabled=\"true\" for disabled menu items",
+      "type": "patch"
+    }
+  ],
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -176,7 +176,6 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
             aria-haspopup={ hasSubmenuItems(item) }
             role='menuitem'
             aria-label={ item.ariaLabel || item.name }
-            aria-disabled={ item.disabled }
           >
             { (hasIcon) ? this._renderIcon(item) : (null) }
             { (!!item.name) && (


### PR DESCRIPTION
… attribute for elements that are not allowed to have a disabled attribute in HTML5”

#### Pull request checklist

- [x] Addresses an existing issue: #1079
- [x] Include a change request file if publishing <!-- see notes below -->
#### Description of changes

Remove aria-disabled="true" for disabled command bar items.  https://www.w3.org/TR/html-aria/

> Use the disabled attribute on any element that is allowed the disabled attribute in HTML5.
> 
> Only use the aria-disabled attribute for elements that are not allowed to have a disabled attribute in HTML5


<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
