### PR TITLE
Fixes TextField flexbox layout (for IE).

### DIFF
--- a/common/changes/office-ui-fabric-react/joem-fix-textfield-flex-values_2017-06-08-00-07.json
+++ b/common/changes/office-ui-fabric-react/joem-fix-textfield-flex-values_2017-06-08-00-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fixes TextField layout (for IE).",
+      "comment": "TextField: improves layout for IE.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/joem-fix-textfield-flex-values_2017-06-08-00-07.json
+++ b/common/changes/office-ui-fabric-react/joem-fix-textfield-flex-values_2017-06-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes TextField layout (for IE).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joem@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -194,7 +194,7 @@ $field-error-color: $errorTextColor;
   }
 
   .fieldGroup {
-    flex: 1 1 0;
+    flex: 1 1 0px;
     border: 0;
     @include ms-text-align(left);
   }


### PR DESCRIPTION
#### Description of changes

* Adds required length unit to `flex-basis` value.
  * [`flex-basis` technically requires a length unit (i.e. "px")](https://msdn.microsoft.com/en-us/library/dn254946(v=vs.85).aspx). Chrome, FF, Edge seem to comprehend the value without the length unit, but IE does not. Explicitly adding a unit so it behaves as expected in IE.
* Observe how TextBox behaves in IE. In other browsers, inner field group properly grows to width of the component.
![image](https://user-images.githubusercontent.com/1019478/26906880-461c47b4-4ba4-11e7-9179-d24688c12cbb.png)
 

