### PR TITLE
Styling: Checked hovered styles for buttons

### DIFF
--- a/common/changes/office-ui-fabric-react/checked-hovered-styles_2017-06-01-00-44.json
+++ b/common/changes/office-ui-fabric-react/checked-hovered-styles_2017-06-01-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Styling: Add support for overriding the styles on the checked hovered, checked pressed, and checked disabled states",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chrisgo@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/checked-hovered-styles_2017-06-01-00-44.json
+++ b/common/changes/office-ui-fabric-react/checked-hovered-styles_2017-06-01-00-44.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Styling: Add support for overriding the styles on the checked hovered, checked pressed, and checked disabled states",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -364,6 +364,13 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
           ':hover .ms-Button-description': styles.descriptionHovered,
           ':active': styles.rootPressed,
           ':active .ms-Button-description': styles.descriptionPressed
+        },
+        disabled && checked && [
+          styles.rootCheckedDisabled
+        ],
+        !disabled && checked && {
+          ':hover': styles.rootCheckedHovered,
+          ':active': styles.rootCheckedPressed
         }
       ) as string,
 

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -198,6 +198,21 @@ export interface IButtonStyles {
   rootPressed?: IStyle;
 
   /**
+   * Style override applied to the root on hover in a checked, enabled state
+   */
+  rootCheckedHovered?: IStyle;
+
+  /**
+   * Style override applied to the root on pressed in a checked, enabled state
+   */
+  rootCheckedPressed?: IStyle;
+
+  /**
+  * Style override applied to the root on hover in a checked, disabled state
+  */
+  rootCheckedDisabled?: IStyle;
+
+  /**
    * Style for the flexbox container within the root element.
    */
   flexContainer?: IStyle;

--- a/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandButton/CommandButton.styles.ts
@@ -41,10 +41,10 @@ export const getStyles = memoizeFunction((
 
     rootChecked: {
       backgroundColor: theme.palette.neutralTertiaryAlt,
+    },
 
-      ':hover': {
-        backgroundColor: theme.palette.neutralLight
-      }
+    rootCheckedHovered: {
+      backgroundColor: theme.palette.neutralLight
     },
 
     flexContainer: {

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.styles.ts
@@ -35,11 +35,10 @@ export const getStyles = memoizeFunction((
 
     rootChecked: {
       backgroundColor: theme.palette.neutralTertiaryAlt,
+    },
 
-      ':hover': {
-        backgroundColor: theme.palette.neutralLight
-      }
-
+    rootCheckedHovered: {
+      backgroundColor: theme.palette.neutralLight
     },
 
     rootDisabled: {

--- a/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/PrimaryButton/PrimaryButton.styles.ts
@@ -39,11 +39,11 @@ export const getStyles = memoizeFunction((
     rootChecked: {
       backgroundColor: palette.themeDark,
       color: palette.white,
+    },
 
-      ':hover': {
-        backgroundColor: theme.palette.neutralLight,
-        color: theme.palette.black
-      }
+    rootCheckedHovered: {
+      backgroundColor: theme.palette.neutralLight,
+      color: theme.palette.black
     }
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
There isn't a way in `IButtonStyles` to override the styles for buttons in the checked state. This PR adds the ability to customize styles for buttons in the following states
* Checked + disabled
* Checked + hovered
* Checked + active

This PR also addresses a bug where the primary button hovered + checked styles weren't being applied.

Before:
![checkedhoverbeforefix](https://cloud.githubusercontent.com/assets/1581488/26659986/da0baddc-4629-11e7-8bc4-a2f942d6f211.gif)

After:
![checkedhoverafterfix](https://cloud.githubusercontent.com/assets/1581488/26659985/d7f253a2-4629-11e7-9995-88c4f04add70.gif)
