### PR TITLE
Date picker: Reduce min-width of the date picker container

### DIFF
--- a/common/changes/master_2017-05-12-20-36.json
+++ b/common/changes/master_2017-05-12-20-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Date picker: Reduce min-width for the holder component",
+      "type": "patch"
+    }
+  ],
+  "email": "johannao@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -367,7 +367,7 @@ $Calendar-dayPicker-margin: 10px;
   }
 
   .holder {
-    min-width: 240px;
+    min-width: 230px;
   }
 
   // Update header text styles.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

The min-width was a bit too large and was causing some issues with the owa calendaring integration, reduced by 10px.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
