### PR TITLE
DetailsList: last column measured correctly when checkboxes are hidden

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-dl-column_2017-05-31-06-44.json
+++ b/common/changes/office-ui-fabric-react/fix-dl-column_2017-05-31-06-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Last column measured correctly when `checkboxVisibility` set to `hidden`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@hotmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -1,36 +1,39 @@
 import * as React from 'react';
+import * as stylesImport from './DetailsList.scss';
+
 import {
   BaseComponent,
   KeyCodes,
   assign,
   autobind,
   css,
-  getRTLSafeKeyCode
+  getRTLSafeKeyCode,
 } from '../../Utilities';
 import {
-  IDetailsListProps,
+  CheckboxVisibility,
   ColumnActionsMode,
   ConstrainMode,
   DetailsListLayoutMode,
   IColumn,
   IDetailsList,
-  CheckboxVisibility
+  IDetailsListProps,
 } from '../DetailsList/DetailsList.Props';
 import { DetailsHeader, SelectAllVisibility } from '../DetailsList/DetailsHeader';
 import { DetailsRow, IDetailsRowProps } from '../DetailsList/DetailsRow';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
-import { GroupedList } from '../../GroupedList';
-import { List } from '../../List';
-import { withViewport } from '../../utilities/decorators/withViewport';
 import {
   IObjectWithKey,
   ISelection,
   Selection,
   SelectionMode,
-  SelectionZone
+  SelectionZone,
 } from '../../utilities/selection/index';
+
 import { DragDropHelper } from '../../utilities/dragdrop/DragDropHelper';
-import * as stylesImport from './DetailsList.scss';
+import { GroupedList } from '../../GroupedList';
+import { List } from '../../List';
+import { withViewport } from '../../utilities/decorators/withViewport';
+
 const styles: any = stylesImport;
 
 export interface IDetailsListState {
@@ -548,10 +551,11 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   private _getJustifiedColumns(newColumns: IColumn[], viewportWidth: number, props: IDetailsListProps) {
     let {
       selectionMode,
+      checkboxVisibility,
       groups
     } = props;
     let outerPadding = DEFAULT_INNER_PADDING;
-    let rowCheckWidth = (selectionMode !== SelectionMode.none) ? CHECKBOX_WIDTH : 0;
+    let rowCheckWidth = (selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden) ? CHECKBOX_WIDTH : 0;
     let groupExpandWidth = groups ? GROUP_EXPAND_WIDTH : 0;
     let totalWidth = 0; // offset because we have one less inner padding.
     let availableWidth = viewportWidth - (outerPadding + rowCheckWidth + groupExpandWidth);


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #581
- [X] Include a change request file using `$ npm run change`

#### Description of changes

When `checkboxVisibility` is set to `hidden`, the final column is now measured correctly.
