### PR TITLE
Memoize: now friendlier with WeakMap missing.

### DIFF
--- a/common/changes/@uifabric/utilities/memoize-fix_2017-06-05-22-33.json
+++ b/common/changes/@uifabric/utilities/memoize-fix_2017-06-05-22-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "memoize: returns the callback in scenarios where WeakMap isn't available.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/api/utilities.api.ts
+++ b/packages/utilities/api/utilities.api.ts
@@ -383,5 +383,6 @@ export function warnMutuallyExclusive < P >(componentName: string,
 // WARNING: disableBodyScroll has incomplete type information
 // WARNING: enableBodyScroll has incomplete type information
 // WARNING: Unsupported export: ISettingsMap
+// WARNING: setMemoizeWeakMap has incomplete type information
 // WARNING: memoize has incomplete type information
 // (No packageDescription for this package)

--- a/packages/utilities/api/utilities.api.ts
+++ b/packages/utilities/api/utilities.api.ts
@@ -338,6 +338,8 @@ class Rectangle {
   readonly width: number;
 }
 
+export function setMemoizeWeakMap(weakMap: any): void;
+
 export function setWarningCallback(warningCallback: (message: string) => void): void;
 
 export function unhoistMethods(source: any, methodNames: string[]): void;
@@ -383,6 +385,5 @@ export function warnMutuallyExclusive < P >(componentName: string,
 // WARNING: disableBodyScroll has incomplete type information
 // WARNING: enableBodyScroll has incomplete type information
 // WARNING: Unsupported export: ISettingsMap
-// WARNING: setMemoizeWeakMap has incomplete type information
 // WARNING: memoize has incomplete type information
 // (No packageDescription for this package)

--- a/packages/utilities/src/common/tests.js
+++ b/packages/utilities/src/common/tests.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Polyfills
-require('es6-weak-map/implement');
-
 /**
  * This is a test entry point to help karma-webpack find all tests in the project.
  **/

--- a/packages/utilities/src/memoize.test.ts
+++ b/packages/utilities/src/memoize.test.ts
@@ -1,11 +1,17 @@
-// Polyfills
-import 'es6-weak-map/implement';
-
-import { memoize, memoizeFunction } from './memoize';
+import { memoize, memoizeFunction, setMemoizeWeakMap } from './memoize';
+import * as weakMapPolyfill from 'es6-weak-map/polyfill';
 
 let { expect } = chai;
 
 describe('memoizeFunction', () => {
+  before(()=> {
+    setMemoizeWeakMap(weakMapPolyfill);
+  });
+
+  after(() => {
+    setMemoizeWeakMap(undefined);
+  });
+
   it('can return a cached result with a no args function', () => {
     let _timesCalled = 0;
     let memoizeFunctiondTimesCalled = memoizeFunction(() => ++_timesCalled);
@@ -89,6 +95,14 @@ describe('memoizeFunction', () => {
 });
 
 describe('memoize', () => {
+  before(()=> {
+    setMemoizeWeakMap(weakMapPolyfill);
+  });
+
+  after(() => {
+    setMemoizeWeakMap(undefined);
+  });
+
   it('can work on multiple instances of a class', () => {
     let _count = 0;
 
@@ -108,4 +122,17 @@ describe('memoize', () => {
     expect(f.bar('bye')).equals('bye1');
   });
 
+});
+
+describe('memoizeFunctionWithoutPolyfill', () => {
+  it('passes through function without polyfill', () => {
+    let count = 0;
+    let func = memoizeFunction((
+      a: string
+    ) => a + count++, 1);
+
+    expect(func('a')).equals('a0');
+    expect(func('a')).equals('a1');
+    expect(func('a')).equals('a2');
+  });
 });

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -14,7 +14,7 @@ interface IMemoizeNode {
 }
 
 /** Test utility for providing a custom weakmap. */
-export function setMemoizeWeakMap(weakMap) {
+export function setMemoizeWeakMap(weakMap: any): void {
   _weakMap = weakMap;
 }
 

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -6,10 +6,16 @@ declare class WeakMap {
 
 const _emptyObject = { empty: true };
 const _dictionary = {};
+let _weakMap = (typeof WeakMap === 'undefined') ? null : WeakMap;
 
 interface IMemoizeNode {
   map: WeakMap;
   value?: any;
+}
+
+/** Test utility for providing a custom weakmap. */
+export function setMemoizeWeakMap(weakMap) {
+  _weakMap = weakMap;
 }
 
 export function memoize<T extends Function>(
@@ -32,7 +38,9 @@ export function memoize<T extends Function>(
 /**
  * Memoizes a function; when you pass in the same parameters multiple times, it returns a cached result.
  * Be careful when passing in objects, you need to pass in the same INSTANCE for caching to work. Otherwise
- * it will grow the cache unnecessarily.
+ * it will grow the cache unnecessarily. Also avoid using default values that evaluate functions; passing in
+ * undefined for a value and relying on a default function will execute it the first time, but will not
+ * re-evaluate subsequent times which may have been unexpected.
  *
  * By default, the cache will reset after 100 permutations, to avoid abuse cases where the function is
  * unintendedly called with unique objects. Without a reset, the cache could grow infinitely, so we safeguard
@@ -49,6 +57,11 @@ export function memoizeFunction<T extends (...args: any[]) => RET_TYPE, RET_TYPE
 
   let rootNode: any;
   let cacheSize = 0;
+
+  // Avoid breaking scenarios which don't have weak map.
+  if (!_weakMap) {
+    return cb;
+  }
 
   // tslint:disable-next-line:no-function-expression
   return function memoizedFunction(...args: any[]): RET_TYPE {
@@ -95,6 +108,6 @@ function _normalizeArg(val: any) {
 
 function _createNode(): IMemoizeNode {
   return {
-    map: new WeakMap()
+    map: new _weakMap()
   };
 }


### PR DESCRIPTION
This avoids a nullref when WeakMap is missing.