### PR TITLE
Message bar styling and single line support

### DIFF
--- a/common/changes/office-ui-fabric-react/juwar-message-bar-single-line_2017-05-31-15-57.json
+++ b/common/changes/office-ui-fabric-react/juwar-message-bar-single-line_2017-05-31-15-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix css for MessageBar, and support single line message bar styling",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "juwar@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.scss
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.scss
@@ -181,7 +181,7 @@
   @include right(0);
 }
 
-.ms-MessageBar-dismissalOneline {
+.dismissalOneline {
   min-width: 16px;
   min-height: 16px;
   // We want padding between the outside of the dismiss button to be 8px

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.scss
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.scss
@@ -9,6 +9,7 @@
 
 .root {
   @include ms-bgColor-info;
+  min-height: 32px;
   color: $ms-color-infoText;
   width: 100%;
   box-sizing: border-box;
@@ -106,9 +107,7 @@
 }
 
 // Shared
-
 .content {
-  padding: 16px;
   display: flex;
   width: 100%;
   box-sizing: border-box;
@@ -132,17 +131,39 @@
   }
 }
 
-.actionables {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  min-width: 0;
+.actions {
+  padding: 12px 0px;
 }
 
-.actionables > .dismissal {
-  right: 0;
-  top: 0;
-  position: absolute !important; // Needed because we're using focus-border mixin
+.innerTextPadding {
+  span, .innerText > span {
+    @include padding-right(4px); // Add padding between text and hyperlink.
+  }
+}
+
+// Single line specific attributes
+.singleline {
+  height: 32px;
+  .content {
+    align-items: center;
+    padding: 8px 0px;
+    .icon {
+      padding: 0px 8px;
+    }
+
+    .text {
+      align-items: center;
+
+      .innerText,
+      .innerTextPadding {
+        @include padding-right(8px);
+        max-height: 1.3em;
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
 }
 
 .actions, .actionsOneline {
@@ -152,64 +173,70 @@
   align-items: center;
 }
 
-.actionsOneline {
-  position: relative;
-}
-
 .dismissal {
   @include focus-border();
   min-width: 0;
-}
-.dismissalOneline .dismissal {
-  @include ms-margin-right(-8px);
-}
-
-// Add space between adjacent MessageBars.
-.root + .root {
-  margin-top: 6px;
+  position: absolute;
+  top: 0;
+  @include right(0);
 }
 
-.innerTextPadding {
-  @include padding-right(24px); // Add padding if we have a dismiss to prevent button overlapping text.
+.ms-MessageBar-dismissalOneline {
+  min-width: 16px;
+  min-height: 16px;
+  // We want padding between the outside of the dismiss button to be 8px
+  // and the padding between the dismiss button and the text to be 12px
+  @include padding(8px, 12px, 8px, 12px);
+}
 
-  span, .innerText > span {
-    @include padding-right(4px); // Add padding between text and hyperlink.
+.actionsOneline {
+  position: relative;
+  padding: 0px 8px;
+}
+
+.actionableOneline {
+  height: 48px;
+  .content {
+    .icon {
+      padding: 0px 16px;
+    }
+    .innerText {
+      @include padding-right(0px);
+    }
   }
 }
 
-// When we can have multiple lines in the message bar.
-.multiline > .content > .actionables {
+// Multi line specific attributes
+.multiline {
+  .content {
+      padding-top: 16px;
+      flex-direction: row;
+      @include padding-left(16px);
+
+    .icon {
+      @include padding-right(8px);
+    }
+
+    .innerText {
+      line-height: 16px; // Each line should add 16px to the height
+    }
+  }
+
+  .actions {
+    @include padding-right(12px);
+  }
+
+  .dismissal {
+    margin: 0px 12px;
+  }
+}
+
+.multiline {
   flex-direction: column;
 }
 
-// When we should have only a single line of text in the message bar.
-.singleline {
-  .content {
-    .icon{
-      align-items: center;
-    }
-
-    .actionables > .text {
-      justify-content: center;
-      align-items: center;
-
-      .innerText,
-      .innerTextPadding {
-        max-height: 1.3em;
-        line-height: 1.3em;
-        overflow-x: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-    }
+.actionableMultiline.dismissalMultiline {
+  .innerTextPadding {
+    @include padding-right(48px);
   }
-
-  .content > .actionables {
-    flex-direction: row;
-  }
-}
-
-// Because of an odd behaviour in other CSS, ms-MessageBar--remove causes children's icons to use 8px, and not inherit.
-.root :global(.ms-Icon--Cancel) {
-  font-size: 14px;
 }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.scss
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.scss
@@ -148,6 +148,7 @@
     align-items: center;
     padding: 8px 0px;
     .icon {
+      font-family: 'FabricMDL2Icons';
       padding: 0px 8px;
     }
 
@@ -217,6 +218,7 @@
 
     .icon {
       @include padding-right(8px);
+      font-family: 'FabricMDL2Icons';
     }
 
     .innerText {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.scss
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.scss
@@ -153,6 +153,7 @@
 
     .text {
       align-items: center;
+      flex: 1 1 auto;
 
       .innerText,
       .innerTextPadding {
@@ -175,10 +176,11 @@
 
 .dismissal {
   @include focus-border();
+  @include right(0);
+  max-height: 16px;
   min-width: 0;
   position: absolute;
   top: 0;
-  @include right(0);
 }
 
 .dismissalOneline {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -6,6 +6,7 @@ import {
   getId
 } from '../../Utilities';
 import { IconButton } from '../../Button';
+import { Icon } from '../../Icon';
 import { IMessageBarProps, MessageBarType } from './MessageBar.Props';
 import * as stylesImport from './MessageBar.scss';
 const styles: any = stylesImport;
@@ -100,7 +101,7 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
   private _getIconSpan(): JSX.Element {
     return (
       <div className={ css('ms-MessageBar-icon', styles.icon) }>
-        <i className={ `ms-Icon ms-Icon--${this.ICON_MAP[this.props.messageBarType]}` }></i>
+        <Icon iconName={ this.ICON_MAP[this.props.messageBarType] } />
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -86,10 +86,10 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
     return null;
   }
 
-  private _getDismissalOneLine(): JSX.Element {
+  private _getDismissOneLine(): JSX.Element {
     if (this.props.onDismiss) {
       return (
-        <div className={ css('ms-MessageBar-dismissalOneline', styles.dismissalOneline) }>
+        <div className={ css('ms-MessageBar-dismissOneline', styles.dismissOneline) }>
           { this._getDismissDiv() }
         </div>
       );
@@ -139,16 +139,16 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
         css(this._getClassName(),
           'ms-MessageBar-singleline',
           styles.singleline,
-          this.props.onDismiss && styles.dismissalOneline,
+          this.props.onDismiss && 'ms-MessageBar-dismissalOneline ' + styles.dismissalOneline,
           this.props.actions && styles.actionableOneline
         )
       } >
         <div className={ css(styles.content, 'ms-MessageBar-content') }>
           { this._getIconSpan() }
           { this._renderInnerText() }
+          { this._getDismissOneLine() }
         </div>
         { this._getActionsDiv() }
-        { this._getDismissalOneLine() }
       </div >
     );
   }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -6,7 +6,6 @@ import {
   getId
 } from '../../Utilities';
 import { IconButton } from '../../Button';
-import { Icon } from '../../Icon';
 import { IMessageBarProps, MessageBarType } from './MessageBar.Props';
 import * as stylesImport from './MessageBar.scss';
 const styles: any = stylesImport;
@@ -73,7 +72,7 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
   }
 
   private _getDismissDiv(): JSX.Element {
-    if (this.props.onDismiss != null) {
+    if (this.props.onDismiss) {
       return (
         <IconButton
           disabled={ false }
@@ -87,10 +86,21 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
     return null;
   }
 
+  private _getDismissalOneLine(): JSX.Element {
+    if (this.props.onDismiss) {
+      return (
+        <div className={ css('ms-MessageBar-dismissalOneline', styles.dismissalOneline) }>
+          { this._getDismissDiv() }
+        </div>
+      );
+    }
+    return null;
+  }
+
   private _getIconSpan(): JSX.Element {
     return (
       <div className={ css('ms-MessageBar-icon', styles.icon) }>
-        <Icon iconName={ this.ICON_MAP[this.props.messageBarType] } />
+        <i className={ `ms-Icon ms-Icon--${this.ICON_MAP[this.props.messageBarType]}` }></i>
       </div>
     );
   }
@@ -103,34 +113,42 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
   private _renderMultiLine(): React.ReactElement<React.HTMLProps<HTMLAreaElement>> {
     return (
       <div
-        className={ this._getClassName() + ' ms-MessageBar-multiline ' + styles.multiline }
+        className={
+          css(this._getClassName(),
+            'ms-MessageBar-multiline',
+            styles.multiline,
+            this.props.onDismiss && styles.dismissalMultiline,
+            this.props.actions && styles.actionableMultiline
+          )
+        }
         role='status'
         aria-live={ this._getAnnouncementPriority() }>
-        <div className={ css('ms-MessageBar-content', styles.content) }>
+        <div className={ css(styles.content, 'ms-MessageBar-content') }>
           { this._getIconSpan() }
-          <div className={ css('ms-MessageBar-actionables', styles.actionables) }>
-            { this._renderInnerText() }
-            { this._getActionsDiv() }
-            { this._getDismissDiv() }
-          </div>
+          { this._renderInnerText() }
+          { this._getDismissDiv() }
         </div>
-      </div>
+        { this._getActionsDiv() }
+      </div >
     );
   }
 
   private _renderSingleLine(): React.ReactElement<React.HTMLProps<HTMLAreaElement>> {
     return (
-      <div className={ this._getClassName() + ' ms-MessageBar-singleline ' + styles.singleline }>
-        <div className={ css('ms-MessageBar-content', styles.content) }>
+      <div className={
+        css(this._getClassName(),
+          'ms-MessageBar-singleline',
+          styles.singleline,
+          this.props.onDismiss && styles.dismissalOneline,
+          this.props.actions && styles.actionableOneline
+        )
+      } >
+        <div className={ css(styles.content, 'ms-MessageBar-content') }>
           { this._getIconSpan() }
-          <div className={ css('ms-MessageBar-actionables', styles.actionables) }>
-            { this._renderInnerText() }
-          </div>
-          { this._getActionsDiv() }
-          <div className={ css('ms-MessageBar-dismissalOneline', styles.dismissalOneline) }>
-            { this._getDismissDiv() }
-          </div>
+          { this._renderInnerText() }
         </div>
+        { this._getActionsDiv() }
+        { this._getDismissalOneLine() }
       </div >
     );
   }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
@@ -19,9 +19,10 @@ export const MessageBarBasicExample = () => (
       onDismiss={ () => { console.log('test'); } }>
       Error - lorem ipsum dolor sit amet, a elit sem interdum consectetur adipiscing elit. <Link href='www.bing.com'>Visit our website</Link></MessageBar>
 
-    <Label>Blocked MessageBar - single line no buttons or dismiss</Label>
+    <Label>Blocked MessageBar - single line no buttons</Label>
     <MessageBar messageBarType={ MessageBarType.blocked }
-      isMultiline={ false }>
+      isMultiline={ false }
+      onDismiss={ () => { console.log('test'); } }>
       Blocked - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio augue pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae orci nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac placerat erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi a, fermentum suscipit magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris. <Link href='www.bing.com'>Visit our website</Link></MessageBar>
 
     <Label>SevereWarning MessageBar - multiline (default)</Label>

--- a/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
@@ -12,20 +12,16 @@ export const MessageBarBasicExample = () => (
     <Label>Info/Default MessageBar</Label>
     <MessageBar>Info - lorem ipsum dolor sit amet, a elit sem interdum consectetur adipiscing elit. <Link href='www.bing.com'>Visit our website</Link></MessageBar>
 
-    <Label>Error MessageBar - only dismiss</Label>
+    <Label>Error MessageBar - only dismiss single line</Label>
     <MessageBar
       messageBarType={ MessageBarType.error }
+      isMultiline={ false }
       onDismiss={ () => { console.log('test'); } }>
       Error - lorem ipsum dolor sit amet, a elit sem interdum consectetur adipiscing elit. <Link href='www.bing.com'>Visit our website</Link></MessageBar>
-    <p>
-      Add a close box when the user can safely dismiss the message. They’ll want to do this to reclaim space or if they feel too disrupted.
-          </p>
 
-    <Label>Blocked MessageBar - single line</Label>
+    <Label>Blocked MessageBar - single line no buttons or dismiss</Label>
     <MessageBar messageBarType={ MessageBarType.blocked }
-      onDismiss={ () => { console.log('test'); } }
-      isMultiline={ false }
-      actions={ <div><DefaultButton>Yes</DefaultButton><DefaultButton>No</DefaultButton></div> }>
+      isMultiline={ false }>
       Blocked - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio augue pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae orci nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac placerat erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi a, fermentum suscipit magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris. <Link href='www.bing.com'>Visit our website</Link></MessageBar>
 
     <Label>SevereWarning MessageBar - multiline (default)</Label>
@@ -41,7 +37,7 @@ export const MessageBarBasicExample = () => (
       <Link href='www.bing.com'>Visit our website</Link>
     </MessageBar>
 
-    <Label>Success MessageBar - single line, long text with buttons</Label>
+    <Label>Success MessageBar - single line, short text with buttons</Label>
     <MessageBar
       actions={
         <div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Primary issue was a single line without action buttons should have a height of 32. The height was not this, and looks funny. I went over the redlines posted in the OneNote from Design about the sizes of everything. I've got two class names for multiline and singleline to decide what to do, including padding/margins between icon and text, the button area, the dismiss icon, and more.

#### Focus areas to test

Image of after is below.

After photo:
![image](https://cloud.githubusercontent.com/assets/2288818/26643289/bcd49772-45e5-11e7-83a7-02f8efda1244.png)

