### PR TITLE
List: Correctly measure pages when using display: none.

### DIFF
--- a/common/changes/listToUpdatePagesFromDisplayNone_2017-04-24-09-42.json
+++ b/common/changes/listToUpdatePagesFromDisplayNone_2017-04-24-09-42.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: correctly measure pages when using display: none.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "v-panu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -518,22 +518,24 @@ export class List extends BaseComponent<IListProps, IListState> {
     if (pageElement && (!cachedHeight || cachedHeight.measureVersion !== this._measureVersion)) {
       let newClientRect = _measurePageRect(pageElement);
 
-      hasChangedHeight = page.height !== newClientRect.height;
+      if (newClientRect.height || newClientRect.width) {
+        hasChangedHeight = page.height !== newClientRect.height;
 
-      // console.warn(' *** expensive page measure', page.startIndex, page.height, newClientRect.height);
+        // console.warn(' *** expensive page measure', page.startIndex, page.height, newClientRect.height);
 
-      page.height = newClientRect.height;
+        page.height = newClientRect.height;
 
-      this._cachedPageHeights[page.startIndex] = {
-        height: newClientRect.height,
-        measureVersion: this._measureVersion
-      };
+        this._cachedPageHeights[page.startIndex] = {
+          height: newClientRect.height,
+          measureVersion: this._measureVersion
+        };
 
-      this._estimatedPageHeight = Math.round(
-        ((this._estimatedPageHeight * this._totalEstimates) + newClientRect.height) /
-        (this._totalEstimates + 1));
+        this._estimatedPageHeight = Math.round(
+          ((this._estimatedPageHeight * this._totalEstimates) + newClientRect.height) /
+          (this._totalEstimates + 1));
 
-      this._totalEstimates++;
+        this._totalEstimates++;
+      }
     }
 
     return hasChangedHeight;


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file if publishing
- [X] New bugfix

#### Description of changes

**Bug:** When using a List inside an element that conditionally uses display: none, pages were not updated properly. Reason being that height was cached when list was hidden, and when it became visible, it as not calculated again unless something else changes (like resizing browser window).

See bug here: http://codepen.io/pablonete/pen/LyRZjW?editors=0010

**Fix:** Explicitly ignore height when it comes from an empty rectangle (zero x zero).

**Note:** I realize this might break lists where first 10 items don't get rendered. This seems a very strange use case, furthermore I've not been able to get this working before my fix either, see here:
http://codepen.io/pablonete/pen/XRjjae?editors=0010
It only renders something if nullItemsCount is less than 10, so I feel confident my fix is not altering behavior.