### PR TITLE
FocusZone should reset active element if it is not tabbable. This

### DIFF
--- a/common/changes/office-ui-fabric-react/users-AbhinavSinghT-AccessibilityBugFix_2017-06-08-16-01.json
+++ b/common/changes/office-ui-fabric-react/users-AbhinavSinghT-AccessibilityBugFix_2017-06-08-16-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone should reset active element if it is not tabbable.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "abhinavsingh.bits@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -589,4 +589,54 @@ describe('FocusZone', () => {
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
     assert(lastFocusedElement === divB, 'pressing left did not skip back to divB');
   });
+
+  it('Focus first tabbable element, when active elemet is dynamically disabled', () => {
+    let focusZone: FocusZone = null;
+    let buttonA, buttonB = null;
+    const component = ReactTestUtils.renderIntoDocument(
+      <div { ...{ onFocusCapture: _onFocus } }>
+        <textarea className='t'></textarea>
+        <FocusZone ref={(focusZ) => { focusZone = focusZ; }}>
+          <button className='a' ref={(button) => { buttonA = button; }}>a</button>
+          <button className='b' ref={(button) => { buttonB = button; }}>b</button>
+        </FocusZone>
+      </div>
+    );
+
+    const rootNode = ReactDOM.findDOMNode(component as React.ReactInstance) as Element;
+    const textArea = rootNode.children[0];
+    const focusZoneElement = rootNode.children[1];
+
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 0,
+        right: 20
+      }
+    });
+
+    setupElement(buttonB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 20,
+        right: 40
+      }
+    });
+
+    // ButtonA should be focussed.
+    focusZone.focus();
+    assert(lastFocusedElement === buttonA, 'buttonA was not focused');
+
+    buttonA.disabled = true;
+
+    // Focus the text area, outside focus zone.
+    ReactTestUtils.Simulate.focus(textArea);
+    assert(lastFocusedElement === textArea, 'textArea was not focused');
+
+    // ButtonB should be focussed.
+    focusZone.focus();
+    assert(lastFocusedElement === buttonB, 'buttonB was not focused ');
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -596,7 +596,7 @@ describe('FocusZone', () => {
     const component = ReactTestUtils.renderIntoDocument(
       <div { ...{ onFocusCapture: _onFocus } }>
         <textarea className='t'></textarea>
-        <FocusZone ref={(focusZ) => { focusZone = focusZ; }}>
+        <FocusZone ref={(focus) => { focusZone = focus; }}>
           <button className='a' ref={(button) => { buttonA = button; }}>a</button>
           <button className='b' ref={(button) => { buttonB = button; }}>b</button>
         </FocusZone>

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -135,9 +135,10 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
     if (!forceIntoFirstElement && this.refs.root.getAttribute(IS_FOCUSABLE_ATTRIBUTE) === 'true' && this._isInnerZone) {
       // The parent focus zone should take responsibility for focusing this element.
       return true;
-    } else if (this._activeElement && elementContains(this.refs.root, this._activeElement)) {
-      this._activeElement.focus();
-      return true;
+     } else if (this._activeElement && elementContains(this.refs.root, this._activeElement)
+        && isElementTabbable(this._activeElement)) {
+        this._activeElement.focus();
+        return true;
     } else {
       const firstChild = this.refs.root.firstChild as HTMLElement;
 
@@ -635,11 +636,18 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   }
 
   private _updateTabIndexes(element?: HTMLElement) {
+
     if (!element) {
       element = this.refs.root;
       if (this._activeElement && !elementContains(element, this._activeElement)) {
         this._activeElement = null;
       }
+    }
+
+    // If active element changes state to disabled, set it to null. 
+    // Otherwise, we lose keyboard accessibility to other elements in focus zone.
+    if (this._activeElement && !isElementTabbable(this._activeElement)) {
+      this._activeElement = null;
     }
 
     const childNodes = element.children;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -636,7 +636,6 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   }
 
   private _updateTabIndexes(element?: HTMLElement) {
-
     if (!element) {
       element = this.refs.root;
       if (this._activeElement && !elementContains(element, this._activeElement)) {


### PR DESCRIPTION
allows keyboard accessibility to rest of elements in case of active
element changing state to disabled.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1674
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added check to reset activeElement if activeElement is not tabbable.

#### Focus areas to test

FocusZone, CommandBar
