### PR TITLE
Enable no implicit any in the utilities package

### DIFF
--- a/common/changes/@uifabric/example-app-base/strict-typescript_2017-06-10-01-29.json
+++ b/common/changes/@uifabric/example-app-base/strict-typescript_2017-06-10-01-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Enable no implicit any in utilities package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/@uifabric/fabric-website/strict-typescript_2017-06-10-01-29.json
+++ b/common/changes/@uifabric/fabric-website/strict-typescript_2017-06-10-01-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Enable no implicit any in utilities package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/@uifabric/styling/strict-typescript_2017-06-10-01-29.json
+++ b/common/changes/@uifabric/styling/strict-typescript_2017-06-10-01-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Enable no implicit any in utilities package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/@uifabric/utilities/strict-typescript_2017-06-10-01-29.json
+++ b/common/changes/@uifabric/utilities/strict-typescript_2017-06-10-01-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Enable no implicit any in utilities package",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/strict-typescript_2017-06-10-01-29.json
+++ b/common/changes/office-ui-fabric-react/strict-typescript_2017-06-10-01-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Enable no implicit any in utilities package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -1648,9 +1648,9 @@
       }
     },
     "@uifabric/styling": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-0.7.2.tgz",
-      "integrity": "sha512-HZLvm7OU+gXeXO+QHnAJXimzBtEq/UoQwCUTb+gdFJP0oU43gLm40G1G+tPDjS0+ZB2CIIrkH7v0jQ2paKprSg=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-0.7.1.tgz",
+      "integrity": "sha512-PZ0ryYqj1Wu4Ojsb7e2VesvgsiY9Lghz9ByEXirywk0im/83fB58exrLtLUBsBU6H037kp8q2RaO2wuaQEnwMw=="
     },
     "@uifabric/utilities": {
       "version": "4.1.2",
@@ -2379,9 +2379,9 @@
       "integrity": "sha1-s7026T3Uy/s5WjwmiWNSRFJlwFs="
     },
     "clean-css": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.27.tgz",
-      "integrity": "sha1-re91sxwWD/pdcvTeZ5ZuJmDBolU=",
+      "version": "3.4.26",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.26.tgz",
+      "integrity": "sha1-VTI7NE/zvO5oSi6sgck9+Ppz3us=",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
@@ -3202,9 +3202,9 @@
       "integrity": "sha1-R5Y2v6P+Ox3r1SCH8KyyBLTxnIg="
     },
     "electron-to-chromium": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
-      "integrity": "sha1-ZK8Pnv08PGrNV9cfg7Scp+6cS0M="
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz",
+      "integrity": "sha1-GzperObgh7teJXoQCwy/6Bsokfw="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -7380,9 +7380,9 @@
       "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
     },
     "office-ui-fabric-core": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-7.1.0.tgz",
-      "integrity": "sha1-IKhrQW4f8WSvetiqzoMoUVigPiM="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-7.0.0.tgz",
+      "integrity": "sha1-5rl2yY1wuKoAvVAGTIgOE3dFiY4="
     },
     "office-ui-fabric-react": {
       "version": "4.4.2",
@@ -8172,28 +8172,9 @@
       "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
-        }
-      }
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs="
     },
     "randombytes": {
       "version": "2.0.5",

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -1415,6 +1415,11 @@
       "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
       "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0="
     },
+    "@types/es6-weak-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/es6-weak-map/-/es6-weak-map-1.2.0.tgz",
+      "integrity": "sha1-2fb4WDaaiLvGnvQCOAgfLWu8hhQ="
+    },
     "@types/express": {
       "version": "4.0.35",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.35.tgz",
@@ -1643,9 +1648,9 @@
       }
     },
     "@uifabric/styling": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-0.7.1.tgz",
