### PR TITLE
Fixing aria details for dropdown

### DIFF
--- a/common/changes/office-ui-fabric-react/users-prmittal-dropdown-aria-fix_2017-06-13-13-03.json
+++ b/common/changes/office-ui-fabric-react/users-prmittal-dropdown-aria-fix_2017-06-13-13-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "[Accessibility] [DropDown] Fix aria-required-children",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "prmittal@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -131,13 +131,12 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           onClick={ this._onDropdownClick }
           aria-expanded={ isOpen ? 'true' : 'false' }
           role='combobox'
-          aria-readonly={ true }
           aria-live={ disabled || isOpen ? 'off' : 'assertive' }
           aria-label={ ariaLabel || label }
           aria-describedby={ id + '-option' }
           aria-activedescendant={ isOpen && selectedIndex >= 0 ? (this._id + '-list' + selectedIndex) : null }
           aria-disabled={ disabled }
-          aria-owns={ id + '-list' }
+          aria-owns={ isOpen ? id + '-list' : null }
         >
           <span
             id={ id + '-option' }
@@ -148,6 +147,8 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             }
             key={ selectedIndex }
             aria-atomic={ true }
+            role='textbox'
+            aria-readonly='true'
           >
             { // If option is selected render title, otherwise render the placeholder text
               selectedOption ? (


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1076 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added role textbox to span and moved aria-readonly there.
Check for aria-owns component since it will not be available if dropdown is not expanded.
