### PR TITLE
Textfield: reverted to 14px.

### DIFF
--- a/common/changes/textfield-size_2017-05-11-16-56.json
+++ b/common/changes/textfield-size_2017-05-11-16-56.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: font size of textfield reverted to 14px.",
+      "type": "patch"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -102,6 +102,7 @@ $field-error-color: $errorTextColor;
 .field {
   @include ms-u-normalize;
   @include ms-baseFont;
+  font-size: $ms-font-size-m;
   border-radius: 0;
   border: none;
   color: $field-text-color;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #1763
- [X] Include a change request file if publishing <!-- see notes below -->
- [X] New feature, bugfix, or enhancement

#### Description of changes

Reverting textfield fontsize to medium.
