### PR TITLE
Add a prop to Breadcrumb allowing disabling of auto overflow collapsing

### DIFF
--- a/common/changes/office-ui-fabric-react/breadcrumb-auto-collapse_2017-06-15-15-10.json
+++ b/common/changes/office-ui-fabric-react/breadcrumb-auto-collapse_2017-06-15-15-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add a prop to Breadcrumb allowing disabling of auto overflow collapsing.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "trgau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.Props.ts
@@ -38,6 +38,12 @@ export interface IBreadcrumbProps extends React.Props<Breadcrumb> {
    * Aria label to place on the navigation landmark for breadcrumb
    */
   ariaLabel?: string;
+
+  /**
+   * If set to false, don't collapse overflow items based on container width.
+   * @default true
+   */
+  autoCollapseOverflowItems?: boolean;
 }
 
 export interface IBreadcrumbItem {

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -28,8 +28,8 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
             { text: 'This is folder 4', 'key': 'f4', onClick: this._onBreadcrumbItemClicked },
             { text: 'This is folder 5', 'key': 'f5', onClick: this._onBreadcrumbItemClicked, isCurrentItem: true },
           ] }
-          maxDisplayedItems={ 3 } 
-          ariaLabel={'Website breadcrumb'} />
+          maxDisplayedItems={ 3 }
+          ariaLabel={ 'Website breadcrumb' } />
         <Breadcrumb
           items={ [
             { text: 'Files', 'key': 'Files', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked },
@@ -39,8 +39,9 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
             { text: 'This is link 4', 'key': 'l4', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked },
             { text: 'This is link 5', 'key': 'l5', href: '#/examples/breadcrumb', onClick: this._onBreadcrumbItemClicked, isCurrentItem: true },
           ] }
-          maxDisplayedItems={ 3 }
-          ariaLabel={'Website breadcrumb'} />
+          maxDisplayedItems={ 5 }
+          autoCollapseOverflowItems={ false }
+          ariaLabel={ 'Website breadcrumb' } />
       </div>
     );
   }


### PR DESCRIPTION
Workaround for #1824

#### Pull request checklist

- [x] Addresses an existing issue: Workaround #1824
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When `autoCollapseOverflowItems` is set explicitly to `false`, don't set up the window resize handler or use computed space to automatically collapse overflow items.
