### PR TITLE
Toggle: Adding a min-width to innerContainer

### DIFF
--- a/common/changes/toggle-container-min-width_2017-04-11-17-29.json
+++ b/common/changes/toggle-container-min-width_2017-04-11-17-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: Adding min width to inner container.",
+      "type": "patch"
+    }
+  ],
+  "email": "v-krbrow@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.scss
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.scss
@@ -118,6 +118,7 @@
 
 .innerContainer {
   display: inline-block;
+  min-width: 45px;
 }
 
 :global(.ms-Fabric.is-focusVisible) .root.isEnabled .button:focus + .background .focus {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1447
- [x] Include a change request file if publishing <!-- see notes below -->

#### Description of changes

Portions of the Toggle component become unclickable if the on/off label is absent and the label has less than ~5 characters. Adding a minimum width to .innerContainer keeps the entire toggle clickable.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
