### PR TITLE
Fix screenreader compatibility issues with the toggle control

### DIFF
--- a/common/changes/scriby-toggle-ax-fixes_2017-04-27-10-33.json
+++ b/common/changes/scriby-toggle-ax-fixes_2017-04-27-10-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: Make toggle control more universally accessible across screen readers.",
+      "type": "patch"
+    }
+  ],
+  "email": "chscribn@microsoft.com"
+} 

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.scss
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.scss
@@ -33,7 +33,7 @@
 // Interactive overrides
 .isEnabled {
 
-  .button {
+  .invisibleToggle {
     cursor: pointer;
   }
 
@@ -121,11 +121,11 @@
   min-width: 45px;
 }
 
-:global(.ms-Fabric.is-focusVisible) .root.isEnabled .button:focus + .background .focus {
+:global(.ms-Fabric.is-focusVisible) .root.isEnabled .invisibleToggle:focus + .background .focus {
   border: 1px solid $focusedBorderColor;
 }
 
-.button {
+.invisibleToggle {
   position: absolute;
   opacity: 0;
   left: 0;

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
@@ -35,7 +35,7 @@ describe('Toggle', () => {
       />
     );
     let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
-    let button = renderedDOM.querySelector('.ms-Toggle-button');
+    let button = renderedDOM.querySelector('input');
 
     ReactTestUtils.Simulate.click(button);
     expect(isToggledValue).to.equal(true);
@@ -50,7 +50,7 @@ describe('Toggle', () => {
       />
     );
     let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
-    let button = renderedDOM.querySelector('.ms-Toggle-button');
+    let button = renderedDOM.querySelector('input');
 
     ReactTestUtils.Simulate.click(button);
 

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -51,11 +51,11 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
   }
 
   public render() {
-    //This control is using an input element for more universal accessibility support.
-    //Previously a button and the aria-pressed attribute were used. This technique works well with Narrator + Edge and NVDA + FireFox.
-    //However, JAWS and VoiceOver did not announce anything when the toggle was checked or unchecked.
-    //In the future when more screenreaders support aria-pressed it would be a good idea to change this control back to using it as it is
-    //more semantically correct.
+    // This control is using an input element for more universal accessibility support.
+    // Previously a button and the aria-pressed attribute were used. This technique works well with Narrator + Edge and NVDA + FireFox.
+    // However, JAWS and VoiceOver did not announce anything when the toggle was checked or unchecked.
+    // In the future when more screenreaders support aria-pressed it would be a good idea to change this control back to using it as it is
+    // more semantically correct.
 
     let { label, onAriaLabel, offAriaLabel, onText, offText, className, disabled } = this.props;
     let { isChecked } = this.state;
@@ -83,6 +83,7 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
           ) }
           <div className={ css(styles.slider, 'ms-Toggle-slider') }>
             <input
+              key='invisibleToggle'
               ref={ (c): HTMLInputElement => this._toggleInput = c }
               type='checkbox'
               id={ this._id }
@@ -135,8 +136,8 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
   private _onInputKeyDown(ev: React.KeyboardEvent<HTMLElement>) {
     switch (ev.which) {
       case KeyCodes.enter:
-        //Also support toggling via the enter key.
-        //While toggling via the space bar is technically correct for a checkbox, this control looks more like a button to sighted users.
+        // Also support toggling via the enter key.
+        // While toggling via the space bar is technically correct for a checkbox, this control looks more like a button to sighted users.
         this._onClick();
 
         break;

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import {
   BaseComponent,
+  KeyCodes,
   autobind,
   css,
   getId,
-  buttonProperties,
+  inputProperties,
   getNativeProps
 } from '../../Utilities';
 import { IToggleProps, IToggle } from './Toggle.Props';
@@ -19,7 +20,7 @@ export interface IToggleState {
 export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements IToggle {
 
   private _id: string;
-  private _toggleButton: HTMLButtonElement;
+  private _toggleInput: HTMLInputElement;
 
   constructor(props: IToggleProps) {
     super();
@@ -50,11 +51,17 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
   }
 
   public render() {
+    //This control is using an input element for more universal accessibility support.
+    //Previously a button and the aria-pressed attribute were used. This technique works well with Narrator + Edge and NVDA + FireFox.
+    //However, JAWS and VoiceOver did not announce anything when the toggle was checked or unchecked.
+    //In the future when more screenreaders support aria-pressed it would be a good idea to change this control back to using it as it is
+    //more semantically correct.
+
     let { label, onAriaLabel, offAriaLabel, onText, offText, className, disabled } = this.props;
     let { isChecked } = this.state;
     let stateText = isChecked ? onText : offText;
     const ariaLabel = isChecked ? onAriaLabel : offAriaLabel;
-    const toggleNativeProps = getNativeProps(this.props, buttonProperties);
+    const toggleNativeProps = getNativeProps(this.props, inputProperties);
     return (
       <div className={
         css(
@@ -75,17 +82,18 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
             <Label className='ms-Toggle-label' htmlFor={ this._id }>{ label }</Label>
           ) }
           <div className={ css(styles.slider, 'ms-Toggle-slider') }>
-            <button
-              ref={ (c): HTMLButtonElement => this._toggleButton = c }
-              type='button'
+            <input
+              ref={ (c): HTMLInputElement => this._toggleInput = c }
+              type='checkbox'
               id={ this._id }
               { ...toggleNativeProps }
+              className={ styles.invisibleToggle }
               name={ this._id }
-              className={ css(styles.button, 'ms-Toggle-button') }
               disabled={ disabled }
-              aria-pressed={ isChecked }
+              checked={ isChecked }
               aria-label={ ariaLabel }
               onClick={ this._onClick }
+              onKeyDown={ this._onInputKeyDown }
             />
             <div className={ css(styles.background, 'ms-Toggle-background') }>
               <div className={ css(styles.focus, 'ms-Toggle-focus') } />
@@ -101,8 +109,8 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
   }
 
   public focus() {
-    if (this._toggleButton) {
-      this._toggleButton.focus();
+    if (this._toggleInput) {
+      this._toggleInput.focus();
     }
   }
 
@@ -120,6 +128,18 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
 
     if (onChanged) {
       onChanged(!isChecked);
+    }
+  }
+
+  @autobind
+  private _onInputKeyDown(ev: React.KeyboardEvent<HTMLElement>) {
+    switch (ev.which) {
+      case KeyCodes.enter:
+        //Also support toggling via the enter key.
+        //While toggling via the space bar is technically correct for a checkbox, this control looks more like a button to sighted users.
+        this._onClick();
+
+        break;
     }
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1619 

#### Description of changes

This changes the toggle control to use an invisible checkbox instead of an invisible button. There are no aesthetic changes; it only affects how screen reader users interact with the control.

This approach works better for JAWS and VoiceOver because they announce when the value of checkboxes change, but they do not announce when aria-pressed changes.

Note that the previous approach of using the button and aria-pressed is more semantic and should be preferred at the point there is more universal screen reader support. Alternatively, we could look into some solutions using aria-live to manually announce toggle changes if we wanted to keep with that approach, but it's hard for me to say whether that's really better or worse than using the checkbox.

I tested the changes in JAWS + IE11, JAWS + Chrome, FF + NVDA, Narrator + Edge, and VoiceOver + Chrome on OSX.

Thanks,

Chris