### PR TITLE
Button: restructured variant rendering, deprecated icon for iconprops

### DIFF
--- a/src/components/Button/Button.Props.ts
+++ b/src/components/Button/Button.Props.ts
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { Button } from './Button';
 
-export interface IButtonProps extends React.Props<Button> {
+export interface IButton {
+  /**
+   * Focuses the button.
+   */
+  focus();
+}
+
+export interface IButtonProps extends React.HTMLProps<HTMLButtonElement | HTMLAnchorElement | Button> {
   /**
    * If provided, this component will be rendered as an anchor.
    * @default ElementType.anchor
@@ -53,12 +60,9 @@ export interface IButtonProps extends React.Props<Button> {
   ariaDescription?: string;
 
   /**
-   * If provided, HTMLProps which will be mixed in onto the root element emitted by this component, before
-   * other props are applied. This allows you to extend the root element with additional attributes, such as
-   * data-automation-id needed for automation.
-   *
-   * The root element will either be a button or an anchor, depending on what value is specified for
-   * the elementType prop.
+   * Deprecated at v0.56.2, to be removed at >= v1.0.0. Just pass in button props instead;
+   * they will be mixed into the button/anchor element rendered by the component.
+   * @deprecated
    */
   rootProps?: React.HTMLProps<HTMLButtonElement> | React.HTMLProps<HTMLAnchorElement>;
 }

--- a/src/components/Button/Button.Props.ts
+++ b/src/components/Button/Button.Props.ts
@@ -60,9 +60,9 @@ export interface IButtonProps extends React.HTMLProps<HTMLButtonElement | HTMLAn
   ariaDescription?: string;
 
   /**
+   * @deprecated
    * Deprecated at v0.56.2, to be removed at >= v1.0.0. Just pass in button props instead;
    * they will be mixed into the button/anchor element rendered by the component.
-   * @deprecated
    */
   rootProps?: React.HTMLProps<HTMLButtonElement> | React.HTMLProps<HTMLAnchorElement>;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { css } from '../../utilities/css';
 import { assign } from '../../utilities/object';
-import { IButtonProps, ButtonType } from './Button.Props';
+import { IButtonProps, IButton, ButtonType } from './Button.Props';
 import { getId } from '../../utilities/object';
+import { getNativeProps, buttonProperties, anchorProperties } from '../../utilities/properties';
 import './Button.scss';
 
 export interface IButtonState {
@@ -11,7 +12,7 @@ export interface IButtonState {
   ariaDescriptionId?: string;
 }
 
-export class Button extends React.Component<IButtonProps, IButtonState> {
+export class Button extends React.Component<IButtonProps, IButtonState> implements IButton {
   public static defaultProps: IButtonProps = {
     buttonType: ButtonType.normal
   };
@@ -33,7 +34,7 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
 
     const renderAsAnchor: boolean = !!href;
     const tag = renderAsAnchor ? 'a' : 'button';
-
+    const nativeProps = getNativeProps(this.props.rootProps || this.props, renderAsAnchor ? anchorProperties : buttonProperties);
     const className = css((this.props.className), 'ms-Button', {
       'ms-Button--primary': buttonType === ButtonType.primary,
       'ms-Button--hero': buttonType === ButtonType.hero,
@@ -64,7 +65,7 @@ export class Button extends React.Component<IButtonProps, IButtonState> {
       tag,
       assign(
         {},
-        this.props.rootProps,
+        nativeProps,
         href ? { href } : null,
         {
           'aria-label': ariaLabel,

--- a/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -56,8 +56,8 @@ export interface IChoiceGroupOption {
 
   // @todo: Update version numbers for depriate and removal
   /**
-   * Deprecated at v0.52.0, to be removed at >= v1.0.0. Use 'disabled' instead.
    * @deprecated
+   * Deprecated at v0.52.0, to be removed at >= v1.0.0. Use 'disabled' instead.
    */
   isDisabled?: boolean;
 }

--- a/src/components/Dropdown/Dropdown.Props.ts
+++ b/src/components/Dropdown/Dropdown.Props.ts
@@ -31,8 +31,8 @@ export interface IDropdownProps {
 
   // @todo: Update version numbers for depriate and removal
   /**
-   * Deprecated at v0.52.0, to be removed at >= v1.0.0. Use 'disabled' instead.
    * @deprecated
+   * Deprecated at v0.52.0, to be removed at >= v1.0.0. Use 'disabled' instead.
    */
   isDisabled?: boolean;
 

--- a/src/components/MessageBar/MessageBar.Props.ts
+++ b/src/components/MessageBar/MessageBar.Props.ts
@@ -52,8 +52,8 @@ export enum MessageBarType {
   /** Warning styled MessageBar */
   warning,
   /**
-   * Deprecated at v0.48.0, to be removed at >= v1.0.0. Use 'blocked' instead.
    * @deprecated
+   * Deprecated at v0.48.0, to be removed at >= v1.0.0. Use 'blocked' instead.
    */
   remove
 }

--- a/src/components/MessageBar/MessageBar.tsx
+++ b/src/components/MessageBar/MessageBar.tsx
@@ -69,7 +69,6 @@ export class MessageBar extends React.Component<IMessageBarProps, IMessageBarSta
         buttonType={ ButtonType.icon }
         onClick={ this.props.onDismiss }
         icon='Cancel'
-        rootProps={ { title: 'Close' } }
         ariaLabel={ this.props.dismissButtonAriaLabel }
       />;
     }

--- a/src/components/ProgressIndicator/ProgressIndicator.Props.ts
+++ b/src/components/ProgressIndicator/ProgressIndicator.Props.ts
@@ -21,8 +21,8 @@ export interface IProgressIndicatorProps {
   percentComplete?: number;
 
   /**
-   * Deprecated at v0.43.0, to be removed at >= v0.53.0. Use 'label' instead.
    * @deprecated
+   * Deprecated at v0.43.0, to be removed at >= v0.53.0. Use 'label' instead.
    */
   title?: string;
 }

--- a/src/components/SearchBox/SearchBox.Props.ts
+++ b/src/components/SearchBox/SearchBox.Props.ts
@@ -15,8 +15,8 @@ export interface ISearchBoxProps extends React.Props<SearchBox> {
   onChange?: (newValue: any) => void;
 
   /**
-   * Deprecated at v0.52.2, to be removed at >= v1.0.0. Use 'onChange' instead.
    * @deprecated
+   * Deprecated at v0.52.2, to be removed at >= v1.0.0. Use 'onChange' instead.
    */
   onChanged?: (newValue: any) => void;
 

--- a/src/components/TeachingBubble/TeachingBubble.Props.ts
+++ b/src/components/TeachingBubble/TeachingBubble.Props.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { TeachingBubble } from './TeachingBubble';
 import { TeachingBubbleContent } from './TeachingBubbleContent';
-import { IImageProps } from '../Image/Image.Props';
-import { IButtonProps } from '../Button/Button.Props';
+import { IImageProps } from '../../Image';
+import { IButtonProps } from '../../Button';
 import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
 import { ICalloutProps } from '../../index';
 

--- a/src/components/TeachingBubble/TeachingBubbleContent.tsx
+++ b/src/components/TeachingBubble/TeachingBubbleContent.tsx
@@ -76,8 +76,8 @@ export class TeachingBubbleContent extends BaseComponent<ITeachingBubbleProps, I
     if (primaryButtonProps || secondaryButtonProps) {
       footerContent = (
         <div className='ms-TeachingBubble-footer'>
-          { primaryButtonProps ? <Button className='ms-TeachingBubble-primaryButton' { ...primaryButtonProps }/> : null }
-          { secondaryButtonProps ? <Button className='ms-TeachingBubble-secondaryButton' { ...secondaryButtonProps }/> : null }
+          { primaryButtonProps ? <Button className='ms-TeachingBubble-primaryButton' { ...primaryButtonProps } /> : null }
+          { secondaryButtonProps ? <Button className='ms-TeachingBubble-secondaryButton' { ...secondaryButtonProps } /> : null }
         </div>
       );
     }
@@ -88,7 +88,7 @@ export class TeachingBubbleContent extends BaseComponent<ITeachingBubbleProps, I
           className='ms-TeachingBubble-closebutton'
           buttonType={ ButtonType.icon }
           icon='Cancel'
-          rootProps={ { title: closeButtonAriaLabel } }
+          title={ closeButtonAriaLabel }
           ariaLabel={ closeButtonAriaLabel }
           onClick={ onDismiss }
         />

--- a/src/demo/pages/ButtonPage/examples/Button.Anchor.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Anchor.Example.tsx
@@ -18,6 +18,7 @@ export class ButtonAnchorExample extends React.Component<IButtonProps, {}> {
       <div className='ms-BasicButtonsExample'>
         <Label>Button like anchor</Label>
         <Button
+          data-automation-id='test'
           disabled={ isDisabled }
           buttonType={ ButtonType.primary }
           href='http://bing.com'

--- a/src/demo/pages/ButtonPage/examples/Button.Command.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Command.Example.tsx
@@ -18,10 +18,12 @@ export class ButtonCommandExample extends React.Component<IButtonProps, any> {
       <div className='ms-BasicButtonsExample'>
         <Label>Command button</Label>
         <Button
+          data-automation-id='test'
           buttonType={ ButtonType.command }
           icon='AddFriend'
           description='Description of the action this button takes'
-          rootProps={ { disabled: isDisabled } }>
+          disabled={ isDisabled }
+        >
           Create account
         </Button>
       </div>

--- a/src/demo/pages/ButtonPage/examples/Button.Icon.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Icon.Example.tsx
@@ -21,7 +21,7 @@ export class ButtonIconExample extends React.Component<IButtonProps, {}> {
           disabled={ isDisabled }
           buttonType={ ButtonType.icon }
           icon='Emoji2'
-          rootProps={ { title: 'Emoji' } }
+          title='Emoji'
           ariaLabel='Emoji' />
       </div>
     );

--- a/src/demo/pages/ButtonPage/examples/Button.Normal.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Normal.Example.tsx
@@ -16,7 +16,7 @@ export class ButtonNormalExample extends React.Component<IButtonProps, {}> {
     return (
       <div className='ms-BasicButtonsExample'>
         <Label>Normal button</Label>
-        <Button disabled={ isDisabled }>Create account</Button>
+        <Button data-automation-id='test' disabled={ isDisabled }>Create account</Button>
       </div>
     );
   }

--- a/src/demo/pages/ButtonPage/examples/Button.Primary.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.Primary.Example.tsx
@@ -17,7 +17,11 @@ export class ButtonPrimaryExample extends React.Component<IButtonProps, {}> {
     return (
       <div className='ms-BasicButtonsExample'>
         <Label>Primary button</Label>
-        <Button disabled={ isDisabled } buttonType={ ButtonType.primary }>Create account</Button>
+        <Button
+          data-automation-id='test'
+          disabled={ isDisabled }
+          buttonType={ ButtonType.primary }
+        >Create account</Button>
       </div>
     );
   }

--- a/src/demo/pages/ButtonPage/examples/Button.ScreenReader.Example.tsx
+++ b/src/demo/pages/ButtonPage/examples/Button.ScreenReader.Example.tsx
@@ -18,6 +18,7 @@ export class ButtonScreenReaderExample extends React.Component<IButtonProps, {}>
       <div className='ms-BasicButtonsExample'>
         <Label>Button with aria description for screen reader</Label>
         <Button
+          data-automation-id='test'
           disabled={ isDisabled }
           buttonType={ ButtonType.primary }
           ariaDescription='This is aria description used for screen reader.'>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [X] Documentation update

#### Description of changes

* `icon` for all button variants is now `iconProps`, allowing for custom icons.
* `menuIconName` has been deprecated in favor of `menuIconProps`.
* Button variants are now rendered as HOC around BaseButton.