### PR TITLE
Adding test-bundle-button package.

### DIFF
--- a/apps/test-bundle-button/index.html
+++ b/apps/test-bundle-button/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" user-scalable="no" />
+
+  <title>Button example</title>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/react/15.4.0/react.min.js"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/react/15.4.0/react-dom.min.js"></script>
+
+</head>
+
+<body>
+  <script type="text/javascript" src="test-bundle-button.js"></script>
+</body>
+
+</html>

--- a/apps/test-bundle-button/package.json
+++ b/apps/test-bundle-button/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "test-bundle-button",
+  "version": "0.0.1",
+  "description": "Testing the button for bundling.",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OfficeDev/office-ui-fabric-react"
+  },
+  "license": "MIT",
+  "scripts": {
+    "build": "node node_modules/webpack/bin/webpack --config webpack.config.js && echo Done",
+    "clean": "",
+    "start": "node node_modules/webpack-dev-server/bin/webpack-dev-server.js --config webpack.serve.config.js --open"
+  },
+  "devDependencies": {
+    "@microsoft/web-library-build": ">=3.0.0-0 <4.0.0-0",
+    "@types/react": "^15.0.16",
+    "@types/react-dom": "^0.14.23",
+    "@types/webpack-env": "^1.13.0",
+    "source-map-loader": "^0.2.1",
+    "ts-loader": "^2.0.1",
+    "typescript": "^2.2.2",
+    "webpack": "^2.2.1",
+    "webpack-bundle-analyzer": "^2.2.1",
+    "webpack-dev-server": "^2.4.1"
+  },
+  "dependencies": {
+    "react": "^0.14 || ^15.0.1-0 || ^16.0.0-0",
+    "react-dom": "^0.14 || ^15.0.1-0 || ^16.0.0-0",
+    "office-ui-fabric-react": ">=2.23.0 <13.0.0"
+  }
+}

--- a/apps/test-bundle-button/src/index.tsx
+++ b/apps/test-bundle-button/src/index.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+
+function start(): void {
+  const div: HTMLElement = document.createElement('div');
+
+  document.body.appendChild(div);
+  ReactDOM.render((
+    <DefaultButton
+      iconProps={ { iconName: 'Snow' } }
+      text='hi'
+      menuProps={ {
+        items: [
+          { key: 'a', name: 'Item a' },
+          { key: 'c', name: 'Item b' },
+          { key: 'b', name: 'Item c' },
+        ]
+      } }
+    />
+  ), div);
+}
+
+// tslint:disable-next-line:no-string-literal
+if (document && document['body']) {
+  start();
+} else {
+  window.onload = start;
+}

--- a/apps/test-bundle-button/tsconfig.json
+++ b/apps/test-bundle-button/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "es5",
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "types": [
+      "webpack-env"
+    ],
+    "paths": {}
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "lib",
+    "lib-amd"
+  ]
+}

--- a/apps/test-bundle-button/tslint.json
+++ b/apps/test-bundle-button/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ],
+  "rules": {}
+}

--- a/apps/test-bundle-button/webpack.config.js
+++ b/apps/test-bundle-button/webpack.config.js
@@ -1,0 +1,60 @@
+const path = require('path');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const webpack = require('webpack');
+const PACKAGE_NAME = require('./package.json').name;
+
+module.exports = {
+  entry: './src/index.tsx',
+
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: PACKAGE_NAME + '.js',
+  },
+
+  externals: {
+    'react': 'React',
+    'react-dom': 'ReactDOM'
+  },
+
+  resolve: {
+    alias: {},
+    extensions: ['.ts', '.tsx', '.js']
+  },
+
+  devServer: {
+    inline: true,
+    port: 4321
+  },
+
+  module: {
+    loaders: [
+      {
+        test: [/\.tsx?$/],
+        loader: 'ts-loader',
+        exclude: [
+          /node_modules/,
+          /\.scss.ts$/
+        ]
+      }
+    ]
+  },
+
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production')
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      minimize: true,
+      compress: {
+        warnings: false
+      }
+    }),
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      reportFilename: PACKAGE_NAME + '.stats.html',
+      openAnalyzer: false,
+      generateStatsFile: true,
+      statsFilename: PACKAGE_NAME + '.stats.json'
+    }),
+  ]
+}

--- a/common/npm-shrinkwrap.json
+++ b/common/npm-shrinkwrap.json
@@ -927,6 +927,11 @@
       "from": "@types/z-schema@3.16.31",
       "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz"
     },
