### PR TITLE
Adds the ability to pass in NativeProps to DetailsRow.

### DIFF
--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -4,7 +4,9 @@ import {
   IDisposable,
   assign,
   css,
-  shallowCompare
+  shallowCompare,
+  getNativeProps,
+  divProperties
 } from '../../Utilities';
 import { IColumn, CheckboxVisibility } from './DetailsList.Props';
 import { DetailsRowCheck, IDetailsRowCheckProps } from './DetailsRowCheck';
@@ -182,6 +184,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
 
     return (
       <div
+        {...getNativeProps(this.props, divProperties)}
         ref='root'
         role='row'
         aria-label={ ariaLabel }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
@@ -27,7 +27,13 @@ export class DetailsListCustomRowsExample extends React.Component<any, any> {
 
   @autobind
   private _onRenderRow(props) {
-    return <DetailsRow { ...props } onRenderCheck={ this._onRenderCheck } />;
+    return (
+      <DetailsRow
+        { ...props}
+        onRenderCheck={ this._onRenderCheck }
+        aria-busy={ false } 
+      />
+    );
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1775
- [ ] Include a change request file if publishing <!-- see notes below -->
- [ ] New feature, bugfix, or enhancement
  - [ ] Includes tests
- [x] Documentation update

#### Description of changes

Allows users of the DetailsRow component to pass in NativeProps to be added to the root Div of the component. Also changes the DetailsList.CustomRows.Example.tsx example to make use of the new functionality.

<!--
For change request files, you need to use the `rush` tool. You can globally install it:

```
npm i -g @microsoft/rush
```

To generate a file, you simply run:

```
rush change
```

This will ask you questions about your change and create a json file under the `common/changes` folder. The comments you include in the file will show up in the public changelog notes, so please follow the existing conventions. Commit this file and include it in your PR.
-->
