### PR TITLE
Adjust homepage project logos & positioning

### DIFF
--- a/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
@@ -108,11 +108,6 @@
   flex-direction: column;
   margin-bottom: 60px;
 
-  // Place the second flavor at the top
-  &:nth-of-type(2) {
-    order: -1;
-  }
-
   img {
     margin-bottom: 12px;
   }
@@ -162,11 +157,16 @@
     margin-bottom: 0;
     width: 30%; // Ensure that the 4th one wraps
 
-    // Lift out the second flavor
-    &:nth-of-type(2) {
-      order: 0; // Restore default order
+    // Lift out the first flavor
+    &:nth-of-type(1) {
       position: relative;
       top: -96px;
+      margin: 0 30%; // Pushes other items into their own row
+    }
+
+    // Move the Angular flavor to the last column
+    &:nth-of-type(3) {
+      order: 4;
     }
   }
 }

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -17,19 +17,17 @@ export class HomePage extends React.Component<any, any> {
 
         <div className={ styles.flavors }>
           <div className={ styles.flavor }>
-            <img src={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/images/logo-js-white.svg' } width='48' height='48' alt='Javascript logo' />
-            <span className={ styles.flavorTitle }>Fabric JS</span>
-            <span className={ styles.flavorDescription }>Lightweight and simple components in vanilla JavaScript</span>
-            <a href='#/fabric-js'>Learn more</a>
-          </div>
-          <div className={ styles.flavor }>
             <img src={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/images/logo-react.svg' } width='72' height='64' alt='React logo' />
             <span className={ styles.flavorTitle }>Built with React</span>
             <span className={ styles.flavorDescription }>Fabric&rsquo;s robust, up-to-date components are built with React</span>
             <a href='#/components' className={ styles.button }>See components</a>
           </div>
           <div className={ styles.flavor }>
-            <img src={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/images/logo-angular-white.svg' } width='48' height='48' alt='Angular JS Logo' />
+            <span className={ styles.flavorTitle }>Fabric JS</span>
+            <span className={ styles.flavorDescription }>Lightweight and simple components in vanilla JavaScript</span>
+            <a href='#/fabric-js'>Learn more</a>
+          </div>
+          <div className={ styles.flavor }>
             <span className={ styles.flavorTitle }>AngularJS</span>
             <span className={ styles.flavorDescription }>Community-driven project for Angular apps</span>
             <a href='#/angular-js'>Learn more</a>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: N/A
- [ ] Include a change request file if publishing: N/A
- [x] Bugfix
  - [ ] Includes tests
- [x] Documentation update

#### Description of changes

This removes the logo graphics for the Fabric JS & Angular projects and brings them down to same line as the Fabric iOS project.

#### Focus areas to test

The homepage of the Fabric website.

Here's a before/after of the changes.

Before:
![image](https://cloud.githubusercontent.com/assets/307118/25320746/6114507a-285e-11e7-8eab-a5fe9da1c820.png)

After:
![image](https://cloud.githubusercontent.com/assets/307118/25320734/4f42af18-285e-11e7-9940-af6f59edcf9e.png)
