### PR TITLE
Overhaul DetailsList accessibility to support improved keyboarding flows and screen reader semantics

### DIFF
--- a/common/changes/accessibility_2017-05-05-20-51.json
+++ b/common/changes/accessibility_2017-05-05-20-51.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Update DetailsList to support screen readers with cleaner keyboarding flow",
+      "type": "minor"
+    },
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Update Focus handling to suport immediately-nested focus zones",
+      "type": "patch"
+    }
+  ],
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_focusBorder.scss
+++ b/packages/office-ui-fabric-react/src/common/_focusBorder.scss
@@ -1,6 +1,6 @@
 @import './semanticColorVariables';
 
-@mixin focus-border($padding: 0, $color: $focusedBorderColor, $thickness: 1px, $onFocus: true) {
+@mixin focus-clear() {
   &::-moz-focus-inner {
     // Clear the focus border in Firefox. Reference: http://stackoverflow.com/a/199319/1436671
     border: 0;
@@ -9,18 +9,30 @@
   & {
     // Clear browser specific focus styles and use transparent as placeholder for focus style
     outline: transparent;
+  }
+}
 
+@mixin focus($onFocus: true) {
+  @if $onFocus {
+    :global(.ms-Fabric.is-focusVisible) &:focus {
+      @content;
+    }
+  }
+  @else {
+    @content;
+  }
+}
+
+@mixin focus-border($padding: 0, $color: $focusedBorderColor, $thickness: 1px, $onFocus: true) {
+  @include focus-clear();
+
+  & {
     // It is MUST because the pseudo-element is absolute position.
     position: relative;
   }
 
-  @if $onFocus {
-    :global(.ms-Fabric.is-focusVisible) &:focus:after {
-      @include after-outline($padding, $color, $thickness);
-    }
-  }
-  @else {
-    &::after {
+  @include focus($onFocus) {
+    &:after {
       @include after-outline($padding, $color, $thickness);
     }
   }

--- a/packages/office-ui-fabric-react/src/common/_focusBorder.scss
+++ b/packages/office-ui-fabric-react/src/common/_focusBorder.scss
@@ -23,12 +23,12 @@
   }
 }
 
-@mixin focus-border($padding: 0, $color: $focusedBorderColor, $thickness: 1px, $onFocus: true) {
+@mixin focus-border($padding: 0, $color: $focusedBorderColor, $thickness: 1px, $onFocus: true, $position: relative) {
   @include focus-clear();
 
   & {
     // It is MUST because the pseudo-element is absolute position.
-    position: relative;
+    position: $position;
   }
 
   @include focus($onFocus) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -25,21 +25,6 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
   }
 }
 
-.cell.cellIsCheck :global(.ms-Check-circle) {
-  opacity: 0;
-}
-
-.cell.cellIsCheck:hover :global(.ms-Check-circle),
-.cell.cellIsCheck:focus :global(.ms-Check-circle),
-.root.rootIsAllSelected :global(.ms-Check-circle) {
-  opacity: 1;
-}
-
-.cellWrapper {
-  display: inline-block;
-  position: relative;
-}
-
 .cell {
   @include ms-font-s;
   background: transparent;
@@ -56,14 +41,13 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
   @include text-align(left);
   height: $rowHeight;
   vertical-align: top;
-  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
   @include text-align(left);
 
   &.cellIsCheck {
     position: relative;
-    padding: 6px;
+    padding: 0;
     margin: 0;
   }
 
@@ -80,38 +64,47 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
     }
   }
 
-  &.cellIsSizer {
-    position: absolute;
-    width: 16px;
-
-    @include margin-left(-10px);
-    cursor: ew-resize;
-    bottom: 0;
-    top: 0;
-    height: inherit;
-    background: transparent;
-  }
-
   &.cellIsEmpty {
     text-overflow: clip;
   }
 }
 
-.cell.cellIsSizer:after {
-  content: '';
-  position: absolute;
-  left: 50%;
-  top: 0;
-  bottom: 0;
-  width: 1px;
-  background: $resizerColor;
-  opacity: 0;
-}
+.cellSizer {
+  @include focus-clear();
 
-.cell.cellIsSizer:hover:after,
-.cell.cellIsSizer.cellIsResizing:after {
-  opacity: 1;
-  transition: opacity .3s linear;
+  display: inline-block;
+  position: relative;
+  cursor: ew-resize;
+  bottom: 0;
+  top: 0;
+  margin: 0 -8px;
+  overflow: hidden;
+  height: inherit;
+  background: transparent;
+  z-index: 1;
+  width: 16px;
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: $resizerColor;
+    opacity: 0;
+    left: 50%;
+  }
+
+  &:focus:after,
+  &:hover:after,
+  &.cellIsResizing:after {
+    opacity: 1;
+    transition: opacity .3s linear;
+  }
+
+  &.cellIsResizing:after {
+    @include ms-drop-shadow();
+  }
 }
 
 .collapseButton {
@@ -137,6 +130,29 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
   color: $dropdownChevronForegroundColor;
   @include ms-padding-left(4px);
   vertical-align: middle;
+}
+
+.cellTitle {
+  display: block;
+  overflow: hidden;
+  @include focus-border($position: absolute);
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  padding: 0 8px;
+}
+
+:global(.ms-TooltipHost).checkTooltip {
+  display: block;
+}
+
+.cellTooltip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .sizingOverlay {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -28,7 +28,7 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
   onColumnResized?: (column: IColumn, newWidth: number) => void;
   onColumnAutoResized?: (column: IColumn, columnIndex: number) => void;
   onColumnClick?: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void;
-  onColumnContextMenu?: (column: IColumn, ev: Event) => void;
+  onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => void;
   groupNestingDepth?: number;
   isAllCollapsed?: boolean;
   onToggleCollapseAll?: (isAllCollapsed: boolean) => void;
@@ -380,7 +380,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
     }
   }
 
