### PR TITLE
Toggle: Improve screen-reader accessibility

### DIFF
--- a/common/changes/bugfix-togglescreenreader_2017-04-19-12-50.json
+++ b/common/changes/bugfix-togglescreenreader_2017-04-19-12-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: Improve screen-reader accessibility.",
+      "type": "minor"
+    }
+  ],
+  "email": "clewolff@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
@@ -26,7 +26,7 @@ export interface IToggleProps extends React.HTMLProps<HTMLInputElement | Toggle>
   onText?: string;
 
   /**
-   * Test display when toggle is OFF.
+   * Text to display when toggle is OFF.
    */
   offText?: string;
 

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
@@ -31,6 +31,16 @@ export interface IToggleProps extends React.HTMLProps<HTMLInputElement | Toggle>
   offText?: string;
 
   /**
+   * Text for screen-reader to announce when toggle is ON.
+   */
+  onAriaLabel?: string;
+
+  /**
+   * Text for screen-reader to announce when toggle is OFF.
+   */
+  offAriaLabel?: string;
+
+  /**
    * Checked state of the toggle. If you are maintaining state yourself, use this property. Otherwise refer to 'defaultChecked'.
    */
   checked?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -49,9 +49,10 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
   }
 
   public render() {
-    let { label, onText, offText, className, disabled } = this.props;
+    let { label, onAriaLabel, offAriaLabel, onText, offText, className, disabled } = this.props;
     let { isChecked } = this.state;
     let stateText = isChecked ? onText : offText;
+    const ariaLabel = isChecked ? onAriaLabel : offAriaLabel;
     const toggleNativeProps = getNativeProps(this.props, buttonProperties);
     return (
       <div className={
@@ -82,6 +83,7 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
               className={ css(styles.button, 'ms-Toggle-button') }
               disabled={ disabled }
               aria-pressed={ isChecked }
+              aria-label={ ariaLabel }
               onClick={ this._onClick }
             />
             <div className={ css(styles.background, 'ms-Toggle-background') }>

--- a/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx
@@ -8,6 +8,8 @@ export const ToggleBasicExample = () => (
     <Toggle
       defaultChecked={ true }
       label='Enabled and checked'
+      onAriaLabel='This toggle is checked. Press to uncheck.'
+      offAriaLabel='This toggle is unchecked. Press to check.'
       onText='On'
       offText='Off' />
     <Toggle


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue
- [x] Include a change request file if publishing
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

The Toggle is currently not very accessible for screen-reader users as it doesn't have hooks that let us provide context on the option that's being toggled. This pull request adds two optional aria-labels that lets us provide more context on the on/off states for screen-reader users.

[Video of screen-reader behavior after applying the pull-request.](http://www.screencast.com/t/aiqsbvcv)

It's not ideal that the screen-reader re-announces the toggle onText and offText, however, this is not easily preventable as many browser/screenreader combinations will announce aria-hidden children while reading the parent.

#### Focus areas to test

1) Open Narrator on Windows 10.
2) Open [the Toggle example](http://localhost:4321/#/examples/toggle) in Edge.
3) Navigate to "enabled and checked" toggle.
4) Hear the screen-reader speak the onAriaLabel.
5) Press enter to state-switch the toggle.
6) Hear the screen-reader speak the offAriaLabel.