### PR TITLE
Fix alignment issues caused by single-select mode or unselectable items in DetailsList

### DIFF
--- a/common/changes/list-selection_2017-04-11-17-38.json
+++ b/common/changes/list-selection_2017-04-11-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix alignment issues for unselectable items in DetailsList",
+      "type": "patch"
+    }
+  ],
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -18,7 +18,9 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
   user-select: none;
 
   &.rootIsSelectAllHidden {
-    @include padding-left(36px);
+    .cell.cellIsCheck {
+      visibility: hidden;
+    }
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -116,8 +116,8 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         onMouseMove={ this._onRootMouseMove }
         data-automationid='DetailsHeader'>
         <FocusZone ref='focusZone' direction={ FocusZoneDirection.horizontal }>
-          <div className={ css('ms-DetailsHeader-cellWrapper', styles.cellWrapper) } role='columnheader'>
-            { (selectAllVisibility !== SelectAllVisibility.none) ? (
+          { (selectAllVisibility !== SelectAllVisibility.none) ? (
+            <div className={ css('ms-DetailsHeader-cellWrapper', styles.cellWrapper) } role='columnheader'>
               <button
                 type='button'
                 className={ css('ms-DetailsHeader-cell is-check', styles.cell, styles.cellIsCheck) }
@@ -127,8 +127,8 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
               >
                 <Check checked={ isAllSelected } />
               </button>
-            ) : null }
-          </div>
+            </div>
+          ) : null }
           { groupNestingDepth > 0 ? (
             <button
               type='button'

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -117,7 +117,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         data-automationid='DetailsHeader'>
         <FocusZone ref='focusZone' direction={ FocusZoneDirection.horizontal }>
           <div className={ css('ms-DetailsHeader-cellWrapper', styles.cellWrapper) } role='columnheader'>
-            { (selectAllVisibility === SelectAllVisibility.visible) ? (
+            { (selectAllVisibility !== SelectAllVisibility.none) ? (
               <button
                 type='button'
                 className={ css('ms-DetailsHeader-cell is-check', styles.cell, styles.cellIsCheck) }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
@@ -82,6 +82,10 @@ $unselectedHoverColor: $ms-color-neutralLighter;
   opacity: 0;
 }
 
+.checkDisabled {
+  visibility: hidden;
+}
+
 .root:hover .check,
 .rootIsSelected .check,
 .rootIsCheckVisible .check {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -22,17 +22,17 @@ export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
   return (
     <button
       type='button'
-      className={ css('ms-DetailsRow-check', styles.check) }
+      className={ css('ms-DetailsRow-check', styles.check, {
+        [styles.checkDisabled]: !props.canSelect,
+        'ms-DetailsRow-check--isDisabled': !props.canSelect
+      }) }
       role='button'
       aria-pressed={ selected }
       data-selection-toggle={ true }
       data-automationid='DetailsRowCheck'
       aria-label={ props.ariaLabel }
     >
-      { props.canSelect ?
-        <Check checked={ selected } /> :
-        <div className={ css('ms-DetailsRow-checkSpacer', styles.checkSpacer) } />
-      }
+      <Check checked={ selected } />
     </button>
   );
 };


### PR DESCRIPTION
#### Pull request checklist

This is a bugfix for alignment issues when using custom selection behavior with the `DetailsList` component. Specifically, when in single-select mode, or when specific items may not be selected, this fixes an issue where there the `DetailsHeader` becomes too wide due to improper padding, or the row contents shift-left due to not enough space being allocated for the checkbox.

Added fix for bug #1011 by aligning SelectAll column visibility with the selection mode.

#### Description of changes

This fix restores rendering of the selection checkbox to the header cell as well as rows, if selection is supported overall for the `DetailsList` but the list is either in single-select mode or an individual row may not be selected. Instead of not rendering the checkbox at all, the visibility of the checkbox is simply changed to `hidden` under these conditions. This is a better solution because `width` is not normally specified for the rendering of the checkboxes, so attempting to use a placeholder will always be slightly wrong.

#### Focus areas to test

Test situations involving single-select or selection unavailability (e.g. OneDrive file picker).  
Verify no regressions in normal multi-select behavior.
