### PR TITLE
Replace deprecated VSCode settings to current one

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,8 @@
     "**/*.scss.ts": true
   },
   // Controls after how many characters the editor will wrap to the next line. Setting this to 0 turns on viewport width wrapping
-  "editor.wrappingColumn": 140,
+  "editor.wordWrap": "wordWrapColumn",
+  "editor.wordWrapColumn": 140,
   "tslint.enable": true,
   "tslint.rulesDirectory": "./common/node_modules/tslint-microsoft-contrib",
   // Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.


### PR DESCRIPTION
#### Description of changes

Update VSCode setting.

In detail, `editor.wrappingColumn` is already [deprecated](https://code.visualstudio.com/updates/v1_10#_word-wrap-settings-redesign).

Latest VSCode (1.12.1) cannot recognize this option, it cause an warning that indicates `Unknown configuration setting`. So I'd like to fix it.