### PR TITLE
Fix for People Picker issue in IE11

### DIFF
--- a/common/changes/people-picker-fix-IE11-overflow_2017-04-11-18-04.json
+++ b/common/changes/people-picker-fix-IE11-overflow_2017-04-11-18-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "People Picker: Fix issue in IE11 where long names were not properly truncated",
+      "type": "patch"
+    }
+  ],
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PickerItemsDefault.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PickerItemsDefault.scss
@@ -9,11 +9,11 @@
   cursor: default;
   user-select: none;
   max-width: 100%;
-  
+
   &:hover {
     background: $ms-color-neutralLight;
   }
-  
+
   &.personaContainerIsSelected {
     background: $ms-color-neutralQuaternary;
 
@@ -25,6 +25,10 @@
   .itemContent {
     flex: 0 1 auto;
     min-width: 0px;
+
+    /** CSS below is needed for IE 11 to properly truncate long persona names in the picker **/
+    max-width: 100%;
+    overflow-x: hidden;
   }
 
   .removeButton {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1456 
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement

#### Description of changes

Add CSS to people picker items to have IE11 properly truncate long people names

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
