### PR TITLE
ResizeGroup: Make sure initial render always renders some content

### DIFF
--- a/common/changes/office-ui-fabric-react/resize-group-initial-render_2017-05-31-19-59.json
+++ b/common/changes/office-ui-fabric-react/resize-group-initial-render_2017-05-31-19-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ResizeGroup: Make sure that it renders contents when there are no more scaling steps and it doesn't fit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chrisgo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.test.tsx
@@ -6,6 +6,7 @@ import { ResizeGroup, IResizeGroupState } from './ResizeGroup';
 import * as sinon from 'sinon';
 import * as stylesImport from './ResizeGroup.scss';
 import { injectWrapperMethod, setRenderSpy } from '@uifabric/utilities/lib/test/';
+import { IResizeGroupProps } from './ResizeGroup.Props';
 const styles: any = stylesImport;
 
 interface ITestScalingData {
@@ -23,7 +24,7 @@ function getWrapperWithMocks(data: ITestScalingData = { scalingIndex: 5 },
   const onReduceDataSpy = sinon.spy(onReduceData);
   const onRenderDataSpy = sinon.spy();
 
-  let wrapper = mount<ResizeGroup, IResizeGroupState>(<ResizeGroup
+  let wrapper = mount<IResizeGroupProps, IResizeGroupState>(<ResizeGroup
     data={ data }
     onReduceData={ onReduceDataSpy }
     onRenderData={ onRenderDataSpy }
@@ -37,7 +38,7 @@ function getWrapperWithMocks(data: ITestScalingData = { scalingIndex: 5 },
   };
 }
 
-function getMeasurementMocks(wrapper: ReactWrapper<ResizeGroup, IResizeGroupState>) {
+function getMeasurementMocks(wrapper: ReactWrapper<IResizeGroupProps, IResizeGroupState>) {
   let rootGetClientRectMock = sinon.stub();
   let measuredGetClientRectMock = sinon.stub();
   rootGetClientRectMock.returns({ width: 0 });
@@ -65,7 +66,7 @@ describe('ResizeGroup', () => {
   it('does not render ResizeGroup when no data is passed', () => {
     const onReduceData = sinon.spy();
     const onRenderData = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallow<IResizeGroupProps, IResizeGroupState>(
       <ResizeGroup
         onReduceData={ onReduceData }
         onRenderData={ onRenderData }
@@ -78,7 +79,7 @@ describe('ResizeGroup', () => {
   it('does not render ResizeGroup when empty data is passed', () => {
     const onReduceData = sinon.spy();
     const onRenderData = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallow<IResizeGroupProps, IResizeGroupState>(
       <ResizeGroup
         data={ {} }
         onReduceData={ onReduceData }
@@ -87,6 +88,27 @@ describe('ResizeGroup', () => {
     );
 
     expect(onRenderData.called).to.equal(false);
+  });
+
+  it('renders the result of onRenderData', () => {
+    const initialData = { content: 5 };
+    const renderedDataId = 'onRenderDataId';
+    const onRenderData = (data) => <div id={ renderedDataId }> Rendered data: { data.content }</div >;
+
+    const wrapper = shallow<IResizeGroupProps, IResizeGroupState>(
+      <ResizeGroup
+        data={ initialData }
+        onReduceData={ onReduceScalingData }
+        onRenderData={ onRenderData }
+      />
+    );
+
+    expect(wrapper.containsMatchingElement(onRenderData(initialData))).to.be.true;
+
+    // Updating the renderedData state should also render new data
+    const nextData = { content: 5 };
+    wrapper.setState({ renderedData: nextData });
+    expect(wrapper.containsMatchingElement(onRenderData(nextData)));
   });
 
   it('remeasures if props are updated', () => {
@@ -320,7 +342,7 @@ describe('ResizeGroup', () => {
     onReduceDataStub.returns({});
     const onRenderDataMock = sinon.spy();
 
-    let wrapper = mount<ResizeGroup, IResizeGroupState>(<ResizeGroup
+    let wrapper = mount<IResizeGroupProps, IResizeGroupState>(<ResizeGroup
       data={ mockData }
       onReduceData={ onReduceDataStub }
       onRenderData={ onRenderDataMock }
@@ -365,7 +387,10 @@ describe('ResizeGroup', () => {
     measuredGetClientRectMock.returns({ width: 52 });
 
     // Reset the internal rendered state of the component
-    wrapper.setState({ renderedData: null });
+    wrapper.setState({
+      shouldMeasure: true,
+      renderedData: null
+    });
 
     expect(wrapper.state().renderedData).to.deep.equal(data);
   });

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.test.tsx
@@ -351,4 +351,22 @@ describe('ResizeGroup', () => {
     expect(onReduceDataStub.callCount).to.equal(2);
     expect(wrapper.state().shouldMeasure).to.equal(false);
   });
+
+  it('initially renders content even if it does not fit', () => {
+    let data = { scalingIndex: 5 };
+
+    // Simulate an onReduce data that has no more scaling operations
+    let onReduceData = (_) => undefined;
+
+    let { rootGetClientRectMock, measuredGetClientRectMock, wrapper } = getWrapperWithMocks(data, onReduceData);
+
+    // Make sure the content never fits
+    rootGetClientRectMock.returns({ width: 27 });
+    measuredGetClientRectMock.returns({ width: 52 });
+
+    // Reset the internal rendered state of the component
+    wrapper.setState({ renderedData: null });
+
+    expect(wrapper.state().renderedData).to.deep.equal(data);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
@@ -121,6 +121,16 @@ export class ResizeGroup extends BaseComponent<IResizeGroupProps, IResizeGroupSt
     }
   }
 
+  private _setStateToDoneMeasuring() {
+    this.setState((prevState, props) => {
+      return {
+        renderedData: prevState.measuredData,
+        measuredData: { ...this.props.data },
+        shouldMeasure: false
+      };
+    });
+  }
+
   private _measureItems() {
     const { data, onReduceData } = this.props;
     const { shouldMeasure } = this.state;
@@ -139,19 +149,11 @@ export class ResizeGroup extends BaseComponent<IResizeGroupProps, IResizeGroupSt
             measuredData: nextMeasuredData,
           });
         } else {
-          this.setState({
-            shouldMeasure: false
-          });
+          this._setStateToDoneMeasuring();
         }
 
       } else {
-        this.setState((prevState, props) => {
-          return {
-            renderedData: prevState.measuredData,
-            measuredData: { ...this.props.data },
-            shouldMeasure: false
-          };
-        });
+        this._setStateToDoneMeasuring();
       }
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
When there are no more scaling operations to be performed by a resize group, onReduceData is expected to return undefined. The expected behavior is that it will render the last valid value obtained from onReduceData, even though it doesn't fit. The current implementation doesn't explicitly set rendered data in this flow, which results in no content being rendered when the initial data does not fit. Rather than displaying no content, the component should render the last measured data.

Also added some tests to make sure that rendered data is actually rendered based on the results of onRenderData.
