### PR TITLE
Searchbox: Fixes for IE11 keystroke miss + flex overflow

### DIFF
--- a/common/changes/searchbox_fixes_2017-04-24-09-53.json
+++ b/common/changes/searchbox_fixes_2017-04-24-09-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Searchbox: IE11 keystroke miss, overflow fix",
+      "type": "patch"
+    }
+  ],
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
@@ -49,7 +49,7 @@
   font-size: inherit;
   color: $ms-color-black;
   background-color: transparent;
-  flex: 1;
+  flex: 1 1 0;
   overflow: hidden;
   text-overflow: ellipsis;
   // This padding forces the text placement to round up.

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
@@ -49,7 +49,7 @@
   font-size: inherit;
   color: $ms-color-black;
   background-color: transparent;
-  flex-grow: 1;
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   // This padding forces the text placement to round up.

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -140,17 +140,13 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
   @autobind
   private _onInputChange(ev: React.ChangeEvent<HTMLInputElement>) {
     const value = this._inputElement.value;
-
     if (value === this._latestValue) {
       return;
     }
-
     this._latestValue = value;
 
-    this.setState({
-      value: this._inputElement.value
-    });
-    this._callOnChange(this._inputElement.value);
+    this.setState({ value });
+    this._callOnChange(value);
   }
 
   private _handleDocumentFocus(ev: FocusEvent) {

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -26,6 +26,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
 
   private _rootElement: HTMLElement;
   private _inputElement: HTMLInputElement;
+  private _latestValue: string;
 
   public constructor(props: ISearchBoxProps) {
     super(props);
@@ -39,6 +40,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
 
   public componentWillReceiveProps(newProps: ISearchBoxProps) {
     if (newProps.value !== undefined) {
+      this._latestValue = newProps.value;
       this.setState({
         value: newProps.value
       });
@@ -67,6 +69,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
           className={ css('ms-SearchBox-field', styles.field) }
           placeholder={ labelText }
           onChange={ this._onInputChange }
+          onInput={ this._onInputChange }
           onKeyDown={ this._onKeyDown }
           value={ value }
           ref={ this._resolveRef('_inputElement') }
@@ -136,6 +139,14 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
 
   @autobind
   private _onInputChange(ev: React.ChangeEvent<HTMLInputElement>) {
+    const value = this._inputElement.value;
+
+    if (value === this._latestValue) {
+      return;
+    }
+
+    this._latestValue = value;
+
     this.setState({
       value: this._inputElement.value
     });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #1571
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes
1. Similar to textfield we need changes in Searchbox to avoid keystroke misses in IE11 https://github.com/OfficeDev/office-ui-fabric-react/pull/1077

2. In IE11, the clear "X" button is overflown due to space crunch in flexbox container.
  Fix: use flex: 1 1 0; on input field to allow both shrink and grow
![searchbox](https://cloud.githubusercontent.com/assets/12109362/25332164/23f4dd9a-2903-11e7-91aa-7469341a9485.gif)

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
