### PR TITLE
Switch from using React.HTMLProps to React.HTMLAttributes

### DIFF
--- a/apps/fabric-website/src/components/CodeBlock/CodeBlock.tsx
+++ b/apps/fabric-website/src/components/CodeBlock/CodeBlock.tsx
@@ -5,7 +5,7 @@ const styles: any = stylesImport;
 
 const Highlight = require('react-highlight');
 
-export interface ICodeBlockProps extends React.HTMLProps<HTMLElement> {
+export interface ICodeBlockProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * The language of the code block. See https://highlightjs.org/static/demo/ for a list of supported languages.
    * @default html

--- a/apps/todo-app/src/components/Todo.tsx
+++ b/apps/todo-app/src/components/Todo.tsx
@@ -54,7 +54,7 @@ export default class Todo extends React.Component<ITodoProps, ITodoState> {
     );
   }
 
-  private _renderWorkingOnItSpinner(): React.ReactElement<React.HTMLProps<HTMLDivElement>> {
+  private _renderWorkingOnItSpinner(): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> {
     return this.props.dataProvider.isLoading && this.state.items.length > 0
       ? <div className={ styles.workingOnItSpinner }>
         <Spinner type={ SpinnerType.normal } />
@@ -62,7 +62,7 @@ export default class Todo extends React.Component<ITodoProps, ITodoState> {
       : undefined;
   }
 
-  private _renderFetchingTasksSpinner(): React.ReactElement<React.HTMLProps<HTMLDivElement>> {
+  private _renderFetchingTasksSpinner(): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> {
     return this.props.dataProvider.isLoading && this.state.items.length === 0
       ? <div className={ styles.fetchingTasksSpinner }>
         <Spinner type={ SpinnerType.large } label={ strings.fetchingTasksLabel } />

--- a/apps/todo-app/src/components/TodoItem.tsx
+++ b/apps/todo-app/src/components/TodoItem.tsx
@@ -35,7 +35,7 @@ export default class TodoItem extends React.Component<ITodoItemProps, {}> {
     window.clearTimeout(this._animationTimeoutId);
   }
 
-  public render(): React.ReactElement<React.HTMLProps<HTMLDivElement>> {
+  public render(): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> {
     const className: string = css(
       styles.todoItem,
       this.props.item.isComplete === true ? styles.isCompleted : '',

--- a/common/changes/@uifabric/example-app-base/types-switch-from-props-to-attributes_2017-06-09-20-27.json
+++ b/common/changes/@uifabric/example-app-base/types-switch-from-props-to-attributes_2017-06-09-20-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "miclo@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/types-switch-from-props-to-attributes_2017-06-09-20-27.json
+++ b/common/changes/@uifabric/fabric-website/types-switch-from-props-to-attributes_2017-06-09-20-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "miclo@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/types-switch-from-props-to-attributes_2017-06-09-20-27.json
+++ b/common/changes/@uifabric/styling/types-switch-from-props-to-attributes_2017-06-09-20-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "miclo@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/types-switch-from-props-to-attributes_2017-06-09-20-27.json
+++ b/common/changes/@uifabric/utilities/types-switch-from-props-to-attributes_2017-06-09-20-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "miclo@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/types-switch-from-props-to-attributes_2017-06-09-20-27.json
+++ b/common/changes/office-ui-fabric-react/types-switch-from-props-to-attributes_2017-06-09-20-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Component properties now extend React.HTMLAttributes, rather than React.HTMLProps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/example-app-base/src/components/Highlight/Highlight.tsx
+++ b/packages/example-app-base/src/components/Highlight/Highlight.tsx
@@ -5,7 +5,7 @@ import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 
 hljs.registerLanguage('javascript', javascript);
 
-export class Highlight extends BaseComponent<React.HTMLProps<HTMLDivElement>, {}> {
+export class Highlight extends BaseComponent<React.HTMLAttributes<HTMLDivElement>, {}> {
   private _codeElement: HTMLElement;
 
   public render() {

--- a/packages/example-component/src/ExampleComponent.Props.ts
+++ b/packages/example-component/src/ExampleComponent.Props.ts
@@ -1,7 +1,7 @@
 import { ExampleComponent } from './ExampleComponent';
 import { IRenderFunction } from '@uifabric/utilities';
 
-export interface IExampleComponentProps extends React.HTMLProps<HTMLDivElement | ExampleComponent> {
+export interface IExampleComponentProps extends React.HTMLAttributes<HTMLDivElement | ExampleComponent> {
   /**
    * Optional icon name using fabric icons.
    *

--- a/packages/example-component/src/ExampleComponent.tsx
+++ b/packages/example-component/src/ExampleComponent.tsx
@@ -42,7 +42,7 @@ export class ExampleComponent extends BaseComponent<IExampleComponentProps, {}> 
     const { className, href }: IExampleComponentProps = this.props;
 
     if (!!href) {
-      const anchorProps: React.HTMLProps<HTMLAnchorElement> =
+      const anchorProps: React.HTMLAttributes<HTMLAnchorElement> =
         getNativeProps(this.props, anchorProperties);
 
       return (
@@ -53,7 +53,7 @@ export class ExampleComponent extends BaseComponent<IExampleComponentProps, {}> 
         />
       );
     } else {
-      const buttonProps: React.HTMLProps<HTMLButtonElement> =
+      const buttonProps: React.HTMLAttributes<HTMLButtonElement> =
         getNativeProps(this.props, buttonProperties);
 
       return (

--- a/packages/office-ui-fabric-react/src/common/connect.test.tsx
+++ b/packages/office-ui-fabric-react/src/common/connect.test.tsx
@@ -13,7 +13,7 @@ import { ISubscribable } from './ISubscribable';
 
 let { expect } = chai;
 
-interface ITestComponentProps extends React.HTMLProps<HTMLDivElement> { }
+interface ITestComponentProps extends React.HTMLAttributes<HTMLDivElement> { }
 
 // Dumb component.
 const TestComponent = (props: ITestComponentProps) => (

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -138,7 +138,7 @@ export interface IButtonProps extends React.HTMLAttributes<HTMLButtonElement | H
    * they will be mixed into the button/anchor element rendered by the component.
    * @deprecated
    */
-  rootProps?: React.HTMLProps<HTMLButtonElement> | React.HTMLProps<HTMLAnchorElement>;
+  rootProps?: React.HTMLAttributes<HTMLButtonElement> | React.HTMLAttributes<HTMLAnchorElement>;
 
   /**
    * Deprecated on 4/15/2017, use iconProps={ { iconName: 'Emoji2' } }.

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.Props.ts
@@ -14,7 +14,7 @@ export interface ICheckbox {
 /**
  * Checkbox properties.
  */
-export interface ICheckboxProps extends React.HTMLProps<HTMLElement | HTMLInputElement> {
+export interface ICheckboxProps extends React.HTMLAttributes<HTMLElement | HTMLInputElement> {
   /**
    * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
@@ -59,5 +59,5 @@ export interface ICheckboxProps extends React.HTMLProps<HTMLElement | HTMLInputE
    * Note that if you provide, for example, "disabled" as well as "inputProps.disabled", the former will take
    * precedence over the later.
    */
-  inputProps?: React.HTMLProps<HTMLElement | HTMLInputElement>;
+  inputProps?: React.HTMLAttributes<HTMLElement | HTMLInputElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -6,7 +6,7 @@ export interface IChoiceGroup {
 
 }
 
-export interface IChoiceGroupProps extends React.HTMLProps<HTMLElement | HTMLInputElement> {
+export interface IChoiceGroupProps extends React.HTMLAttributes<HTMLElement | HTMLInputElement> {
   /**
    * Optional callback to access the IChoiceGroup interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts
@@ -8,7 +8,7 @@ export interface ICommandBar {
   focus(): void;
 }
 
-export interface ICommandBarProps extends React.HTMLProps<HTMLDivElement> {
+export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the ICommandBar interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -5,7 +5,7 @@ import { css } from '../../Utilities';
 import { Check } from '../../Check';
 import * as styles from './DetailsRowCheck.scss';
 
-export interface IDetailsRowCheckProps extends React.HTMLProps<HTMLElement> {
+export interface IDetailsRowCheckProps extends React.HTMLAttributes<HTMLElement> {
   selected?: boolean;
   /**
    * Deprecated at v.65.1 and will be removed by v 1.0. Use 'selected' instead.

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -40,7 +40,7 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
     );
   }
 
-  private _renderPreviewImage(previewImage: IDocumentCardPreviewImage): React.ReactElement<React.HTMLProps<HTMLDivElement>> {
+  private _renderPreviewImage(previewImage: IDocumentCardPreviewImage): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> {
     let { width, height, imageFit } = previewImage;
 
     let image = (
@@ -66,7 +66,7 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
   }
 
   @autobind
-  private _renderPreviewList(previewImages: IDocumentCardPreviewImage[]): React.ReactElement<React.HTMLProps<HTMLDivElement>> {
+  private _renderPreviewList(previewImages: IDocumentCardPreviewImage[]): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> {
     let { getOverflowDocumentCountText } = this.props;
 
     // Determine how many documents we won't be showing

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.tsx
@@ -33,7 +33,7 @@ if (typeof (document) === 'object' && document.documentElement && !document.docu
   document.documentElement.setAttribute('dir', 'ltr');
 }
 
-export class Fabric extends BaseComponent<React.HTMLProps<HTMLDivElement>, IFabricState> {
+export class Fabric extends BaseComponent<React.HTMLAttributes<HTMLDivElement>, IFabricState> {
   public refs: {
     [key: string]: React.ReactInstance;
     root: HTMLElement;

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.Props.ts
@@ -53,14 +53,14 @@ export interface IFacepileProps extends React.Props<Facepile> {
 
   /** Method to access properties on the underlying Persona control */
   getPersonaProps?: (persona: IFacepilePersona) => IPersonaProps;
-  
+
   /**
    * Optional class for Facepile root element.
    */
   className?: string;
 }
 
-export interface IFacepilePersona extends React.HTMLProps<HTMLButtonElement | HTMLDivElement> {
+export interface IFacepilePersona extends React.HTMLAttributes<HTMLButtonElement | HTMLDivElement> {
   /**
    * Name of the person.
    */

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.Props.ts
@@ -7,7 +7,7 @@ export interface IFocusTrapZone {
   focus: () => void;
 }
 
-export interface IFocusTrapZoneProps extends React.HTMLProps<HTMLDivElement> {
+export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the IFocusTrapZone interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Click.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Click.Example.tsx
@@ -14,7 +14,7 @@ export interface IBoxNoClickExampleExampleState {
   isToggled: boolean;
 }
 
-export default class BoxNoClickExample extends React.Component<React.HTMLProps<HTMLDivElement>, IBoxNoClickExampleExampleState> {
+export default class BoxNoClickExample extends React.Component<React.HTMLAttributes<HTMLDivElement>, IBoxNoClickExampleExampleState> {
   private _toggle: IToggle;
 
   constructor(props) {

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Example.tsx
@@ -14,7 +14,7 @@ export interface IBoxExampleExampleState {
   isChecked: boolean;
 }
 
-export default class BoxExample extends React.Component<React.HTMLProps<HTMLDivElement>, IBoxExampleExampleState> {
+export default class BoxExample extends React.Component<React.HTMLAttributes<HTMLDivElement>, IBoxExampleExampleState> {
   private _toggle: IToggle;
 
   constructor(props) {

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx
@@ -13,7 +13,7 @@ export interface IBoxExampleExampleState {
   isChecked: boolean;
 }
 
-export default class BoxExample extends React.Component<React.HTMLProps<HTMLDivElement>, IBoxExampleExampleState> {
+export default class BoxExample extends React.Component<React.HTMLAttributes<HTMLDivElement>, IBoxExampleExampleState> {
   private _toggle: IToggle;
 
   constructor(props) {

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx
@@ -75,7 +75,7 @@ export interface IFocusTrapZoneNestedExampleState {
 
 const NAMES: string[] = ['One', 'Two', 'Three', 'Four', 'Five'];
 
-export default class FocusTrapZoneNestedExample extends React.Component<React.HTMLProps<HTMLDivElement>, IFocusTrapZoneNestedExampleState> {
+export default class FocusTrapZoneNestedExample extends React.Component<React.HTMLAttributes<HTMLDivElement>, IFocusTrapZoneNestedExampleState> {
 
   constructor() {
     super();

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
@@ -24,7 +24,7 @@ export interface IFocusZone {
 /**
  * FocusZone component props.
  */
-export interface IFocusZoneProps extends React.HTMLProps<HTMLElement | FocusZone> {
+export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | FocusZone> {
   /**
    * Optional callback to access the IFocusZone interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
@@ -86,7 +86,7 @@ export interface IFocusZoneProps extends React.HTMLProps<HTMLElement | FocusZone
    * Deprecated at v1.12.1. DIV props provided to the FocusZone will be mixed into the root element.
    * @deprecated
    */
-  rootProps?: React.HTMLProps<HTMLDivElement>;
+  rootProps?: React.HTMLAttributes<HTMLDivElement>;
 
   /**
    * Callback method for determining if focus should indeed be set on the given element.

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.Props.ts
@@ -34,7 +34,7 @@ export interface IIconStyles {
   imageContainer?: IStyle;
 }
 
-export interface IIconProps extends React.HTMLProps<HTMLElement> {
+export interface IIconProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * The name of the icon to use from the icon font.
    *

--- a/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.Props.ts
@@ -4,7 +4,7 @@ export interface IImage {
 
 }
 
-export interface IImageProps extends React.HTMLProps<HTMLImageElement> {
+export interface IImageProps extends React.HTMLAttributes<HTMLImageElement> {
   /**
    * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Label/Label.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.Props.ts
@@ -6,7 +6,7 @@ export interface ILabel {
 
 }
 
-export interface ILabelProps extends React.HTMLProps<HTMLLabelElement> {
+export interface ILabelProps extends React.HTMLAttributes<HTMLLabelElement> {
   /**
    * Optional callback to access the ILabel interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.Props.ts
@@ -5,7 +5,7 @@ export interface ILayer {
 
 }
 
-export interface ILayerProps extends React.HTMLProps<HTMLDivElement | Layer> {
+export interface ILayerProps extends React.HTMLAttributes<HTMLDivElement | Layer> {
   /**
    * Optional callback to access the ILayer interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.Props.ts
@@ -4,7 +4,7 @@ export interface ILayerHost {
 
 }
 
-export interface ILayerHostProps extends React.HTMLProps<HTMLElement> {
+export interface ILayerHostProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Optional callback to access the ILayerHost interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.tsx
@@ -7,7 +7,7 @@ import {
   Layer
 } from './Layer';
 
-export class LayerHost extends BaseComponent<React.HTMLProps<HTMLElement>, {}> {
+export class LayerHost extends BaseComponent<React.HTMLAttributes<HTMLElement>, {}> {
 
   public shouldComponentUpdate() {
     return false;

--- a/packages/office-ui-fabric-react/src/components/Link/Link.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.Props.ts
@@ -8,7 +8,7 @@ export interface ILink {
   focus(): void;
 }
 
-export interface ILinkProps extends React.HTMLProps<HTMLAnchorElement | HTMLButtonElement | HTMLElement | Link> {
+export interface ILinkProps extends React.HTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement | Link> {
   /**
    * Optional callback to access the ILink interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/List/List.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.Props.ts
@@ -16,7 +16,7 @@ export interface IList {
   scrollToIndex(index: number, measureItem?: (itemIndex: number) => number): void;
 }
 
-export interface IListProps extends React.HTMLProps<List | HTMLDivElement> {
+export interface IListProps extends React.HTMLAttributes<List | HTMLDivElement> {
   /**
    * Optional callback to access the IList interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.Props.ts
@@ -21,7 +21,7 @@ export interface IMarqueeSelectionProps extends React.Props<MarqueeSelection> {
   /**
    * Optional props to mix into the root DIV element.
    */
-  rootProps?: React.HTMLProps<HTMLDivElement>;
+  rootProps?: React.HTMLAttributes<HTMLDivElement>;
 
   /**
    * Optional callback that is called, when the mouse down event occurs, in order to determine

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.Props.ts
@@ -4,7 +4,7 @@ export interface IMessageBar {
 
 }
 
-export interface IMessageBarProps extends React.HTMLProps<HTMLElement> {
+export interface IMessageBarProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Optional callback to access the IMessageBar interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -111,7 +111,7 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
       'ms-MessageBar-innerTextPadding ' + styles.innerTextPadding : 'ms-MessageBar-innerText ' + styles.innerText;
   }
 
-  private _renderMultiLine(): React.ReactElement<React.HTMLProps<HTMLAreaElement>> {
+  private _renderMultiLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
     return (
       <div
         className={
@@ -134,7 +134,7 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
     );
   }
 
-  private _renderSingleLine(): React.ReactElement<React.HTMLProps<HTMLAreaElement>> {
+  private _renderSingleLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
     return (
       <div className={
         css(this._getClassName(),

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.Props.ts
@@ -4,7 +4,7 @@ export interface IOverlay {
 
 }
 
-export interface IOverlayProps extends React.HTMLProps<HTMLElement> {
+export interface IOverlayProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Optional callback to access the IOverlay interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
@@ -6,7 +6,7 @@ export interface IPersona {
 
 }
 
-export interface IPersonaProps extends React.HTMLProps<Persona> {
+export interface IPersonaProps extends React.HTMLAttributes<Persona> {
   /**
    * Optional callback to access the IPersona interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.Props.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IRenderFunction } from '../../Utilities';
 
-export interface IPivotItemProps extends React.HTMLProps<HTMLDivElement> {
+export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * The text displayed of each pivot link.
    */

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.Props.ts
@@ -7,7 +7,7 @@ export interface IPopup {
 
 }
 
-export interface IPopupProps extends React.HTMLProps<Popup> {
+export interface IPopupProps extends React.HTMLAttributes<Popup> {
   /**
    * Optional callback to access the IPopup interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.Props.ts
@@ -7,7 +7,7 @@ export interface IRating {
 /**
  * Rating component props.
  */
-export interface IRatingProps extends React.HTMLProps<HTMLElement> {
+export interface IRatingProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Optional callback to access the IRating interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.Props.ts
@@ -5,7 +5,7 @@ export interface IResizeGroup {
 
 }
 
-export interface IResizeGroupProps extends React.HTMLProps<ResizeGroup | HTMLElement> {
+export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroup | HTMLElement> {
 
   /**
    * Optional callback to access the IResizeGroup interface. Use this instead of ref for accessing

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
@@ -77,5 +77,5 @@ export interface ISliderProps {
   /**
    * Optional mixin for additional props on the thumb button within the slider.
    */
-  buttonProps?: React.HTMLProps<HTMLButtonElement>;
+  buttonProps?: React.HTMLAttributes<HTMLButtonElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.Props.ts
@@ -29,7 +29,7 @@ export interface ITextField {
 /**
  * TextField component props.
  */
-export interface ITextFieldProps extends React.HTMLProps<HTMLInputElement | HTMLTextAreaElement> {
+export interface ITextFieldProps extends React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
   /**
    * Optional callback to access the ITextField interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -285,7 +285,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     return errorMessage;
   }
 
-  private _renderTextArea(): React.ReactElement<React.HTMLProps<HTMLAreaElement>> {
+  private _renderTextArea(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
     let textAreaProps = getNativeProps(this.props, textAreaProperties, ['defaultValue']);
 
     return (
@@ -306,8 +306,8 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     );
   }
 
-  private _renderInput(): React.ReactElement<React.HTMLProps<HTMLInputElement>> {
-    let inputProps = getNativeProps<React.HTMLProps<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
+  private _renderInput(): React.ReactElement<React.HTMLAttributes<HTMLInputElement>> {
+    let inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
 
     return (
       <input

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.Props.ts
@@ -9,7 +9,7 @@ export interface IToggle {
 /**
  * Toggle component props.
  */
-export interface IToggleProps extends React.HTMLProps<HTMLElement | Toggle> {
+export interface IToggleProps extends React.HTMLAttributes<HTMLElement | Toggle> {
   /**
    * Optional callback to access the IToggle interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
@@ -11,7 +11,7 @@ export interface ITooltip {
 /**
  * Tooltip component props.
  */
-export interface ITooltipProps extends React.HTMLProps<HTMLDivElement | Tooltip> {
+export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Tooltip> {
   /**
    * Optional callback to access the ITooltip interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
@@ -19,7 +19,7 @@ export enum TooltipOverflowMode {
 /**
  * Tooltip component props.
  */
-export interface ITooltipHostProps extends React.HTMLProps<HTMLDivElement | TooltipHost> {
+export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement | TooltipHost> {
   /**
    * Optional callback to access the ITooltipHost interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/pickers/AutoFill/BaseAutoFill.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/AutoFill/BaseAutoFill.Props.ts
@@ -40,7 +40,7 @@ export interface IBaseAutoFill {
   clear(): void;
 }
 
-export interface IBaseAutoFillProps extends React.HTMLProps<HTMLInputElement | BaseAutoFill> {
+export interface IBaseAutoFillProps extends React.HTMLAttributes<HTMLInputElement | BaseAutoFill> {
   /**
    * The suggested autofill value that will display.
    */

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts
@@ -52,7 +52,7 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    * AutoFill input native props
    * @default undefined
    */
-  inputProps?: React.HTMLProps<HTMLInputElement>;
+  inputProps?: React.HTMLAttributes<HTMLInputElement>;
   /**
    * A callback for when a persona is removed from the suggestion list
    */

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePickerExampleData.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePickerExampleData.ts
@@ -1,7 +1,7 @@
 import { IPersonaProps, PersonaPresence } from 'office-ui-fabric-react/lib/Persona';
 import { TestImages } from '../../../../common/TestImages';
 
-export const people: IPersonaProps[] = [
+export const people: (IPersonaProps & { key: string | number })[] = [
   {
     key: 0,
 

--- a/packages/styling/src/examples/IconTile/IconTile.tsx
+++ b/packages/styling/src/examples/IconTile/IconTile.tsx
@@ -3,7 +3,7 @@ import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { IconClassNames } from '@uifabric/styling';
 import { IIconTileStyles, getStyles } from './IconTile.styles';
 
-export interface IIconTileProps extends React.HTMLProps<HTMLDivElement> {
+export interface IIconTileProps extends React.HTMLAttributes<HTMLDivElement> {
   iconName: string;
 }
 

--- a/packages/utilities/src/properties.test.ts
+++ b/packages/utilities/src/properties.test.ts
@@ -8,21 +8,21 @@ let { expect } = chai;
 describe('getNativeProps', () => {
 
   it('can pass through data tags', () => {
-    let result = getNativeProps<React.HTMLProps<HTMLDivElement>>({
+    let result = getNativeProps<React.HTMLAttributes<HTMLDivElement>>({
       'data-automation-id': 1
     }, divProperties);
     expect(result['data-automation-id']).equals(1);
   });
 
   it('can pass through aria tags', () => {
-    let result = getNativeProps<React.HTMLProps<HTMLDivElement>>({
+    let result = getNativeProps<React.HTMLAttributes<HTMLDivElement>>({
       'aria-label': 1
     }, divProperties);
     expect(result['aria-label']).equals(1);
   });
 
   it('can pass through basic div properties and events', () => {
-    let result = getNativeProps<React.HTMLProps<HTMLDivElement>>({
+    let result = getNativeProps<React.HTMLAttributes<HTMLDivElement>>({
       className: 'foo',
       onClick: () => { /* no-op */ },
       onClickCapture: () => { /* no-op */ }
@@ -33,7 +33,7 @@ describe('getNativeProps', () => {
   });
 
   it('can remove unexpected properties', () => {
-    let result = getNativeProps<React.HTMLProps<HTMLDivElement>>({
+    let result = getNativeProps<React.HTMLAttributes<HTMLDivElement>>({
       'foobar': 1,
       className: 'hi'
     }, divProperties);


### PR DESCRIPTION
Props that extend `React.HTMLProps` are difficult to extend, because you end up getting errors like the following if you try to extend them:
```
[12:20:04] packages/options/owa-options-mail/lib/components/common/ChoiceGroupWithImages.tsx(23,17): error TS2322: Type '{ options: any[]; children?: ReactNode; componentRef?: (component: IChoiceGroup) => void;
  Type '{ options: any[]; children?: ReactNode; componentRef?: (component: IChoiceGroup) => void; default...' is not assignable to type 'IntrinsicClassAttributes<ChoiceGroup>'.
    Types of property 'ref' are incompatible.
      Type 'Ref<HTMLElement | HTMLInputElement>' is not assignable to type 'Ref<ChoiceGroup>'.
        Type '(instance: HTMLElement | HTMLInputElement) => any' is not assignable to type 'Ref<ChoiceGroup>'.
          Type '(instance: HTMLElement | HTMLInputElement) => any' is not assignable to type '(instance: ChoiceGroup) => any'.
            Types of parameters 'instance' and 'instance' are incompatible.
              Type 'ChoiceGroup' is not assignable to type 'HTMLElement | HTMLInputElement'.
                Type 'ChoiceGroup' is not assignable to type 'HTMLInputElement'.
                  Property 'accept' is missing in type 'ChoiceGroup'.
```

However, the `ref` and `key` props that make the only difference between `HTMLProps` and `HTMLAttributes` aren't really needed for the property interfaces. So, just get rid of them.