### PR TITLE
Added focus zone around navigation to make it more keyboard accessible

### DIFF
--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -25,7 +25,7 @@ export class Nav extends React.Component<INavProps, INavState> {
       : null;
 
     return (
-      <FocusZone ref='focusZone' direction={ FocusZoneDirection.vertical } role='menubar' >
+      <FocusZone direction={ FocusZoneDirection.vertical } role='menu' >
         <nav className={ styles.nav } role='navigation'>
           { links }
         </nav>

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
+import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import * as stylesImport from './Nav.module.scss';
 const styles: any = stylesImport;
 import {
@@ -24,9 +25,11 @@ export class Nav extends React.Component<INavProps, INavState> {
       : null;
 
     return (
-      <nav className={ styles.nav } role='navigation'>
-        { links }
-      </nav>
+      <FocusZone ref='focusZone' direction={ FocusZoneDirection.vertical } role='menubar' >
+        <nav className={ styles.nav } role='navigation'>
+          { links }
+        </nav>
+      </FocusZone>
     );
   }
 

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -25,7 +25,7 @@ export class Nav extends React.Component<INavProps, INavState> {
       : null;
 
     return (
-      <FocusZone direction={ FocusZoneDirection.vertical } role='menu' >
+      <FocusZone direction={ FocusZoneDirection.vertical } >
         <nav className={ styles.nav } role='navigation'>
           { links }
         </nav>


### PR DESCRIPTION
After Ben's accessibility pass, he mentioned how frustrating it was to keyboard around our website. Turns out you can easily tab to our nav, but once you click a link you have to tab through the entire nav before getting to the content.

This focuszone makes the nav work with keyboard up/down, and a single tab goes to and returns to navigation.