-  private _onColumnContextMenu(column, ev) {
+  private _onColumnContextMenu(column: IColumn, ev: React.MouseEvent<HTMLElement>) {
     let { onColumnContextMenu } = this.props;
 
     if (column.onContextMenu) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -1,16 +1,21 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import {
   BaseComponent,
   autobind,
   css,
-  getRTL
+  getRTL,
+  getId,
+  KeyCodes
 } from '../../Utilities';
 import { IColumn, DetailsListLayoutMode, ColumnActionsMode } from './DetailsList.Props';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
-import { Check } from '../../Check';
 import { Icon } from '../../Icon';
 import { Layer } from '../../Layer';
 import { GroupSpacer } from '../GroupedList/GroupSpacer';
+import { DetailsRowCheck } from './DetailsRowCheck';
+import { TooltipHost } from '../../Tooltip';
+import * as checkStyles from './DetailsRowCheck.scss';
 import { ISelection, SelectionMode, SELECTION_CHANGE } from '../../utilities/selection/interfaces';
 import * as stylesImport from './DetailsHeader.scss';
 const styles: any = stylesImport;
@@ -36,6 +41,7 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
   ariaLabel?: string;
   /** ariaLabel for the header checkbox that selects or deselects everything */
   ariaLabelForSelectAllCheckbox?: string;
+  ariaLabelForSelectionColumn?: string;
   selectAllVisibility?: SelectAllVisibility;
 }
 
@@ -55,7 +61,7 @@ export interface IDetailsHeaderState {
 
 export interface IColumnResizeDetails {
   columnIndex: number;
-  originX: number;
+  originX?: number;
   columnMinWidth: number;
 }
 
@@ -66,9 +72,10 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
 
   public refs: {
     [key: string]: React.ReactInstance;
-    root: HTMLElement;
-    focusZone: FocusZone;
+    root: FocusZone;
   };
+
+  private _id: string;
 
   constructor(props: IDetailsHeaderProps) {
     super(props);
@@ -81,6 +88,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
 
     this._onToggleCollapseAll = this._onToggleCollapseAll.bind(this);
     this._onSelectAllClicked = this._onSelectAllClicked.bind(this);
+    this._id = getId('header');
   }
 
   public componentDidMount() {
@@ -88,8 +96,12 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
 
     this._events.on(selection, SELECTION_CHANGE, this._onSelectionChanged);
 
+    const rootElement = ReactDOM.findDOMNode(this.refs.root);
+
     // We need to use native on this to avoid MarqueeSelection from handling the event before us.
-    this._events.on(this.refs.root, 'mousedown', this._onRootMouseDown);
+    this._events.on(rootElement, 'mousedown', this._onRootMouseDown);
+
+    this._events.on(rootElement, 'keydown', this._onRootKeyDown);
   }
 
   public componentWillReceiveProps(newProps) {
@@ -101,11 +113,13 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
   }
 
   public render() {
-    let { columns, ariaLabel, ariaLabelForSelectAllCheckbox, selectAllVisibility } = this.props;
+    let { columns, ariaLabel, ariaLabelForSelectAllCheckbox, selectAllVisibility, ariaLabelForSelectionColumn } = this.props;
     let { isAllSelected, columnResizeDetails, isSizing, groupNestingDepth, isAllCollapsed } = this.state;
 
+    const showCheckbox = selectAllVisibility !== SelectAllVisibility.none;
+
     return (
-      <div
+      <FocusZone
         role='row'
         aria-label={ ariaLabel }
         className={ css('ms-DetailsHeader', styles.root, {
@@ -115,48 +129,62 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         }) }
         ref='root'
         onMouseMove={ this._onRootMouseMove }
-        data-automationid='DetailsHeader'>
-        <FocusZone ref='focusZone' direction={ FocusZoneDirection.horizontal }>
-          { (selectAllVisibility !== SelectAllVisibility.none) ? (
-            <div className={ css('ms-DetailsHeader-cellWrapper', styles.cellWrapper) } role='columnheader'>
-              <button
-                type='button'
-                className={ css('ms-DetailsHeader-cell is-check', styles.cell, styles.cellIsCheck) }
-                onClick={ this._onSelectAllClicked }
-                aria-label={ ariaLabelForSelectAllCheckbox }
-                aria-pressed={ isAllSelected }
-              >
-                <Check checked={ isAllSelected } />
-              </button>
-            </div>
-          ) : null }
-          { groupNestingDepth > 0 ? (
-            <button
-              type='button'
-              className={ css('ms-DetailsHeader-cell', styles.cell) }
-              onClick={ this._onToggleCollapseAll }>
-              <Icon
-                className={ css(
-                  'ms-DetailsHeader-collapseButton',
-                  styles.collapseButton,
-                  isAllCollapsed && ('is-collapsed ' + styles.collapseButtonIsCollapsed)
-                ) }
-                iconName='ChevronDown'
+        data-automationid='DetailsHeader'
+        direction={ FocusZoneDirection.horizontal }
+      >
+        { showCheckbox ? (
+          <div
+            className={ css('ms-DetailsHeader-cell', 'ms-DetailsHeader-cellIsCheck', styles.cell, styles.cellIsCheck, checkStyles.owner, {
+              [checkStyles.isSelected]: isAllSelected
+            }) }
+            onClick={ this._onSelectAllClicked }
+            aria-colindex={ 0 }
+            role='columnheader'>
+            <span
+              aria-label={ ariaLabelForSelectionColumn }
+            ></span>
+            <TooltipHost
+              hostClassName={ css(styles.checkTooltip) }
+              id={ `${this._id}-checkTooltip` }
+              setAriaDescribedBy={ false }
+              content={ ariaLabelForSelectAllCheckbox }>
+              <DetailsRowCheck
+                aria-describedby={ `${this._id}-checkTooltip` }
+                selected={ isAllSelected }
+                anySelected={ false }
+                canSelect={ true }
               />
-            </button>
-          ) : (null) }
-          { GroupSpacer({ count: groupNestingDepth - 1 }) }
-          { columns.map((column, columnIndex) => (
-            <div
-              key={ column.key }
-              className={ css('ms-DetailsHeader-cellWrapper', styles.cellWrapper) }
-              role='columnheader'
-              aria-sort={ column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none' }
-            >
-              <button
-                type='button'
-                key={ column.fieldName }
-                disabled={ column.columnActionsMode === ColumnActionsMode.disabled }
+            </TooltipHost>
+          </div>
+        ) : null }
+        { groupNestingDepth > 0 ? (
+          <div
+            className={ css('ms-DetailsHeader-cell', styles.cell) }
+            onClick={ this._onToggleCollapseAll }
+          >
+            <Icon
+              className={ css(
+                'ms-DetailsHeader-collapseButton',
+                styles.collapseButton,
+                isAllCollapsed && ('is-collapsed ' + styles.collapseButtonIsCollapsed)
+              ) }
+              iconName='ChevronDown'
+            />
+          </div>
+        ) : (null) }
+        { GroupSpacer({ count: groupNestingDepth - 1 }) }
+        { columns.map((column: IColumn, columnIndex: number) => {
+          const previousColumnIndex = columnIndex - 1;
+          const previousColumn = columns[previousColumnIndex];
+
+          return (
+            [
+              <div
+                key={ column.key }
+                role='columnheader'
+                aria-sort={ column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none' }
+                aria-disabled={ column.columnActionsMode === ColumnActionsMode.disabled }
+                aria-colindex={ (showCheckbox ? 1 : 0) + columnIndex }
                 className={ css(
                   'ms-DetailsHeader-cell',
                   styles.cell,
@@ -166,55 +194,60 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                     'is-icon-visible': column.isSorted || column.isGrouped || column.isFiltered
                   }) }
                 style={ { width: column.calculatedWidth + INNER_PADDING } }
-                onClick={ this._onColumnClick.bind(this, column) }
-                onContextMenu={ this._onColumnContextMenu.bind(this, column) }
                 aria-haspopup={ column.columnActionsMode === ColumnActionsMode.hasDropdown }
-                aria-label={ column.ariaLabel || column.name }
                 data-automationid='ColumnsHeaderColumn'
                 data-item-key={ column.key }
               >
+                <TooltipHost
+                  hostClassName={ css(styles.cellTooltip) }
+                  id={ `${this._id}-${column.key}-tooltip` }
+                  setAriaDescribedBy={ false }
+                  content={ column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '' }
+                >
+                  <span
+                    className={ css('ms-DetailsHeader-cellTitle', styles.cellTitle) }
+                    data-is-focusable={ column.columnActionsMode !== ColumnActionsMode.disabled }
+                    role={ column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined }
+                    aria-describedby={ `${this._id}-${column.key}-tooltip` }
+                    onContextMenu={ this._onColumnContextMenu.bind(this, column) }
+                    onClick={ this._onColumnClick.bind(this, column) }
+                  >
+                    { column.isFiltered && (
+                      <Icon className={ styles.nearIcon } iconName='Filter' />
+                    ) }
 
-                { column.isFiltered && (
-                  <Icon className={ styles.nearIcon } iconName='Filter' />
-                ) }
+                    { column.isSorted && (
+                      <Icon className={ styles.nearIcon } iconName={ column.isSortedDescending ? 'SortDown' : 'SortUp' } />
+                    ) }
 
-                { column.isSorted && (
-                  <Icon className={ styles.nearIcon } iconName={ column.isSortedDescending ? 'SortDown' : 'SortUp' } />
-                ) }
+                    { column.isGrouped && (
+                      <Icon className={ styles.nearIcon } iconName='GroupedDescending' />
+                    ) }
 
-                { column.isGrouped && (
-                  <Icon className={ styles.nearIcon } iconName='GroupedDescending' />
-                ) }
+                    <span
+                      aria-label={ column.isIconOnly ? column.name : undefined }
+                      className={ css('ms-DetailsHeader-cellName', styles.cellName) }
+                    >
+                      { (column.iconName || column.iconClassName) && (
+                        <Icon className={ css(styles.nearIcon, column.iconClassName) } iconName={ column.iconName } />
+                      ) }
 
-                { column.iconClassName && (
-                  <Icon className={ css(styles.nearIcon, column.iconClassName) } iconName={ column.iconName } />
-                ) }
+                      { !column.isIconOnly ? column.name : undefined }
+                    </span>
 
-                { column.name }
-
-                { column.columnActionsMode === ColumnActionsMode.hasDropdown && (
-                  <Icon
-                    className={ css('ms-DetailsHeader-filterChevron', styles.filterChevron) }
-                    iconName='ChevronDown'
-                  />
-                ) }
-              </button>
-              { (column.isResizable) && (
-                <div
-                  data-sizer-index={ columnIndex }
-                  className={ css(
-                    'ms-DetailsHeader-cell is-sizer',
-                    styles.cell,
-                    styles.cellIsSizer,
-                    {
-                      ['is-resizing ' + styles.cellIsResizing]: isSizing && columnResizeDetails.columnIndex === columnIndex
-                    }) }
-                  onDoubleClick={ this._onSizerDoubleClick.bind(this, columnIndex) }
-                />
-              ) }
-            </div>
-          )) }
-        </FocusZone>
+                    { column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
+                      <Icon
+                        className={ css('ms-DetailsHeader-filterChevron', styles.filterChevron) }
+                        iconName='ChevronDown'
+                      />
+                    ) }
+                  </span>
+                </TooltipHost>
+              </div>,
+              (column.isResizable) && this._renderColumnSizer(columnIndex)
+            ]
+          );
+        }) }
         { isSizing && (
           <Layer>
             <div
@@ -224,13 +257,38 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
             />
           </Layer>
         ) }
-      </div>
+      </FocusZone>
     );
   }
 
   /** Set focus to the active thing in the focus area. */
   public focus(): boolean {
-    return this.refs.focusZone.focus();
+    return this.refs.root.focus();
+  }
+
+  private _renderColumnSizer(columnIndex: number) {
+    const { columns } = this.props;
+    const column = this.props.columns[columnIndex];
+    const { isSizing, columnResizeDetails } = this.state;
+
+    return (
+      <div
+        aria-hidden={ true }
+        role='button'
+        data-is-focusable={ false }
+        onClick={ stopPropagation }
+        data-sizer-index={ columnIndex }
+        onBlur={ this._onSizerBlur }
+        className={ css(
+          'ms-DetailsHeader-cellSizer',
+          styles.cellSizer,
+          columnIndex < columns.length - 1 ? styles.cellSizerStart : styles.cellSizerEnd,
+          {
+            ['is-resizing ' + styles.cellIsResizing]: columnResizeDetails && columnResizeDetails.columnIndex === columnIndex
+          }) }
+        onDoubleClick={ this._onSizerDoubleClick.bind(this, columnIndex) }
+      />
+    );
   }
 
   /**
@@ -291,6 +349,69 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
     }
   }
 
+  @autobind
+  private _onRootKeyDown(ev: KeyboardEvent) {
+    const { columnResizeDetails, isSizing } = this.state;
+    const { columns, onColumnResized } = this.props;
+
+    const columnIndexAttr = (ev.target as HTMLElement).getAttribute('data-sizer-index');
+
+    if (!columnIndexAttr || isSizing) {
+      return;
+    }
+
+    const columnIndex = Number(columnIndexAttr);
+
+    if (!columnResizeDetails) {
+      if (ev.which === KeyCodes.enter) {
+        this.setState({
+          columnResizeDetails: {
+            columnIndex: columnIndex,
+            columnMinWidth: columns[columnIndex].calculatedWidth
+          }
+        });
+
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
+    } else {
+      let increment: number;
+
+      if (ev.which === KeyCodes.enter) {
+        this.setState({
+          columnResizeDetails: null
+        });
+
+        ev.preventDefault();
+        ev.stopPropagation();
+      } else if (ev.which === KeyCodes.left) {
+        increment = getRTL() ? 1 : -1;
+      } else if (ev.which === KeyCodes.right) {
+        increment = getRTL() ? -1 : 1;
+      }
+
+      if (increment) {
+        if (!ev.shiftKey) {
+          increment *= 10;
+        }
+
+        this.setState({
+          columnResizeDetails: {
+            ...columnResizeDetails,
+            columnMinWidth: columnResizeDetails.columnMinWidth + increment
+          }
+        });
+
+        if (onColumnResized) {
+          onColumnResized(columns[columnIndex], columnResizeDetails.columnMinWidth + increment);
+        }
+
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
+    }
+  }
+
   /**
    * mouse move event handler in the header
    * it will set isSizing state to true when user clicked on the sizer and move the mouse.
@@ -333,6 +454,18 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
       );
     }
 
+  }
+
+  @autobind
+  private _onSizerBlur(ev: React.FocusEvent<HTMLElement>) {
+    const { columnResizeDetails } = this.state;
+
+    if (columnResizeDetails) {
+      this.setState({
+        columnResizeDetails: null,
+        isSizing: false
+      });
+    }
   }
 
   /**
@@ -383,12 +516,16 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
   private _onColumnContextMenu(column: IColumn, ev: React.MouseEvent<HTMLElement>) {
     let { onColumnContextMenu } = this.props;
 
-    if (column.onContextMenu) {
+    if (column.onColumnContextMenu) {
       column.onColumnContextMenu(column, ev);
+
+      ev.preventDefault();
     }
 
     if (onColumnContextMenu) {
       onColumnContextMenu(column, ev);
+
+      ev.preventDefault();
     }
   }
 
@@ -402,5 +539,8 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
       onToggleCollapseAll(newCollapsed);
     }
   }
+}
 
+function stopPropagation(ev: React.MouseEvent<HTMLElement>) {
+  ev.stopPropagation();
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -143,6 +143,11 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
   /** The aria-label attribute to stamp out on select all checkbox for the list */
   ariaLabelForSelectAllCheckbox?: string;
 
+  /**
+   * An ARIA label for the name of the selection column, for localization.
+   */
+  ariaLabelForSelectionColumn?: string;
+
   /** Optional callback to get the aria-label string for a given item. */
   getRowAriaLabel?: (item: any) => string;
 
@@ -161,7 +166,7 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
   /** Boolean value to indicate if the role application should be applied on details list. Set to false by default */
   shouldApplyApplicationRole?: boolean;
 
-  /** 
+  /**
    * The minimum mouse move distance to interpret the action as drag event.
    * @defaultValue 5
    */
@@ -222,6 +227,12 @@ export interface IColumn {
    * Optional iconName to use for the column header.
    */
   iconName?: IconName;
+
+  /**
+   * Whether or not only the icon is used in the column header.
+   * Set this to true so the column name and dropdown chevron are not displayed.
+   */
+  isIconOnly?: boolean;
 
   /**
    * Class name to add to the Icon component.

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -103,7 +103,7 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
   onColumnHeaderClick?: (ev?: React.MouseEvent<HTMLElement>, column?: IColumn) => void;
 
   /** Callback for when the user asks for a contextual menu (usually via right click) from a column header. */
-  onColumnHeaderContextMenu?: (column?: IColumn, ev?: Event) => void;
+  onColumnHeaderContextMenu?: (column?: IColumn, ev?: React.MouseEvent<HTMLElement>) => void;
 
   /** Callback fired on column resize */
   onColumnResize?: (column?: IColumn, newWidth?: number) => void;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -1,5 +1,7 @@
+
 import * as React from 'react';
 import * as stylesImport from './DetailsList.scss';
+import * as ReactDOM from 'react-dom';
 
 import {
   BaseComponent,
@@ -189,6 +191,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     let {
       ariaLabelForListHeader,
       ariaLabelForSelectAllCheckbox,
+      ariaLabelForSelectionColumn,
       className,
       checkboxVisibility,
       constrainMode,
@@ -257,7 +260,11 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
         data-is-scrollable='false'
         aria-label={ ariaLabel }
         { ...(shouldApplyApplicationRole ? { role: 'application' } : {}) }>
-        <div role='grid' aria-label={ ariaLabelForGrid } aria-rowcount={ items ? items.length : 0 } aria-colcount={ adjustedColumns ? adjustedColumns.length : 0 }>
+        <div role='grid'
+          aria-label={ ariaLabelForGrid }
+          aria-rowcount={ (isHeaderVisible ? 1 : 0) + (items ? items.length : 0) }
+          aria-colcount={ (selectAllVisibility !== SelectAllVisibility.none ? 1 : 0) + (adjustedColumns ? adjustedColumns.length : 0) }
+          aria-readonly='true'>
           <div onKeyDown={ this._onHeaderKeyDown } role='presentation'>
             { isHeaderVisible && (
               <DetailsHeader
@@ -276,6 +283,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
                 onToggleCollapseAll={ this._onToggleCollapse }
                 ariaLabel={ ariaLabelForListHeader }
                 ariaLabelForSelectAllCheckbox={ ariaLabelForSelectAllCheckbox }
+                ariaLabelForSelectionColumn={ ariaLabelForSelectionColumn }
                 selectAllVisibility={ selectAllVisibility }
               />
             ) }
@@ -285,7 +293,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
               ref='focusZone'
               className={ styles.focusZone }
               direction={ FocusZoneDirection.vertical }
-              isInnerZoneKeystroke={ (ev) => (ev.which === getRTLSafeKeyCode(KeyCodes.right)) }
+              isInnerZoneKeystroke={ isRightArrow }
               onActiveElementChanged={ this._onActiveRowChanged }
             >
               <SelectionZone
@@ -313,7 +321,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
                   />
                 ) : (
                     <List
-                      role={ null }
+                      role='presentation'
                       items={ items }
                       onRenderCell={ (item, itemIndex) => this._onRenderCell(0, item, itemIndex) }
                       { ...additionalListProps }
@@ -444,7 +452,9 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       if (this.refs.selectionZone) {
         this.refs.selectionZone.ignoreNextFocus();
       }
-      this._async.setTimeout(() => row.focus(), 0);
+      this._async.setTimeout(() => {
+        row.focus();
+      }, 0);
 
       delete this._initialFocusedIndex;
     }
@@ -699,7 +709,7 @@ export function buildColumns(
           isRowHeader: false,
           columnActionsMode: ColumnActionsMode.clickable,
           isResizable: canResizeColumns,
-          onColumnClick,
+          onColumnClick: onColumnClick,
           isGrouped: groupedColumnKey === propName
         });
 
@@ -709,4 +719,8 @@ export function buildColumns(
   }
 
   return columns;
+}
+
+function isRightArrow(event: React.KeyboardEvent<HTMLElement>) {
+  return event.which === getRTLSafeKeyCode(KeyCodes.right);
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
@@ -45,11 +45,12 @@ $detailsList-item-selected-hover-color: $listItemSelectedHoverColor;
 }
 
 .cell {
+  @include focus-border();
+
   display: inline-block;
   position: relative;
   box-sizing: border-box;
-  padding: $rowVerticalPadding 0;
-  margin: 0 8px;
+  padding: $rowVerticalPadding 8px;
   min-height: $rowHeight;
   vertical-align: top;
   white-space: nowrap;
@@ -58,6 +59,11 @@ $detailsList-item-selected-hover-color: $listItemSelectedHoverColor;
 
   & > button {
     max-width: 100%;
+  }
+
+  &.checkCell {
+    padding: 0;
+    margin: 0;
   }
 }
 
@@ -71,36 +77,7 @@ $detailsList-item-selected-hover-color: $listItemSelectedHoverColor;
   display: inline-block;
 }
 
-.check {
-  @include focus-border();
-
-  display: inline-block;
-  cursor: default;
-  padding: 6px;
-  box-sizing: border-box;
-  vertical-align: top;
-  background: none;
-  border: none;
-  opacity: 0;
-}
-
-.checkDisabled {
-  visibility: hidden;
-}
-
-.root:hover .check,
-.rootIsSelected .check,
-.rootIsCheckVisible .check {
-  opacity: 1;
-}
-
 .cellMeasurer .cell {
   overflow: visible;
   white-space: nowrap;
-}
-
-.checkSpacer {
-  display: inline-block;
-  height: 20px;
-  width: 20px;
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -23,6 +23,7 @@ import { IViewport } from '../../utilities/decorators/withViewport';
 import * as stylesImport from './DetailsRow.scss';
 const styles: any = stylesImport;
 import { AnimationClassNames } from '../../Styling';
+import * as checkStyles from './DetailsRowCheck.scss';
 
 export interface IDetailsRowProps extends React.Props<DetailsRow> {
   item: any;
@@ -87,7 +88,9 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
     this._hasSetFocus = false;
 
     this._droppingClassNames = '';
+
     this._updateDroppingState = this._updateDroppingState.bind(this);
+    this._onToggleSelection = this._onToggleSelection.bind(this);
   }
 
   public componentDidMount() {
@@ -182,10 +185,12 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
     const ariaLabel = getRowAriaLabel ? getRowAriaLabel(item) : null;
     const canSelect = selection.canSelectItem(item);
     const isContentUnselectable = selectionMode === SelectionMode.multiple;
+    const showCheckbox = selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden;
 
     return (
-      <div
+      <FocusZone
         {...getNativeProps(this.props, divProperties) }
+        direction={ FocusZoneDirection.horizontal }
         ref='root'
         role='row'
         aria-label={ ariaLabel }
@@ -193,11 +198,12 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
           'ms-DetailsRow',
           AnimationClassNames.fadeIn400,
           styles.root,
+          checkStyles.owner,
           droppingClassName,
           {
-            ['is-contentUnselectable ' + styles.rootIsContentUnselectable]: isContentUnselectable,
-            ['is-selected ' + styles.rootIsSelected]: isSelected,
-            ['is-check-visible ' + styles.rootIsCheckVisible]: checkboxVisibility === CheckboxVisibility.always
+            [`is-contentUnselectable ${styles.rootIsContentUnselectable}`]: isContentUnselectable,
+            [`is-selected ${checkStyles.isSelected} ${styles.rootIsSelected}`]: isSelected,
+            [`is-check-visible ${checkStyles.isVisible}`]: checkboxVisibility === CheckboxVisibility.always
           }) }
         data-is-focusable={ true }
         data-selection-index={ itemIndex }
@@ -209,42 +215,47 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
         style={ { minWidth: viewport ? viewport.width : 0 } }
         aria-selected={ isSelected }
       >
-        <FocusZone direction={ FocusZoneDirection.horizontal }>
-          { (selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden) && (
-            <span role='gridcell'>
-              { onRenderCheck({
-                isSelected,
-                anySelected,
-                ariaLabel: checkButtonAriaLabel,
-                canSelect
-              }) }
-            </span>
-          ) }
+        { showCheckbox && (
+          <div
+            role='gridcell'
+            aria-colindex={ 0 }
+            className={ css('ms-DetailsRow-cell', 'ms-DetailsRow-cellCheck', checkStyles.owner, styles.cell, styles.checkCell) }
+          >
+            { onRenderCheck({
+              isSelected,
+              anySelected,
+              title: checkButtonAriaLabel,
+              canSelect
+            }) }
+          </div>
+        ) }
 
-          { GroupSpacer({ count: groupNestingDepth }) }
+        { GroupSpacer({ count: groupNestingDepth }) }
 
-          { item && (
+        { item && (
+          <DetailsRowFields
+            columns={ columns }
+            item={ item }
+            itemIndex={ itemIndex }
+            columnStartIndex={ showCheckbox ? 1 : 0 }
+            onRenderItemColumn={ onRenderItemColumn } />
+        ) }
+
+        { columnMeasureInfo && (
+          <span
+            role='presentation'
+            className={ css('ms-DetailsRow-cellMeasurer ms-DetailsRow-cell', styles.cellMeasurer, styles.cell) }
+            ref='cellMeasurer'
+          >
             <DetailsRowFields
-              columns={ columns }
+              columns={ [columnMeasureInfo.column] }
               item={ item }
               itemIndex={ itemIndex }
+              columnStartIndex={ (showCheckbox ? 1 : 0) + columns.length }
               onRenderItemColumn={ onRenderItemColumn } />
-          ) }
-
-          { columnMeasureInfo && (
-            <span
-              className={ css('ms-DetailsRow-cellMeasurer ms-DetailsRow-cell', styles.cellMeasurer, styles.cell) }
-              ref='cellMeasurer'
-            >
-              <DetailsRowFields
-                columns={ [columnMeasureInfo.column] }
-                item={ item }
-                itemIndex={ itemIndex }
-                onRenderItemColumn={ onRenderItemColumn } />
-            </span>
-          ) }
-        </FocusZone>
-      </div>
+          </span>
+        ) }
+      </FocusZone>
     );
   }
 
