### PR TITLE
Moving deprecation flags to be after the comment on props

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -83,18 +83,17 @@ export interface IButtonProps extends React.HTMLProps<HTMLButtonElement | HTMLAn
   description?: string;
 
   /**
-   * The type of button to render.
+   * Deprecated at v1.2.3, to be removed at >= v2.0.0. Use specific button component instead
    * @defaultvalue ButtonType.default
    * @deprecated
-   * Deprecated at v1.2.3, to be removed at >= v2.0.0. Use specific button component instead
    */
 
   buttonType?: ButtonType;
 
   /**
-   * @deprecated
    * Deprecated at v0.56.2, to be removed at >= v1.0.0. Just pass in button props instead;
    * they will be mixed into the button/anchor element rendered by the component.
+   * @deprecated
    */
   rootProps?: React.HTMLProps<HTMLButtonElement> | React.HTMLProps<HTMLAnchorElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/Button/Button.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.tsx
@@ -13,8 +13,8 @@ import { IconButton } from './IconButton/IconButton';
 import { PrimaryButton } from './PrimaryButton/PrimaryButton';
 
 /**
- * @deprecated
  * This class is deprecated. Use the individual *Button components instead.
+ * @deprecated
  */
 export class Button extends BaseComponent<IButtonProps, {}> implements IButton {
   private _button: BaseButton;

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
@@ -67,9 +67,8 @@ export interface ICalendarProps extends React.Props<Calendar> {
   showGoToToday?: boolean;
 
   /**
-   * @deprecated
    * This property has been removed at 0.80.0 in place of the focus method, to be removed @ 1.0.0.
-   *
+   * @deprecated
    */
   shouldFocusOnMount?: boolean;
 

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -121,14 +121,14 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
   setInitialFocus?: boolean;
 
   /**
-    * @deprecated
     * Deprecated at v0.59.1, to be removed at >= v1.0.0. Pass in a beakWidth to dictate size.
+    * @deprecated
     */
   beakStyle?: string;
 
   /**
-   * @deprecated
    * Deprecated at v0.72.1 and will no longer exist after 1.0 use target instead.
+   * @deprecated
    */
   targetElement?: HTMLElement;
 }

--- a/packages/office-ui-fabric-react/src/components/Check/Check.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.tsx
@@ -9,8 +9,8 @@ export interface ICheckProps extends React.Props<Check> {
    */
   checked?: boolean;
   /**
+   * Deprecated at v0.65.1 and will be removed by v 1.0. Use 'checked' instead.
    * @deprecated
-   * Deprecated at v.65.1 and will be removed by v 1.0. Use 'checked' instead.
    */
   isChecked?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -39,8 +39,8 @@ export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement | HTMLInp
   label?: string;
 
   /**
-   * @deprecated
    * Deprecated and will be removed by 07/17/2017 Use 'onChange' instead.
+   * @deprecated
    */
   onChanged?: (option: IChoiceGroupOption, evt?: React.FormEvent<HTMLElement | HTMLInputElement>) => void;
 }
@@ -77,16 +77,16 @@ export interface IChoiceGroupOption {
   imageSize?: { width: number, height: number };
 
   /**
-   * @deprecated
    * Deprectated at 2.9.0 and will be removed after August 2017. Use 'selectedKey' or
    * 'defaultSelectedKey' on the ChoiceGroup instead.
+   * @deprecated
    * @defaultvalue false
    */
   checked?: boolean;
 
   /**
-   * @deprecated
    * Deprecated at v.65.1 and will be removed by v 1.0. Use 'checked' instead.
+   * @deprecated
    */
   isChecked?: boolean;
 
@@ -97,8 +97,8 @@ export interface IChoiceGroupOption {
 
   // @todo: Update version numbers for depriate and removal
   /**
-   * @deprecated
    * Deprecated at v0.52.0, to be removed at >= v1.0.0. Use 'disabled' instead.
+   * @deprecated
    */
   isDisabled?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -34,8 +34,8 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu> {
   target?: HTMLElement | string | MouseEvent;
 
   /**
-   * The element that the ContextualMenu should be positioned based on.'
-   * @deprecated at version 0.72.1 and will no longer exist after 1.0 use target instead
+   * Deprecated at version 0.72.1 and will no longer exist after 1.0 use 'target' instead.
+   * @deprecated
    */
   targetElement?: HTMLElement;
 
@@ -190,9 +190,8 @@ export interface IContextualMenuItem {
   submenuIconProps?: IIconProps;
 
   /**
-   * Icon to display next to the menu item
-   * @deprecated at .69 and will no longer exist after 1.0 use IconProps instead.
-   * If you need to change icon colors you will need to switch entirely to iconProps.
+   * Deprecated at v0.69.0 and will no longer exist after 1.0 use IconProps instead.
+   * @deprecated
    */
   icon?: string;
 
@@ -203,8 +202,8 @@ export interface IContextualMenuItem {
   disabled?: boolean;
 
   /**
+   * Deprecated at v0.65.1 and will be removed by v 1.0. Use 'disabled' instead.
    * @deprecated
-   * Deprecated at v.65.1 and will be removed by v 1.0. Use 'disabled' instead.
    */
   isDisabled?: boolean;
 
@@ -226,8 +225,8 @@ export interface IContextualMenuItem {
   checked?: boolean;
 
   /**
-   * @deprecated
    * Deprecated at v.65.1 and will be removed by v 1.0. Use 'checked' instead.
+   * @deprecated
    */
   isChecked?: boolean;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -8,8 +8,8 @@ import styles = require('./DetailsRow.scss');
 export interface IDetailsRowCheckProps {
   selected?: boolean;
   /**
-   * @deprecated
    * Deprecated at v.65.1 and will be removed by v 1.0. Use 'selected' instead.
+   * @deprecated
    */
   isSelected?: boolean;
   anySelected: boolean;

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
@@ -80,8 +80,8 @@ export interface IDialogProps extends React.Props<Dialog>, IWithResponsiveModeSt
   onLayerDidMount?: () => void;
 
   /**
+   * Deprecated at 0.81.2, use 'onLayerDidMount' instead.
    * @deprecated
-   * Use onLayerDidMount instead. Deprecated at 0.81.2, to be removed at 1.0.0.
    */
   onLayerMounted?: () => void;
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
@@ -90,9 +90,8 @@ export interface IDocumentCardPreviewImage {
   previewImageSrc?: string;
 
   /**
-   * @deprecated
    * Deprecated at v1.3.6, to be removed at >= v2.0.0.
-   * Path to the image to display if the preview image won't load.
+   * @deprecated
    */
   errorImageSrc?: string;
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
@@ -91,8 +91,8 @@ export interface IDropdownProps extends React.Props<Dropdown> {
 
   // @todo: Update version numbers for depriate and removal
   /**
+   * Deprecated at v0.52.0, use 'disabled' instead.
    * @deprecated
-   * Deprecated at v0.52.0, to be removed at >= v1.0.0. Use 'disabled' instead.
    */
   isDisabled?: boolean;
 
@@ -118,8 +118,8 @@ export interface IDropdownOption {
   selected?: boolean;
 
   /**
+   * Deprecated at v.65.1, use 'selected' instead.
    * @deprecated
-   * Deprecated at v.65.1 and will be removed by v 1.0. Use 'selected' instead.
    */
   isSelected?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts
@@ -40,9 +40,8 @@ export interface IFacepileProps extends React.Props<Facepile> {
   addButtonProps?: IButtonProps;
 
   /**
+   * Deprecated at v0.70, use 'overflowButtonProps' instead;
    * @deprecated
-   * Deprecated at v0.70, to be removed at >= v1.0.0. User overflowButtonProps instead;
-   * Button properties for the chevron button
    */
   chevronButtonProps?: IButtonProps;
 

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
@@ -83,9 +83,8 @@ export interface IFocusZoneProps extends React.HTMLProps<HTMLElement | FocusZone
   onActiveElementChanged?: (element?: HTMLElement, ev?: React.FocusEvent<HTMLElement>) => void;
 
   /**
-   * Root props to mix into the root element.
+   * Deprecated at v1.12.1. DIV props provided to the FocusZone will be mixed into the root element.
    * @deprecated
-   * Deprecated at v1.12.1, to be removed at >= v2.0.0. Use specific button component instead
    */
   rootProps?: React.HTMLProps<HTMLDivElement>;
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
@@ -114,8 +114,8 @@ export interface IGroup {
   level?: number;
 
   /**
+   * Deprecated at 1.0.0, selection state will be controled by the selection store only.
    * @deprecated
-   * This is no longer supported. Selection state will be controled by the selection store only. Will be removed in 1.0.0.
    */
   isSelected?: boolean;
 
@@ -199,8 +199,8 @@ export interface IGroupDividerProps {
   selected?: boolean;
 
   /**
-   * @deprecated
    * Deprecated at v.65.1 and will be removed by v 1.0. Use 'selected' instead.
+   * @deprecated
    */
   isSelected?: boolean;
 

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -38,10 +38,9 @@ export interface IImageProps extends React.HTMLProps<HTMLImageElement> {
   imageFit?: ImageFit;
 
   /**
+   * Deprecated at v1.3.6, to replace the src in case of errors, use onLoadingStateChange instead and
+   * rerender the Image with a difference src.
    * @deprecated
-   * Deprecated at v1.3.6, to be removed at >= v2.0.0.
-   * To replace the src in case of errors, use onLoadingStateChange instead and rerender the Image with a
-   * difference src.
    */
   errorSrc?: string;
 
@@ -103,10 +102,9 @@ export enum ImageLoadState {
   error = 2,
 
   /**
+   * Deprecated at v1.3.6, to replace the src in case of errors, use onLoadingStateChange instead
+   * and rerender the Image with a difference src.
    * @deprecated
-   * Deprecated at v1.3.6, to be removed at >= v2.0.0.
-   * To replace the src in case of errors, use onLoadingStateChange instead and rerender the Image with a
-   * difference src.
    */
   errorLoaded = 3
 }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts
@@ -61,8 +61,8 @@ export enum MessageBarType {
   /** Warning styled MessageBar */
   warning = 5,
   /**
-   * @deprecated
    * Deprecated at v0.48.0, to be removed at >= v1.0.0. Use 'blocked' instead.
+   * @deprecated
    */
   remove = 6
 }

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
@@ -64,16 +64,14 @@ export interface INavProps {
   expandButtonAriaLabel?: string;
 
   /**
+   * Deprecated at v0.68.1 and will be removed at >= V1.0.0.
    * @deprecated
-   * deprecated at v0.68.1 and will be removed at >= V1.0.0  not used.
-   * (Optional) The accessibility text for the expanded state
    **/
   expandedStateText?: string;
 
   /**
+   * Deprecated at v0.68.1 and will be removed at >= V1.0.0.
    * @deprecated
-   * deprecated at v0.68.1 and will be removed at >= V1.0.0  not used.
-   * (Optional) The accessibility text for the collapsed state text
    **/
   collapsedStateText?: string;
 }
@@ -132,16 +130,14 @@ export interface INavLink {
   iconClassName?: string;
 
   /**
+   * Deprecated at v0.68.1 and will be removed at >= v1.0.0.
    * @deprecated
-   * deprecated at v0.68.1 and will be removed at >= V1.0.0  not used.
-   * The name of the item to be used in logging engagement data
    */
   engagementName?: string;
 
   /**
+   * Deprecated at v0.68.1 and will be removed at >= v1.0.0.
    * @deprecated
-   * deprecated at v0.68.1 and will be removed at >= V1.0.0  not used.
-   * The alt text for the item
    */
   altText?: string;
 

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.Props.ts
@@ -35,8 +35,8 @@ export interface IProgressIndicatorProps {
   ariaValueText?: string;
 
   /**
-   * @deprecated
    * Deprecated at v0.43.0, to be removed at >= v0.53.0. Use 'label' instead.
+   * @deprecated
    */
   title?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
@@ -29,8 +29,8 @@ export interface ISearchBoxProps extends React.Props<SearchBox> {
   onSearch?: (newValue: any) => void;
 
   /**
+   * Deprecated at v0.52.2, use 'onChange' instead.
    * @deprecated
-   * Deprecated at v0.52.2, to be removed at >= v1.0.0. Use 'onChange' instead.
    */
   onChanged?: (newValue: any) => void;
 

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.Props.ts
@@ -13,8 +13,8 @@ export interface ISpinnerProps extends React.Props<Spinner> {
   componentRef?: (component: ISpinner) => void;
 
   /**
-   * @deprecated
    * Deprecated and will be removed at >= 2.0.0. Use SpinnerSize instead.
+   * @deprecated
    */
   type?: SpinnerType;
 
@@ -58,8 +58,8 @@ export enum SpinnerSize {
 }
 
 /**
+ * Deprecated at v2.0.0, use 'SpinnerSize' instead.
  * @deprecated
- * Deprecated and will be removed at >= 2.0.0. Use SpinnerSize instead.
  */
 export enum SpinnerType {
   /**

--- a/packages/office-ui-fabric-react/src/components/Spinner/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/components/Spinner/interfaces.ts
@@ -1,6 +1,6 @@
 /**
+ * Deprecated at 2.0.0. Use SpinnerSize instead.
  * @deprecated
- * TODO remove deprecated value at >= 2.0.0
  */
 export enum SpinnerType {
   normal = 0,

--- a/packages/office-ui-fabric-react/src/utilities/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning.ts
@@ -24,9 +24,9 @@ export interface IPositionProps {
 
   target?: HTMLElement | MouseEvent;
 
-  /** The element that the callout should be positioned based on.
-   * @deprecated use target instead.
-  */
+  /** Deprecated at v1.0.0, use 'target' instead.
+   * @deprecated
+   */
   targetElement?: HTMLElement;
 
   /** how the element should be positioned */
@@ -44,22 +44,22 @@ export interface IPositionProps {
   bounds?: IRectangle;
 
   /**
-   * The event that created the contextualmenu.
-   * @deprecated use target with event passed in.
+   * Deprecated at v1.0.0, use 'target' with event passed in.
+   * @deprecated
    * @default null
    */
   creationEvent?: MouseEvent;
 
   /**
-   * If true use a point rather than rectangle to position the callout.
-   * For example it can be used to position based on a click.
-   * @deprecated use target with event passed in
+   * Deprecated at v1.0.0, use 'target' with event passed in.
+   * @deprecated
    */
   useTargetPoint?: boolean;
 
-  /** Point used to position
-   * @deprecated use target with event passed in
-  */
+  /**
+   * Deprecated at v1.0.0, use 'target' with event passed in.
+   * @deprecated
+   */
   targetPoint?: IPoint;
 
   /** If true then the beak is visible. If false it will not be shown. */


### PR DESCRIPTION
This doesn't require a change file; i'm simply moving @deprecated flags in jsdoc comments to live after the comment. This allows intellisense to work and render the comments.
