### PR TITLE
Fix TSLint error that is blocking publish

### DIFF
--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -57,7 +57,7 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
   public componentWillUnmount() {
     let { ignoreExternalFocusing, elementToFocusOnDismiss } = this.props;
 
-    this._previouslyFocusedElement = elementToFocusOnDismiss ? elementToFocusOnDismiss : document.activeElement as HTMLElement
+    this._previouslyFocusedElement = elementToFocusOnDismiss ? elementToFocusOnDismiss : document.activeElement as HTMLElement;
 
     this._events.dispose();
     if (this._isInFocusStack || this._isInClickStack) {


### PR DESCRIPTION
The publish task for the latest version of Fabric is hitting the following error:

```
================================

FAILURE (1)
================================
office-ui-fabric-react
[33mWarning - [36mtslint[33m - src\components\FocusTrapZone\FocusTrapZone.tsx(60,127): error semicolon: Missing semicolon[39m
D:\agent\4\_work\42\s\common\temp\node_modules\.bin\gulp returned error code: 1
================================
```

I'm unclear why this is suddenly blocking publish, since the line in question was last touched by @dzearing 10 months ago, but this change fixes it nonetheless.