### PR TITLE
Example app base fix

### DIFF
--- a/common/changes/@uifabric/example-app-base/example-app-base-fix_2017-06-07-23-54.json
+++ b/common/changes/@uifabric/example-app-base/example-app-base-fix_2017-06-07-23-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Bumping fabric dependency in example-app-base",
+      "type": "major"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -44,7 +44,7 @@
     "@uifabric/utilities": ">=4.1.1 <5.0.0",
     "highlight.js": "^9.9.0",
     "office-ui-fabric-core": ">=7.0.0 <8.0.0",
-    "office-ui-fabric-react": ">=2.0.0 <3.0.0",
+    "office-ui-fabric-react": ">=4.4.0 <5.0.0",
     "tslib": "^1.6.0"
   }
 }


### PR DESCRIPTION
The version of oufr dependent in the example-app-base package is old and wasn't updated during publish, which is odd. Fixing the dependency.