### PR TITLE
Button type default to type='button' to avoid form submit action

### DIFF
--- a/common/changes/button-type_2017-05-15-19-09.json
+++ b/common/changes/button-type_2017-05-15-19-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button: default type to 'button'",
+      "type": "patch"
+    }
+  ],
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -87,7 +87,10 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     const renderAsAnchor: boolean = !!href;
     const tag = renderAsAnchor ? 'a' : 'button';
     const nativeProps = getNativeProps(
-      assign({}, this.props.rootProps, this.props),
+      assign(
+        renderAsAnchor ? {} : { type: 'button' },
+        this.props.rootProps,
+        this.props),
       renderAsAnchor ? anchorProperties : buttonProperties,
       [
         'disabled' // Let disabled buttons be focused and styled as disabled.

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.scss
@@ -43,12 +43,4 @@ $button-iconButtonSize: $button-core-default-height;
 .isDisabled {
   @include button-core-disabled;
   background-color: transparent;
-
-  @media screen and (-ms-high-contrast: active) {
-    color: $ms-color-yellowLight;
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    color: $ms-color-blueMid;
-  }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1783, #1687 
- [x] Include a change request file if publishing <!-- see notes below -->
- [x] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [ ] Documentation update

#### Description of changes
1. Defaulting button's to use type='button' to avoid unexpected form submit operation on consumer sites.

2. Remove Icon button's custom color for disabled state.

#### Focus areas to test

(optional)

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
