### PR TITLE
Try to make the styling package compile with "noimplicitany"

### DIFF
--- a/packages/styling/api/styling.api.ts
+++ b/packages/styling/api/styling.api.ts
@@ -108,6 +108,8 @@ interface IAnimationStyles {
 // (undocumented)
 interface IColorClassNames {
   // (undocumented)
+  [ index: string ]: string;
+  // (undocumented)
   black?: string;
   // (undocumented)
   blackBackground?: string;
@@ -687,6 +689,8 @@ interface IColorClassNames {
 
 interface IColorStyles {
   // (undocumented)
+  [ index: string ]: string;
+  // (undocumented)
   black?: string;
   // (undocumented)
   blackTranslucent40?: string;
@@ -794,6 +798,8 @@ interface IFontClassNames extends IClassNames<IFontStyles> {
 
 interface IFontStyles {
   // (undocumented)
+  [ index: string ]: CSSProperties;
+  // (undocumented)
   icon?: CSSProperties;
   // (undocumented)
   large?: CSSProperties;
@@ -825,6 +831,8 @@ interface IIconClassNames extends IClassNames<IIconCodes> {
 
 // (undocumented)
 interface IIconCodes {
+  // (undocumented)
+  [ index: string ]: string;
   // (undocumented)
   aadLogo: string;
   // (undocumented)
@@ -2254,7 +2262,7 @@ interface ITheme {
 export function loadTheme(theme: ITheme): void;
 
 // (undocumented)
-export function mergeRules(...args: Object[]): Object;
+export function mergeRules(...args: {[index: string]: Object}[]): Object;
 
 export function parent(selector: string, props: CSSProperties): StyleAttribute;
 

--- a/packages/styling/src/classNames/colorClassNames.ts
+++ b/packages/styling/src/classNames/colorClassNames.ts
@@ -3,6 +3,7 @@ import { css, CSSProperties } from 'glamor';
 import { defaultColorStyles } from '../styles/colorStyles';
 
 export interface IColorClassNames {
+  [index: string]: string;
   themeDarker?: string;
   themeDarkerHover?: string;
   themeDarkerBackground?: string;

--- a/packages/styling/src/examples/AnimationPage.tsx
+++ b/packages/styling/src/examples/AnimationPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { BaseComponent } from '@uifabric/utilities';
 import { Page, PageHeader } from './components';
 import { AnimationTile } from './AnimationTile';
-import { animationClassNames } from '@uifabric/styling';
+import { animationClassNames, IAnimationClassNames } from '@uifabric/styling';
 import { getStyles } from './AnimationPage.styles';
 import { CSSProperties } from 'glamor';
 
@@ -44,7 +44,7 @@ export class AnimationPage extends BaseComponent<{}, {}> {
 
         <PageHeader text='Animations' />
         <div className={ styles.grid }>
-          { Object.keys(animationClassNames).map((name: string) => (
+          { Object.keys(animationClassNames).map((name: keyof IAnimationClassNames) => (
             <div className={ styles.tile } key={ name }>
               <AnimationTile name={ name } />
             </div>

--- a/packages/styling/src/examples/AnimationTile.tsx
+++ b/packages/styling/src/examples/AnimationTile.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseComponent } from '@uifabric/utilities';
-import { getTheme, ITheme, animationClassNames } from '@uifabric/styling';
+import { getTheme, ITheme, animationClassNames, IAnimationClassNames } from '@uifabric/styling';
 import { css, CSSProperties } from 'glamor';
 
 function getStyles(theme?: ITheme): CSSProperties {
@@ -63,7 +63,7 @@ function getStyles(theme?: ITheme): CSSProperties {
 }
 
 export interface IAnimationTileProps {
-  name: string;
+  name: keyof IAnimationClassNames;
 }
 
 export interface IAnimationTileState {

--- a/packages/styling/src/examples/ColorPage.tsx
+++ b/packages/styling/src/examples/ColorPage.tsx
@@ -53,6 +53,7 @@ const COLUMNS: IColumn[] = [
 ];
 
 export interface IColorItem {
+  [index: string]: string;
   key: string;
   colorValue: string;
   name: string;

--- a/packages/styling/src/index.demo.tsx
+++ b/packages/styling/src/index.demo.tsx
@@ -3,8 +3,8 @@ import * as Glamor from 'glamor';
 import './utilities/glamorPlugins';
 
 // Force glamor speedy mode.
-// tslint:disable-next-line:no-string-literal
-Glamor['speedy'](false);
+// tslint:disable-next-line:no-string-literal no-any
+(Glamor as any)['speedy'](false);
 
 import { loadTheme } from '@uifabric/styling';
 

--- a/packages/styling/src/styles/colorStyles.ts
+++ b/packages/styling/src/styles/colorStyles.ts
@@ -4,6 +4,7 @@ import { getTheme } from '../utilities/theme';
  * UI Fabric color palette.
  */
 export interface IColorStyles {
+  [index: string]: string;
   themeDarker?: string;
   themeDark?: string;
   themeDarkAlt?: string;

--- a/packages/styling/src/styles/defaultFontStyles.ts
+++ b/packages/styling/src/styles/defaultFontStyles.ts
@@ -27,6 +27,7 @@ const MEGA_SIZE: string = '72px';
  * UI Fabric font set.
  */
 export interface IFontStyles {
+  [index: string]: CSSProperties;
   tiny?: CSSProperties;
   xSmall?: CSSProperties;
   small?: CSSProperties;

--- a/packages/styling/src/styles/fontStyles.ts
+++ b/packages/styling/src/styles/fontStyles.ts
@@ -16,7 +16,8 @@ for (const fontName in defaultFontStyles) {
  */
 function _defineFontGetter(obj: IFontStyles, fontName: string): void {
   Object.defineProperty(obj, fontName, {
-    get: (): string => getTheme().fonts[fontName],
+    // tslint:disable-next-line:no-any
+    get: (): string => (<any>getTheme().fonts)[fontName],
     enumerable: true,
     configurable: true
   });

--- a/packages/styling/src/styles/iconCodes.ts
+++ b/packages/styling/src/styles/iconCodes.ts
@@ -1,4 +1,5 @@
 export interface IIconCodes {
+  [index: string]: string;
   aadLogo: string;
   accept: string;
   accessLogo: string;

--- a/packages/styling/src/utilities/getClassNames.ts
+++ b/packages/styling/src/utilities/getClassNames.ts
@@ -8,7 +8,8 @@ export function getClassNames<T>(styles: T): IClassNames<T> {
   return Object
     .keys(styles)
     .reduce((classNames: IClassNames<T>, className: string) => {
-      classNames[className] = css(styles[className]).toString();
+      // tslint:disable-next-line:no-any
+      classNames[className] = css((<any>styles)[className]).toString();
       return classNames;
     }, {});
 }

--- a/packages/styling/src/utilities/glamorPlugins.ts
+++ b/packages/styling/src/utilities/glamorPlugins.ts
@@ -10,8 +10,8 @@ interface IGlamorRulePair {
 // force speedy.
 // Glamor['speedy'](true);
 
-// tslint:disable-next-line:no-string-literal
-Glamor['plugins'].add(
+// tslint:disable-next-line:no-string-literal no-any
+(<any>Glamor)['plugins'].add(
   ({ selector, style }: IGlamorRulePair): IGlamorRulePair => (
     {
       selector,

--- a/packages/styling/src/utilities/mergeRules.ts
+++ b/packages/styling/src/utilities/mergeRules.ts
@@ -1,14 +1,14 @@
 import { css } from './css';
 
-export function mergeRules(...args: Object[]): Object {
-  let styles: Object = {};
+export function mergeRules(...args: {[index: string]: Object}[]): Object {
+  let styles: {[index: string]: Object} = {};
   let styleToMerge: Object = args[0];
 
   for (let prop in styleToMerge) {
     if (styleToMerge.hasOwnProperty(prop)) {
       let allArgs: Object[] = [];
       for (let i: number = 0; i < args.length; i++) {
-        let currentArg: Object = args[i];
+        let currentArg: {[index: string]: Object}= args[i];
 
         if (currentArg && currentArg[prop]) {
           allArgs.push(currentArg[prop]);

--- a/packages/styling/src/utilities/theme.ts
+++ b/packages/styling/src/utilities/theme.ts
@@ -1,4 +1,3 @@
-import * as assign from 'object-assign';
 import { defaultFontStyles } from '../styles/defaultFontStyles';
 import { IFontStyles } from '../styles/fontStyles';
 import { IColorStyles, defaultColorStyles } from '../styles/colorStyles';
@@ -24,6 +23,6 @@ export function getTheme(): ITheme {
  * Mixes the given theme settings into the current theme object.
  */
 export function loadTheme(theme: ITheme): void {
-  _theme.colors = assign({}, _theme.colors, theme.colors);
-  _theme.fonts = assign({}, _theme.fonts, theme.fonts);
+  _theme.colors =  {..._theme.colors, ...theme.colors};
+  _theme.fonts = {..._theme.fonts, ...theme.fonts};
 }

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -9,11 +9,12 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "noImplicitAny": true,
+    "typeRoots" : ["./typings", "./node_modules"],
     "types": [
       "chai",
       "mocha",
-      "webpack-env"
+      "webpack-env",
+      "rtl-css-js"
     ],
     "outDir": "../lib",
     "paths": {

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -9,12 +9,10 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "typeRoots" : ["./typings", "./node_modules"],
     "types": [
       "chai",
       "mocha",
-      "webpack-env",
-      "rtl-css-js"
+      "webpack-env"
     ],
     "outDir": "../lib",
     "paths": {

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "noImplicitAny": true,
     "types": [
       "chai",
       "mocha",


### PR DESCRIPTION
Currently the "noimplicitany" tsconfig option is not set in the styling package. This change was an attempt to get rid of all implicity any usages in the styling package. I can't enable the compiler option because of this statement:

import rtlify from 'rtl-css-js';

There is no type declaration for rtl-css-js, which means it is an implicit any.

The assign import also has similar issues, so I just replaced those usages with the spread operator. 