### PR TITLE
Fixed bug where props/state were passed in reverse order

### DIFF
--- a/common/changes/modal-bug-fix_2017-05-02-17-16.json
+++ b/common/changes/modal-bug-fix_2017-05-02-17-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Modal: Fixed bug where props and state were passed in reversed order",
+      "type": "patch"
+    }
+  ],
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.tsx
@@ -71,7 +71,7 @@ export class Modal extends BaseComponent<IModalProps, IDialogState> {
     }
   }
 
-  public componentDidUpdate(prevState: IDialogState, prevProps: IModalProps) {
+  public componentDidUpdate(prevProps: IModalProps, prevState: IDialogState) {
     if (!prevProps.isOpen && !prevState.isVisible) {
       this.setState({
         isVisible: true


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #1624 