-      "integrity": "sha512-PZ0ryYqj1Wu4Ojsb7e2VesvgsiY9Lghz9ByEXirywk0im/83fB58exrLtLUBsBU6H037kp8q2RaO2wuaQEnwMw=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-0.7.2.tgz",
+      "integrity": "sha512-HZLvm7OU+gXeXO+QHnAJXimzBtEq/UoQwCUTb+gdFJP0oU43gLm40G1G+tPDjS0+ZB2CIIrkH7v0jQ2paKprSg=="
     },
     "@uifabric/utilities": {
       "version": "4.1.2",
@@ -2374,9 +2379,9 @@
       "integrity": "sha1-s7026T3Uy/s5WjwmiWNSRFJlwFs="
     },
     "clean-css": {
-      "version": "3.4.26",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.26.tgz",
-      "integrity": "sha1-VTI7NE/zvO5oSi6sgck9+Ppz3us=",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.27.tgz",
+      "integrity": "sha1-re91sxwWD/pdcvTeZ5ZuJmDBolU=",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
@@ -3197,9 +3202,9 @@
       "integrity": "sha1-R5Y2v6P+Ox3r1SCH8KyyBLTxnIg="
     },
     "electron-to-chromium": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz",
-      "integrity": "sha1-GzperObgh7teJXoQCwy/6Bsokfw="
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
+      "integrity": "sha1-ZK8Pnv08PGrNV9cfg7Scp+6cS0M="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -7375,9 +7380,9 @@
       "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
     },
     "office-ui-fabric-core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-7.0.0.tgz",
