### PR TITLE
Fixing AMD dependency break introduced in 2.23.1.

### DIFF
--- a/common/changes/tooltiphost-fix_2017-04-28-17-38.json
+++ b/common/changes/tooltiphost-fix_2017-04-28-17-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltiphost: Fixing AMD import to pull getId from the Utilities AMD-friendly top-level import.",
+      "type": "patch"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/tooltiphost-fix_2017-04-28-17-38.json
+++ b/common/changes/tooltiphost-fix_2017-04-28-17-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Tooltiphost: Fixing AMD import to pull getId from the Utilities AMD-friendly top-level import.",
+      "comment": "TooltipHost: Fixing AMD import to pull getId from the Utilities AMD-friendly top-level import.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -7,6 +7,7 @@ import {
   css,
   divProperties,
   getNativeProps,
+  getId,
   assign,
   hasOverflow
 } from '../../Utilities';
@@ -16,7 +17,6 @@ import { TooltipDelay } from './Tooltip.Props';
 
 import * as stylesImport from './TooltipHost.scss';
 const styles: any = stylesImport;
-import { getId } from '@uifabric/utilities';
 
 export interface ITooltipHostState {
   isTooltipVisible?: boolean;


### PR DESCRIPTION
#### Pull request checklist

TooltipHost has an import directly from the utilities package which will break AMD consumers.

Fixing to pull from the Utilities import.