### PR TITLE
Dropdown: Add ability to open via space bar

### DIFF
--- a/common/changes/feature-dropdownopenspace_2017-04-11-10-39.json
+++ b/common/changes/feature-dropdownopenspace_2017-04-11-10-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Add ability to open and close via space bar.",
+      "type": "minor"
+    }
+  ],
+  "email": "clewolff@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -119,6 +119,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           }) }
           tabIndex={ disabled ? -1 : 0 }
           onKeyDown={ this._onDropdownKeyDown }
+          onKeyUp={ this._onDropdownKeyUp }
           onClick={ this._onDropdownClick }
           aria-expanded={ isOpen ? 'true' : 'false' }
           role='combobox'
@@ -332,6 +333,27 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
 
       case KeyCodes.end:
         this.setSelectedIndex(this.props.options.length - 1);
+        break;
+
+      case KeyCodes.space:
+        // event handled in _onDropdownKeyUp
+        break;
+
+      default:
+        return;
+    }
+
+    ev.stopPropagation();
+    ev.preventDefault();
+  }
+
+  @autobind
+  private _onDropdownKeyUp(ev: React.KeyboardEvent<HTMLElement>) {
+    switch (ev.which) {
+      case KeyCodes.space:
+        this.setState({
+          isOpen: !this.state.isOpen
+        });
         break;
 
       default:


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1445
- [x] Include a change request file if publishing
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

Users who make use of our accessibility features will expect dropdowns to be controllable via space-bar in addition to the enter key. We currently only support the latter. This pull request adds support for the former.

#### Focus areas to test

Manually verified on Dropdown.Basic.Example:
1) Navigate via keyboard to dropdown. Press space. Dropdown opens.
2) Press space. Dropdown closes.