-      "integrity": "sha1-5rl2yY1wuKoAvVAGTIgOE3dFiY4="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-7.1.0.tgz",
+      "integrity": "sha1-IKhrQW4f8WSvetiqzoMoUVigPiM="
     },
     "office-ui-fabric-react": {
       "version": "4.4.2",
@@ -8167,9 +8172,28 @@
       "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "randomatic": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
+        }
+      }
     },
     "randombytes": {
       "version": "2.0.5",

--- a/packages/utilities/api/utilities.api.ts
+++ b/packages/utilities/api/utilities.api.ts
@@ -1,3 +1,5 @@
+export function assign(target: any, ...args: any[]): any;
+
 // WARNING: dispose has incomplete type information
 // WARNING: clearImmediate has incomplete type information
 // WARNING: clearInterval has incomplete type information
@@ -50,10 +52,11 @@ class BaseComponent<P extends IBaseProps, S> extends React.Component<P, S> {
 
 // WARNING: contextTypes has incomplete type information
 // WARNING: childContextTypes has incomplete type information
-// WARNING: __constructor has incomplete type information
 // WARNING: componentWillReceiveProps has incomplete type information
 // WARNING: render has incomplete type information
 class Customizer extends BaseComponent<ICustomizerProps, ICustomizerState> {
+  // (undocumented)
+  constructor(props: any, context: any);
   public static addChangeListener(onChanged: IChangeListener): void;
   // (undocumented)
   public getChildContext(): any;
@@ -149,6 +152,8 @@ export function hasHorizontalOverflow(element: HTMLElement): boolean;
 export function hasOverflow(element: HTMLElement): boolean;
 
 export function hasVerticalOverflow(element: HTMLElement): boolean;
+
+export function hoistMethods(destination: any, source: any, exclusions: string[] = REACT_LIFECYCLE_EXCLUSIONS): string[];
 
 // (undocumented)
 interface IBaseProps {
@@ -374,10 +379,8 @@ export function warnMutuallyExclusive < P >(componentName: string,
 // WARNING: getWindow has incomplete type information
 // WARNING: getDocument has incomplete type information
 // WARNING: doesElementContainFocus has incomplete type information
-// WARNING: hoistMethods has incomplete type information
 // WARNING: setLanguage has incomplete type information
 // WARNING: shallowCompare has incomplete type information
-// WARNING: assign has incomplete type information
 // WARNING: filteredAssign has incomplete type information
 // WARNING: Unsupported export: baseElementEvents
 // WARNING: Unsupported export: baseElementProperties

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -20,6 +20,7 @@
     "@types/chai": "^3.4.35",
     "@types/enzyme": "^2.7.5",
     "@types/es6-promise": "^0.0.32",
+    "@types/es6-weak-map": "1.2.0",
     "@types/mocha": "^2.2.39",
     "@types/prop-types": "^15.5.1",
     "@types/react": "^15.0.25",

--- a/packages/utilities/src/Async.ts
+++ b/packages/utilities/src/Async.ts
@@ -10,9 +10,9 @@ declare function setTimeout(cb: Function, delay: number): number;
 declare function setInterval(cb: Function, delay: number): number;
 
 export class Async {
-  private _timeoutIds = null;
-  private _immediateIds = null;
-  private _intervalIds = null;
+  private _timeoutIds: any = null;
+  private _immediateIds: any = null;
+  private _intervalIds: any = null;
   private _animationFrameIds: { [id: number]: boolean } = null;
   private _isDisposed = false;
   private _parent: any;
@@ -38,7 +38,7 @@ export class Async {
     if (this._timeoutIds) {
       for (id in this._timeoutIds) {
         if (this._timeoutIds.hasOwnProperty(id)) {
-          this.clearTimeout(id);
+          this.clearTimeout(parseInt(id, 10));
         }
       }
 
@@ -49,7 +49,7 @@ export class Async {
     if (this._immediateIds) {
       for (id in this._immediateIds) {
         if (this._immediateIds.hasOwnProperty(id)) {
-          this.clearImmediate(id);
+          this.clearImmediate(parseInt(id, 10));
         }
       }
 
@@ -60,7 +60,7 @@ export class Async {
     if (this._intervalIds) {
       for (id in this._intervalIds) {
         if (this._intervalIds.hasOwnProperty(id)) {
-          this.clearInterval(id);
+          this.clearInterval(parseInt(id, 10));
         }
       }
       this._intervalIds = null;
@@ -70,7 +70,7 @@ export class Async {
     if (this._animationFrameIds) {
       for (id in this._animationFrameIds) {
         if (this._animationFrameIds.hasOwnProperty(id)) {
-          this.cancelAnimationFrame(id);
+          this.cancelAnimationFrame(parseInt(id, 10));
         }
       }
 
@@ -254,7 +254,7 @@ export class Async {
     let leading = true;
     let trailing = true;
     let lastExecuteTime = 0;
-    let lastResult;
+    let lastResult: any;
     let lastArgs: any[];
     let timeoutId: number = null;
 
@@ -320,10 +320,10 @@ export class Async {
     let waitMS = wait || 0;
     let leading = false;
     let trailing = true;
-    let maxWait = null;
+    let maxWait: any = null;
     let lastCallTime = 0;
     let lastExecuteTime = (new Date).getTime();
-    let lastResult;
+    let lastResult: any;
     let lastArgs: any[];
     let timeoutId: number = null;
 

--- a/packages/utilities/src/BaseComponent.test.tsx
+++ b/packages/utilities/src/BaseComponent.test.tsx
@@ -85,7 +85,7 @@ describe('BaseComponent', () => {
   });
 });
 
-function _buildTestFor(methodName) {
+function _buildTestFor(methodName: string) {
   it(`calls the error logger on ${methodName} exception`, () => {
     let lastErrorMessage = null;
 
@@ -93,7 +93,7 @@ function _buildTestFor(methodName) {
 
     let c = new TestComponent();
 
-    c[methodName]();
+    (c as any)[methodName]();
 
     assert(lastErrorMessage !== null, 'Error callback not called');
   });

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -146,7 +146,7 @@ export class BaseComponent<P extends IBaseProps, S> extends React.Component<P, S
     }
     if (!this.__resolves[refName]) {
       this.__resolves[refName] = (ref) => {
-        return this[refName] = ref;
+        return (this as any)[refName] = ref;
       };
     }
 
@@ -202,11 +202,11 @@ function _makeAllSafe(obj: BaseComponent<any, any>, prototype: Object, methodNam
 }
 
 function _makeSafe(obj: BaseComponent<any, any>, prototype: Object, methodName: string) {
-  let classMethod = obj[methodName];
-  let prototypeMethod = prototype[methodName];
+  let classMethod = (obj as any)[methodName];
+  let prototypeMethod = (prototype as any)[methodName];
 
   if (classMethod || prototypeMethod) {
-    obj[methodName] = function () {
+    (obj as any)[methodName] = function () {
       let retVal;
 
       try {

--- a/packages/utilities/src/Customizer.tsx
+++ b/packages/utilities/src/Customizer.tsx
@@ -77,7 +77,7 @@ export class Customizer extends BaseComponent<ICustomizerProps, ICustomizerState
     }
   }
 
-  constructor(props, context) {
+  constructor(props: any, context: any) {
     super(props);
 
     this.state = this._getInjectedProps(props, context);
@@ -87,7 +87,7 @@ export class Customizer extends BaseComponent<ICustomizerProps, ICustomizerState
     return this.state;
   }
 
-  public componentWillReceiveProps(newProps, newContext) {
+  public componentWillReceiveProps(newProps: any, newContext: any) {
     this.setState(this._getInjectedProps(newProps, newContext));
   }
 

--- a/packages/utilities/src/DelayedRender.tsx
+++ b/packages/utilities/src/DelayedRender.tsx
@@ -24,7 +24,7 @@ export class DelayedRender extends React.Component<IDelayedRenderProps, IDelayed
     delay: 0
   };
 
-  private _timeoutId;
+  private _timeoutId: number | undefined;
 
   constructor(props: IDelayedRenderProps) {
     super(props);

--- a/packages/utilities/src/EventGroup.ts
+++ b/packages/utilities/src/EventGroup.ts
@@ -33,7 +33,7 @@ export interface IDeclaredEventsByName {
  */
 export class EventGroup {
   private static _uniqueId = 0;
-  private _parent;
+  private _parent: any;
   private _eventRecords: IEventRecord[];
   private _id = EventGroup._uniqueId++;
   private _isDisposed: boolean;
@@ -56,10 +56,10 @@ export class EventGroup {
         let ev = document.createEvent('HTMLEvents');
 
         ev.initEvent(eventName, bubbleEvent, true);
-        ev['args'] = eventArgs;
+        (ev as any)['args'] = eventArgs;
         retVal = target.dispatchEvent(ev);
-      } else if (document['createEventObject']) { // IE8
-        let evObj = document['createEventObject'](eventArgs);
+      } else if ((document as any)['createEventObject']) { // IE8
+        let evObj = (document as any)['createEventObject'](eventArgs);
         // cannot set cancelBubble on evObj, fireEvent will overwrite it
         target.fireEvent('on' + eventName, evObj);
       }

--- a/packages/utilities/src/autobind.ts
+++ b/packages/utilities/src/autobind.ts
@@ -30,7 +30,7 @@ export function autobind<T extends Function>(target: any, key: string, descripto
       return fnBound;
     },
 
-    set(newValue) {
+    set(newValue: any) {
       Object.defineProperty(this, key, {
         configurable: true,
         writable: true,

--- a/packages/utilities/src/css.ts
+++ b/packages/utilities/src/css.ts
@@ -20,7 +20,7 @@ export function css(...args: ICssInput[]) {
         classes.push(arg.toString());
       } else {
         for (let key in arg as any) {
-          if (arg[key]) {
+          if ((arg as any)[key]) {
             classes.push(key);
           }
         }

--- a/packages/utilities/src/customizable.test.tsx
+++ b/packages/utilities/src/customizable.test.tsx
@@ -10,7 +10,7 @@ class Foo extends React.Component<{ field: string; }, {}> {
   public name: any;
 
   public render() {
-    return <div>{ this.props[this.props.field] }</div>;
+    return <div>{ (this.props as any)[this.props.field] }</div>;
   }
 }
 

--- a/packages/utilities/src/customizable.tsx
+++ b/packages/utilities/src/customizable.tsx
@@ -29,7 +29,7 @@ export function customizable<P>(fields: string[]) {
         let defaultProps = {};
 
         for (let propName of fields) {
-          defaultProps[propName] = (this.context.injectedProps) ?
+          (defaultProps as any)[propName] = (this.context.injectedProps) ?
             this.context.injectedProps[propName] :
             Customizer.getDefault(propName);
         }

--- a/packages/utilities/src/dom.ts
+++ b/packages/utilities/src/dom.ts
@@ -106,7 +106,7 @@ let _isSSR = false;
 /**
  * Helper to set ssr mode to simulate no window object returned from getWindow helper.
  */
-export function setSSR(isEnabled) {
+export function setSSR(isEnabled: boolean) {
   _isSSR = isEnabled;
 }
 

--- a/packages/utilities/src/focus.test.tsx
+++ b/packages/utilities/src/focus.test.tsx
@@ -8,9 +8,9 @@ let { expect } = chai;
 
 import { isElementVisible, isElementTabbable } from './focus';
 
-let _hiddenElement;
-let _visibleElement;
-let _element;
+let _hiddenElement: HTMLElement | undefined;
+let _visibleElement: HTMLElement | undefined;
+let _element: HTMLElement | undefined;
 
 function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
   const component = ReactTestUtils.renderIntoDocument(element);

--- a/packages/utilities/src/hoist.ts
+++ b/packages/utilities/src/hoist.ts
@@ -18,7 +18,7 @@ const REACT_LIFECYCLE_EXCLUSIONS = [
  * @param exclusions - (Optional) What methods to exclude from being hoisted.
  * @returns An array of names of methods that were hoisted.
  */
-export function hoistMethods(destination, source, exclusions: string[] = REACT_LIFECYCLE_EXCLUSIONS): string[] {
+export function hoistMethods(destination: any, source: any, exclusions: string[] = REACT_LIFECYCLE_EXCLUSIONS): string[] {
   let hoisted: string[] = [];
   for (let methodName in source) {
     if (

--- a/packages/utilities/src/memoize.test.ts
+++ b/packages/utilities/src/memoize.test.ts
@@ -1,10 +1,10 @@
 import { memoize, memoizeFunction, setMemoizeWeakMap } from './memoize';
-import * as weakMapPolyfill from 'es6-weak-map/polyfill';
+import weakMapPolyfill = require('es6-weak-map');
 
 let { expect } = chai;
 
 describe('memoizeFunction', () => {
-  before(()=> {
+  before(() => {
     setMemoizeWeakMap(weakMapPolyfill);
   });
 
@@ -95,7 +95,7 @@ describe('memoizeFunction', () => {
 });
 
 describe('memoize', () => {
-  before(()=> {
+  before(() => {
     setMemoizeWeakMap(weakMapPolyfill);
   });
 

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -1,11 +1,11 @@
 declare class WeakMap {
   public get(key: any): any;
   public set(key: any, value: any): void;
-  public has(key: any);
+  public has(key: any): boolean;
 }
 
 const _emptyObject = { empty: true };
-const _dictionary = {};
+const _dictionary: any = {};
 let _weakMap = (typeof WeakMap === 'undefined') ? null : WeakMap;
 
 interface IMemoizeNode {

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -9,7 +9,7 @@ if (_global[CURRENT_ID_PROPERTY] === undefined) {
   _global[CURRENT_ID_PROPERTY] = 0;
 }
 
-function checkProperties(a, b) {
+function checkProperties(a: any, b: any) {
   for (let propName in a) {
     if (a.hasOwnProperty(propName)) {
       if (!b.hasOwnProperty(propName) || (b[propName] !== a[propName])) {
@@ -22,7 +22,7 @@ function checkProperties(a, b) {
 }
 
 // Compare a to b and b to a
-export function shallowCompare(a, b) {
+export function shallowCompare(a: any, b: any) {
   return checkProperties(a, b) && checkProperties(b, a);
 }
 
@@ -35,7 +35,7 @@ export function shallowCompare(a, b) {
  * @param args - One or more objects that will be mixed into the target in the order they are provided.
  * @returns Resulting merged target.
  */
-export function assign(target: any, ...args): any {
+export function assign(target: any, ...args: any[]): any {
   return filteredAssign.apply(this, [null, target].concat(args));
 }
 
@@ -50,7 +50,7 @@ export function assign(target: any, ...args): any {
  * @param args - One or more objects that will be mixed into the target in the order they are provided.
  * @returns Resulting merged target.
  */
-export function filteredAssign(isAllowed: (propName: string) => boolean, target: any, ...args) {
+export function filteredAssign(isAllowed: (propName: string) => boolean, target: any, ...args: any[]) {
   target = target || {};
 
   for (let sourceObject of args) {

--- a/packages/utilities/src/properties.test.ts
+++ b/packages/utilities/src/properties.test.ts
@@ -11,14 +11,14 @@ describe('getNativeProps', () => {
     let result = getNativeProps<React.HTMLProps<HTMLDivElement>>({
       'data-automation-id': 1
     }, divProperties);
-    expect(result['data-automation-id']).equals(1);
+    expect((result as any)['data-automation-id']).equals(1);
   });
 
   it('can pass through aria tags', () => {
     let result = getNativeProps<React.HTMLProps<HTMLDivElement>>({
       'aria-label': 1
     }, divProperties);
-    expect(result['aria-label']).equals(1);
+    expect((result as any)['aria-label']).equals(1);
   });
 
   it('can pass through basic div properties and events', () => {
@@ -29,7 +29,8 @@ describe('getNativeProps', () => {
     }, divProperties);
     expect(result.className).equals('foo');
     expect(result.onClick).is.instanceof(Function, 'onClick not function');
-    expect(result['onClickCapture']).is.instanceof(Function, 'onClickCapture not function');  // tslint:disable-line:no-string-literal
+    // tslint:disable-next-line:no-string-literal
+    expect((result as any)['onClickCapture']).is.instanceof(Function, 'onClickCapture not function');
   });
 
   it('can remove unexpected properties', () => {
@@ -38,11 +39,11 @@ describe('getNativeProps', () => {
       className: 'hi'
     }, divProperties);
     expect(result.className).equals('hi');
-    expect(result['foobar']).equals(undefined); // tslint:disable-line:no-string-literal
+    expect((result as any)['foobar']).equals(undefined); // tslint:disable-line:no-string-literal
   });
 
   it('can exclude properties', () => {
-    let result = getNativeProps<any>({ a: 1, b: 2}, ['a', 'b'], ['b']);
+    let result = getNativeProps<any>({ a: 1, b: 2 }, ['a', 'b'], ['b']);
 
     expect(result.a).to.exist;
     expect(result.b).to.not.exist;

--- a/packages/utilities/src/resources.ts
+++ b/packages/utilities/src/resources.ts
@@ -1,11 +1,11 @@
 let _baseUrl = '';
 
 /** Sets the current base url used for fetching images. */
-export function getResourceUrl(url) {
+export function getResourceUrl(url: string) {
   return _baseUrl + url;
 }
 
 /** Gets the current base url used for fetching images. */
-export function setBaseUrl(baseUrl) {
+export function setBaseUrl(baseUrl: string) {
   _baseUrl = baseUrl;
 }

--- a/packages/utilities/src/string.ts
+++ b/packages/utilities/src/string.ts
@@ -11,20 +11,20 @@ const FORMAT_REGEX = /\{\d+\}/g;
  * Example "I love {0} every {1}".format("CXP") will result in a Debug Exception.
  */
 export function format(s: string, ...values: any[]): string {
-    'use strict';
+  'use strict';
 
-    let args = values;
-    // Callback match function
-    function replace_func(match: string) {
-        // looks up in the args
-        let replacement = args[match.replace(FORMAT_ARGS_REGEX, '')];
+  let args = values;
+  // Callback match function
+  function replace_func(match: string) {
+    // looks up in the args
+    let replacement = args[match.replace(FORMAT_ARGS_REGEX, '') as any];
 
-        // catches undefined in nondebug and null in debug and nondebug
-        if (replacement === null || replacement === undefined) {
-            replacement = '';
-        }
-
-        return replacement;
+    // catches undefined in nondebug and null in debug and nondebug
+    if (replacement === null || replacement === undefined) {
+      replacement = '';
     }
-    return (s.replace(FORMAT_REGEX, replace_func));
+
+    return replacement;
+  }
+  return (s.replace(FORMAT_REGEX, replace_func));
 }

--- a/packages/utilities/src/test/injectWrapperMethod.ts
+++ b/packages/utilities/src/test/injectWrapperMethod.ts
@@ -7,13 +7,13 @@ import { ReactWrapper } from 'enzyme';
  * @param fn - The function to run prior to the call of the original method
  */
 export function injectWrapperMethod(wrapper: ReactWrapper<any, any>, methodName: string, fn: () => void) {
-  const originalMethod = wrapper.instance()[methodName];
+  const originalMethod = (wrapper.instance() as any)[methodName];
 
   if (typeof originalMethod !== 'function') {
     throw new Error(`Tried to override the method ${methodName} on a ReactWrapper that does not have that function`);
   }
 
-  wrapper.instance()[methodName] = function (prevProps: any) {
+  (wrapper.instance() as any)[methodName] = function (prevProps: any) {
     fn();
     originalMethod.call(this, prevProps);
   };

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -11,6 +11,7 @@
     "sourceMap": true,
     "experimentalDecorators": true,
     "importHelpers": true,
+    "noImplicitAny": true,
     "moduleResolution": "node",
     "types": [
       "chai",


### PR DESCRIPTION
Slowly getting us on the road to enabling strict mode for Typescript. I'll be doing these package by package and a single option at a time to help catch any issues. This  enables the no implicit any option in the utilities package. Most of the fixes here are not adding new typings, but rather explicitly stating that something is of any type. 
