### PR TITLE
With responsive mode error

### DIFF
--- a/common/changes/office-ui-fabric-react/withResponsiveModeError_2017-06-08-12-44.json
+++ b/common/changes/office-ui-fabric-react/withResponsiveModeError_2017-06-08-12-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "withResponsiveMode: Adding error handling around the case where window.innerWidth throws an exception.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "admitt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
@@ -80,7 +80,8 @@ export function withResponsiveMode<P extends { responsiveMode?: ResponsiveMode }
             responsiveMode++;
           }
         } catch (e) {
-          responsiveMode = undefined;
+          // Return a best effort result in cases where we're in the browser but it throws on getting innerWidth.
+          responsiveMode = ResponsiveMode.large;
         }
       } else {
         if (_defaultMode !== undefined) {

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
@@ -75,8 +75,12 @@ export function withResponsiveMode<P extends { responsiveMode?: ResponsiveMode }
       let win = getWindow();
 
       if (typeof win !== 'undefined') {
-        while (win.innerWidth > RESPONSIVE_MAX_CONSTRAINT[responsiveMode]) {
-          responsiveMode++;
+        try {
+          while (win.innerWidth > RESPONSIVE_MAX_CONSTRAINT[responsiveMode]) {
+            responsiveMode++;
+          }
+        } catch (e) {
+          responsiveMode = undefined;
         }
       } else {
         if (_defaultMode !== undefined) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Window.innerwidth is not defined in some cases in getResponsiveMode when the component is getting mounted. Adding error handling for such cases. Setting responsiveMode to undefined.

#### Focus areas to test

(optional)
