### PR TITLE
CommandBar: Support item tooltips

### DIFF
--- a/common/changes/commandBar-tooltips_2017-05-26-15-50.json
+++ b/common/changes/commandBar-tooltips_2017-05-26-15-50.json
@@ -1,0 +1,30 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: support tooltip on items",
+      "type": "minor"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    },
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "email": "v-panu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -18,6 +18,7 @@ import {
   IconName,
   IIconProps
 } from '../../Icon';
+import { TooltipHost } from '../../Tooltip';
 import * as stylesImport from './CommandBar.scss';
 const styles: any = stylesImport;
 
@@ -173,65 +174,77 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     );
     let hasIcon = !!item.icon || !!item.iconProps;
 
+    let itemButton: React.ReactNode;
+    if (isLink) {
+      itemButton = <button
+        { ...getNativeProps(item, buttonProperties) }
+        id={ this._id + item.key }
+        className={ className }
+        onClick={ (ev) => this._onItemClick(ev, item) }
+        data-command-key={ index }
+        aria-haspopup={ hasSubmenuItems(item) }
+        role='menuitem'
+        aria-label={ item.ariaLabel || item.name }
+      >
+        { (hasIcon) ? this._renderIcon(item) : (null) }
+        { (!!item.name) && (
+          <span
+            className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
+          >
+            { item.name }
+          </span>
+        ) }
+        { hasSubmenuItems(item) ? (
+          <i className={ css('ms-CommandBarItem-chevronDown ms-Icon ms-Icon--ChevronDown', styles.itemChevronDown) } />
+        ) : (null) }
+      </button>;
+    } else if (item.href) {
+      itemButton = <a
+        { ...getNativeProps(item, anchorProperties) }
+        id={ this._id + item.key }
+        className={ className }
+        href={ item.href }
+        data-command-key={ index }
+        aria-haspopup={ hasSubmenuItems(item) }
+        role='menuitem'
+        aria-label={ item.ariaLabel || item.name }
+      >
+        { (hasIcon) ? this._renderIcon(item) : (null) }
+        { (!!item.name) && (
+          <span
+            className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
+          >
+            { item.name }
+          </span>
+        ) }
+      </a>;
+    } else {
+      itemButton = <div
+        { ...getNativeProps(item, divProperties) }
+        id={ this._id + item.key }
+        className={ className }
+        data-command-key={ index }
+        aria-haspopup={ hasSubmenuItems(item) }
+      >
+        { (hasIcon) ? this._renderIcon(item) : (null) }
+        <span className={ css('ms-CommandBarItem-commandText ms-font-m ms-font-weight-regular', styles.itemCommandText) } aria-hidden='true' role='presentation'>{ item.name }</span>
+      </div>;
+    }
+
+    if (item.tooltip) {
+      itemButton = this._renderTooltip(itemButton, item.tooltip);
+    }
+
     return <div className={ css('ms-CommandBarItem', styles.item, item.className) } key={ itemKey } ref={ itemKey }>
-      { (() => {
-        if (isLink) {
-          return <button
-            { ...getNativeProps(item, buttonProperties) }
-            id={ this._id + item.key }
-            className={ className }
-            onClick={ (ev) => this._onItemClick(ev, item) }
-            data-command-key={ index }
-            aria-haspopup={ hasSubmenuItems(item) }
-            role='menuitem'
-            aria-label={ item.ariaLabel || item.name }
-          >
-            { (hasIcon) ? this._renderIcon(item) : (null) }
-            { (!!item.name) && (
-              <span
-                className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
-              >
-                { item.name }
-              </span>
-            ) }
-            { hasSubmenuItems(item) ? (
-              <i className={ css('ms-CommandBarItem-chevronDown ms-Icon ms-Icon--ChevronDown', styles.itemChevronDown) } />
-            ) : (null) }
-          </button>;
-        } else if (item.href) {
-          return <a
-            { ...getNativeProps(item, anchorProperties) }
-            id={ this._id + item.key }
-            className={ className }
-            href={ item.href }
-            data-command-key={ index }
-            aria-haspopup={ hasSubmenuItems(item) }
-            role='menuitem'
-            aria-label={ item.ariaLabel || item.name }
-          >
-            { (hasIcon) ? this._renderIcon(item) : (null) }
-            { (!!item.name) && (
-              <span
-                className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
-              >
-                { item.name }
-              </span>
-            ) }
-          </a>;
-        } else {
-          return <div
-            { ...getNativeProps(item, divProperties) }
-            id={ this._id + item.key }
-            className={ className }
-            data-command-key={ index }
-            aria-haspopup={ hasSubmenuItems(item) }
-          >
-            { (hasIcon) ? this._renderIcon(item) : (null) }
-            <span className={ css('ms-CommandBarItem-commandText ms-font-m ms-font-weight-regular', styles.itemCommandText) } aria-hidden='true' role='presentation'>{ item.name }</span>
-          </div>;
-        }
-      })() }
+      { itemButton }
     </div>;
+  }
+
+  private _renderTooltip(renderedItem: React.ReactNode, tooltip: string): React.ReactNode {
+    return (
+      <TooltipHost content={ tooltip }>
+        { renderedItem }
+      </TooltipHost>);
   }
 
   private _renderIcon(item: IContextualMenuItem) {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
@@ -20,12 +20,14 @@ export class CommandBarBasicExample extends React.Component<any, any> {
 
     let filteredItems = items.map(item => assign({}, item, {
       name: namesVisible ? item.name : '',
-      icon: iconsVisible ? item.icon : ''
+      icon: iconsVisible ? item.icon : '',
+      tooltip: namesVisible ? '' : item.name
     }));
 
     let filteredFarItems = farItems.map(item => assign({}, item, {
       name: namesVisible ? item.name : '',
-      icon: iconsVisible ? item.icon : ''
+      icon: iconsVisible ? item.icon : '',
+      tooltip: namesVisible ? '' : item.name
     }));
 
     return (

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -189,6 +189,12 @@ export interface IContextualMenuItem {
    */
   name?: string;
 
+  /**
+   * Description to display on a tooltip
+   * Only for CommandBar, ignored in ContextualMenu
+   */
+  tooltip?: string;
+
   itemType?: ContextualMenuItemType;
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1831
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Support tooltip in items. This provides an easy, consistent way to provide tooltip for commands, especially but not limited to, when they are rendered as an icon without text.

Use `?w=1` to review diffs, there are a lot of lines changed only for indentation.

@micahgodbolt This should integrate smoothly with your current refactor, let me know otherwise.