### PR TITLE
Selection zone eating button clicks

### DIFF
--- a/common/changes/selection-zone-eating-button-clicks_2017-04-17-18-40.json
+++ b/common/changes/selection-zone-eating-button-clicks_2017-04-17-18-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SelectionZone: Spacebar and Enter key presses within selectionzone button/a/input will work properly",
+      "type": "patch"
+    }
+  ],
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -319,6 +319,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
           // For toggle elements, assuming they are rendered as buttons, they will generate a click event,
           // so we can no-op for any keydowns in this case.
           break;
+        } else if (target.tagName === 'BUTTON' || target.tagName === 'A' || target.tagName === 'INPUT') {
+          return false;
         } else if (target === itemRoot) {
           if (ev.which === KeyCodes.enter) {
             this._onInvokeClick(ev, index);


### PR DESCRIPTION
#### Pull request checklist
Previously, spacebar and enter would not work on input/a/button within selection zone. 


- [x] Addresses an existing issue: #1529
- [x] Include a change request file if publishing <!-- see notes below -->
