### PR TITLE
Toggle: Prevent a warning from being emitted if isChecked is set to null

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -45,7 +45,7 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
   public componentWillReceiveProps(newProps: IToggleProps) {
     if (newProps.checked !== undefined) {
       this.setState({
-        isChecked: !!newProps.checked //convert null to false
+        isChecked: !!newProps.checked // convert null to false
       });
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -45,7 +45,7 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
   public componentWillReceiveProps(newProps: IToggleProps) {
     if (newProps.checked !== undefined) {
       this.setState({
-        isChecked: newProps.checked
+        isChecked: !!newProps.checked //convert null to false
       });
     }
   }


### PR DESCRIPTION
This prevents React from printing a warning about switching the input used within the toggle to an uncontrolled component if isChecked gets set to null.