### PR TITLE
Added isHidden attribute to website nav props 

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
@@ -152,6 +152,11 @@ export interface INavLink {
   isExpanded?: boolean;
 
   /**
+   * Whether or not the link is hidden from navigation
+   */
+  isHidden?: boolean;
+
+  /**
    * Aria label for nav link
    */
   ariaLabel?: string;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -152,6 +152,9 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
   }
 
   private _renderLink(link: INavLink, linkIndex: number, nestingLevel: number): React.ReactElement<{}> {
+    if (link.isHidden) {
+      return null;
+    }
     return (
       <li key={ link.key || linkIndex } role='listitem' className={ css(styles.navItem) }>
         { this._renderCompositeLink(link, linkIndex, nestingLevel) }


### PR DESCRIPTION
Added isHidden attribute to website nav props so that we can soft launch a component (like overflowSet) without exposing it in the navigation.
