### PR TITLE
Fix broken links to PDFs on color and brand icon pages

### DIFF
--- a/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
@@ -52,7 +52,7 @@ export class BrandIconsPage extends React.Component<any, any> {
         <div className={ pageStyles.u_maxTextWidth }>
           <h2 id='overview'>Overview</h2>
           <p>Fabric includes product and document icons that you can use to connect your experience with other Office and Office 365 endpoints. The icons come in three formats &mdash; SVG and PNG for multicolor and the icon font for monochrome &mdash; in a variety of sizes and resolutions.</p>
-          <p>Usage of these icons is subject to the <a href='https://static2.sharepointonline.com/files/fabric/assets/license.txt'>assets license agreement (DOCX)</a> and our <a href={ 'files/OfficeBrandGuide_16Sep2016.pdf' }>brand guidelines (PDF)</a>. Please read this document and the resolution/size guidance carefully to ensure that you use our branded icons correctly to create the best experience.</p>
+          <p>Usage of these icons is subject to the <a href='https://static2.sharepointonline.com/files/fabric/assets/license.txt'>assets license agreement (DOCX)</a> and our <a href={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/files/officebrandguide_16sep2016.pdf' }>brand guidelines (PDF)</a>. Please read this document and the resolution/size guidance carefully to ensure that you use our branded icons correctly to create the best experience.</p>
         </div>
         <h3>Product icons</h3>
         <div className='ms-Grid ms-Grid--wide'>

--- a/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.tsx
@@ -38,7 +38,7 @@ export class ColorsPage extends React.Component<any, any> {
         />
         <div className={ pageStyles.u_maxTextWidth }>
           <h2 id='Overview'>Overview</h2>
-          <p>Fabric includes 9 theme colors and 11 neutral colors. Each has helper classes for text, background, border, and hover states. When selecting colors, refer to the <a href={ baseURL + 'https://static2.sharepointonline.com/files/fabric/fabric-website/files/ColorAccessibility_29Sep2016.pdf' }>color accessibility guidance (PDF)</a> to ensure that your text can be ready by everyone.</p>
+          <p>Fabric includes 9 theme colors and 11 neutral colors. Each has helper classes for text, background, border, and hover states. When selecting colors, refer to the <a href={ baseURL + 'https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf' }>color accessibility guidance (PDF)</a> to ensure that your text can be ready by everyone.</p>
         </div>
         <h2 id='implementation'>Implementation</h2>
         <p>Colors can be applied to text, backgrounds, or borders using the following class name conventions:</p>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: n/a
- [x] Bugfix
- [x] Documentation update

#### Description of changes

This fixes broken links to PDFs on color and brand icon pages of the Fabric website.