### PR TITLE
ContextualMenu: Document onRender accessibility requirement

### DIFF
--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -283,7 +283,9 @@ export interface IContextualMenuItem {
   title?: string;
 
   /**
-   * Method to custom render this menu item
+   * Method to custom render this menu item.
+   * For keyboard accessibility, the top-level rendered item should be a focusable element
+   * (like an anchor or a button) or have the `data-is-focusable` property set to true.
    * @defaultvalue undefined
    */
   onRender?: (item: any) => React.ReactNode;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #0000
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Description of changes

For keyboard accessibility, all custom-rendered context menus entries need to be focusable so that the FocusZone can set the appropriate tabIndex while navigating through the menu.

Previously, this requirement was not documented which made it very easy to inadvertently create non-accessible context menus. For example, the ["ContextualMenu customization example"](https://dev.office.com/fabric#/components/contextualmenu) is currently not keyboard-accessible.

Hopefully this documentation update will make it easier for users to create accessible custom-rendered context menus.