@@ -271,11 +282,13 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
     });
   }
 
-  public focus() {
-    if (this.refs && this.refs.root) {
-      this.refs.root.tabIndex = 0;
+  public focus(): boolean {
+    if (this.refs.root) {
       this.refs.root.focus();
+      return true;
     }
+
+    return false;
   }
 
   protected _onRenderCheck(props: IDetailsRowCheckProps) {
@@ -299,6 +312,12 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
         selectionState: selectionState
       });
     }
+  }
+
+  private _onToggleSelection() {
+    const { selection } = this.props;
+
+    selection.toggleIndexSelected(this.props.itemIndex);
   }
 
   private _getRowDragDropOptions(): IDragDropOptions {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
@@ -1,0 +1,37 @@
+
+@import '../../common/common';
+
+.check {
+  @include focus-border();
+
+  display: inline-block;
+  cursor: default;
+  box-sizing: border-box;
+  vertical-align: top;
+  background: none;
+  border: none;
+  opacity: 0;
+
+  &:focus {
+    opacity: 1;
+  }
+}
+
+button.check {
+  padding: 6px;
+}
+
+.owner {
+  &.isSelected,
+  &.isVisible,
+  &:hover,
+  &:focus {
+    .check {
+      opacity: 1;
+    }
+  }
+}
+
+.isDisabled {
+  visibility: hidden;
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -3,10 +3,9 @@ import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 import { css } from '../../Utilities';
 import { Check } from '../../Check';
-import * as stylesImport from './DetailsRow.scss';
-const styles: any = stylesImport;
+import * as styles from './DetailsRowCheck.scss';
 
-export interface IDetailsRowCheckProps {
+export interface IDetailsRowCheckProps extends React.HTMLProps<HTMLElement> {
   selected?: boolean;
   /**
    * Deprecated at v.65.1 and will be removed by v 1.0. Use 'selected' instead.
@@ -14,26 +13,33 @@ export interface IDetailsRowCheckProps {
    */
   isSelected?: boolean;
   anySelected: boolean;
-  ariaLabel: string;
   canSelect: boolean;
 }
 
 export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
-  let selected = props.isSelected || props.selected;
+  const {
+    canSelect,
+    isSelected,
+    anySelected,
+    selected,
+    ...buttonProps
+  } = props;
+
+  let isPressed = props.isSelected || props.selected;
+
   return (
     <button
-      type='button'
+      { ...buttonProps }
+      role='checkbox'
       className={ css('ms-DetailsRow-check', styles.check, {
-        [styles.checkDisabled]: !props.canSelect,
+        [styles.isDisabled]: !props.canSelect,
         'ms-DetailsRow-check--isDisabled': !props.canSelect
       }) }
-      role='button'
-      aria-pressed={ selected }
+      aria-checked={ isPressed }
       data-selection-toggle={ true }
       data-automationid='DetailsRowCheck'
-      aria-label={ props.ariaLabel }
     >
-      <Check checked={ selected } />
+      <Check checked={ isPressed } />
     </button>
   );
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -4,9 +4,12 @@ import { BaseComponent, css } from '../../Utilities';
 import * as stylesImport from './DetailsRow.scss';
 const styles: any = stylesImport;
 
+const INNER_PADDING = 16; // Account for padding around the cell.
+
 export interface IDetailsRowFieldsProps {
   item: any;
   itemIndex: number;
+  columnStartIndex: number;
   columns: IColumn[];
   onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => any;
 }
@@ -27,21 +30,24 @@ export class DetailsRowFields extends BaseComponent<IDetailsRowFieldsProps, IDet
   }
 
   public render() {
-    let { columns } = this.props;
+    let { columns, columnStartIndex } = this.props;
     let { cellContent } = this.state;
 
     return (
-      <div className={ css('ms-DetailsRow-fields', styles.fields) } data-automationid='DetailsRowFields'>
+      <div
+        className={ css('ms-DetailsRow-fields', styles.fields) }
+        data-automationid='DetailsRowFields'
+        role='presentation'>
         { columns.map((column, columnIndex) => (
           <div
             key={ columnIndex }
             role={ column.isRowHeader ? 'rowheader' : 'gridcell' }
-            aria-colindex={ columnIndex }
+            aria-colindex={ columnIndex + columnStartIndex }
             className={ css('ms-DetailsRow-cell', styles.cell, column.className, {
               'is-multiline': column.isMultiline,
               [styles.isMultiline]: column.isMultiline
             }) }
-            style={ { width: column.calculatedWidth } }
+            style={ { width: column.calculatedWidth + INNER_PADDING } }
             data-automationid='DetailsRowCell'
             data-automation-key={ column.key }>
             { cellContent[columnIndex] }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -76,7 +76,7 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
       selectionMode: SelectionMode.multiple,
       canResizeColumns: true,
       checkboxVisibility: CheckboxVisibility.onHover,
-      columns: this._buildColumns(_items, true, this._onColumnClick, ''),
+      columns: this._buildColumns(_items, true, this._onColumnClick, '', undefined, undefined, this._onColumnContextMenu),
       contextualMenuProps: null,
       sortedColumnKey: 'name',
       isSortedDescending: false,
@@ -450,9 +450,20 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
 
   @autobind
   private _onColumnClick(ev: React.MouseEvent<HTMLElement>, column: IColumn) {
+    if (column.columnActionsMode !== ColumnActionsMode.disabled) {
+      this.setState({
+        contextualMenuProps: this._getContextualMenuProps(ev, column)
+      });
+    }
+  }
+
+  @autobind
+  private _onColumnContextMenu(column: IColumn, ev: React.MouseEvent<HTMLElement>) {
+    if (column.columnActionsMode !== ColumnActionsMode.disabled) {
     this.setState({
       contextualMenuProps: this._getContextualMenuProps(ev, column)
     });
+  }
   }
 
   @autobind
@@ -469,7 +480,14 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     this.setState({
       items: sortedItems,
       groups: null,
-      columns: this._buildColumns(sortedItems, true, this._onColumnClick, key, isSortedDescending),
+      columns: this._buildColumns(
+        sortedItems,
+        true,
+        this._onColumnClick,
+        key,
+        isSortedDescending,
+        undefined,
+        this._onColumnContextMenu),
       isSortedDescending: isSortedDescending,
       sortedColumnKey: key
     });
@@ -578,7 +596,8 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     onColumnClick?: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => any,
     sortedColumnKey?: string,
     isSortedDescending?: boolean,
-    groupedColumnKey?: string) {
+    groupedColumnKey?: string,
+    onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => any) {
     let columns = buildColumns(items, canResizeColumns, onColumnClick, sortedColumnKey, isSortedDescending, groupedColumnKey);
 
     columns.forEach(column => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -139,6 +139,7 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
           onItemContextMenu={ this._onItemContextMenu }
           ariaLabelForListHeader='Column headers. Use menus to perform column operations like sort and filter'
           ariaLabelForSelectAllCheckbox='Toggle selection for all items'
+          ariaLabelForSelectionColumn='Toggle selection'
           onRenderMissingItem={ (index) => {
             this._onDataMiss(index);
             return null;
@@ -460,10 +461,10 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
   @autobind
   private _onColumnContextMenu(column: IColumn, ev: React.MouseEvent<HTMLElement>) {
     if (column.columnActionsMode !== ColumnActionsMode.disabled) {
-    this.setState({
-      contextualMenuProps: this._getContextualMenuProps(ev, column)
-    });
-  }
+      this.setState({
+        contextualMenuProps: this._getContextualMenuProps(ev, column)
+      });
+    }
   }
 
   @autobind
@@ -601,7 +602,12 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
     let columns = buildColumns(items, canResizeColumns, onColumnClick, sortedColumnKey, isSortedDescending, groupedColumnKey);
 
     columns.forEach(column => {
-      if (column.key === 'description') {
+      column.onColumnContextMenu = onColumnContextMenu;
+      column.ariaLabel = `Operations for ${column.name}`;
+      if (column.key === 'thumbnail') {
+        column.iconName = 'Picture';
+        column.isIconOnly = true;
+      } else if (column.key === 'description') {
         column.isMultiline = true;
         column.minWidth = 200;
       } else if (column.key === 'name') {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -5,20 +5,22 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import {
   DetailsList,
   DetailsListLayoutMode,
-  Selection
+  Selection,
+  IColumn
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 
 let _items = [];
 
-let _columns = [
+let _columns: IColumn[] = [
   {
     key: 'column1',
     name: 'Name',
     fieldName: 'name',
     minWidth: 100,
     maxWidth: 200,
-    isResizable: true
+    isResizable: true,
+    ariaLabel: 'Operations for name'
   },
   {
     key: 'column2',
@@ -26,7 +28,8 @@ let _columns = [
     fieldName: 'value',
     minWidth: 100,
     maxWidth: 200,
-    isResizable: true
+    isResizable: true,
+    ariaLabel: 'Operations for value'
   },
 ];
 
@@ -75,6 +78,8 @@ export class DetailsListBasicExample extends React.Component<any, any> {
             layoutMode={ DetailsListLayoutMode.fixedColumns }
             selection={ this._selection }
             selectionPreservedOnEmptyClick={ true }
+            ariaLabelForSelectionColumn='Toggle selection'
+            ariaLabelForSelectAllCheckbox='Toggle selection for all items'
             onItemInvoked={ (item) => alert(`Item invoked: ${item.name}`) }
           />
         </MarqueeSelection>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
@@ -100,6 +100,8 @@ export class DetailsListGroupedExample extends React.Component<any, any> {
           items={ items }
           groups={ groupBy(items, 'color') }
           columns={ _columns }
+          ariaLabelForSelectAllCheckbox='Toggle selection for all items'
+          ariaLabelForSelectionColumn='Toggle selection'
         />
       </Fabric>
     );

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -9,17 +9,49 @@ import { KeyCodes } from '../../Utilities';
 import { FocusZone } from './FocusZone';
 import { FocusZoneDirection } from './FocusZone.Props';
 
-let { assert } = chai;
-let _lastFocusedElement;
-
-function _onFocus(ev) {
-  _lastFocusedElement = ev.target;
-}
+import { assert } from 'chai';
 
 describe('FocusZone', () => {
+  let lastFocusedElement: HTMLElement;
+
+  function _onFocus(ev) {
+    lastFocusedElement = ev.target;
+  }
+
+  function setupElement(element: HTMLElement, {
+    clientRect,
+    isVisible = true
+  }: {
+      clientRect: {
+        top: number;
+        left: number;
+        bottom: number;
+        right: number;
+      };
+      isVisible?: boolean;
+    }): void {
+    element.getBoundingClientRect = () => ({
+      top: clientRect.top,
+      left: clientRect.left,
+      bottom: clientRect.bottom,
+      right: clientRect.right,
+      width: clientRect.right - clientRect.left,
+      height: clientRect.bottom - clientRect.top
+    });
+    if (isVisible) {
+      (element as any).isVisible = isVisible;
+    } else {
+      (element as any).hidden = !isVisible;
+    }
+    element.focus = () => ReactTestUtils.Simulate.focus(element);
+  }
+
+  beforeEach(() => {
+    lastFocusedElement = undefined;
+  });
 
   it('can use arrows vertically', () => {
-    let component = ReactTestUtils.renderIntoDocument(
+    const component = ReactTestUtils.renderIntoDocument(
       <div { ...{ onFocusCapture: _onFocus } }>
         <FocusZone direction={ FocusZoneDirection.vertical }>
           <button className='a'>a</button>
@@ -28,93 +60,95 @@ describe('FocusZone', () => {
         </FocusZone>
       </div>
     );
-    let focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
-    let buttonA = focusZone.querySelector('.a') as HTMLElement;
-    let buttonB = focusZone.querySelector('.b') as HTMLElement;
-    let buttonC = focusZone.querySelector('.c') as HTMLElement;
+
+    const focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
+
+    const buttonA = focusZone.querySelector('.a') as HTMLElement;
+    const buttonB = focusZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusZone.querySelector('.c') as HTMLElement;
 
     // Assign bounding locations to buttons.
-    buttonA.getBoundingClientRect = () => ({
-      top: 0, bottom: 30,
-      left: 0, right: 100,
-      width: 100,
-      height: 30
-    } as ClientRect);
-    (buttonA as any).isVisible = true;
-    buttonA.focus = () => ReactTestUtils.Simulate.focus(buttonA);
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 30,
+        left: 0,
+        right: 100
+      }
+    });
 
-    buttonB.getBoundingClientRect = () => ({
-      top: 30, bottom: 60,
-      left: 0, right: 100,
-      width: 100,
-      height: 30
-    } as ClientRect);
-    (buttonB as any).isVisible = true;
-    buttonB.focus = () => ReactTestUtils.Simulate.focus(buttonB);
+    setupElement(buttonB, {
+      clientRect: {
+        top: 30,
+        bottom: 60,
+        left: 0,
+        right: 100
+      }
+    });
 
-    buttonC.getBoundingClientRect = () => ({
-      top: 60, bottom: 90,
-      left: 0, right: 100,
-      width: 100,
-      height: 30
-    } as ClientRect);
-    (buttonC as any).isVisible = true;
-    buttonC.focus = () => ReactTestUtils.Simulate.focus(buttonC);
+    setupElement(buttonC, {
+      clientRect: {
+        top: 60,
+        bottom: 90,
+        left: 0,
+        right: 100
+      }
+    });
 
     // Focus the first button.
     ReactTestUtils.Simulate.focus(buttonA);
-    assert(_lastFocusedElement === buttonA, 'buttonA was not focused');
+    assert(lastFocusedElement === buttonA, 'buttonA was not focused');
 
     // Pressing down should go to b.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
-    assert(_lastFocusedElement === buttonB, 'pressing down did not focus b');
+    assert(lastFocusedElement === buttonB, 'pressing down did not focus b');
 
     // Pressing down should go to c.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
-    assert(_lastFocusedElement === buttonC, 'pressing down did not focus c');
+    assert(lastFocusedElement === buttonC, 'pressing down did not focus c');
 
     // Pressing down should stay on c.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
-    assert(_lastFocusedElement === buttonC, 'pressing down again did not stay on c');
+    assert(lastFocusedElement === buttonC, 'pressing down again did not stay on c');
 
     // Pressing up should go to b.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
-    assert(_lastFocusedElement === buttonB, 'pressing up did not focus b');
+    assert(lastFocusedElement === buttonB, 'pressing up did not focus b');
 
     // Pressing up should go to a.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
-    assert(_lastFocusedElement === buttonA, 'pressing up did not focus a');
+    assert(lastFocusedElement === buttonA, 'pressing up did not focus a');
 
     // Pressing up should stay on a.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
-    assert(_lastFocusedElement === buttonA, 'pressing up again did not stay on a');
+    assert(lastFocusedElement === buttonA, 'pressing up again did not stay on a');
 
     // Click on c to focus it.
     ReactTestUtils.Simulate.focus(buttonC);
-    assert(_lastFocusedElement === buttonC, 'buttonC was not focused');
+    assert(lastFocusedElement === buttonC, 'buttonC was not focused');
 
     // Pressing up should move to b.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
-    assert(_lastFocusedElement === buttonB, 'pressing up after clicking on c did not focus b');
+    assert(lastFocusedElement === buttonB, 'pressing up after clicking on c did not focus b');
 
     // Test that pressing horizontal buttons don't move focus.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
-    assert(_lastFocusedElement === buttonB, 'pressing left did not keep focus on b');
+    assert(lastFocusedElement === buttonB, 'pressing left did not keep focus on b');
 
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    assert(_lastFocusedElement === buttonB, 'pressing right did not keep focus on b');
+    assert(lastFocusedElement === buttonB, 'pressing right did not keep focus on b');
 
     // Press home should go to the first target.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.home });
-    assert(_lastFocusedElement === buttonA, 'pressing home did not move focus to a');
+    assert(lastFocusedElement === buttonA, 'pressing home did not move focus to a');
 
     // // Press end should go to the last target.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.end });
-    assert(_lastFocusedElement === buttonC, 'pressing end did not move focus to c');
+    assert(lastFocusedElement === buttonC, 'pressing end did not move focus to c');
   });
 
   it('can use arrows horizontally', () => {
-    let component = ReactTestUtils.renderIntoDocument(
+    const component = ReactTestUtils.renderIntoDocument(
       <div { ...{ onFocusCapture: _onFocus } }>
         <FocusZone direction={ FocusZoneDirection.horizontal }>
           <button className='a'>a</button>
@@ -123,93 +157,94 @@ describe('FocusZone', () => {
         </FocusZone>
       </div>
     );
-    let focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
-    let buttonA = focusZone.querySelector('.a') as HTMLElement;
-    let buttonB = focusZone.querySelector('.b') as HTMLElement;
-    let buttonC = focusZone.querySelector('.c') as HTMLElement;
+
+    const focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
+    const buttonA = focusZone.querySelector('.a') as HTMLElement;
+    const buttonB = focusZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusZone.querySelector('.c') as HTMLElement;
 
     // Assign bounding locations to buttons.
-    buttonA.getBoundingClientRect = () => ({
-      left: 0, right: 30,
-      top: 0, bottom: 100,
-      width: 30,
-      height: 100
-    } as ClientRect);
-    (buttonA as any).isVisible = true;
-    buttonA.focus = () => ReactTestUtils.Simulate.focus(buttonA);
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 100,
+        left: 0,
+        right: 30
+      }
+    });
 
-    buttonB.getBoundingClientRect = () => ({
-      left: 30, right: 60,
-      top: 0, bottom: 100,
-      width: 30,
-      height: 100
-    } as ClientRect);
-    (buttonB as any).isVisible = true;
-    buttonB.focus = () => ReactTestUtils.Simulate.focus(buttonB);
+    setupElement(buttonB, {
+      clientRect: {
+        top: 0,
+        bottom: 100,
+        left: 30,
+        right: 60
+      }
+    });
 
-    buttonC.getBoundingClientRect = () => ({
-      left: 60, right: 90,
-      top: 0, bottom: 100,
-      width: 30,
-      height: 100
-    } as ClientRect);
-    (buttonC as any).isVisible = true;
-    buttonC.focus = () => ReactTestUtils.Simulate.focus(buttonC);
+    setupElement(buttonC, {
+      clientRect: {
+        top: 0,
+        bottom: 100,
+        left: 60,
+        right: 90
+      }
+    });
 
     // Focus the first button.
     ReactTestUtils.Simulate.focus(buttonA);
-    assert(_lastFocusedElement === buttonA, 'buttonA was not focused');
+    assert(lastFocusedElement === buttonA, 'buttonA was not focused');
 
     // Pressing right should go to b.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    assert(_lastFocusedElement === buttonB, 'pressing right did not focus b');
+    assert(lastFocusedElement === buttonB, 'pressing right did not focus b');
 
     // Pressing right should go to c.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    assert(_lastFocusedElement === buttonC, 'pressing right did not focus c');
+    assert(lastFocusedElement === buttonC, 'pressing right did not focus c');
 
     // Pressing right should stay on c.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    assert(_lastFocusedElement === buttonC, 'pressing right again did not stay on c');
+    assert(lastFocusedElement === buttonC, 'pressing right again did not stay on c');
 
     // Pressing left should go to b.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
-    assert(_lastFocusedElement === buttonB, 'pressing left did not focus b');
+    assert(lastFocusedElement === buttonB, 'pressing left did not focus b');
 
     // Pressing left should go to a.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
-    assert(_lastFocusedElement === buttonA, 'pressing left did not focus a');
+    assert(lastFocusedElement === buttonA, 'pressing left did not focus a');
 
     // Pressing left should stay on a.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
-    assert(_lastFocusedElement === buttonA, 'pressing left again did not stay on a');
+    assert(lastFocusedElement === buttonA, 'pressing left again did not stay on a');
 
     // Click on c to focus it.
     ReactTestUtils.Simulate.focus(buttonC);
-    assert(_lastFocusedElement === buttonC, 'buttonC was not focused');
+    assert(lastFocusedElement === buttonC, 'buttonC was not focused');
 
     // Pressing left should move to b.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
-    assert(_lastFocusedElement === buttonB, 'pressing left after clicking on c did not focus b');
+    assert(lastFocusedElement === buttonB, 'pressing left after clicking on c did not focus b');
 
     // Test that pressing vertical buttons don't move focus.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
-    assert(_lastFocusedElement === buttonB, 'pressing up did not keep focus on b');
+    assert(lastFocusedElement === buttonB, 'pressing up did not keep focus on b');
 
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
-    assert(_lastFocusedElement === buttonB, 'pressing down did not keep focus on b');
+    assert(lastFocusedElement === buttonB, 'pressing down did not keep focus on b');
 
     // Press home should go to the first target.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.home });
-    assert(_lastFocusedElement === buttonA, 'pressing home did not move focus to a');
+    assert(lastFocusedElement === buttonA, 'pressing home did not move focus to a');
 
     // // Press end should go to the last target.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.end });
-    assert(_lastFocusedElement === buttonC, 'pressing end did not move focus to c');
+    assert(lastFocusedElement === buttonC, 'pressing end did not move focus to c');
   });
 
   it('can use arrows bidirectionally', () => {
-    let component = ReactTestUtils.renderIntoDocument(
+    const component = ReactTestUtils.renderIntoDocument(
       <div { ...{ onFocusCapture: _onFocus } }>
         <FocusZone>
           <button className='a'>a</button>
@@ -221,13 +256,14 @@ describe('FocusZone', () => {
         </FocusZone>
       </div>
     );
-    let focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
-    let buttonA = focusZone.querySelector('.a') as HTMLElement;
-    let buttonB = focusZone.querySelector('.b') as HTMLElement;
-    let buttonC = focusZone.querySelector('.c') as HTMLElement;
-    let hiddenButton = focusZone.querySelector('.hidden') as HTMLElement;
-    let buttonD = focusZone.querySelector('.d') as HTMLElement;
-    let buttonE = focusZone.querySelector('.e') as HTMLElement;
+
+    const focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
+    const buttonA = focusZone.querySelector('.a') as HTMLElement;
+    const buttonB = focusZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusZone.querySelector('.c') as HTMLElement;
+    const hiddenButton = focusZone.querySelector('.hidden') as HTMLElement;
+    const buttonD = focusZone.querySelector('.d') as HTMLElement;
+    const buttonE = focusZone.querySelector('.e') as HTMLElement;
 
     // Set up a grid like so:
     // A B
@@ -236,92 +272,93 @@ describe('FocusZone', () => {
     //
     // We will iterate from A to B, press down to skip hidden and go to C,
     // down again to E, left to D, then back up to A.
-    buttonA.getBoundingClientRect = () => ({
-      left: 0, right: 20,
-      top: 0, bottom: 20,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    (buttonA as any).isVisible = true;
-    buttonA.focus = () => ReactTestUtils.Simulate.focus(buttonA);
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 0,
+        right: 30
+      }
+    });
 
-    buttonB.getBoundingClientRect = () => ({
-      left: 20, right: 40,
-      top: 0, bottom: 20,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    (buttonB as any).isVisible = true;
-    buttonB.focus = () => ReactTestUtils.Simulate.focus(buttonB);
+    setupElement(buttonB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 20,
+        right: 40
+      }
+    });
 
-    buttonC.getBoundingClientRect = () => ({
-      left: 0, right: 20,
-      top: 20, bottom: 40,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    (buttonC as any).isVisible = true;
-    buttonC.focus = () => ReactTestUtils.Simulate.focus(buttonC);
+    setupElement(buttonC, {
+      clientRect: {
+        top: 20,
+        bottom: 40,
+        left: 0,
+        right: 20
+      }
+    });
 
     // hidden button should be ignored.
-    hiddenButton.getBoundingClientRect = () => ({
-      left: 2, right: 40,
-      top: 20, bottom: 40,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    hiddenButton.hidden = true;
-    hiddenButton.focus = () => ReactTestUtils.Simulate.focus(hiddenButton);
+    setupElement(hiddenButton, {
+      clientRect: {
+        top: 20,
+        bottom: 40,
+        left: 2,
+        right: 40
+      },
+      isVisible: false
+    });
 
-    buttonD.getBoundingClientRect = () => ({
-      left: 0, right: 20,
-      top: 40, bottom: 60,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    (buttonD as any).isVisible = true;
-    buttonD.focus = () => ReactTestUtils.Simulate.focus(buttonD);
+    setupElement(buttonD, {
+      clientRect: {
+        top: 40,
+        bottom: 60,
+        left: 0,
+        right: 20
+      }
+    });
 
-    buttonE.getBoundingClientRect = () => ({
-      left: 20, right: 40,
-      top: 40, bottom: 60,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    (buttonE as any).isVisible = true;
-    buttonE.focus = () => ReactTestUtils.Simulate.focus(buttonE);
+    setupElement(buttonE, {
+      clientRect: {
+        top: 40,
+        bottom: 60,
+        left: 20,
+        right: 40
+      }
+    });
 
     // Focus the first button.
     ReactTestUtils.Simulate.focus(buttonA);
-    assert(_lastFocusedElement === buttonA, 'buttonA was not focused');
+    assert(lastFocusedElement === buttonA, 'buttonA was not focused');
 
     // Pressing right should go to b.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    assert(_lastFocusedElement === buttonB, 'pressing right did not focus b');
+    assert(lastFocusedElement === buttonB, 'pressing right did not focus b');
 
     // Pressing down should go to c.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
-    assert(_lastFocusedElement === buttonC, 'pressing down did not focus c');
+    assert(lastFocusedElement === buttonC, 'pressing down did not focus c');
 
     // Pressing down should go to e.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
-    assert(_lastFocusedElement === buttonE, 'pressing down did not focus e');
+    assert(lastFocusedElement === buttonE, 'pressing down did not focus e');
 
     // Pressing left should go to d.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
-    assert(_lastFocusedElement === buttonD, 'pressing left did not focus d');
+    assert(lastFocusedElement === buttonD, 'pressing left did not focus d');
 
     // Pressing up should go to c.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
-    assert(_lastFocusedElement === buttonC, 'pressing up did not focus c');
+    assert(lastFocusedElement === buttonC, 'pressing up did not focus c');
 
     // Pressing up should go to a.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
-    assert(_lastFocusedElement === buttonA, 'pressing up did not focus a');
+    assert(lastFocusedElement === buttonA, 'pressing up did not focus a');
   });
 
   it('correctly skips data-not-focusable elements', () => {
-    let component = ReactTestUtils.renderIntoDocument(
+    const component = ReactTestUtils.renderIntoDocument(
       <div { ...{ onFocusCapture: _onFocus } }>
         <FocusZone>
           <button className='a'>a</button>
@@ -330,10 +367,11 @@ describe('FocusZone', () => {
         </FocusZone>
       </div>
     );
-    let focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
-    let buttonA = focusZone.querySelector('.a') as HTMLElement;
-    let buttonB = focusZone.querySelector('.b') as HTMLElement;
-    let buttonC = focusZone.querySelector('.c') as HTMLElement;
+
+    const focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
+    const buttonA = focusZone.querySelector('.a') as HTMLElement;
+    const buttonB = focusZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusZone.querySelector('.c') as HTMLElement;
 
     // Set up a grid like so:
     // A B
@@ -342,44 +380,44 @@ describe('FocusZone', () => {
     //
     // We will iterate from A to B, press down to skip hidden and go to C,
     // down again to E, left to D, then back up to A.
-    buttonA.getBoundingClientRect = () => ({
-      left: 0, right: 20,
-      top: 0, bottom: 20,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    (buttonA as any).isVisible = true;
-    buttonA.focus = () => ReactTestUtils.Simulate.focus(buttonA);
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 0,
+        right: 20
+      }
+    });
 
-    buttonB.getBoundingClientRect = () => ({
-      left: 20, right: 40,
-      top: 0, bottom: 20,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    (buttonB as any).isVisible = true;
-    buttonB.focus = () => ReactTestUtils.Simulate.focus(buttonB);
+    setupElement(buttonB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 20,
+        right: 40
+      }
+    });
 
-    buttonC.getBoundingClientRect = () => ({
-      left: 0, right: 20,
-      top: 20, bottom: 40,
-      width: 20,
-      height: 20
-    } as ClientRect);
-    (buttonC as any).isVisible = true;
-    buttonC.focus = () => ReactTestUtils.Simulate.focus(buttonC);
+    setupElement(buttonC, {
+      clientRect: {
+        top: 20,
+        bottom: 40,
+        left: 0,
+        right: 20
+      }
+    });
 
     // Focus the first button.
     ReactTestUtils.Simulate.focus(buttonA);
-    assert(_lastFocusedElement === buttonA, 'buttonA was not focused');
+    assert(lastFocusedElement === buttonA, 'buttonA was not focused');
 
     // Pressing right should go to b.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
-    assert(_lastFocusedElement === buttonC, 'pressing down did not focus c');
+    assert(lastFocusedElement === buttonC, 'pressing down did not focus c');
 
     // Pressing down should go to c.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
-    assert(_lastFocusedElement === buttonA, 'pressing down did not focus a');
+    assert(lastFocusedElement === buttonA, 'pressing down did not focus a');
   });
 
 });

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -420,4 +420,173 @@ describe('FocusZone', () => {
     assert(lastFocusedElement === buttonA, 'pressing down did not focus a');
   });
 
+  it('skips subzone elements until manually entered', () => {
+    const component = ReactTestUtils.renderIntoDocument(
+      <div { ...{ onFocusCapture: _onFocus } }>
+        <FocusZone
+          direction={ FocusZoneDirection.horizontal }
+          isInnerZoneKeystroke={ (e: React.KeyboardEvent<HTMLElement>) => e.which === KeyCodes.enter }>
+          <button className='a'>a</button>
+          <div
+            className='b'
+            data-is-focusable={ true }
+            data-is-sub-focuszone={ true }>
+            <button className='bsub'>bsub</button>
+          </div>
+          <button className='c'>c</button>
+        </FocusZone>
+      </div>
+    );
+
+    const focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
+
+    const buttonA = focusZone.querySelector('.a') as HTMLElement;
+    const divB = focusZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusZone.querySelector('.c') as HTMLElement;
+
+    const buttonB = focusZone.querySelector('.bsub') as HTMLElement;
+
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 0,
+        right: 20
+      }
+    });
+
+    setupElement(divB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 20,
+        right: 40
+      }
+    });
+
+    setupElement(buttonB, {
+      clientRect: {
+        top: 5,
+        bottom: 15,
+        left: 25,
+        right: 35
+      }
+    });
+
+    setupElement(buttonC, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 40,
+        right: 60
+      }
+    });
+
+    // Focus the first button.
+    ReactTestUtils.Simulate.focus(buttonA);
+    assert(lastFocusedElement === buttonA, 'buttonA was not focused');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    assert(lastFocusedElement === divB, 'pressing right did not focus divB');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    assert(lastFocusedElement === buttonC, 'pressing right did not skip to buttonC');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    assert(lastFocusedElement === divB, 'pressing left did not skip back to divB');
+
+    ReactTestUtils.Simulate.keyDown(divB, { which: KeyCodes.enter });
+    assert(lastFocusedElement === buttonB, 'pressing enter did not jump in to buttonB');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    assert(lastFocusedElement === buttonC, 'pressing enter did not move to buttonC');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    assert(lastFocusedElement === divB, 'pressing left did not skip back to divB');
+  });
+
+  it('skips child focusZone elements until manually entered', () => {
+    const component = ReactTestUtils.renderIntoDocument(
+      <div { ...{ onFocusCapture: _onFocus } }>
+        <FocusZone
+          direction={ FocusZoneDirection.horizontal }
+          isInnerZoneKeystroke={ (e: React.KeyboardEvent<HTMLElement>) => e.which === KeyCodes.enter }>
+          <button className='a'>a</button>
+          <FocusZone
+            direction={ FocusZoneDirection.horizontal }
+            className='b'
+            data-is-focusable={ true }>
+            <button className='bsub'>bsub</button>
+          </FocusZone>
+          <button className='c'>c</button>
+        </FocusZone>
+      </div>
+    );
+
+    const focusZone = ReactDOM.findDOMNode(component as React.ReactInstance).firstChild as Element;
+
+    const buttonA = focusZone.querySelector('.a') as HTMLElement;
+    const divB = focusZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusZone.querySelector('.c') as HTMLElement;
+
+    const buttonB = focusZone.querySelector('.bsub') as HTMLElement;
+
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 0,
+        right: 20
+      }
+    });
+
+    setupElement(divB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 20,
+        right: 40
+      }
+    });
+
+    setupElement(buttonB, {
+      clientRect: {
+        top: 5,
+        bottom: 15,
+        left: 25,
+        right: 35
+      }
+    });
+
+    setupElement(buttonC, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 40,
+        right: 60
+      }
+    });
+
+    // Focus the first button.
+    ReactTestUtils.Simulate.focus(buttonA);
+    assert(lastFocusedElement === buttonA, 'buttonA was not focused');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    assert(lastFocusedElement === divB, 'pressing right did not focus divB');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    assert(lastFocusedElement === buttonC, 'pressing right did not skip to buttonC');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    assert(lastFocusedElement === divB, 'pressing left did not skip back to divB');
+
+    ReactTestUtils.Simulate.keyDown(divB, { which: KeyCodes.enter });
+    assert(lastFocusedElement === buttonB, 'pressing enter did not jump in to buttonB');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    assert(lastFocusedElement === buttonC, 'pressing enter did not move to buttonC');
+
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    assert(lastFocusedElement === divB, 'pressing left did not skip back to divB');
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -20,6 +20,7 @@ import {
   getPreviousElement,
   getRTL,
   isElementFocusZone,
+  isElementFocusSubZone,
   isElementTabbable
 } from '../../Utilities';
 
@@ -282,7 +283,15 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
       // Try to focus
       let innerZone = this._getFirstInnerZone();
 
-      if (!innerZone || !innerZone.focus(true)) {
+      if (innerZone) {
+        if (!innerZone.focus(true)) {
+          return;
+        }
+      } else if (isElementFocusSubZone(ev.target as HTMLElement)) {
+        if (!this.focusElement(getNextElement(ev.target as HTMLElement, (ev.target as HTMLElement).firstChild as HTMLElement, true))) {
+          return;
+        }
+      } else {
         return;
       }
     } else if (ev.altKey) {

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -303,7 +303,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
 
     return (
       <div ref='root' { ...divProps } role={ role } className={ css('ms-List', className) } >
-        <div ref='surface' className='ms-List-surface'>
+        <div ref='surface' className='ms-List-surface' role='presentation'>
           { pageElements }
         </div>
       </div>
@@ -316,7 +316,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     let pageStyle = this._getPageStyle(page);
 
     // only assign list item role if no role is assigned
-    role = (role === undefined) ? 'listitem' : null;
+    role = (role === undefined) ? 'listitem' : 'presentation';
 
     for (let i = 0; page.items && i < page.items.length; i++) {
       let item = page.items[i];
@@ -338,7 +338,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     }
 
     return (
-      <div className='ms-List-page' key={ page.key } ref={ page.key } style={ pageStyle }>
+      <div className='ms-List-page' key={ page.key } ref={ page.key } style={ pageStyle } role='presentation'>
         { cells }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
@@ -37,6 +37,12 @@ export interface ITooltipHostProps extends React.HTMLProps<HTMLDivElement | Tool
   tooltipProps?: ITooltipProps;
 
   /**
+   * Whether or not to mark the container as described by the tooltip.
+   * If not specified, the caller should mark as element as described by the tooltip id.
+   */
+  setAriaDescribedBy?: boolean;
+
+  /**
    * Length of delay
    * @default medium
    */

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -49,6 +49,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
       directionalHint,
       delay,
       id,
+      setAriaDescribedBy = true,
       hostClassName
     } = this.props;
     const { isTooltipVisible } = this.state;
@@ -61,22 +62,23 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
         { ...{ onBlurCapture: this._onTooltipMouseLeave } }
         onMouseEnter={ this._onTooltipMouseEnter }
         onMouseLeave={ this._onTooltipMouseLeave }
-        aria-describedby={ isTooltipVisible ? tooltipId : undefined }
+        aria-describedby={ setAriaDescribedBy && isTooltipVisible && content ? tooltipId : undefined }
       >
         { children }
-        { isTooltipVisible && (
-          <Tooltip
-            { ...tooltipProps }
-            id={ tooltipId }
-            delay={ delay }
-            content={ content }
-            targetElement={ this._getTargetElement() }
-            directionalHint={ directionalHint }
-            calloutProps={ assign(calloutProps, { onDismiss: this._onTooltipCallOutDismiss }) }
-            { ...getNativeProps(this.props, divProperties) }
-          >
-          </Tooltip>
-        ) }
+        { isTooltipVisible &&
+          content ? (
+            <Tooltip
+              { ...tooltipProps }
+              id={ tooltipId }
+              delay={ delay }
+              content={ content }
+              targetElement={ this._getTargetElement() }
+              directionalHint={ directionalHint }
+              calloutProps={ assign(calloutProps, { onDismiss: this._onTooltipCallOutDismiss }) }
+              { ...getNativeProps(this.props, divProperties) }
+            >
+            </Tooltip>
+          ) : undefined }
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -84,6 +84,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         onKeyDown={ this._onKeyDown }
         onMouseDown={ this._onMouseDown }
         onClick={ this._onClick }
+        role='presentation'
 
         onDoubleClick={ this._onDoubleClick }
         onContextMenu={ this._onContextMenu }

--- a/packages/utilities/api/utilities.api.ts
+++ b/packages/utilities/api/utilities.api.ts
@@ -255,6 +255,9 @@ interface IRenderFunction<P> {
 }
 
 // (undocumented)
+export function isElementFocusSubZone(element?: HTMLElement): boolean;
+
+// (undocumented)
 export function isElementFocusZone(element?: HTMLElement): boolean;
 
 // (undocumented)

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -5,6 +5,7 @@ import { elementContains, getDocument } from './dom';
 const IS_FOCUSABLE_ATTRIBUTE = 'data-is-focusable';
 const IS_VISIBLE_ATTRIBUTE = 'data-is-visible';
 const FOCUSZONE_ID_ATTRIBUTE = 'data-focuszone-id';
+const FOCUSZONE_SUB_ATTRIBUTE = 'data-is-sub-focuszone';
 
 export function getFirstFocusable(
   rootElement: HTMLElement,
@@ -55,7 +56,8 @@ export function getPreviousElement(
   let isCurrentElementVisible = isElementVisible(currentElement);
 
   // Check its children.
-  if (traverseChildren && isCurrentElementVisible && (includeElementsInFocusZones || !isElementFocusZone(currentElement))) {
+  if (traverseChildren && isCurrentElementVisible &&
+    (includeElementsInFocusZones || !(isElementFocusZone(currentElement) || isElementFocusSubZone(currentElement)))) {
     const childMatch = getPreviousElement(
       rootElement,
       currentElement.lastElementChild as HTMLElement,
@@ -118,7 +120,8 @@ export function getNextElement(
   }
 
   // Check its children.
-  if (!suppressChildTraversal && isCurrentElementVisible && (includeElementsInFocusZones || !isElementFocusZone(currentElement))) {
+  if (!suppressChildTraversal && isCurrentElementVisible &&
+    (includeElementsInFocusZones || !(isElementFocusZone(currentElement) || isElementFocusSubZone(currentElement)))) {
     const childMatch = getNextElement(
       rootElement,
       currentElement.firstElementChild as HTMLElement,
@@ -207,6 +210,10 @@ export function isElementTabbable(element: HTMLElement): boolean {
 
 export function isElementFocusZone(element?: HTMLElement): boolean {
   return element && element.getAttribute && !!element.getAttribute(FOCUSZONE_ID_ATTRIBUTE);
+}
+
+export function isElementFocusSubZone(element?: HTMLElement): boolean {
+  return element && element.getAttribute && element.getAttribute(FOCUSZONE_SUB_ATTRIBUTE) === 'true';
 }
 
 export function doesElementContainFocus(element: HTMLElement) {

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -55,7 +55,7 @@ export function getPreviousElement(
   let isCurrentElementVisible = isElementVisible(currentElement);
 
   // Check its children.
-  if (traverseChildren && (includeElementsInFocusZones || !isElementFocusZone(currentElement)) && isCurrentElementVisible) {
+  if (traverseChildren && isCurrentElementVisible && (includeElementsInFocusZones || !isElementFocusZone(currentElement))) {
     const childMatch = getPreviousElement(
       rootElement,
       currentElement.lastElementChild as HTMLElement,
@@ -206,7 +206,7 @@ export function isElementTabbable(element: HTMLElement): boolean {
 }
 
 export function isElementFocusZone(element?: HTMLElement): boolean {
-  return element && !!element.getAttribute(FOCUSZONE_ID_ATTRIBUTE);
+  return element && element.getAttribute && !!element.getAttribute(FOCUSZONE_ID_ATTRIBUTE);
 }
 
 export function doesElementContainFocus(element: HTMLElement) {


### PR DESCRIPTION
#### Description of changes

Overhauled the keyboarding and screen reader reporting semantics for `DetailsList` and relevant components:

- Added the ability for `FocusZone` to itself be focusable, to clean up redundant elements when creating nested models.
- Fixed a performance issue in `FocusZone` where every zone added a `document`-level keyboard handler.
- Added some missing sub-element tracking to `FocusZone` when leaving active elements of nested zones.
- `DetailsRow` and `DetailsHeader` now share checkbox render logic and semantics.
- `DetailsHeader` only reports column names to screen readers, deferring instructions to tooltips.
- All cells in `DetailsRow` components are their own `FocusZone` elements, ensuring that all fields are keyboard-navigable.
- Interacting with a cell's content can be performed by hitting Enter, which allows child components to be focused.
- Added a flow to resize columns using the keyboard, by focusing the resizers and using the arrow keys.
- Added some basic `aria-colspan` attributes to group headers, which still don't quite play nice with the `grid` role.
- Fixed the typing of `onContextMenu` eventing. Also fixed naming to allow this scenario to actually work in the demo.
- Adjusted the demo examples slightly to show off the new features better, such as labeling for iconified columns.

#### Focus areas to test

I tested the keyboarding of the demo site, which works for all cases and examples (and better from before).
Narrator and JAWS work decently with the basic and advanced grids, but not the grouped lists (the lack of proper column data in group headers breaks the `grid` structure).
Verified that the consumer (OneDrive and SharePoint) work well without modification.

