### PR TITLE
Jostrick/fix viewport

### DIFF
--- a/common/changes/jostrick-fix-viewport_2017-04-28-20-56.json
+++ b/common/changes/jostrick-fix-viewport_2017-04-28-20-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "This fixes an issue with updating items by a KnockoutObservable that is used by the React Details list. The first time the item is updated via KO, the item in the details list is not updated. Subsequent updates work just fine. I've tracked down the issue to the _updateViewPort method. When a forceUpdate() is called, it won't actually force the udpate if it needs to set the viewport because ti doesn't pass through the withForceUpdate param. Fixed it so that it respects the parameter even after updating the view port height/width.",
+      "type": "patch"
+    }
+  ],
+  "email": "jostrick@microsoft.com"
+}

--- a/common/changes/jostrick-fix-viewport_2017-04-28-20-56.json
+++ b/common/changes/jostrick-fix-viewport_2017-04-28-20-56.json
@@ -1,8 +1,8 @@
 {
   "changes": [
     {
-      "packageName": "office-ui-fabric-react",
-      "comment": "This fixes an issue with updating items by a KnockoutObservable that is used by the React Details list. The first time the item is updated via KO, the item in the details list is not updated. Subsequent updates work just fine. I've tracked down the issue to the _updateViewPort method. When a forceUpdate() is called, it won't actually force the udpate if it needs to set the viewport because ti doesn't pass through the withForceUpdate param. Fixed it so that it respects the parameter even after updating the view port height/width.",
+      "packageName": "@uifabric/utilities",
+      "comment": "withViewport: Preserving the `forceUpdate` parameter when asynchronously re-resolving the viewport size.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -99,7 +99,7 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
             width: clientRect.width,
             height: scrollRect.height
           }
-        }, this._updateViewport);
+        }, () => { this._updateViewport(withForceUpdate); });
       } else {
         this._resizeAttempts = 0;
         updateComponent();

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -15,6 +15,7 @@ export interface IWithViewportState {
 }
 
 const RESIZE_DELAY = 500;
+
 const MAX_RESIZE_ATTEMPTS = 3;
 
 export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComponent: (new (props: P, ...args: any[]) => React.Component<P, S>)): any {

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -15,7 +15,6 @@ export interface IWithViewportState {
 }
 
 const RESIZE_DELAY = 500;
-
 const MAX_RESIZE_ATTEMPTS = 3;
 
 export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComponent: (new (props: P, ...args: any[]) => React.Component<P, S>)): any {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file if publishing <!-- see notes below -->
- [X ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes

This fixes an issue with updating items by a KnockoutObservable that is used by the React Details list. The first time the item is updated via KO, the item in the details list is not updated. Subsequent updates work just fine. I've tracked down the issue to the _updateViewPort method. When a forceUpdate() is called, it won't actually force the udpate if it needs to set the viewport because ti doesn't pass through the withForceUpdate param. Fixed it so that it respects the parameter even after updating the view port height/width.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
