### PR TITLE
DetailsList: setting min-width correctly, adjusting column sizing to respect newProps.

### DIFF
--- a/common/changes/detailslist-width-fixes_2017-04-17-18-17.json
+++ b/common/changes/detailslist-width-fixes_2017-04-17-18-17.json
@@ -1,0 +1,20 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: header now stretches correctly, group headers stretch correctly, column width calculations respect newProps rather than current props.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -8,6 +8,7 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
 
 .root {
   display: inline-block;
+  min-width: 100%;
   vertical-align: top;
   height: $rowHeight;
   line-height: $rowHeight;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.scss
@@ -8,7 +8,7 @@
 .focusZone {
   display: inline-block;
   vertical-align: top;
-  min-width: 1px;
+  min-width: 100%;
   min-height: 1px;
 }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -504,7 +504,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     if (layoutMode === DetailsListLayoutMode.fixedColumns) {
       adjustedColumns = this._getFixedColumns(newColumns);
     } else {
-      adjustedColumns = this._getJustifiedColumns(newColumns, viewportWidth);
+      adjustedColumns = this._getJustifiedColumns(newColumns, viewportWidth, newProps);
     }
 
     // Preserve adjusted column calculated widths.
@@ -530,16 +530,16 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   }
 
   /** Builds a set of columns to fix within the viewport width. */
-  private _getJustifiedColumns(newColumns: IColumn[], viewportWidth: number) {
+  private _getJustifiedColumns(newColumns: IColumn[], viewportWidth: number, props: IDetailsListProps) {
     let {
       selectionMode,
       groups
-    } = this.props;
+    } = props;
     let outerPadding = DEFAULT_INNER_PADDING;
     let rowCheckWidth = (selectionMode !== SelectionMode.none) ? CHECKBOX_WIDTH : 0;
     let groupExpandWidth = groups ? GROUP_EXPAND_WIDTH : 0;
     let totalWidth = 0; // offset because we have one less inner padding.
-    let availableWidth = viewportWidth - outerPadding - rowCheckWidth - groupExpandWidth;
+    let availableWidth = viewportWidth - (outerPadding + rowCheckWidth + groupExpandWidth);
     let adjustedColumns: IColumn[] = newColumns.map((column, i) => {
       let newColumn = assign(
         {},

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -1,16 +1,35 @@
 /* tslint:disable:no-unused-variable */
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
-import { Link } from 'office-ui-fabric-react/lib/Link';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import {
   DetailsList,
+  DetailsListLayoutMode,
   Selection
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { createListItems } from '@uifabric/example-app-base';
 
-let _items: any[];
+let _items = [];
+
+let _columns = [
+  {
+    key: 'column1',
+    name: 'Name',
+    fieldName: 'name',
+    minWidth: 100,
+    maxWidth: 200,
+    isResizable: true
+  },
+  {
+    key: 'column2',
+    name: 'Value',
+    fieldName: 'value',
+    minWidth: 100,
+    maxWidth: 200,
+    isResizable: true
+  },
+];
 
 export class DetailsListBasicExample extends React.Component<any, any> {
   private _selection: Selection;
@@ -18,9 +37,17 @@ export class DetailsListBasicExample extends React.Component<any, any> {
   constructor() {
     super();
 
-    _items = _items || createListItems(500);
+    // Populate with items for demos.
+    if (_items.length === 0) {
+      for (let i = 0; i < 200; i++) {
+        _items.push({
+          key: i,
+          name: 'Item ' + i,
+          value: i
+        });
+      }
+    }
 
-    this._onRenderItemColumn = this._onRenderItemColumn.bind(this);
     this._selection = new Selection({
       onSelectionChanged: () => this.setState({ selectionDetails: this._getSelectionDetails() })
     });
@@ -44,23 +71,16 @@ export class DetailsListBasicExample extends React.Component<any, any> {
         <MarqueeSelection selection={ this._selection }>
           <DetailsList
             items={ items }
+            columns={ _columns }
             setKey='set'
+            layoutMode={ DetailsListLayoutMode.fixedColumns }
             selection={ this._selection }
             selectionPreservedOnEmptyClick={ true }
             onItemInvoked={ (item) => alert(`Item invoked: ${item.name}`) }
-            onRenderItemColumn={ this._onRenderItemColumn }
           />
         </MarqueeSelection>
       </div>
     );
-  }
-
-  private _onRenderItemColumn(item, index, column) {
-    if (column.key === 'name') {
-      return <Link data-selection-invoke={ true }>{ item[column.key] }</Link>;
-    }
-
-    return item[column.key];
   }
 
   private _getSelectionDetails(): string {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -8,7 +8,6 @@ import {
   Selection
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { createListItems } from '@uifabric/example-app-base';
 
 let _items = [];
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement
  
#### Description of changes

When details list rows don't expand beyond the horizontal fold in fixed layout mode, they should stretch a minimum of the contain width. They weren't after a recent change, now they do.

Also found a bug where when the input props change and we calculate the columns, we use the old props instead of the new ones.

