### PR TITLE
Overflow set empty overflow bug fix and API tweaks

### DIFF
--- a/common/changes/overflow-set-overflowitems_2017-05-11-04-52.json
+++ b/common/changes/overflow-set-overflowitems_2017-05-11-04-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fix some bugs in the overflow set API that prevent it from working when there are no overflow items",
+      "comment": "OverflowSet: Fixed issue that prevented it from working when there are no overflow items.",
       "type": "minor"
     },
     {

--- a/common/changes/overflow-set-overflowitems_2017-05-11-04-52.json
+++ b/common/changes/overflow-set-overflowitems_2017-05-11-04-52.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix some bugs in the overflow set API that prevent it from working when there are no overflow items",
+      "type": "minor"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "chrisgo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/karma.config.js
+++ b/packages/office-ui-fabric-react/karma.config.js
@@ -34,9 +34,8 @@ module.exports = function (config) {
       module: {
         loaders: [
           {
-            test: /sinon\.js$/,
-            loader: 'imports?define=>false',
-            enforce: 'pre'
+            test: /sinon\/pkg\/sinon/,
+            loader: "imports?define=>false,require=>false"
           },
           debugRun ? {} : {
             test: /\.js/,

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.Props.ts
@@ -23,7 +23,8 @@ export interface IOverflowSetProps extends React.Props<OverflowSet> {
   onRenderItem: IRenderFunction<any>;
 
   /**
-   * Rendering method for overflow button and contextual menu.
+   * Rendering method for overflow button and contextual menu. The argument to the function is
+   * the overflowItems passed in as props to this function.
   */
-  onRenderOverflowButton: IRenderFunction<IButtonProps>;
+  onRenderOverflowButton: IRenderFunction<any[]>;
 }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.Props.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { OverflowSet } from './OverflowSet';
-import { IContextualMenuItem } from '../../ContextualMenu';
-import { IButtonProps } from '../../Button';
 import { IRenderFunction } from '../../Utilities';
 import { IObjectWithKey } from '../../Selection';
 

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.Props.ts
@@ -15,7 +15,7 @@ export interface IOverflowSetProps extends React.Props<OverflowSet> {
   /**
    * An array of items to be passed to overflow contextual menu
   */
-  overflowItems?: IContextualMenuItem[];
+  overflowItems?: any[];
 
   /**
    * Method to call when trying to render an item.

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { OverflowSet } from './OverflowSet';
 import * as sinon from 'sinon';
 
-describe('Overflow Set', () => {
+describe('OverflowSet', () => {
   it('does not render overflow when there are no overflow items', () => {
     const onRenderItem = sinon.spy();
     const onRenderOverflowButton = sinon.spy();

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { OverflowSet } from './OverflowSet';
+import * as sinon from 'sinon';
+
+describe('Overflow Set', () => {
+  it('does not render overflow when there are no overflow items', () => {
+    const onRenderItem = sinon.spy();
+    const onRenderOverflowButton = sinon.spy();
+    const wrapper = shallow(<OverflowSet onRenderItem={ onRenderItem } onRenderOverflowButton={ onRenderOverflowButton } />);
+
+    expect(onRenderOverflowButton.called).to.equal(false);
+  });
+
+  it('does not render overflow when overflow items is an empty array', () => {
+    const onRenderItem = sinon.spy();
+    const onRenderOverflowButton = sinon.spy();
+    const wrapper = shallow(<OverflowSet onRenderItem={ onRenderItem } onRenderOverflowButton={ onRenderOverflowButton } overflowItems={ [] } />);
+
+    expect(onRenderOverflowButton.called).to.equal(false);
+  })
+});

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -19,5 +19,5 @@ describe('Overflow Set', () => {
     const wrapper = shallow(<OverflowSet onRenderItem={ onRenderItem } onRenderOverflowButton={ onRenderOverflowButton } overflowItems={ [] } />);
 
     expect(onRenderOverflowButton.called).to.equal(false);
-  })
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -4,7 +4,6 @@ import {
   autobind,
   BaseComponent
 } from '../../Utilities';
-import { IButtonProps } from '../../Button';
 import { IOverflowSetProps } from './OverflowSet.Props';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -20,14 +20,10 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, null> {
       onRenderOverflowButton
     } = this.props;
 
-    const overflowButtonProps: IButtonProps = {
-      menuProps: { items: overflowItems }
-    };
-
     return (
       <FocusZone className={ css('ms-OverflowSet', styles.root) } direction={ FocusZoneDirection.horizontal } role='menubar' >
         { items && this._onRenderItems(items) }
-        { overflowItems && overflowItems.length > 0 && onRenderOverflowButton(overflowButtonProps) }
+        { overflowItems && overflowItems.length > 0 && onRenderOverflowButton(overflowItems) }
       </FocusZone>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -27,7 +27,7 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, null> {
     return (
       <FocusZone className={ css('ms-OverflowSet', styles.root) } direction={ FocusZoneDirection.horizontal } role='menubar' >
         { items && this._onRenderItems(items) }
-        { overflowItems.length && onRenderOverflowButton(overflowButtonProps) }
+        { overflowItems && overflowItems.length > 0 && onRenderOverflowButton(overflowButtonProps) }
       </FocusZone>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
@@ -47,13 +47,13 @@ export class OverflowSetBasicExample extends BaseComponent<any, any> {
           }
         ]
         }
-          onRenderOverflowButton={ (overflowItems) => {
+        onRenderOverflowButton={ (overflowItems) => {
           return (
             <IconButton
               className={ css(styles.overflowButton) }
               iconProps={ { iconName: 'More' } }
               menuIconProps={ null }
-                menuProps={ { items: overflowItems } }
+              menuProps={ { items: overflowItems } }
             />
           );
         } }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
@@ -1,71 +1,96 @@
 /* tslint:disable:no-unused-variable */
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
-import { BaseComponent, css } from 'office-ui-fabric-react/lib/Utilities';
+import { BaseComponent, css, autobind } from 'office-ui-fabric-react/lib/Utilities';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox'
 import {
   OverflowSet
 } from 'office-ui-fabric-react/lib/OverflowSet';
 
 import * as stylesImport from './OverflowSet.Example.scss';
+
 const styles: any = stylesImport;
 
-export class OverflowSetBasicExample extends BaseComponent<any, any> {
+export interface IOverflowSetBasicExampleState {
+  hasOverflowItems: boolean;
+}
+
+export class OverflowSetBasicExample extends BaseComponent<any, IOverflowSetBasicExampleState> {
+  public constructor() {
+    super();
+
+    this.state = {
+      hasOverflowItems: true
+    };
+  }
 
   public render() {
+    let { hasOverflowItems } = this.state;
     return (
-      <OverflowSet
-        items={ [
-          {
-            key: 'item1',
-            name: 'Link 1',
-            ariaLabel: 'New. Use left and right arrow keys to navigate',
-            onClick: () => { return; },
-          },
-          {
-            key: 'item2',
-            name: 'Link 2',
-            onClick: () => { return; },
-          },
-          {
-            key: 'item3',
-            name: 'Link 3',
-            onClick: () => { return; }
+      <div>
+        <OverflowSet
+          items={ [
+            {
+              key: 'item1',
+              name: 'Link 1',
+              ariaLabel: 'New. Use left and right arrow keys to navigate',
+              onClick: () => { return; },
+            },
+            {
+              key: 'item2',
+              name: 'Link 2',
+              onClick: () => { return; },
+            },
+            {
+              key: 'item3',
+              name: 'Link 3',
+              onClick: () => { return; }
+            }
+          ] }
+          overflowItems={ hasOverflowItems ? [
+            {
+              key: 'item4',
+              name: 'Overflow Link 1',
+              onClick: () => { return; }
+            },
+            {
+              key: 'item5',
+              name: 'Overflow Link 2',
+              onClick: () => { return; }
+            }
+          ] : undefined
           }
-        ] }
-        overflowItems={ [
-          {
-            key: 'item4',
-            name: 'Overflow Link 1',
-            onClick: () => { return; }
-          },
-          {
-            key: 'item5',
-            name: 'Overflow Link 2',
-            onClick: () => { return; }
-          }
-        ]
-        }
-        onRenderOverflowButton={ (buttonProps) => {
-          return (
-            <IconButton
-              className={ css(styles.overflowButton) }
-              iconProps={ { iconName: 'More' } }
-              menuIconProps={ null }
-              menuProps={ buttonProps.menuProps }
-            />
-          );
-        } }
-        onRenderItem={ (item) => {
-          return (
-            <Link
-              className={ css(styles.overflowLinks) }
-              onClick={ item.onClick }
-            >{ item.name }</Link>
-          );
-        } }
-      />
+          onRenderOverflowButton={ (buttonProps) => {
+            return (
+              <IconButton
+                className={ css(styles.overflowButton) }
+                iconProps={ { iconName: 'More' } }
+                menuIconProps={ null }
+                menuProps={ buttonProps.menuProps }
+              />
+            );
+          } }
+          onRenderItem={ (item) => {
+            return (
+              <Link
+                className={ css(styles.overflowLinks) }
+                onClick={ item.onClick }
+              >{ item.name }</Link>
+            );
+          } }
+        />
+
+        <Checkbox label='Has Overflow Items' checked={ hasOverflowItems } onChange={ this._onHasOverflowItemsChange } />
+      </div>
     );
+  }
+
+  @autobind
+  private _onHasOverflowItemsChange(ev: React.FormEvent<HTMLElement>, isVisible: boolean) {
+    this.setState({
+      hasOverflowItems: isVisible
+    });
   }
 }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
@@ -1,96 +1,71 @@
 /* tslint:disable:no-unused-variable */
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
-import { BaseComponent, css, autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { BaseComponent, css } from 'office-ui-fabric-react/lib/Utilities';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox'
 import {
   OverflowSet
 } from 'office-ui-fabric-react/lib/OverflowSet';
 
 import * as stylesImport from './OverflowSet.Example.scss';
-
 const styles: any = stylesImport;
 
-export interface IOverflowSetBasicExampleState {
-  hasOverflowItems: boolean;
-}
-
-export class OverflowSetBasicExample extends BaseComponent<any, IOverflowSetBasicExampleState> {
-  public constructor() {
-    super();
-
-    this.state = {
-      hasOverflowItems: true
-    };
-  }
+export class OverflowSetBasicExample extends BaseComponent<any, any> {
 
   public render() {
-    let { hasOverflowItems } = this.state;
     return (
-      <div>
-        <OverflowSet
-          items={ [
-            {
-              key: 'item1',
-              name: 'Link 1',
-              ariaLabel: 'New. Use left and right arrow keys to navigate',
-              onClick: () => { return; },
-            },
-            {
-              key: 'item2',
-              name: 'Link 2',
-              onClick: () => { return; },
-            },
-            {
-              key: 'item3',
-              name: 'Link 3',
-              onClick: () => { return; }
-            }
-          ] }
-          overflowItems={ hasOverflowItems ? [
-            {
-              key: 'item4',
-              name: 'Overflow Link 1',
-              onClick: () => { return; }
-            },
-            {
-              key: 'item5',
-              name: 'Overflow Link 2',
-              onClick: () => { return; }
-            }
-          ] : undefined
+      <OverflowSet
+        items={ [
+          {
+            key: 'item1',
+            name: 'Link 1',
+            ariaLabel: 'New. Use left and right arrow keys to navigate',
+            onClick: () => { return; },
+          },
+          {
+            key: 'item2',
+            name: 'Link 2',
+            onClick: () => { return; },
+          },
+          {
+            key: 'item3',
+            name: 'Link 3',
+            onClick: () => { return; }
           }
+        ] }
+        overflowItems={ [
+          {
+            key: 'item4',
+            name: 'Overflow Link 1',
+            onClick: () => { return; }
+          },
+          {
+            key: 'item5',
+            name: 'Overflow Link 2',
+            onClick: () => { return; }
+          }
+        ]
+        }
           onRenderOverflowButton={ (overflowItems) => {
-            return (
-              <IconButton
-                className={ css(styles.overflowButton) }
-                iconProps={ { iconName: 'More' } }
-                menuIconProps={ null }
+          return (
+            <IconButton
+              className={ css(styles.overflowButton) }
+              iconProps={ { iconName: 'More' } }
+              menuIconProps={ null }
                 menuProps={ { items: overflowItems } }
-              />
-            );
-          } }
-          onRenderItem={ (item) => {
-            return (
-              <Link
-                className={ css(styles.overflowLinks) }
-                onClick={ item.onClick }
-              >{ item.name }</Link>
-            );
-          } }
-        />
-
-        <Checkbox label='Has Overflow Items' checked={ hasOverflowItems } onChange={ this._onHasOverflowItemsChange } />
-      </div>
+            />
+          );
+        } }
+        onRenderItem={ (item) => {
+          return (
+            <Link
+              className={ css(styles.overflowLinks) }
+              onClick={ item.onClick }
+            >{ item.name }</Link>
+          );
+        } }
+      />
     );
-  }
-
-  @autobind
-  private _onHasOverflowItemsChange(ev: React.FormEvent<HTMLElement>, isVisible: boolean) {
-    this.setState({
-      hasOverflowItems: isVisible
-    });
   }
 }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
@@ -62,13 +62,13 @@ export class OverflowSetBasicExample extends BaseComponent<any, IOverflowSetBasi
             }
           ] : undefined
           }
-          onRenderOverflowButton={ (buttonProps) => {
+          onRenderOverflowButton={ (overflowItems) => {
             return (
               <IconButton
                 className={ css(styles.overflowButton) }
                 iconProps={ { iconName: 'More' } }
                 menuIconProps={ null }
-                menuProps={ buttonProps.menuProps }
+                menuProps={ { items: overflowItems } }
               />
             );
           } }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
@@ -110,13 +110,13 @@ export class OverflowSetCustomExample extends BaseComponent<any, any> {
           }
         ]
         }
-        onRenderOverflowButton={ (buttonProps) => {
+        onRenderOverflowButton={ (overflowItems) => {
           return (
             <DefaultButton
               className={ css(styles.overflowButton) }
               iconProps={ { iconName: 'More' } }
               menuIconProps={ null }
-              menuProps={ buttonProps.menuProps }
+              menuProps={ { items: overflowItems } }
             />
           );
         } }


### PR DESCRIPTION
#### Pull request checklist

Addresses an existing issue: Fixes #1757
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement
  - [x] Includes tests
- [ ] Documentation update 

#### Description of changes
OverflowSet rendering causes an exception when the overflow items are not passed in. Since the overflowitems property is optional, we should make sure it isn't undefined before we try to access the length.

OverflowSet also renders a "0" when the overflowitems array is empty since 0 && {} is 0. Updated to check overflowItems.length > 0 to still enable this functionality without rendering a 0.

Also changed the OverflowSet API to make overflowitems[] an any type like items[]. This allows for scenarios where you want to use something other than IContextualMenuItem for the overflow commands. It also enables you to use the same type for overflowItems and items[].  I think a better long term fix here will be to use a generic type for OverflowSetProps, but I think that well be less cumbersome after the upgrade to Typescript 2.3, where we can specify a default type for generics. 

