### PR TITLE
Fixing AMD imports for oufr package.

### DIFF
--- a/common/changes/fix-imports_2017-04-19-14-27.json
+++ b/common/changes/fix-imports_2017-04-19-14-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "References to @uifabric/utilities have been updated to refer to the root Utilities.ts export, which is more AMD friendly than the package import.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/VisualTestRoot.tsx
+++ b/packages/office-ui-fabric-react/src/VisualTestRoot.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { VisualTestState } from './VisualTestState';
 import { Route, Router } from './utilities/router/index';
-import { setBaseUrl } from '@uifabric/utilities/lib/resources';
+import { setBaseUrl } from './Utilities';
 
 setBaseUrl('./dist/');
 

--- a/packages/office-ui-fabric-react/src/components/Button/Button.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.tsx
@@ -2,14 +2,13 @@
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 
-import { BaseComponent } from '../../Utilities';
+import { BaseComponent, warn } from '../../Utilities';
 import { ButtonType, IButtonProps } from './Button.Props';
 import { DefaultButton } from './DefaultButton/DefaultButton';
 import { CommandButton } from './CommandButton/CommandButton';
 import { CompoundButton } from './CompoundButton/CompoundButton';
 import { IconButton } from './IconButton/IconButton';
 import { PrimaryButton } from './PrimaryButton/PrimaryButton';
-import { warn } from '@uifabric/utilities';
 /**
  * This class is deprecated. Use the individual *Button components instead.
  * @deprecated

--- a/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseButton, IButtonClassNames } from '../BaseButton';
-import { BaseComponent, nullRender } from '@uifabric/utilities';
+import { BaseComponent, nullRender } from '../../../Utilities';
 import { IButtonProps } from '../Button.Props';
 import styles = require('./CommandButton.scss');
 

--- a/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseButton, IButtonClassNames } from '../BaseButton';
-import { BaseComponent } from '@uifabric/utilities';
+import { BaseComponent } from '../../../Utilities';
 import { IButtonProps } from '../Button.Props';
 
 import styles = require('./CompoundButton.scss');

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseButton, IButtonClassNames } from '../BaseButton';
-import { BaseComponent, nullRender } from '@uifabric/utilities';
+import { BaseComponent, nullRender } from '../../../Utilities';
 import { IButtonProps } from '../Button.Props';
 
 import styles = require('./DefaultButton.scss');

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseButton, IButtonClassNames } from '../BaseButton';
-import { BaseComponent, nullRender } from '@uifabric/utilities';
+import { BaseComponent, nullRender } from '../../../Utilities';
 import { IButtonProps } from '../Button.Props';
 import styles = require('./IconButton.scss');
 

--- a/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, nullRender } from '@uifabric/utilities';
+import { BaseComponent, nullRender } from '../../../Utilities';
 import { BaseButton, IButtonClassNames } from '../BaseButton';
 import { IButtonProps } from '../Button.Props';
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   BaseComponent,
+  IDisposable,
   assign,
   css,
   shallowCompare
@@ -18,7 +19,6 @@ import {
 } from './../../utilities/dragdrop/interfaces';
 import { IViewport } from '../../utilities/decorators/withViewport';
 import styles = require('./DetailsRow.scss');
-import { IDisposable } from '@uifabric/utilities';
 
 export interface IDetailsRowProps extends React.Props<DetailsRow> {
   item: any;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -13,6 +13,7 @@ import {
 import {
   BaseComponent,
   IRenderFunction,
+  IDisposable,
   autobind
 } from '../../Utilities';
 
@@ -34,7 +35,6 @@ import {
 import { assign, css } from '../../Utilities';
 import { IViewport } from '../../utilities/decorators/withViewport';
 import styles = require('./GroupedList.scss');
-import { IDisposable } from '@uifabric/utilities';
 
 export interface IGroupedListSectionProps extends React.Props<GroupedListSection> {
   /** Map of callback functions related to drag and drop functionality. */


### PR DESCRIPTION
Some imports were introduced in Button updates which are not AMD friendly. Updating @uifabric/utilities imports to refer to the top level Utilities import.