### PR TITLE
Dropdown: Tab should close dropdown and tab to next item in tab order

### DIFF
--- a/common/changes/master_2017-05-03-17-52.json
+++ b/common/changes/master_2017-05-03-17-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Tab should close dropdown and tab to next item in tab order",
+      "type": "patch"
+    }
+  ],
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -445,6 +445,10 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
         this.setState({ isOpen: false });
         break;
 
+      case KeyCodes.tab:
+        this.setState({ isOpen: false });
+        return;
+
       default:
         return;
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1654
