### PR TITLE
Fix issue with JAWS + DatePicker opening

### DIFF
--- a/common/changes/datepicker-jaws-enter-key_2017-04-26-19-25.json
+++ b/common/changes/datepicker-jaws-enter-key_2017-04-26-19-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker: Fix an issue with JAWS users needing to hit enter twice to open the date picker.",
+      "type": "patch"
+    }
+  ],
+  "email": "chscribn@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -164,8 +164,11 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     let { isDatePickerShown, formattedDate, selectedDate, errorMessage } = this.state;
 
     return (
+      // role='application' is used to work around undesirable behavior in JAWS.
+      // Without role='application', when pressing enter to open the date picker popup,
+      // JAWS swallows the first enter key press and nothing happens.
       <div className={ css('ms-DatePicker', styles.root) } ref='root'>
-        <div ref={ (c): HTMLElement => this._datepicker = c }>
+        <div ref={ (c): HTMLElement => this._datepicker = c } role='application'>
           <TextField
             className={ styles.textField }
             ariaLabel={ ariaLabel }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement
  
#### Description of changes

When using the JAWS screen reader, the first time the user presses enter to open the date picker popup, nothing happens. If the user presses enter again, it works. This problem is more noticeable when setting disableAutoFocus on the DatePicker to true, but it still happens regardless of the setting.

I tested the change in Edge + Narrator, IE11 + JAWS, Chrome + JAWS, and Chrome OSX + VoiceOver.