### PR TITLE
Adjusting typings for the warn utilities to be less restrictive.

### DIFF
--- a/common/changes/warn-fix_2017-05-22-18-32.json
+++ b/common/changes/warn-fix_2017-05-22-18-32.json
@@ -1,0 +1,30 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    },
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "warn: Making ISettingsMap have optionals so that the warn utilities can be used for Prop interfaces containing required params.",
+      "type": "minor"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/src/warn.ts
+++ b/packages/utilities/src/warn.ts
@@ -1,7 +1,7 @@
 let _warningCallback: (message: string) => void = warn;
 
 export type ISettingsMap<T> = {
-  [P in keyof T]: string;
+  [P in keyof T]?: string;
 };
 
 /**


### PR DESCRIPTION
If warnMutuallyExclusive is used on a prop interface that has required props, it would give a build error. This addresses that.