### PR TITLE
Search box onblur

### DIFF
--- a/common/changes/search-box-onblur_2017-05-24-16-13.json
+++ b/common/changes/search-box-onblur_2017-05-24-16-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SearchBox: Fixed onBlur not removing focus",
+      "type": "patch"
+    }
+  ],
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -5,8 +5,6 @@ import {
   autobind,
   css,
   getId,
-  elementContains,
-  getDocument,
   KeyCodes
 } from '../../Utilities';
 

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -113,7 +113,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
       hasFocus: true
     });
 
-    this._events.on(getDocument().body, 'focus', this._handleDocumentFocus, true);
+    this._events.on(this._rootElement, 'blur', this._onBlur, true);
   }
 
   @autobind
@@ -140,6 +140,14 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
   }
 
   @autobind
+  private _onBlur(ev: React.ChangeEvent<HTMLInputElement>) {
+    this._events.off(this._rootElement, 'blur');
+    this.setState({
+      hasFocus: false
+    });
+  }
+
+  @autobind
   private _onInputChange(ev: React.ChangeEvent<HTMLInputElement>) {
     const value = this._inputElement.value;
     if (value === this._latestValue) {
@@ -149,15 +157,6 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
 
     this.setState({ value });
     this._callOnChange(value);
-  }
-
-  private _handleDocumentFocus(ev: FocusEvent) {
-    if (!elementContains(this._rootElement, ev.target as HTMLElement)) {
-      this._events.off(getDocument().body, 'focus');
-      this.setState({
-        hasFocus: false
-      });
-    }
   }
 
   private _callOnChange(newValue: string): void {


### PR DESCRIPTION
#### Pull request checklist

`events.on(getDocument().body, 'focus',...)` wasn't firing on blur, only when focus moved to another element. 

This change to using blur is more consistent with other components as well. 

- [x] Addresses an existing issue: Fixes #1848
