### PR TITLE
Use overflow-wrap: break-word instead of word-break: break-all in tooltips, labels and dropdowns

### DIFF
--- a/common/changes/fixwordbreak_2017-04-26-21-06.json
+++ b/common/changes/fixwordbreak_2017-04-26-21-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Don't break intra-word in tooltips UNLESS required for overflow by using CSS overflow-wrap property. Fixes #1627.",
+      "type": "patch"
+    }
+  ],
+  "email": "trgau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -198,6 +198,7 @@ $DropDown-item-height: 36px;
   position: relative;
   border: 1px solid transparent;
   word-wrap: break-word;
+  overflow-wrap: break-word;
   text-align: left;
 
   @media screen and (-ms-high-contrast: active) {
@@ -275,6 +276,7 @@ $DropDown-item-height: 36px;
   text-overflow: ellipsis;
   min-width: 0px;
   max-width: 100%;
-  word-break: break-all;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
   margin: 1px;
 }

--- a/packages/office-ui-fabric-react/src/components/Label/Label.scss
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.scss
@@ -16,7 +16,8 @@
   box-sizing: border-box;
   display: block;
   padding: 5px 0;
-  word-break: break-all;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .isRequired {

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.scss
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.scss
@@ -21,5 +21,6 @@
   margin: 0;
   font-size: $ms-font-size-s;
   color: $ms-color-neutralPrimary;
-  word-break: break-all;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
Fix #1627

#### Pull request checklist

- [x] Addresses an existing issue: #1627 
- [x] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

See #1627 

