### PR TITLE
Toggle: theme is now injectable.

### DIFF
--- a/common/changes/office-ui-fabric-react/toggle_2017-06-06-07-11.json
+++ b/common/changes/office-ui-fabric-react/toggle_2017-06-06-07-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: theme now injectable through Customizer.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.styles.ts
@@ -1,7 +1,6 @@
 import { IButtonStyles } from '../Button.Props';
 import {
   ITheme,
-  getTheme,
   mergeStyleSets
 } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
@@ -14,7 +13,7 @@ const DEFAULT_BUTTON_MINWIDTH = '80px';
 const DEFAULT_PADDING = '0 16px';
 
 export const getStyles = memoizeFunction((
-  theme: ITheme = getTheme(),
+  theme: ITheme,
   customStyles?: IButtonStyles,
   focusInset?: string,
   focusColor?: string

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Toggle } from './Toggle';
-import { IStyle } from '../../Styling';
+import { IStyle, ITheme } from '../../Styling';
 
 export interface IToggle {
   focus: () => void;
@@ -60,6 +60,11 @@ export interface IToggleProps extends React.HTMLProps<HTMLElement | Toggle> {
    * onchange callback.
    */
   onChanged?: (checked: boolean) => void;
+
+  /**
+   * Theme provided by HOC.
+   */
+  theme?: ITheme;
 
   /**
    * Custom styles for this component

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -1,14 +1,13 @@
 import { IToggleStyles } from './Toggle.Props';
 import {
   ITheme,
-  getTheme,
   mergeStyleSets,
   getFocusStyle
 } from '../../Styling';
 import { memoizeFunction } from '../../Utilities';
 
 export const getStyles = memoizeFunction((
-  theme: ITheme = getTheme(),
+  theme: ITheme,
   customStyles?: IToggleStyles
 ): IToggleStyles => {
   const { semanticColors } = theme;

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
@@ -28,8 +28,11 @@ describe('Toggle', () => {
     let callback = (isToggled) => {
       isToggledValue = isToggled;
     };
-    let component = ReactTestUtils.renderIntoDocument<React.ReactInstance>(
+    let component;
+
+    ReactTestUtils.renderIntoDocument<React.ReactInstance>(
       <Toggle
+        componentRef={ ref => component = ref }
         label='Label'
         onChanged={ callback }
       />
@@ -43,8 +46,11 @@ describe('Toggle', () => {
   });
 
   it(`doesn't update the state if the user provides checked`, () => {
-    let component = ReactTestUtils.renderIntoDocument(
+    let component;
+
+    ReactTestUtils.renderIntoDocument(
       <Toggle
+        componentRef={ ref => component = ref }
         label='Label'
         checked={ false }
       />
@@ -66,6 +72,7 @@ describe('Toggle', () => {
     let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
     let label = renderedDOM.querySelector('label');
 
+    // tslint:disable-next-line:no-unused-expression
     expect(label).is.null;
   });
 

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -14,6 +14,9 @@ import {
 } from './Toggle.Props';
 import { Label } from '../../Label';
 import {
+  customizable
+} from '../../Utilities';
+import {
   mergeStyles
 } from '../../Styling';
 
@@ -32,6 +35,7 @@ interface IToggleClassNames {
   text: string;
 }
 
+@customizable(['theme'])
 export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements IToggle {
 
   private _id: string;
@@ -74,6 +78,7 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
 
     let {
       className,
+      theme,
       styles: customStyles,
       disabled,
       label,
@@ -87,7 +92,7 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
     const ariaLabel = isChecked ? onAriaLabel : offAriaLabel;
     const toggleNativeProps = getNativeProps(this.props, inputProperties, ['defaultChecked']);
     const classNames = this._getClassNames(
-      getStyles(undefined, customStyles),
+      getStyles(theme, customStyles),
       className,
       disabled,
       isChecked


### PR DESCRIPTION
#### Description of changes

When rendering Toggle components, they now respect injectable themes.

This can mean the default theme using the `loadTheme` helper:

```tsx
import { loadTheme } from 'office-ui-fabric-react/lib/Styling';

loadTheme({{ palette: { themePrimary: 'green' }});
```

Or injected using the Customizer:

```tsx
let greenTheme = createTheme({ palette: { themePrimary: 'green' }});

return (
  <Customizer settings={{ theme: greenTheme }}>
    <Toggle/>
  </Customizer>
);
```