+    "@uifabric/example-app-base": {
+      "version": "1.3.11",
+      "from": "@uifabric/example-app-base@>=1.3.11 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/example-app-base/-/example-app-base-1.3.11.tgz"
+    },
     "@uifabric/utilities": {
       "version": "1.8.7",
       "from": "@uifabric/utilities@>=1.8.7 <2.0.0",
@@ -7433,6 +7438,18 @@
           "version": "4.2.1",
           "from": "yargs-parser@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
+        }
+      }
+    },
+    "rush-test-bundle-button": {
+      "version": "0.0.0",
+      "from": "temp_modules/rush-test-bundle-button",
+      "resolved": "file:temp_modules/rush-test-bundle-button",
+      "dependencies": {
+        "@types/react-dom": {
+          "version": "0.14.23",
+          "from": "@types/react-dom@>=0.14.23 <0.15.0",
+          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-0.14.23.tgz"
         }
       }
     },

--- a/common/package.json
+++ b/common/package.json
@@ -13,6 +13,7 @@
     "rush-office-ui-fabric-react": "file:./temp_modules/rush-office-ui-fabric-react",
     "rush-ssr-tests": "file:./temp_modules/rush-ssr-tests",
     "rush-styling": "file:./temp_modules/rush-styling",
+    "rush-test-bundle-button": "file:./temp_modules/rush-test-bundle-button",
     "rush-todo-app": "file:./temp_modules/rush-todo-app",
     "rush-utilities": "file:./temp_modules/rush-utilities"
   },

--- a/common/temp_modules/rush-styling/package.json
+++ b/common/temp_modules/rush-styling/package.json
@@ -13,6 +13,7 @@
     "@types/react-addons-test-utils": "^0.14.17",
     "@types/react-dom": "^15.5.0",
     "@types/webpack-env": "^1.13.0",
+    "@uifabric/example-app-base": ">=1.3.11 <2.0.0",
     "chai": "^3.5.0",
     "enzyme": "^2.7.0",
     "es6-promise": "4.1.0",
@@ -37,7 +38,6 @@
     "rtl-css-js": "^1.1.0"
   },
   "rushDependencies": {
-    "@uifabric/example-app-base": ">=1.3.11 <2.0.0",
     "@uifabric/utilities": ">=1.8.7 <2.0.0"
   }
 }

--- a/common/temp_modules/rush-test-bundle-button/package.json
+++ b/common/temp_modules/rush-test-bundle-button/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "rush-test-bundle-button",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@microsoft/web-library-build": ">=3.0.0-0 <4.0.0-0",
+    "@types/react": "^15.0.16",
+    "@types/react-dom": "^0.14.23",
+    "@types/webpack-env": "^1.13.0",
+    "source-map-loader": "^0.2.1",
+    "ts-loader": "^2.0.1",
+    "typescript": "^2.2.2",
+    "webpack": "^2.2.1",
+    "webpack-bundle-analyzer": "^2.2.1",
+    "webpack-dev-server": "^2.4.1",
+    "react": "^0.14 || ^15.0.1-0 || ^16.0.0-0",
+    "react-dom": "^0.14 || ^15.0.1-0 || ^16.0.0-0"
+  },
+  "rushDependencies": {
+    "office-ui-fabric-react": ">=2.23.0 <13.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "_rushBuild": "node node_modules/@microsoft/rush/bin/rush build --verbose",
     "_rushBuildToFabric": "node node_modules/@microsoft/rush/bin/rush build --to office-ui-fabric-react",
     "_rushRebuild": "node node_modules/@microsoft/rush/bin/rush rebuild --production --verbose",
-    "postinstall": "npm run _rushInstall && npm run _rushLink && npm run _rushBuildToFabric",
+    "postinstall": "npm run _rushInstall && npm run _rushBuildToFabric",
     "test": "npm run _rushBuild",
     "start": "cd packages && cd office-ui-fabric-react && npm start",
     "build": "npm run _rushRebuild",

--- a/rush.json
+++ b/rush.json
@@ -29,7 +29,8 @@
       "projectFolder": "packages/styling",
       "shouldPublish": true,
       "cyclicDependencyProjects": [
-        "office-ui-fabric-react"
+        "office-ui-fabric-react",
+        "@uifabric/example-app-base"
       ]
     },
     {
@@ -51,6 +52,11 @@
       "packageName": "@uifabric/fabric-website",
       "projectFolder": "apps/fabric-website",
       "shouldPublish": true
+    },
+    {
+      "packageName": "test-bundle-button",
+      "projectFolder": "apps/test-bundle-button",
+      "shouldPublish": false
     }
   ]
 }


### PR DESCRIPTION
In order to test what the bundle size and content is for bundling, I've created a test project that only bundles the button using webpack. This helps to understand exactly what the minbar size is of a really trivial scenario, and where we're spending our bytes.

As we evolve our build pipeline, it will be a useful place to try rollup to see what the difference is in the final output.