### PR TITLE
Focus Utility should respect tabindex="-1" on tabable elements

### DIFF
--- a/common/changes/@uifabric/utilities/master_2017-06-09-15-37.json
+++ b/common/changes/@uifabric/utilities/master_2017-06-09-15-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Focus Utility should respect tabindex=-1 on tabable elements",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "cjsheets@gmail.com"
+}

--- a/packages/utilities/src/focus.test.tsx
+++ b/packages/utilities/src/focus.test.tsx
@@ -123,4 +123,13 @@ describe('isElementTabbable', () => {
     expect(isElementTabbable(button)).is.false;
   });
 
+  it('returns false when tabindex=-1', () => {
+    let button = document.createElement('button');
+
+    button.setAttribute('tabindex', '-1');
+
+    expect(isElementTabbable(button)).is.false;
+
+  });
+
 });

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -196,7 +196,7 @@ export function isElementTabbable(element: HTMLElement): boolean {
 
   return (
     !!element && isFocusableAttribute !== 'false' &&
-    (!tabIndex || tabIndex >= 0) &&
+    tabIndex >= 0 || !tabIndex &&
     (element.tagName === 'A' ||
       (element.tagName === 'BUTTON') ||
       (element.tagName === 'INPUT') ||

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -196,11 +196,11 @@ export function isElementTabbable(element: HTMLElement): boolean {
 
   return (
     !!element && isFocusableAttribute !== 'false' &&
+    (tabIndex >= 0) &&
     (element.tagName === 'A' ||
       (element.tagName === 'BUTTON') ||
       (element.tagName === 'INPUT') ||
       (element.tagName === 'TEXTAREA') ||
-      (tabIndex >= 0) ||
       (element.getAttribute && (
         isFocusableAttribute === 'true' ||
         element.getAttribute('role') === 'button'

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -196,7 +196,7 @@ export function isElementTabbable(element: HTMLElement): boolean {
 
   return (
     !!element && isFocusableAttribute !== 'false' &&
-    (tabIndex >= 0) &&
+    (!tabIndex || tabIndex >= 0) &&
     (element.tagName === 'A' ||
       (element.tagName === 'BUTTON') ||
       (element.tagName === 'INPUT') ||


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

The focus.ts utility currently ignores tabindex="-1" on typical tab targets. This caused an issue when nesting FocusZones (though I can imagine numerous other scenarios where this could be an issue).

```
<FocusTrapZone>
    <Button  id="1" />
    <FocusZone>
        <Button id="2" />
        <Button id="3" tabindex="-1" />
    </FocusZone>
</FocusTrapZone>
```

The FocusTrapZone identifies Button 3 as the last focus-able target however the FocusZone causes Button 3 to be passed-over. As a result, focus escapes to the document body.

The solution is to not regard anything with tabindex="-1" as focus-able.