### PR TITLE
Abstract the content of Dialog component into a new component named DialogContent

### DIFF
--- a/common/changes/moyali-DialogContent_2017-05-22-17-22.json
+++ b/common/changes/moyali-DialogContent_2017-05-22-17-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dialog: created a new component (DialogContent) that contains the content of the Modal inside the Dialog",
+      "type": "minor"
+    }
+  ],
+  "email": "moyali@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
@@ -13,7 +13,7 @@ export interface IDialogContentProps extends React.Props<DialogContent>, IWithRe
   /**
   * Show an 'x' close button in the upper-right corner
   */
-  showCloseButton?: boolean,
+  showCloseButton?: boolean;
 
   /**
    * Other top buttons that will show up next to the close button
@@ -39,8 +39,6 @@ export interface IDialogContentProps extends React.Props<DialogContent>, IWithRe
   * The title text to display at the top of the dialog.
   */
   title?: string;
-
-  id?: string;
 }
 
 export interface IDialogProps extends React.Props<Dialog>, IWithResponsiveModeState, IAccessiblePopupProps {

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.Props.ts
@@ -1,11 +1,46 @@
 import * as React from 'react';
 import { Dialog } from './Dialog';
+import { DialogContent } from './DialogContent';
 import { IButtonProps } from '../Button/Button.Props';
 import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
 import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
 
 export interface IDialog {
 
+}
+
+export interface IDialogContentProps extends React.Props<DialogContent>, IWithResponsiveModeState, IAccessiblePopupProps {
+  /**
+  * Show an 'x' close button in the upper-right corner
+  */
+  showCloseButton?: boolean,
+
+  /**
+   * Other top buttons that will show up next to the close button
+   */
+  topButtonsProps?: IButtonProps[];
+
+  /**
+  * Optional override class name
+  */
+  className?: string;
+
+  /**
+  * A callback function for when the Dialog is dismissed from the close button or light dismiss, before the animation completes.
+  */
+  onDismiss?: (ev?: React.MouseEvent<HTMLButtonElement>) => any;
+
+  /**
+  * The subtext to display in the dialog.
+  */
+  subText?: string;
+
+  /**
+  * The title text to display at the top of the dialog.
+  */
+  title?: string;
+
+  id?: string;
 }
 
 export interface IDialogProps extends React.Props<Dialog>, IWithResponsiveModeState, IAccessiblePopupProps {

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
@@ -6,8 +6,6 @@ import {
 } from '../../Utilities';
 import { IDialogProps, DialogType } from './Dialog.Props';
 import { Modal } from '../../Modal';
-import { IconButton } from '../../Button';
-import { DialogFooter } from './DialogFooter';
 import { withResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 import * as stylesImport from './Dialog.scss';
 const styles: any = stylesImport;
@@ -58,6 +56,8 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
       subText,
       title,
       type,
+      contentClassName,
+      topButtonsProps
     } = this.props;
     let { id } = this.state;
 
@@ -88,11 +88,12 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
       >
 
         <DialogContent
-          id={ this.state.id }
           onDismiss={ onDismiss }
           showCloseButton={ !isBlocking && type !== DialogType.largeHeader }
           title={ title }
           subText={ subText }
+          className={ contentClassName }
+          topButtonsProps={ topButtonsProps }
         >
           { this.props.children }
         </DialogContent>

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.tsx
@@ -12,6 +12,8 @@ import { withResponsiveMode } from '../../utilities/decorators/withResponsiveMod
 import * as stylesImport from './Dialog.scss';
 const styles: any = stylesImport;
 
+import { DialogContent } from './DialogContent';
+
 export interface IDialogState {
   id?: string;
 }
@@ -40,7 +42,6 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
 
   public render() {
     let {
-      closeButtonAriaLabel,
       elementToFocusOnDismiss,
       firstFocusableSelector,
       forceFocusInsideTrap,
@@ -60,17 +61,11 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
     } = this.props;
     let { id } = this.state;
 
-    let subTextContent;
     const dialogClassName = css(this.props.className, {
       ['ms-Dialog--lgHeader ' + styles.isLargeHeader]: type === DialogType.largeHeader,
       ['ms-Dialog--close ' + styles.isClose]: type === DialogType.close,
     });
     const containerClassName = css(this.props.containerClassName, styles.main);
-    let groupings = this._groupChildren();
-
-    if (subText) {
-      subTextContent = <p className={ css('ms-Dialog-subText', styles.subText) } id={ id + '-subText' }>{ subText }</p>;
-    }
 
     return (
       <Modal
@@ -92,54 +87,17 @@ export class Dialog extends BaseComponent<IDialogProps, IDialogState> {
         titleAriaId={ title && id + '-title' }
       >
 
-        <div className={ css('ms-Dialog-header', styles.header) }>
-          <p className={ css('ms-Dialog-title', styles.title) } id={ id + '-title' } role='heading'>{ title }</p>
-          <div className={ css('ms-Dialog-topButton', styles.topButton) }>
-            { this.props.topButtonsProps.map((props) => (
-              <IconButton {...props} />
-            )) }
-            <IconButton
-              className={ css(
-                'ms-Dialog-button ms-Dialog-button--close',
-                styles.button,
-                { [styles.isClose]: isBlocking || type === DialogType.largeHeader }
-              ) }
-              iconProps={ { iconName: 'Cancel' } }
-              ariaLabel={ closeButtonAriaLabel }
-              onClick={ onDismiss }
-            />
-          </div>
-        </div>
-        <div className={ css('ms-Dialog-inner', styles.inner) }>
-          <div className={ css('ms-Dialog-content', styles.content, this.props.contentClassName) }>
-            { subTextContent }
-            { groupings.contents }
-          </div>
-          { groupings.footers }
-        </div>
+        <DialogContent
+          id={ this.state.id }
+          onDismiss={ onDismiss }
+          showCloseButton={ !isBlocking && type !== DialogType.largeHeader }
+          title={ title }
+          subText={ subText }
+        >
+          { this.props.children }
+        </DialogContent>
 
       </Modal>
     );
-  }
-
-  // @TODO - typing the footers as an array of DialogFooter is difficult because
-  // casing "child as DialogFooter" causes a problem because
-  // "Neither type 'ReactElement<any>' nor type 'DialogFooter' is assignable to the other."
-  private _groupChildren(): { footers: any[]; contents: any[]; } {
-
-    let groupings: { footers: any[]; contents: any[]; } = {
-      footers: [],
-      contents: []
-    };
-
-    React.Children.map(this.props.children, child => {
-      if (typeof child === 'object' && child !== null && child.type === DialogFooter) {
-        groupings.footers.push(child);
-      } else {
-        groupings.contents.push(child);
-      }
-    });
-
-    return groupings;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import {
+  BaseComponent,
+  css,
+  getId
+} from '../../Utilities';
+import { IDialogContentProps, DialogType } from './Dialog.Props';
+import { Modal } from '../../Modal';
+import { IconButton } from '../../Button';
+import { DialogFooter } from './DialogFooter';
+import { withResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
+import * as stylesImport from './Dialog.scss';
+const styles: any = stylesImport;
+
+export interface IDialogContnetState {
+  id?: string;
+}
+
+@withResponsiveMode
+export class DialogContent extends BaseComponent<IDialogContentProps, IDialogContnetState> {
+
+  public static defaultProps: IDialogContentProps = {
+    showCloseButton: false,
+    className: '',
+    topButtonsProps: []
+  };
+
+  constructor(props: IDialogContentProps) {
+    super(props);
+
+    this.state = {
+      id: props.id || getId('Dialog'),
+    };
+  }
+
+  public render() {
+    let {
+      showCloseButton,
+      closeButtonAriaLabel,
+      onDismiss,
+      subText,
+      title,
+      id
+    } = this.props;
+    let subTextContent;
+
+    let groupings = this._groupChildren();
+    if (subText) {
+      subTextContent = <p className={ css('ms-Dialog-subText', styles.subText) } id={ id + '-subText' }>{ subText }</p>;
+    }
+
+    return (
+      <div>
+        <div className={ css('ms-Dialog-header', styles.header) }>
+          <p className={ css('ms-Dialog-title', styles.title) } id={ id + '-title' } role='heading'>{ title }</p>
+          <div className={ css('ms-Dialog-topButton', styles.topButton) }>
+            { this.props.topButtonsProps.map((props) => (
+              <IconButton {...props} />
+            )) }
+            <IconButton
+              className={ css(
+                'ms-Dialog-button ms-Dialog-button--close',
+                styles.button,
+                { [styles.isClose]: !showCloseButton }
+              ) }
+              iconProps={ { iconName: 'Cancel' } }
+              ariaLabel={ closeButtonAriaLabel }
+              onClick={ onDismiss }
+            />
+          </div>
+        </div>
+        <div className={ css('ms-Dialog-inner', styles.inner) }>
+          <div className={ css('ms-Dialog-content', styles.content, this.props.className) }>
+            { subTextContent }
+            { groupings.contents }
+          </div>
+          { groupings.footers }
+        </div>
+      </div>
+    );
+  }
+
+  // @TODO - typing the footers as an array of DialogFooter is difficult because
+  // casing "child as DialogFooter" causes a problem because
+  // "Neither type 'ReactElement<any>' nor type 'DialogFooter' is assignable to the other."
+  private _groupChildren(): { footers: any[]; contents: any[]; } {
+
+    let groupings: { footers: any[]; contents: any[]; } = {
+      footers: [],
+      contents: []
+    };
+
+    React.Children.map(this.props.children, child => {
+      if (typeof child === 'object' && child !== null && child.type === DialogFooter) {
+        groupings.footers.push(child);
+      } else {
+        groupings.contents.push(child);
+      }
+    });
+
+    return groupings;
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.tsx
@@ -4,8 +4,7 @@ import {
   css,
   getId
 } from '../../Utilities';
-import { IDialogContentProps, DialogType } from './Dialog.Props';
-import { Modal } from '../../Modal';
+import { IDialogContentProps } from './Dialog.Props';
 import { IconButton } from '../../Button';
 import { DialogFooter } from './DialogFooter';
 import { withResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
@@ -29,7 +28,7 @@ export class DialogContent extends BaseComponent<IDialogContentProps, IDialogCon
     super(props);
 
     this.state = {
-      id: props.id || getId('Dialog'),
+      id: getId('Dialog'),
     };
   }
 
@@ -39,12 +38,12 @@ export class DialogContent extends BaseComponent<IDialogContentProps, IDialogCon
       closeButtonAriaLabel,
       onDismiss,
       subText,
-      title,
-      id
+      title
     } = this.props;
-    let subTextContent;
+    let { id } = this.state;
 
     let groupings = this._groupChildren();
+    let subTextContent;
     if (subText) {
       subTextContent = <p className={ css('ms-Dialog-subText', styles.subText) } id={ id + '-subText' }>{ subText }</p>;
     }

--- a/packages/office-ui-fabric-react/src/components/Dialog/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/index.ts
@@ -1,3 +1,4 @@
 export * from './Dialog';
+export * from './DialogContent';
 export * from './DialogFooter';
 export * from './Dialog.Props';


### PR DESCRIPTION
#### Pull request checklist
- [x] Include a change request file if publishing
- [x] New feature, bugfix, or enhancement
- [x] Documentation update

#### Description of changes
This PR abstracts the content of the Modal inside the Dialog component into a new component named DialogContent. This separates the rendering of the dialog itself from the modal and enables creating a dialog without the OUFR Modal component. This is needed when the modal management and the rendering of the dialog content is managed by two separate entities.
