### PR TITLE
Make name optional on contextual menu, update examples on how to place dividers

### DIFF
--- a/common/changes/ContextualMenu-Divider_2017-05-11-23-31.json
+++ b/common/changes/ContextualMenu-Divider_2017-05-11-23-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make name prop optional on ContextualMenu",
+      "type": "patch"
+    }
+  ],
+  "email": "chrisgo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -181,7 +181,7 @@ export interface IContextualMenuItem {
   /**
    * Text description for the menu item to display
    */
-  name: string;
+  name?: string;
 
   itemType?: ContextualMenuItemType;
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ContextualMenu } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ContextualMenu, ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { getRTL } from 'office-ui-fabric-react/lib/Utilities';
@@ -68,7 +68,7 @@ export class ContextualMenuBasicExample extends React.Component<any, any> {
                 },
                 {
                   key: 'divider_1',
-                  name: '-',
+                  itemType: ContextualMenuItemType.Divider
                 },
                 {
                   key: 'rename',
@@ -85,7 +85,7 @@ export class ContextualMenuBasicExample extends React.Component<any, any> {
                 },
                 {
                   key: 'divider_2',
-                  name: '-',
+                  itemType: ContextualMenuItemType.Divider
                 },
                 {
                   key: 'share',
@@ -157,7 +157,7 @@ export class ContextualMenuBasicExample extends React.Component<any, any> {
                 },
                 {
                   key: 'divider_3',
-                  name: '-',
+                  itemType: ContextualMenuItemType.Divider,
                 },
                 {
                   key: 'Bing',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ContextualMenu, IContextualMenuItem, DirectionalHint } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ContextualMenu, IContextualMenuItem, DirectionalHint, ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import './ContextualMenuExample.scss';
 
@@ -65,7 +65,7 @@ export class ContextualMenuCheckmarksExample extends React.Component<any, IConte
                 },
                 {
                   key: 'divider_1',
-                  name: '-',
+                  itemType: ContextualMenuItemType.Divider
                 },
 
                 {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ContextualMenu, DirectionalHint } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ContextualMenu, DirectionalHint, ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { DefaultButton, IconButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import './ContextualMenuExample.scss';
@@ -62,7 +62,7 @@ export class ContextualMenuCustomizationExample extends React.Component<any, ICo
                 },
                 {
                   key: 'divider_1',
-                  name: '-',
+                  itemType: ContextualMenuItemType.Divider
                 },
                 {
                   key: 'charm',
@@ -200,7 +200,7 @@ export class ContextualMenuCustomizationExample extends React.Component<any, ICo
                       },
                       {
                         key: 'divider_1',
-                        name: '-',
+                        itemType: ContextualMenuItemType.Divider
                       },
                       {
                         key: 'clear',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { ContextualMenu, DirectionalHint } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ContextualMenu, DirectionalHint, ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Slider } from 'office-ui-fabric-react/lib/Slider';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
@@ -125,7 +125,7 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
                 },
                 {
                   key: '-',
-                  name: '-',
+                  itemType: ContextualMenuItemType.Divider
                 },
                 {
                   key: 'share',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or **enhancement**

- [ ] Documentation update

#### Description of changes
The existing ContextualMenu examples place dividers in the menu like this:
```typescript
{
  key: 'divider_3',
  name: '-',
}
```
This doesn't seem to be a best practice, since it relies on the trick that using '-' for the name results in a divider being rendered.

Instead, the recommended approach should be to render menu items like this:
```typescript
{
  key: 'divider_3',
  itemType: ContextualMenuItemType.Divider
}
```
In order to enable this, we should make the name property optional on IContextualMenuItem.
