### PR TITLE
Remove inaccurate bit about Tooltips not having tails

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutPage.tsx
@@ -55,7 +55,7 @@ export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
           <div>
             <p>Callouts are a powerful way to simplify a user interface. They host tips and other information users need when they need it, with minimal effort on their part. Callouts can help you use screen space more effectively and reduce screen clutter. However, poorly designed Callouts can be annoying, distracting, unhelpful, overwhelming, or in the way.</p>
 
-            <p>Use a Callout for displaying additional contextual information about an item on the screen. Unlike Tooltips, Callouts also have a tail that identifies their source. A common use for Callout is the introduction of a new feature or capability of an app or site. Alternate usages include pairing the Callout with a button or clickable element for on-demand presentation of additional or supporting content.</p>
+            <p>Use a Callout for displaying additional contextual information about an item on the screen. Callouts also have a tail that identifies their source. A common use for Callout is the introduction of a new feature or capability of an app or site. Alternate usages include pairing the Callout with a button or clickable element for on-demand presentation of additional or supporting content.</p>
 
             <p>Real-world examples of this implementation can be seen in administrative interfaces where a particularly difficult-to-understand concept is paired with the ms-Icon--info "i" icon. In this example, Callout - with its tip text - is opened when the user clicks on or hovers over the icon.</p>
           </div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: N/A
- [ ] Include a change request file if publishing: N/A
- [ ] New feature, bugfix, or enhancement: N/A
- [x] Documentation update

#### Description of changes

This PR removes an inaccurate statement about Tooltips not having tails. Tooltips do indeed have tails.

#### Focus areas to test

The Callout page on the Fabric website: http://dev.office.com/fabric#/components/callout
