### PR TITLE
Revert "Update icons to version 2.30 (#1925)"

### DIFF
--- a/common/changes/@uifabric/styling/miwhea-reverse-1925_2017-06-15-20-15.json
+++ b/common/changes/@uifabric/styling/miwhea-reverse-1925_2017-06-15-20-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Removed new icons that were added recently",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -173,7 +173,6 @@ function _registerDefaultFontFaces(): void {
   if (baseUrl) {
     const fontUrl = `${baseUrl}/fonts`;
     const iconUrl = `${baseUrl}/icons`;
-    const iconVersion = '2.30';
 
     // Produce @font-face definitions for all supported web fonts.
     _registerFontFaceSet(fontUrl, FontNameThai, 'leelawadeeui-thai', 'leelawadeeui');
@@ -195,7 +194,7 @@ function _registerDefaultFontFaces(): void {
     _registerFontFace('Leelawadee UI Web', `${fontUrl}/leelawadeeui-thai/leelawadeeui-bold`, FontWeights.semibold);
 
     // Register icon urls.
-    _registerFontFace('FabricMDL2Icons', `${iconUrl}/fabricmdl2icons-${iconVersion}`, FontWeights.regular);
+    _registerFontFace('FabricMDL2Icons', `${iconUrl}/fabricmdl2icons`, FontWeights.regular);
   }
 }
 

--- a/packages/styling/src/styles/IconCodes.ts
+++ b/packages/styling/src/styles/IconCodes.ts
@@ -1,1114 +1,2830 @@
 export const IconCodes = {
+  /**
+   * Icon code with the value '\uED68'.
+   */
   aadLogo: '\uED68',
+  /**
+   * Icon code with the value '\uE8FB'.
+   */
   accept: '\uE8FB',
+  /**
+   * Icon code with the value '\uED69'.
+   */
   accessLogo: '\uED69',
-  accessLogoFill: '\uF1DB',
+  /**
+   * Icon code with the value '\uE910'.
+   */
   accounts: '\uE910',
-  activityFeed: '\uF056',
+  /**
+   * Icon code with the value '\uE710'.
+   */
   add: '\uE710',
+  /**
+   * Icon code with the value '\uEEB5'.
+   */
   addEvent: '\uEEB5',
+  /**
+   * Icon code with the value '\uF0C8'.
+   */
   addFavorite: '\uF0C8',
+  /**
+   * Icon code with the value '\uF0C9'.
+   */
   addFavoriteFill: '\uF0C9',
+  /**
+   * Icon code with the value '\uE8FA'.
+   */
   addFriend: '\uE8FA',
+  /**
+   * Icon code with the value '\uEE3D'.
+   */
   addGroup: '\uEE3D',
+  /**
+   * Icon code with the value '\uED8E'.
+   */
   addOnlineMeeting: '\uED8E',
+  /**
+   * Icon code with the value '\uED96'.
+   */
   addPhone: '\uED96',
+  /**
+   * Icon code with the value '\uECC8'.
+   */
   addTo: '\uECC8',
+  /**
+   * Icon code with the value '\uE7EF'.
+   */
   admin: '\uE7EF',
+  /**
+   * Icon code with the value '\uED6A'.
+   */
   adminALogo: '\uED6A',
+  /**
+   * Icon code with the value '\uED6B'.
+   */
   adminCLogo: '\uED6B',
+  /**
+   * Icon code with the value '\uED6C'.
+   */
   adminDLogo: '\uED6C',
+  /**
+   * Icon code with the value '\uED6D'.
+   */
   adminELogo: '\uED6D',
+  /**
+   * Icon code with the value '\uED6E'.
+   */
   adminLLogo: '\uED6E',
+  /**
+   * Icon code with the value '\uED6F'.
+   */
   adminMLogo: '\uED6F',
+  /**
+   * Icon code with the value '\uED70'.
+   */
   adminOLogo: '\uED70',
+  /**
+   * Icon code with the value '\uED71'.
+   */
   adminPLogo: '\uED71',
+  /**
+   * Icon code with the value '\uED72'.
+   */
   adminSLogo: '\uED72',
+  /**
+   * Icon code with the value '\uED73'.
+   */
   adminYLogo: '\uED73',
-  airplane: '\uE709',
-  airplaneSolid: '\uEB4C',
+  /**
+   * Icon code with the value '\uEF7A'.
+   */
   airTickets: '\uEF7A',
+  /**
+   * Icon code with the value '\uE709'.
+   */
+  airplane: '\uE709',
+  /**
+   * Icon code with the value '\uE919'.
+   */
   alarmClock: '\uE919',
+  /**
+   * Icon code with the value '\uE7AB'.
+   */
   album: '\uE7AB',
+  /**
+   * Icon code with the value '\uEC62'.
+   */
   albumRemove: '\uEC62',
-  alertSolid: '\uF331',
+  /**
+   * Icon code with the value '\uED74'.
+   */
+  alchemyLogo: '\uED74',
+  /**
+   * Icon code with the value '\uE8E3'.
+   */
   alignCenter: '\uE8E3',
+  /**
+   * Icon code with the value '\uE8E4'.
+   */
   alignLeft: '\uE8E4',
+  /**
+   * Icon code with the value '\uE8E2'.
+   */
   alignRight: '\uE8E2',
-  analyticsLogo: '\uF1DE',
-  analyticsQuery: '\uF1DF',
-  analyticsReport: '\uF1E1',
+  /**
+   * Icon code with the value '\uEF8B'.
+   */
   androidLogo: '\uEF8B',
+  /**
+   * Icon code with the value '\uE924'.
+   */
   annotation: '\uE924',
+  /**
+   * Icon code with the value '\uEEC7'.
+   */
+  appForOfficeLogo: '\uEEC7',
+  /**
+   * Icon code with the value '\uECAA'.
+   */
   appIconDefault: '\uECAA',
-  archive: '\uF03F',
-  areaChart: '\uE9D2',
+  /**
+   * Icon code with the value '\uEB34'.
+   */
   arrivals: '\uEB34',
+  /**
+   * Icon code with the value '\uEED5'.
+   */
   arrowDownRight8: '\uEED5',
+  /**
+   * Icon code with the value '\uEEF0'.
+   */
   arrowDownRightMirrored8: '\uEEF0',
-  arrowTallDownLeft: '\uF2BF',
-  arrowTallDownRight: '\uF2C0',
-  arrowTallUpLeft: '\uF2BD',
-  arrowTallUpRight: '\uF2BE',
+  /**
+   * Icon code with the value '\uEED4'.
+   */
   arrowUpRight8: '\uEED4',
+  /**
+   * Icon code with the value '\uEEEF'.
+   */
   arrowUpRightMirrored8: '\uEEEF',
+  /**
+   * Icon code with the value '\uEAC1'.
+   */
   articles: '\uEAC1',
+  /**
+   * Icon code with the value '\uEDC0'.
+   */
   ascending: '\uEDC0',
-  assessmentGroup: '\uF31A',
-  assessmentGroupTemplate: '\uF2B1',
+  /**
+   * Icon code with the value '\uEEB6'.
+   */
   assetLibrary: '\uEEB6',
-  assign: '\uE9D3',
+  /**
+   * Icon code with the value '\uEA38'.
+   */
   asterisk: '\uEA38',
-  asteriskSolid: '\uF34D',
+  /**
+   * Icon code with the value '\uEF85'.
+   */
   atpLogo: '\uEF85',
+  /**
+   * Icon code with the value '\uE723'.
+   */
   attach: '\uE723',
+  /**
+   * Icon code with the value '\uEE70'.
+   */
   australianRules: '\uEE70',
+  /**
+   * Icon code with the value '\uE78E'.
+   */
   autoEnhanceOff: '\uE78E',
+  /**
+   * Icon code with the value '\uE78D'.
+   */
   autoEnhanceOn: '\uE78D',
-  autoFillTemplate: '\uF313',
+  /**
+   * Icon code with the value '\uEB24'.
+   */
   autoRacing: '\uEB24',
+  /**
+   * Icon code with the value '\uEE6A'.
+   */
   awayStatus: '\uEE6A',
-  azureAPIManagement: '\uF37F',
-  azureKeyVault: '\uF3B4',
+  /**
+   * Icon code with the value '\uEB6A'.
+   */
   azureLogo: '\uEB6A',
-  azureServiceEndpoint: '\uF380',
+  /**
+   * Icon code with the value '\uE72B'.
+   */
   back: '\uE72B',
-  backlog: '\uF2AC',
+  /**
+   * Icon code with the value '\uE73F'.
+   */
   backToWindow: '\uE73F',
+  /**
+   * Icon code with the value '\uEC1B'.
+   */
   badge: '\uEC1B',
+  /**
+   * Icon code with the value '\uED7E'.
+   */
   balloons: '\uED7E',
-  bankSolid: '\uF34F',
+  /**
+   * Icon code with the value '\uEAE7'.
+   */
   barChart4: '\uEAE7',
+  /**
+   * Icon code with the value '\uE9EB'.
+   */
   barChartHorizontal: '\uE9EB',
-  barChartVertical: '\uE9EC',
+  /**
+   * Icon code with the value '\uEB20'.
+   */
   baseball: '\uEB20',
+  /**
+   * Icon code with the value '\uE9AA'.
+   */
   bidiLtr: '\uE9AA',
+  /**
+   * Icon code with the value '\uE9AB'.
+   */
   bidiRtl: '\uE9AB',
+  /**
+   * Icon code with the value '\uEB6B'.
+   */
   bingLogo: '\uEB6B',
+  /**
+   * Icon code with the value '\uE8F8'.
+   */
   blockContact: '\uE8F8',
-  blocked: '\uE733',
+  /**
+   * Icon code with the value '\uECE4'.
+   */
   blocked2: '\uECE4',
+  /**
+   * Icon code with the value '\uE733'.
+   */
+  blocked: '\uE733',
+  /**
+   * Icon code with the value '\uE9C9'.
+   */
   blowingSnow: '\uE9C9',
-  blur: '\uF28E',
+  /**
+   * Icon code with the value '\uEF68'.
+   */
   boards: '\uEF68',
+  /**
+   * Icon code with the value '\uE8DD'.
+   */
   bold: '\uE8DD',
+  /**
+   * Icon code with the value '\uEDC7'.
+   */
   bookingsLogo: '\uEDC7',
+  /**
+   * Icon code with the value '\uE8A4'.
+   */
   bookmarks: '\uE8A4',
+  /**
+   * Icon code with the value '\uEA41'.
+   */
   bookmarksMirrored: '\uEA41',
-  boxAdditionSolid: '\uF2D4',
-  boxCheckmarkSolid: '\uF2D7',
+  /**
+   * Icon code with the value '\uED75'.
+   */
   boxLogo: '\uED75',
-  boxMultiplySolid: '\uF2D5',
-  boxPlaySolid: '\uF2D6',
-  boxSubtractSolid: '\uF2D3',
-  branchCommit: '\uF293',
-  branchCompare: '\uF294',
+  /**
+   * Icon code with the value '\uF173'.
+   */
   branchFork: '\uF173',
-  branchFork2: '\uF291',
-  branchLocked: '\uF292',
-  branchMerge: '\uF295',
-  branchPullRequest: '\uF296',
-  branchSearch: '\uF297',
-  branchShelveset: '\uF298',
+  /**
+   * Icon code with the value '\uEF8C'.
+   */
   breadcrumb: '\uEF8C',
+  /**
+   * Icon code with the value '\uE706'.
+   */
   brightness: '\uE706',
+  /**
+   * Icon code with the value '\uEA99'.
+   */
   broom: '\uEA99',
-  bucketColor: '\uF1B6',
-  bucketColorFill: '\uF1B7',
+  /**
+   * Icon code with the value '\uF0D0'.
+   */
   bufferTimeAfter: '\uF0D0',
+  /**
+   * Icon code with the value '\uF0CF'.
+   */
   bufferTimeBefore: '\uF0CF',
+  /**
+   * Icon code with the value '\uF0D1'.
+   */
   bufferTimeBoth: '\uF0D1',
-  bugSolid: '\uF335',
-  build: '\uF28F',
-  buildIssue: '\uF319',
-  buildQueue: '\uF24F',
-  buildQueueNew: '\uF250',
+  /**
+   * Icon code with the value '\uE8FD'.
+   */
   bulletedList: '\uE8FD',
-  bulletedList2: '\uF2C7',
-  bulletedList2Mirrored: '\uF2C8',
+  /**
+   * Icon code with the value '\uEA42'.
+   */
   bulletedListMirrored: '\uEA42',
-  businessHoursSign: '\uF310',
+  /**
+   * Icon code with the value '\uEB47'.
+   */
   busSolid: '\uEB47',
+  /**
+   * Icon code with the value '\uEC32'.
+   */
   cafe: '\uEC32',
+  /**
+   * Icon code with the value '\uECA4'.
+   */
   cake: '\uECA4',
+  /**
+   * Icon code with the value '\uE948'.
+   */
   calculatorAddition: '\uE948',
-  calculatorEqualTo: '\uE94E',
-  calculatorMultiply: '\uE947',
-  calculatorNotEqualTo: '\uF2D2',
+  /**
+   * Icon code with the value '\uE949'.
+   */
   calculatorSubtract: '\uE949',
+  /**
+   * Icon code with the value '\uE787'.
+   */
   calendar: '\uE787',
+  /**
+   * Icon code with the value '\uEE9A'.
+   */
   calendarAgenda: '\uEE9A',
+  /**
+   * Icon code with the value '\uE8BF'.
+   */
   calendarDay: '\uE8BF',
+  /**
+   * Icon code with the value '\uED28'.
+   */
   calendarMirrored: '\uED28',
+  /**
+   * Icon code with the value '\uE8F5'.
+   */
   calendarReply: '\uE8F5',
+  /**
+   * Icon code with the value '\uE8C0'.
+   */
   calendarWeek: '\uE8C0',
+  /**
+   * Icon code with the value '\uEF51'.
+   */
   calendarWorkWeek: '\uEF51',
+  /**
+   * Icon code with the value '\uF172'.
+   */
   caloriesAdd: '\uF172',
+  /**
+   * Icon code with the value '\uE722'.
+   */
   camera: '\uE722',
+  /**
+   * Icon code with the value '\uE711'.
+   */
   cancel: '\uE711',
-  cannedChat: '\uF0F2',
+  /**
+   * Icon code with the value '\uE804'.
+   */
   car: '\uE804',
-  caretBottomLeftCenter8: '\uF365',
+  /**
+   * Icon code with the value '\uF121'.
+   */
   caretBottomLeftSolid8: '\uF121',
-  caretBottomRightCenter8: '\uF364',
+  /**
+   * Icon code with the value '\uF122'.
+   */
   caretBottomRightSolid8: '\uF122',
+  /**
+   * Icon code with the value '\uEDD8'.
+   */
   caretDown8: '\uEDD8',
+  /**
+   * Icon code with the value '\uEDDC'.
+   */
   caretDownSolid8: '\uEDDC',
+  /**
+   * Icon code with the value '\uE817'.
+   */
   caretHollow: '\uE817',
+  /**
+   * Icon code with the value '\uEA45'.
+   */
   caretHollowMirrored: '\uEA45',
+  /**
+   * Icon code with the value '\uEDD5'.
+   */
   caretLeft8: '\uEDD5',
+  /**
+   * Icon code with the value '\uEDD9'.
+   */
   caretLeftSolid8: '\uEDD9',
-  caretRight: '\uF06B',
+  /**
+   * Icon code with the value '\uEDD6'.
+   */
   caretRight8: '\uEDD6',
+  /**
+   * Icon code with the value '\uEDDA'.
+   */
   caretRightSolid8: '\uEDDA',
+  /**
+   * Icon code with the value '\uE818'.
+   */
   caretSolid: '\uE818',
-  caretSolid16: '\uEE62',
-  caretSolidDown: '\uF08E',
-  caretSolidLeft: '\uF08D',
+  /**
+   * Icon code with the value '\uEA46'.
+   */
   caretSolidMirrored: '\uEA46',
-  caretSolidRight: '\uF08F',
-  caretSolidUp: '\uF090',
-  caretTopLeftCenter8: '\uF367',
+  /**
+   * Icon code with the value '\uEF54'.
+   */
   caretTopLeftSolid8: '\uEF54',
-  caretTopRightCenter8: '\uF366',
+  /**
+   * Icon code with the value '\uEF55'.
+   */
   caretTopRightSolid8: '\uEF55',
+  /**
+   * Icon code with the value '\uEDD7'.
+   */
   caretUp8: '\uEDD7',
+  /**
+   * Icon code with the value '\uEDDB'.
+   */
   caretUpSolid8: '\uEDDB',
+  /**
+   * Icon code with the value '\uED7F'.
+   */
   cat: '\uED7F',
+  /**
+   * Icon code with the value '\uE8EA'.
+   */
   cellPhone: '\uE8EA',
+  /**
+   * Icon code with the value '\uEB95'.
+   */
   certificate: '\uEB95',
+  /**
+   * Icon code with the value '\uE999'.
+   */
   chart: '\uE999',
+  /**
+   * Icon code with the value '\uE901'.
+   */
   chat: '\uE901',
+  /**
+   * Icon code with the value '\uECFE'.
+   */
   chatInviteFriend: '\uECFE',
-  chatSolid: '\uF344',
-  checkbox: '\uE739',
-  checkboxComposite: '\uE73A',
-  checkboxCompositeReversed: '\uE73D',
-  checkboxIndeterminate: '\uE73C',
+  /**
+   * Icon code with the value '\uE9D5'.
+   */
   checkList: '\uE9D5',
+  /**
+   * Icon code with the value '\uE73E'.
+   */
   checkMark: '\uE73E',
+  /**
+   * Icon code with the value '\uE739'.
+   */
+  checkbox: '\uE739',
+  /**
+   * Icon code with the value '\uE73A'.
+   */
+  checkboxComposite: '\uE73A',
+  /**
+   * Icon code with the value '\uE73C'.
+   */
+  checkboxIndeterminate: '\uE73C',
+  /**
+   * Icon code with the value '\uE70D'.
+   */
   chevronDown: '\uE70D',
-  chevronDownEnd6: '\uF36F',
+  /**
+   * Icon code with the value '\uE972'.
+   */
   chevronDownMed: '\uE972',
+  /**
+   * Icon code with the value '\uE96E'.
+   */
   chevronDownSmall: '\uE96E',
-  chevronFold10: '\uF36A',
+  /**
+   * Icon code with the value '\uE76B'.
+   */
   chevronLeft: '\uE76B',
-  chevronLeftEnd6: '\uF371',
+  /**
+   * Icon code with the value '\uE973'.
+   */
   chevronLeftMed: '\uE973',
+  /**
+   * Icon code with the value '\uE96F'.
+   */
   chevronLeftSmall: '\uE96F',
+  /**
+   * Icon code with the value '\uE76C'.
+   */
   chevronRight: '\uE76C',
-  chevronRightEnd6: '\uF372',
+  /**
+   * Icon code with the value '\uE974'.
+   */
   chevronRightMed: '\uE974',
+  /**
+   * Icon code with the value '\uE970'.
+   */
   chevronRightSmall: '\uE970',
-  chevronUnfold10: '\uF369',
+  /**
+   * Icon code with the value '\uE70E'.
+   */
   chevronUp: '\uE70E',
-  chevronUpEnd6: '\uF370',
+  /**
+   * Icon code with the value '\uE971'.
+   */
   chevronUpMed: '\uE971',
+  /**
+   * Icon code with the value '\uE96D'.
+   */
   chevronUpSmall: '\uE96D',
+  /**
+   * Icon code with the value '\uE830'.
+   */
   chromeBack: '\uE830',
+  /**
+   * Icon code with the value '\uEA47'.
+   */
   chromeBackMirrored: '\uEA47',
+  /**
+   * Icon code with the value '\uE8BB'.
+   */
   chromeClose: '\uE8BB',
+  /**
+   * Icon code with the value '\uE921'.
+   */
   chromeMinimize: '\uE921',
-  circleAddition: '\uF2E3',
-  circleAdditionSolid: '\uF2E4',
+  /**
+   * Icon code with the value '\uEA3B'.
+   */
   circleFill: '\uEA3B',
+  /**
+   * Icon code with the value '\uED9E'.
+   */
   circleHalfFull: '\uED9E',
-  circlePause: '\uF2D9',
-  circlePauseSolid: '\uF2D8',
+  /**
+   * Icon code with the value '\uEAEE'.
+   */
   circlePlus: '\uEAEE',
+  /**
+   * Icon code with the value '\uEA3A'.
+   */
   circleRing: '\uEA3A',
-  circleStop: '\uF2DC',
-  circleStopSolid: '\uF2DB',
-  cityNext: '\uEC06',
-  classNotebookLogoInverse: '\uEDC8',
+  /**
+   * Icon code with the value '\uEDC8'.
+   */
+  classNotebookLogo: '\uEDC8',
+  /**
+   * Icon code with the value '\uEF75'.
+   */
   classroomLogo: '\uEF75',
+  /**
+   * Icon code with the value '\uE894'.
+   */
   clear: '\uE894',
+  /**
+   * Icon code with the value '\uEF8F'.
+   */
   clearFilter: '\uEF8F',
+  /**
+   * Icon code with the value '\uEDDD'.
+   */
   clearFormatting: '\uEDDD',
+  /**
+   * Icon code with the value '\uE9C2'.
+   */
   clearNight: '\uE9C2',
+  /**
+   * Icon code with the value '\uE917'.
+   */
   clock: '\uE917',
-  cloneToDesktop: '\uF28C',
-  closedCaption: '\uEF84',
+  /**
+   * Icon code with the value '\uE89F'.
+   */
   closePane: '\uE89F',
+  /**
+   * Icon code with the value '\uEA49'.
+   */
   closePaneMirrored: '\uEA49',
-  cloud: '\uE753',
+  /**
+   * Icon code with the value '\uEF84'.
+   */
+  closedCaption: '\uEF84',
+  /**
+   * Icon code with the value '\uECA9'.
+   */
   cloudAdd: '\uECA9',
+  /**
+   * Icon code with the value '\uEBD3'.
+   */
   cloudDownload: '\uEBD3',
+  /**
+   * Icon code with the value '\uEC8E'.
+   */
   cloudUpload: '\uEC8E',
+  /**
+   * Icon code with the value '\uE9BE'.
+   */
   cloudWeather: '\uE9BE',
+  /**
+   * Icon code with the value '\uE9BF'.
+   */
   cloudy: '\uE9BF',
+  /**
+   * Icon code with the value '\uEA9D'.
+   */
   cocktails: '\uEA9D',
+  /**
+   * Icon code with the value '\uE943'.
+   */
   code: '\uE943',
+  /**
+   * Icon code with the value '\uEAEF'.
+   */
   coffee: '\uEAEF',
-  coffeeScript: '\uF2FA',
-  collapseContent: '\uF165',
-  collapseContentSingle: '\uF166',
+  /**
+   * Icon code with the value '\uEDC9'.
+   */
+  collabsDbLogo: '\uEDC9',
+  /**
+   * Icon code with the value '\uEF66'.
+   */
   collapseMenu: '\uEF66',
+  /**
+   * Icon code with the value '\uEB26'.
+   */
   collegeFootball: '\uEB26',
+  /**
+   * Icon code with the value '\uEB25'.
+   */
   collegeHoops: '\uEB25',
+  /**
+   * Icon code with the value '\uE790'.
+   */
   color: '\uE790',
-  colorSolid: '\uF354',
-  columnLeftTwoThirds: '\uF1D6',
-  columnLeftTwoThirdsEdit: '\uF324',
-  columnOptions: '\uF317',
-  columnRightTwoThirds: '\uF1D7',
-  columnRightTwoThirdsEdit: '\uF325',
+  /**
+   * Icon code with the value '\uEDBB'.
+   */
   combine: '\uEDBB',
-  commandPrompt: '\uE756',
-  comment: '\uE90A',
-  commentAdd: '\uF2B3',
-  commentNext: '\uF2B4',
-  commentPrevious: '\uF2B5',
-  commentUrgent: '\uF307',
-  communications: '\uE95A',
+  /**
+   * Icon code with the value '\uE942'.
+   */
   compassNW: '\uE942',
+  /**
+   * Icon code with the value '\uE930'.
+   */
   completed: '\uE930',
+  /**
+   * Icon code with the value '\uEC61'.
+   */
   completedSolid: '\uEC61',
-  configurationSolid: '\uF334',
-  constructionCone: '\uE98F',
-  constructionConeSolid: '\uF339',
+  /**
+   * Icon code with the value '\uE77B'.
+   */
   contact: '\uE77B',
+  /**
+   * Icon code with the value '\uEEBD'.
+   */
   contactCard: '\uEEBD',
+  /**
+   * Icon code with the value '\uE779'.
+   */
   contactInfo: '\uE779',
+  /**
+   * Icon code with the value '\uE7B8'.
+   */
+  container: '\uE7B8',
+  /**
+   * Icon code with the value '\uE7A1'.
+   */
   contrast: '\uE7A1',
+  /**
+   * Icon code with the value '\uE8C8'.
+   */
   copy: '\uE8C8',
+  /**
+   * Icon code with the value '\uEAF3'.
+   */
   cotton: '\uEAF3',
-  cPlusPlus: '\uF2F4',
-  cPlusPlusLanguage: '\uF2F3',
+  /**
+   * Icon code with the value '\uEB1E'.
+   */
   cricket: '\uEB1E',
-  crmReport: '\uEFFE',
-  crownSolid: '\uF336',
-  cSharp: '\uF2F0',
-  cSharpLanguage: '\uF2EF',
+  /**
+   * Icon code with the value '\uEBEF'.
+   */
   css: '\uEBEF',
+  /**
+   * Icon code with the value '\uEEBE'.
+   */
   customList: '\uEEBE',
+  /**
+   * Icon code with the value '\uEEBF'.
+   */
   customListMirrored: '\uEEBF',
-  cut: '\uE8C6',
+  /**
+   * Icon code with the value '\uEAC7'.
+   */
   cycling: '\uEAC7',
-  database: '\uEFC7',
+  /**
+   * Icon code with the value '\uEEB7'.
+   */
   dataConnectionLibrary: '\uEEB7',
-  dateTime: '\uEC92',
+  /**
+   * Icon code with the value '\uEA17'.
+   */
   dateTime2: '\uEA17',
+  /**
+   * Icon code with the value '\uEC92'.
+   */
+  dateTime: '\uEC92',
+  /**
+   * Icon code with the value '\uEE93'.
+   */
   dateTimeMirrored: '\uEE93',
-  decisionSolid: '\uF350',
+  /**
+   * Icon code with the value '\uE290'.
+   */
   decreaseIndentLegacy: '\uE290',
-  delete: '\uE74D',
+  /**
+   * Icon code with the value '\uEEEE'.
+   */
   delveAnalytics: '\uEEEE',
+  /**
+   * Icon code with the value '\uEDCA'.
+   */
   delveAnalyticsLogo: '\uEDCA',
-  delveLogo: '\uF280',
-  delveLogoFill: '\uF281',
-  delveLogoInverse: '\uED76',
-  deploy: '\uF29D',
+  /**
+   * Icon code with the value '\uED76'.
+   */
+  delveLogo: '\uED76',
+  /**
+   * Icon code with the value '\uEDC1'.
+   */
   descending: '\uEDC1',
+  /**
+   * Icon code with the value '\uEB3C'.
+   */
   design: '\uEB3C',
+  /**
+   * Icon code with the value '\uEC7A'.
+   */
   developerTools: '\uEC7A',
+  /**
+   * Icon code with the value '\uEA6C'.
+   */
   devices3: '\uEA6C',
+  /**
+   * Icon code with the value '\uEB66'.
+   */
   devices4: '\uEB66',
+  /**
+   * Icon code with the value '\uE75F'.
+   */
   dialpad: '\uE75F',
-  diamondSolid: '\uF34C',
+  /**
+   * Icon code with the value '\uE82D'.
+   */
   dictionary: '\uE82D',
+  /**
+   * Icon code with the value '\uEAC8'.
+   */
   dietPlanNotebook: '\uEAC8',
-  diffInline: '\uF309',
-  diffSideBySide: '\uF30A',
+  /**
+   * Icon code with the value '\uE8D8'.
+   */
   disableUpdates: '\uE8D8',
+  /**
+   * Icon code with the value '\uE8E0'.
+   */
   dislike: '\uE8E0',
-  dockLeft: '\uE90C',
-  dockLeftMirrored: '\uEA4C',
-  dockRight: '\uE90D',
+  /**
+   * Icon code with the value '\uEEB8'.
+   */
   docLibrary: '\uEEB8',
-  docsLogoInverse: '\uEDCB',
+  /**
+   * Icon code with the value '\uE90C'.
+   */
+  dockLeft: '\uE90C',
+  /**
+   * Icon code with the value '\uEA4C'.
+   */
+  dockLeftMirrored: '\uEA4C',
+  /**
+   * Icon code with the value '\uE90D'.
+   */
+  dockRight: '\uE90D',
+  /**
+   * Icon code with the value '\uEDCB'.
+   */
+  docsLogo: '\uEDCB',
+  /**
+   * Icon code with the value '\uE8A5'.
+   */
   document: '\uE8A5',
-  documentation: '\uEC17',
-  documentManagement: '\uEFFC',
+  /**
+   * Icon code with the value '\uEF57'.
+   */
   documentReply: '\uEF57',
+  /**
+   * Icon code with the value '\uEF6C'.
+   */
   documentSearch: '\uEF6C',
+  /**
+   * Icon code with the value '\uEED6'.
+   */
   documentSet: '\uEED6',
-  donutChart: '\uF368',
+  /**
+   * Icon code with the value '\uEC17'.
+   */
+  documentation: '\uEC17',
+  /**
+   * Icon code with the value '\uEB75'.
+   */
   door: '\uEB75',
+  /**
+   * Icon code with the value '\uEB8F'.
+   */
   doubleBookmark: '\uEB8F',
-  doubleChevronDown: '\uEE04',
+  /**
+   * Icon code with the value '\uEE97'.
+   */
   doubleChevronDown12: '\uEE97',
-  doubleChevronDown8: '\uF36B',
-  doubleChevronLeft: '\uEDBE',
+  /**
+   * Icon code with the value '\uEE04'.
+   */
+  doubleChevronDown: '\uEE04',
+  /**
+   * Icon code with the value '\uEE98'.
+   */
   doubleChevronLeft12: '\uEE98',
-  doubleChevronLeft8: '\uF36D',
+  /**
+   * Icon code with the value '\uEDBE'.
+   */
+  doubleChevronLeft: '\uEDBE',
+  /**
+   * Icon code with the value '\uE991'.
+   */
   doubleChevronLeftMed: '\uE991',
+  /**
+   * Icon code with the value '\uEA4D'.
+   */
   doubleChevronLeftMedMirrored: '\uEA4D',
-  doubleChevronRight: '\uEDBF',
+  /**
+   * Icon code with the value '\uEE99'.
+   */
   doubleChevronRight12: '\uEE99',
-  doubleChevronRight8: '\uF36E',
-  doubleChevronUp: '\uEDBD',
+  /**
+   * Icon code with the value '\uEDBF'.
+   */
+  doubleChevronRight: '\uEDBF',
+  /**
+   * Icon code with the value '\uEE96'.
+   */
   doubleChevronUp12: '\uEE96',
-  doubleChevronUp8: '\uF36C',
-  doubleColumn: '\uF1D4',
-  doubleColumnEdit: '\uF322',
+  /**
+   * Icon code with the value '\uEDBD'.
+   */
+  doubleChevronUp: '\uEDBD',
+  /**
+   * Icon code with the value '\uE74B'.
+   */
   down: '\uE74B',
+  /**
+   * Icon code with the value '\uE896'.
+   */
   download: '\uE896',
+  /**
+   * Icon code with the value '\uECA8'.
+   */
   drm: '\uECA8',
+  /**
+   * Icon code with the value '\uEB42'.
+   */
   drop: '\uEB42',
+  /**
+   * Icon code with the value '\uED77'.
+   */
   dropboxLogo: '\uED77',
+  /**
+   * Icon code with the value '\uEDC5'.
+   */
   dropdown: '\uEDC5',
+  /**
+   * Icon code with the value '\uE9CD'.
+   */
   duststorm: '\uE9CD',
+  /**
+   * Icon code with the value '\uEDCD'.
+   */
+  dynamicSmbLogo: '\uEDCD',
+  /**
+   * Icon code with the value '\uEDCC'.
+   */
   dynamics365Logo: '\uEDCC',
-  dynamicSMBLogo: '\uEDCD',
+  /**
+   * Icon code with the value '\uE807'.
+   */
   eatDrink: '\uE807',
+  /**
+   * Icon code with the value '\uEC60'.
+   */
   edgeLogo: '\uEC60',
+  /**
+   * Icon code with the value '\uE70F'.
+   */
   edit: '\uE70F',
+  /**
+   * Icon code with the value '\uEF61'.
+   */
   editMail: '\uEF61',
+  /**
+   * Icon code with the value '\uEB7E'.
+   */
   editMirrored: '\uEB7E',
+  /**
+   * Icon code with the value '\uED9D'.
+   */
   editNote: '\uED9D',
+  /**
+   * Icon code with the value '\uEF77'.
+   */
   editPhoto: '\uEF77',
+  /**
+   * Icon code with the value '\uEF60'.
+   */
   editStyle: '\uEF60',
-  egnyteLogo: '\uF373',
+  /**
+   * Icon code with the value '\uECCE'.
+   */
   embed: '\uECCE',
+  /**
+   * Icon code with the value '\uE731'.
+   */
   emi: '\uE731',
-  emoji: '\uE899',
+  /**
+   * Icon code with the value '\uE76E'.
+   */
   emoji2: '\uE76E',
+  /**
+   * Icon code with the value '\uE899'.
+   */
+  emoji: '\uE899',
+  /**
+   * Icon code with the value '\uEA88'.
+   */
   emojiDisappointed: '\uEA88',
+  /**
+   * Icon code with the value '\uEA87'.
+   */
   emojiNeutral: '\uEA87',
+  /**
+   * Icon code with the value '\uEF88'.
+   */
   emptyRecycleBin: '\uEF88',
-  engineeringGroup: '\uF362',
+  /**
+   * Icon code with the value '\uE9E9'.
+   */
   equalizer: '\uE9E9',
+  /**
+   * Icon code with the value '\uE75C'.
+   */
   eraseTool: '\uE75C',
+  /**
+   * Icon code with the value '\uE783'.
+   */
   error: '\uE783',
+  /**
+   * Icon code with the value '\uEA39'.
+   */
   errorBadge: '\uEA39',
+  /**
+   * Icon code with the value '\uECA3'.
+   */
   event: '\uECA3',
-  eventDate: '\uF059',
+  /**
+   * Icon code with the value '\uED8B'.
+   */
   eventInfo: '\uED8B',
+  /**
+   * Icon code with the value '\uEF73'.
+   */
   excelDocument: '\uEF73',
-  excelLogo: '\uF1E5',
-  excelLogo16: '\uF397',
-  excelLogoFill: '\uF1E6',
-  excelLogoFill16: '\uF398',
-  excelLogoInverse: '\uEC28',
-  excelLogoInverse16: '\uF396',
-  exchangeLogo: '\uF284',
-  exchangeLogoFill: '\uF285',
-  exchangeLogoInverse: '\uED78',
+  /**
+   * Icon code with the value '\uEC28'.
+   */
+  excelLogo: '\uEC28',
+  /**
+   * Icon code with the value '\uED78'.
+   */
+  exchangeLogo: '\uED78',
+  /**
+   * Icon code with the value '\uEF67'.
+   */
   expandMenu: '\uEF67',
-  exploreContent: '\uECCD',
-  exploreContentSingle: '\uF164',
-  export: '\uEDE1',
-  exportMirrored: '\uEDE2',
+  /**
+   * Icon code with the value '\uF09C'.
+   */
   fabricAssetLibrary: '\uF09C',
+  /**
+   * Icon code with the value '\uF09D'.
+   */
   fabricDataConnectionLibrary: '\uF09D',
+  /**
+   * Icon code with the value '\uF09E'.
+   */
   fabricDocLibrary: '\uF09E',
+  /**
+   * Icon code with the value '\uF0A9'.
+   */
   fabricFolder: '\uF0A9',
+  /**
+   * Icon code with the value '\uF0AA'.
+   */
   fabricFolderFill: '\uF0AA',
+  /**
+   * Icon code with the value '\uF0A4'.
+   */
   fabricFolderSearch: '\uF0A4',
+  /**
+   * Icon code with the value '\uF09F'.
+   */
   fabricFormLibrary: '\uF09F',
+  /**
+   * Icon code with the value '\uF0A0'.
+   */
   fabricFormLibraryMirrored: '\uF0A0',
+  /**
+   * Icon code with the value '\uF0A5'.
+   */
   fabricMovetoFolder: '\uF0A5',
+  /**
+   * Icon code with the value '\uF0AB'.
+   */
   fabricNewFolder: '\uF0AB',
+  /**
+   * Icon code with the value '\uF0A8'.
+   */
   fabricOpenFolderHorizontal: '\uF0A8',
+  /**
+   * Icon code with the value '\uF0AC'.
+   */
   fabricPictureLibrary: '\uF0AC',
+  /**
+   * Icon code with the value '\uF0A3'.
+   */
   fabricPublicFolder: '\uF0A3',
+  /**
+   * Icon code with the value '\uF0A1'.
+   */
   fabricReportLibrary: '\uF0A1',
+  /**
+   * Icon code with the value '\uF0A2'.
+   */
   fabricReportLibraryMirrored: '\uF0A2',
+  /**
+   * Icon code with the value '\uF0A7'.
+   */
   fabricSyncFolder: '\uF0A7',
+  /**
+   * Icon code with the value '\uF0A6'.
+   */
   fabricUnsyncFolder: '\uF0A6',
+  /**
+   * Icon code with the value '\uECB3'.
+   */
   facebookLogo: '\uECB3',
+  /**
+   * Icon code with the value '\uEBDA'.
+   */
   family: '\uEBDA',
+  /**
+   * Icon code with the value '\uECEB'.
+   */
   fangBody: '\uECEB',
-  fastForward: '\uEB9D',
-  favicon: '\uE737',
+  /**
+   * Icon code with the value '\uE728'.
+   */
   favoriteList: '\uE728',
+  /**
+   * Icon code with the value '\uE734'.
+   */
   favoriteStar: '\uE734',
+  /**
+   * Icon code with the value '\uE735'.
+   */
   favoriteStarFill: '\uE735',
+  /**
+   * Icon code with the value '\uEF5C'.
+   */
   fax: '\uEF5C',
-  feedback: '\uED15',
-  feedbackRequestMirroredSolid: '\uF35A',
-  feedbackRequestSolid: '\uF359',
-  feedbackResponseSolid: '\uF35B',
+  /**
+   * Icon code with the value '\uE7E3'.
+   */
   ferry: '\uE7E3',
+  /**
+   * Icon code with the value '\uEB48'.
+   */
   ferrySolid: '\uEB48',
-  fieldChanged: '\uF2C3',
-  fieldEmpty: '\uF2C1',
-  fieldFilled: '\uF2C2',
-  fieldNotChanged: '\uF2C4',
-  fileASPX: '\uF2E9',
-  fileBug: '\uF30D',
-  fileCode: '\uF30E',
-  fileComment: '\uF30F',
-  fileCSS: '\uF2EA',
-  fileHTML: '\uF2ED',
-  fileImage: '\uF311',
-  fileJAVA: '\uF2E8',
-  fileLess: '\uF2EC',
-  filePDB: '\uF2E5',
-  fileSass: '\uF2EB',
-  fileSQL: '\uF2E7',
-  fileSymlink: '\uF312',
-  fileTemplate: '\uF2E6',
-  fileTypeSolution: '\uF387',
+  /**
+   * Icon code with the value '\uE71C'.
+   */
   filter: '\uE71C',
+  /**
+   * Icon code with the value '\uE795'.
+   */
   filters: '\uE795',
-  filtersSolid: '\uF353',
+  /**
+   * Icon code with the value '\uE7BB'.
+   */
   financial: '\uE7BB',
-  financialMirroredSolid: '\uF347',
-  financialSolid: '\uF346',
+  /**
+   * Icon code with the value '\uE928'.
+   */
   fingerprint: '\uE928',
-  fiveTileGrid: '\uF274',
+  /**
+   * Icon code with the value '\uE7C1'.
+   */
   flag: '\uE7C1',
-  flameSolid: '\uF1F3',
+  /**
+   * Icon code with the value '\uE935'.
+   */
   flickDown: '\uE935',
+  /**
+   * Icon code with the value '\uE937'.
+   */
   flickLeft: '\uE937',
+  /**
+   * Icon code with the value '\uE938'.
+   */
   flickRight: '\uE938',
+  /**
+   * Icon code with the value '\uE936'.
+   */
   flickUp: '\uE936',
+  /**
+   * Icon code with the value '\uEF90'.
+   */
   flow: '\uEF90',
-  focalPoint: '\uF277',
+  /**
+   * Icon code with the value '\uE9CB'.
+   */
   fog: '\uE9CB',
+  /**
+   * Icon code with the value '\uE8B7'.
+   */
   folder: '\uE8B7',
+  /**
+   * Icon code with the value '\uE8D5'.
+   */
   folderFill: '\uE8D5',
+  /**
+   * Icon code with the value '\uF12B'.
+   */
   folderHorizontal: '\uF12B',
-  folderList: '\uF2CE',
-  folderListMirrored: '\uF2CF',
+  /**
+   * Icon code with the value '\uE838'.
+   */
   folderOpen: '\uE838',
-  folderQuery: '\uF2CD',
+  /**
+   * Icon code with the value '\uEF65'.
+   */
   folderSearch: '\uEF65',
+  /**
+   * Icon code with the value '\uE8D2'.
+   */
   font: '\uE8D2',
+  /**
+   * Icon code with the value '\uE8D3'.
+   */
   fontColor: '\uE8D3',
+  /**
+   * Icon code with the value '\uE8E7'.
+   */
   fontDecrease: '\uE8E7',
+  /**
+   * Icon code with the value '\uE8E8'.
+   */
   fontIncrease: '\uE8E8',
+  /**
+   * Icon code with the value '\uE8E9'.
+   */
   fontSize: '\uE8E9',
+  /**
+   * Icon code with the value '\uEEB9'.
+   */
   formLibrary: '\uEEB9',
+  /**
+   * Icon code with the value '\uEEBA'.
+   */
   formLibraryMirrored: '\uEEBA',
+  /**
+   * Icon code with the value '\uE72A'.
+   */
   forward: '\uE72A',
+  /**
+   * Icon code with the value '\uED8C'.
+   */
   forwardEvent: '\uED8C',
+  /**
+   * Icon code with the value '\uE9EF'.
+   */
   freezing: '\uE9EF',
+  /**
+   * Icon code with the value '\uE9CA'.
+   */
   frigid: '\uE9CA',
-  fSharp: '\uF2F6',
-  fSharpLanguage: '\uF2F5',
+  /**
+   * Icon code with the value '\uE91F'.
+   */
   fullCircleMask: '\uE91F',
-  fullHistory: '\uF31C',
+  /**
+   * Icon code with the value '\uE740'.
+   */
   fullScreen: '\uE740',
-  fullWidth: '\uF2FE',
-  fullWidthEdit: '\uF2FF',
+  /**
+   * Icon code with the value '\uE9DA'.
+   */
   generate: '\uE9DA',
-  giftbox: '\uEC1F',
-  giftboxOpen: '\uF133',
-  giftBoxSolid: '\uF341',
+  /**
+   * Icon code with the value '\uEB8E'.
+   */
   giftCard: '\uEB8E',
-  gitGraph: '\uF2CA',
+  /**
+   * Icon code with the value '\uEC1F'.
+   */
+  giftbox: '\uEC1F',
+  /**
+   * Icon code with the value '\uEA16'.
+   */
   glasses: '\uEA16',
+  /**
+   * Icon code with the value '\uECF4'.
+   */
   glimmer: '\uECF4',
+  /**
+   * Icon code with the value '\uE700'.
+   */
   globalNavButton: '\uE700',
+  /**
+   * Icon code with the value '\uE774'.
+   */
   globe: '\uE774',
+  /**
+   * Icon code with the value '\uEF53'.
+   */
   globeFavorite: '\uEF53',
+  /**
+   * Icon code with the value '\uEB1F'.
+   */
   golf: '\uEB1F',
+  /**
+   * Icon code with the value '\uEE0B'.
+   */
   googleDriveLogo: '\uEE0B',
-  googleDriveLogoBottomBlue: '\uF375',
-  googleDriveLogoLeftGreen: '\uF374',
-  googleDriveLogoRightYellow: '\uF376',
+  /**
+   * Icon code with the value '\uE8D1'.
+   */
   gotoToday: '\uE8D1',
-  gripperBarVertical: '\uE784',
+  /**
+   * Icon code with the value '\uE75E'.
+   */
   gripperTool: '\uE75E',
+  /**
+   * Icon code with the value '\uE902'.
+   */
   group: '\uE902',
+  /**
+   * Icon code with the value '\uEE67'.
+   */
   groupedAscending: '\uEE67',
+  /**
+   * Icon code with the value '\uEE66'.
+   */
   groupedDescending: '\uEE66',
+  /**
+   * Icon code with the value '\uEF74'.
+   */
   groupedList: '\uEF74',
+  /**
+   * Icon code with the value '\uEA00'.
+   */
   hailDay: '\uEA00',
+  /**
+   * Icon code with the value '\uEA13'.
+   */
   hailNight: '\uEA13',
-  halfAlpha: '\uE97E',
+  /**
+   * Icon code with the value '\uE929'.
+   */
   handwriting: '\uE929',
-  hardDriveGroup: '\uF18F',
+  /**
+   * Icon code with the value '\uEA19'.
+   */
   header1: '\uEA19',
+  /**
+   * Icon code with the value '\uEF36'.
+   */
   header2: '\uEF36',
+  /**
+   * Icon code with the value '\uEF37'.
+   */
   header3: '\uEF37',
+  /**
+   * Icon code with the value '\uEF38'.
+   */
   header4: '\uEF38',
+  /**
+   * Icon code with the value '\uE95B'.
+   */
   headset: '\uE95B',
-  headsetSolid: '\uF348',
+  /**
+   * Icon code with the value '\uE95E'.
+   */
   health: '\uE95E',
-  healthSolid: '\uF33F',
+  /**
+   * Icon code with the value '\uEB51'.
+   */
   heart: '\uEB51',
+  /**
+   * Icon code with the value '\uEB52'.
+   */
   heartFill: '\uEB52',
+  /**
+   * Icon code with the value '\uE897'.
+   */
   help: '\uE897',
+  /**
+   * Icon code with the value '\uEA51'.
+   */
   helpMirrored: '\uEA51',
-  hide: '\uED1A',
+  /**
+   * Icon code with the value '\uEF89'.
+   */
   hide2: '\uEF89',
-  highlight: '\uE7E6',
-  highlightMappedShapes: '\uF2A1',
+  /**
+   * Icon code with the value '\uED1A'.
+   */
+  hide: '\uED1A',
+  /**
+   * Icon code with the value '\uE81C'.
+   */
   history: '\uE81C',
+  /**
+   * Icon code with the value '\uE80F'.
+   */
   home: '\uE80F',
+  /**
+   * Icon code with the value '\uEA8A'.
+   */
   homeSolid: '\uEA8A',
+  /**
+   * Icon code with the value '\uE91D'.
+   */
   hospital: '\uE91D',
+  /**
+   * Icon code with the value '\uE824'.
+   */
   hotel: '\uE824',
-  iconSetsFlag: '\uF2A4',
-  imageCrosshair: '\uF2C9',
-  imageDiff: '\uF30B',
-  imagePixel: '\uF30C',
-  import: '\uE8B5',
-  important: '\uE8C9',
-  importMirrored: '\uEA52',
-  inboxCheck: '\uEF64',
-  incidentTriangle: '\uE814',
-  increaseIndentLegacy: '\uE291',
-  info: '\uE946',
-  info2: '\uEA1F',
-  infoSolid: '\uF167',
-  insertTextBox: '\uEC7D',
-  installToDrive: '\uF28D',
-  internetSharing: '\uE704',
+  /**
+   * Icon code with the value '\uEF8A'.
+   */
   iOsAppStoreLogo: '\uEF8A',
+  /**
+   * Icon code with the value '\uE8C9'.
+   */
+  important: '\uE8C9',
+  /**
+   * Icon code with the value '\uEF64'.
+   */
+  inboxCheck: '\uEF64',
+  /**
+   * Icon code with the value '\uE814'.
+   */
+  incidentTriangle: '\uE814',
+  /**
+   * Icon code with the value '\uE291'.
+   */
+  increaseIndentLegacy: '\uE291',
+  /**
+   * Icon code with the value '\uEA1F'.
+   */
+  info2: '\uEA1F',
+  /**
+   * Icon code with the value '\uE946'.
+   */
+  info: '\uE946',
+  /**
+   * Icon code with the value '\uEC7D'.
+   */
+  insertTextBox: '\uEC7D',
+  /**
+   * Icon code with the value '\uE704'.
+   */
+  internetSharing: '\uE704',
+  /**
+   * Icon code with the value '\uEEC0'.
+   */
   issueTracking: '\uEEC0',
+  /**
+   * Icon code with the value '\uEEC1'.
+   */
   issueTrackingMirrored: '\uEEC1',
+  /**
+   * Icon code with the value '\uE8DB'.
+   */
   italic: '\uE8DB',
-  javaScriptLanguage: '\uF2EE',
+  /**
+   * Icon code with the value '\uED8F'.
+   */
   joinOnlineMeeting: '\uED8F',
+  /**
+   * Icon code with the value '\uEBF0'.
+   */
   js: '\uEBF0',
+  /**
+   * Icon code with the value '\uE932'.
+   */
   label: '\uE932',
+  /**
+   * Icon code with the value '\uEF6B'.
+   */
   landscapeOrientation: '\uEF6B',
+  /**
+   * Icon code with the value '\uEC76'.
+   */
   laptopSelected: '\uEC76',
+  /**
+   * Icon code with the value '\uEECB'.
+   */
   largeGrid: '\uEECB',
+  /**
+   * Icon code with the value '\uE8F1'.
+   */
   library: '\uE8F1',
+  /**
+   * Icon code with the value '\uEF62'.
+   */
   lifesaver: '\uEF62',
+  /**
+   * Icon code with the value '\uEF63'.
+   */
   lifesaverLock: '\uEF63',
+  /**
+   * Icon code with the value '\uE793'.
+   */
   light: '\uE793',
+  /**
+   * Icon code with the value '\uEA80'.
+   */
   lightbulb: '\uEA80',
+  /**
+   * Icon code with the value '\uE945'.
+   */
   lightningBolt: '\uE945',
+  /**
+   * Icon code with the value '\uE8E1'.
+   */
   like: '\uE8E1',
-  lineChart: '\uE9E6',
+  /**
+   * Icon code with the value '\uE71B'.
+   */
   link: '\uE71B',
-  linkedInLogo: '\uF20A',
+  /**
+   * Icon code with the value '\uEA37'.
+   */
   list: '\uEA37',
+  /**
+   * Icon code with the value '\uEA55'.
+   */
   listMirrored: '\uEA55',
-  localeLanguage: '\uF2B7',
+  /**
+   * Icon code with the value '\uE81D'.
+   */
   location: '\uE81D',
+  /**
+   * Icon code with the value '\uE80E'.
+   */
   locationCircle: '\uE80E',
+  /**
+   * Icon code with the value '\uE827'.
+   */
   locationDot: '\uE827',
+  /**
+   * Icon code with the value '\uE920'.
+   */
   locationFill: '\uE920',
-  locationOutline: '\uF2D0',
+  /**
+   * Icon code with the value '\uE72E'.
+   */
   lock: '\uE72E',
-  lockSolid: '\uE9A2',
-  logRemove: '\uF316',
+  /**
+   * Icon code with the value '\uEC8A'.
+   */
   lowerBrightness: '\uEC8A',
+  /**
+   * Icon code with the value '\uED79'.
+   */
   lyncLogo: '\uED79',
+  /**
+   * Icon code with the value '\uE715'.
+   */
   mail: '\uE715',
+  /**
+   * Icon code with the value '\uED80'.
+   */
   mailAlert: '\uED80',
+  /**
+   * Icon code with the value '\uED81'.
+   */
   mailCheck: '\uED81',
+  /**
+   * Icon code with the value '\uE8A8'.
+   */
   mailFill: '\uE8A8',
+  /**
+   * Icon code with the value '\uE89C'.
+   */
   mailForward: '\uE89C',
+  /**
+   * Icon code with the value '\uEA56'.
+   */
   mailForwardMirrored: '\uEA56',
+  /**
+   * Icon code with the value '\uED82'.
+   */
   mailLowImportance: '\uED82',
+  /**
+   * Icon code with the value '\uED83'.
+   */
   mailPause: '\uED83',
+  /**
+   * Icon code with the value '\uED84'.
+   */
   mailRepeat: '\uED84',
+  /**
+   * Icon code with the value '\uE8CA'.
+   */
   mailReply: '\uE8CA',
+  /**
+   * Icon code with the value '\uE8C2'.
+   */
   mailReplyAll: '\uE8C2',
+  /**
+   * Icon code with the value '\uEA58'.
+   */
   mailReplyAllMirrored: '\uEA58',
+  /**
+   * Icon code with the value '\uEA57'.
+   */
   mailReplyMirrored: '\uEA57',
-  mailSolid: '\uF343',
+  /**
+   * Icon code with the value '\uE816'.
+   */
   mapDirections: '\uE816',
+  /**
+   * Icon code with the value '\uE707'.
+   */
   mapPin: '\uE707',
-  markDownLanguage: '\uF2FB',
+  /**
+   * Icon code with the value '\uEAFC'.
+   */
   market: '\uEAFC',
+  /**
+   * Icon code with the value '\uEF42'.
+   */
   marketDown: '\uEF42',
-  medical: '\uEAD4',
+  /**
+   * Icon code with the value '\uE789'.
+   */
   megaphone: '\uE789',
-  megaphoneSolid: '\uF332',
+  /**
+   * Icon code with the value '\uE77C'.
+   */
   memo: '\uE77C',
+  /**
+   * Icon code with the value '\uE7D5'.
+   */
   merge: '\uE7D5',
-  mergeDuplicate: '\uF29A',
+  /**
+   * Icon code with the value '\uE8BD'.
+   */
   message: '\uE8BD',
+  /**
+   * Icon code with the value '\uEC70'.
+   */
   messageFill: '\uEC70',
+  /**
+   * Icon code with the value '\uE720'.
+   */
   microphone: '\uE720',
+  /**
+   * Icon code with the value '\uF130'.
+   */
   microsoftStaffhubLogo: '\uF130',
+  /**
+   * Icon code with the value '\uE732'.
+   */
   miniLink: '\uE732',
+  /**
+   * Icon code with the value '\uEC75'.
+   */
   mobileSelected: '\uEC75',
+  /**
+   * Icon code with the value '\uEAFD'.
+   */
   money: '\uEAFD',
+  /**
+   * Icon code with the value '\uE712'.
+   */
   more: '\uE712',
+  /**
+   * Icon code with the value '\uEB22'.
+   */
   moreSports: '\uEB22',
-  moreVertical: '\uF2BC',
+  /**
+   * Icon code with the value '\uE7C2'.
+   */
   move: '\uE7C2',
+  /**
+   * Icon code with the value '\uE8DE'.
+   */
   moveToFolder: '\uE8DE',
+  /**
+   * Icon code with the value '\uEB6C'.
+   */
   msnLogo: '\uEB6C',
-  msnVideos: '\uEB1C',
-  msnVideosSolid: '\uF2DA',
+  /**
+   * Icon code with the value '\uE762'.
+   */
   multiSelect: '\uE762',
+  /**
+   * Icon code with the value '\uEA98'.
+   */
   multiSelectMirrored: '\uEA98',
+  /**
+   * Icon code with the value '\uE940'.
+   */
   musicInCollection: '\uE940',
+  /**
+   * Icon code with the value '\uEA36'.
+   */
   musicInCollectionFill: '\uEA36',
+  /**
+   * Icon code with the value '\uEC4F'.
+   */
   musicNote: '\uEC4F',
+  /**
+   * Icon code with the value '\uE800'.
+   */
   nav2DMapView: '\uE800',
-  navigateBack: '\uF2DD',
-  navigateBackMirrored: '\uF2DE',
-  navigateExternalInline: '\uF35F',
-  navigateForward: '\uF2DF',
-  navigateForwardMirrored: '\uF2E0',
-  networkTower: '\uEC05',
-  newAnalyticsQuery: '\uF1E0',
+  /**
+   * Icon code with the value '\uE8F4'.
+   */
   newFolder: '\uE8F4',
+  /**
+   * Icon code with the value '\uE900'.
+   */
   news: '\uE900',
-  newTeamProject: '\uF2B2',
-  next: '\uE893',
+  /**
+   * Icon code with the value '\uED99'.
+   */
   noteForward: '\uED99',
+  /**
+   * Icon code with the value '\uED9A'.
+   */
   notePinned: '\uED9A',
+  /**
+   * Icon code with the value '\uED98'.
+   */
   noteReply: '\uED98',
-  numberedList: '\uEA1C',
+  /**
+   * Icon code with the value '\uEDC4'.
+   */
   numberField: '\uEDC4',
-  officeAddinsLogo: '\uEEC7',
+  /**
+   * Icon code with the value '\uEA1C'.
+   */
+  numberedList: '\uEA1C',
+  /**
+   * Icon code with the value '\uEDCE'.
+   */
   officeAssistantLogo: '\uEDCE',
+  /**
+   * Icon code with the value '\uEF86'.
+   */
   officeFormLogo: '\uEF86',
+  /**
+   * Icon code with the value '\uEB6E'.
+   */
   officeLogo: '\uEB6E',
+  /**
+   * Icon code with the value '\uEDCF'.
+   */
   officeStoreLogo: '\uEDCF',
-  officeVideoLogo: '\uF282',
-  officeVideoLogoFill: '\uF283',
-  officeVideoLogoInverse: '\uED7A',
+  /**
+   * Icon code with the value '\uED7A'.
+   */
+  officeVideoLogo: '\uED7A',
+  /**
+   * Icon code with the value '\uEEC8'.
+   */
   offlineOneDriveParachute: '\uEEC8',
+  /**
+   * Icon code with the value '\uEEC9'.
+   */
   offlineOneDriveParachuteDisabled: '\uEEC9',
-  offlineStorageSolid: '\uF34E',
+  /**
+   * Icon code with the value '\uE941'.
+   */
   oneDrive: '\uE941',
+  /**
+   * Icon code with the value '\uEF32'.
+   */
   oneDriveAdd: '\uEF32',
-  oneNoteEduLogoInverse: '\uEDD0',
-  oneNoteLogo: '\uF1E7',
-  oneNoteLogo16: '\uF39A',
-  oneNoteLogoFill: '\uF1E8',
-  oneNoteLogoFill16: '\uF39B',
-  oneNoteLogoInverse: '\uEC0D',
-  oneNoteLogoInverse16: '\uF399',
+  /**
+   * Icon code with the value '\uEDD0'.
+   */
+  oneNoteEduLogo: '\uEDD0',
+  /**
+   * Icon code with the value '\uEC0D'.
+   */
+  oneNoteLogo: '\uEC0D',
+  /**
+   * Icon code with the value '\uE8E5'.
+   */
   openFile: '\uE8E5',
+  /**
+   * Icon code with the value '\uED25'.
+   */
   openFolderHorizontal: '\uED25',
+  /**
+   * Icon code with the value '\uE8A7'.
+   */
   openInNewWindow: '\uE8A7',
+  /**
+   * Icon code with the value '\uE8A0'.
+   */
   openPane: '\uE8A0',
+  /**
+   * Icon code with the value '\uEA5B'.
+   */
   openPaneMirrored: '\uEA5B',
-  openSource: '\uEBC2',
+  /**
+   * Icon code with the value '\uECA6'.
+   */
   org: '\uECA6',
-  outlookLogo: '\uF1E9',
-  outlookLogo16: '\uF39D',
-  outlookLogoFill: '\uF1EA',
-  outlookLogoFill16: '\uF39E',
-  outlookLogoInverse: '\uEB6D',
-  outlookLogoInverse16: '\uF39C',
+  /**
+   * Icon code with the value '\uED34'.
+   */
   outOfOffice: '\uED34',
-  package: '\uE7B8',
-  packages: '\uF318',
+  /**
+   * Icon code with the value '\uEB6D'.
+   */
+  outlookLogo: '\uEB6D',
+  /**
+   * Icon code with the value '\uE7C3'.
+   */
   page: '\uE7C3',
+  /**
+   * Icon code with the value '\uEA1A'.
+   */
   pageAdd: '\uEA1A',
-  pageCheckedin: '\uF104',
+  /**
+   * Icon code with the value '\uF02C'.
+   */
   pageCheckedOut: '\uF02C',
-  pageEdit: '\uEFB6',
+  /**
+   * Icon code with the value '\uF104'.
+   */
+  pageCheckedin: '\uF104',
+  /**
+   * Icon code with the value '\uE760'.
+   */
   pageLeft: '\uE760',
-  pageListMirroredSolid: '\uF33B',
-  pageListSolid: '\uF33A',
+  /**
+   * Icon code with the value '\uE761'.
+   */
   pageRight: '\uE761',
+  /**
+   * Icon code with the value '\uE729'.
+   */
   pageSolid: '\uE729',
+  /**
+   * Icon code with the value '\uE7B0'.
+   */
   panoIndicator: '\uE7B0',
-  parachute: '\uF351',
-  parachuteSolid: '\uF352',
-  parameter: '\uF306',
+  /**
+   * Icon code with the value '\uED7B'.
+   */
   paratureLogo: '\uED7B',
-  parkingLocation: '\uE811',
-  parkingLocationMirrored: '\uEA5E',
-  parkingMirroredSolid: '\uF34B',
-  parkingSolid: '\uF34A',
+  /**
+   * Icon code with the value '\uE9C0'.
+   */
   partlyCloudyDay: '\uE9C0',
+  /**
+   * Icon code with the value '\uE9C1'.
+   */
   partlyCloudyNight: '\uE9C1',
+  /**
+   * Icon code with the value '\uECA7'.
+   */
   partyLeader: '\uECA7',
-  paste: '\uE77F',
+  /**
+   * Icon code with the value '\uE769'.
+   */
   pause: '\uE769',
+  /**
+   * Icon code with the value '\uE8C7'.
+   */
   paymentCard: '\uE8C7',
+  /**
+   * Icon code with the value '\uE977'.
+   */
   pc1: '\uE977',
+  /**
+   * Icon code with the value '\uEA90'.
+   */
   pdf: '\uEA90',
+  /**
+   * Icon code with the value '\uEF7B'.
+   */
   pencilReply: '\uEF7B',
+  /**
+   * Icon code with the value '\uE716'.
+   */
   people: '\uE716',
+  /**
+   * Icon code with the value '\uEA15'.
+   */
   peopleAdd: '\uEA15',
+  /**
+   * Icon code with the value '\uED93'.
+   */
   peopleAlert: '\uED93',
+  /**
+   * Icon code with the value '\uED91'.
+   */
   peopleBlock: '\uED91',
+  /**
+   * Icon code with the value '\uED94'.
+   */
   peoplePause: '\uED94',
+  /**
+   * Icon code with the value '\uED92'.
+   */
   peopleRepeat: '\uED92',
+  /**
+   * Icon code with the value '\uE8D7'.
+   */
   permissions: '\uE8D7',
-  permissionsSolid: '\uF349',
-  personalize: '\uE771',
+  /**
+   * Icon code with the value '\uE717'.
+   */
   phone: '\uE717',
+  /**
+   * Icon code with the value '\uEB9F'.
+   */
   photo2: '\uEB9F',
+  /**
+   * Icon code with the value '\uECAB'.
+   */
   photo2Add: '\uECAB',
+  /**
+   * Icon code with the value '\uECAC'.
+   */
   photo2Remove: '\uECAC',
+  /**
+   * Icon code with the value '\uE7AA'.
+   */
   photoCollection: '\uE7AA',
+  /**
+   * Icon code with the value '\uE8B9'.
+   */
   picture: '\uE8B9',
+  /**
+   * Icon code with the value '\uEEC2'.
+   */
   pictureLibrary: '\uEEC2',
+  /**
+   * Icon code with the value '\uEB04'.
+   */
   pieDouble: '\uEB04',
-  pieSingle: '\uEB05',
+  /**
+   * Icon code with the value '\uEACB'.
+   */
   pill: '\uEACB',
+  /**
+   * Icon code with the value '\uE718'.
+   */
   pin: '\uE718',
+  /**
+   * Icon code with the value '\uE840'.
+   */
   pinned: '\uE840',
+  /**
+   * Icon code with the value '\uE842'.
+   */
   pinnedFill: '\uE842',
-  pivotChart: '\uF24C',
-  plannerLogo: '\uEDD1',
-  planView: '\uF360',
+  /**
+   * Icon code with the value '\uEDD1'.
+   */
+  planner: '\uEDD1',
+  /**
+   * Icon code with the value '\uE768'.
+   */
   play: '\uE768',
+  /**
+   * Icon code with the value '\uEF58'.
+   */
   playerSettings: '\uEF58',
-  playResume: '\uF2C6',
-  plug: '\uF300',
-  plugConnected: '\uF302',
-  plugDisconnected: '\uF303',
-  plugSolid: '\uF301',
+  /**
+   * Icon code with the value '\uECAF'.
+   */
   poi: '\uECAF',
-  poiSolid: '\uF2D1',
+  /**
+   * Icon code with the value '\uE8F3'.
+   */
   postUpdate: '\uE8F3',
-  powerApps: '\uEDD2',
+  /**
+   * Icon code with the value '\uF092'.
+   */
   powerApps2Logo: '\uF092',
+  /**
+   * Icon code with the value '\uEDD2'.
+   */
+  powerApps: '\uEDD2',
+  /**
+   * Icon code with the value '\uF091'.
+   */
   powerAppsLogo: '\uF091',
+  /**
+   * Icon code with the value '\uEA1E'.
+   */
   powerBiLogo: '\uEA1E',
+  /**
+   * Icon code with the value '\uEF72'.
+   */
   powerPointDocument: '\uEF72',
-  powerPointLogo: '\uF1EB',
-  powerPointLogo16: '\uF394',
-  powerPointLogoFill: '\uF1EC',
-  powerPointLogoFill16: '\uF395',
-  powerPointLogoInverse: '\uEC2A',
-  powerPointLogoInverse16: '\uF393',
+  /**
+   * Icon code with the value '\uEC2A'.
+   */
+  powerPointLogo: '\uEC2A',
+  /**
+   * Icon code with the value '\uE9CF'.
+   */
   precipitation: '\uE9CF',
+  /**
+   * Icon code with the value '\uE979'.
+   */
   presenceChickletVideo: '\uE979',
+  /**
+   * Icon code with the value '\uE8FF'.
+   */
   preview: '\uE8FF',
+  /**
+   * Icon code with the value '\uE8A1'.
+   */
   previewLink: '\uE8A1',
-  previous: '\uE892',
+  /**
+   * Icon code with the value '\uE749'.
+   */
   print: '\uE749',
+  /**
+   * Icon code with the value '\uE956'.
+   */
   printfaxPrinterFile: '\uE956',
-  processing: '\uE9F5',
-  processMetaTask: '\uF290',
-  product: '\uECDC',
+  /**
+   * Icon code with the value '\uEB27'.
+   */
   proFootball: '\uEB27',
-  progressLoopInner: '\uECDE',
-  progressLoopOuter: '\uECDF',
-  progressRingDots: '\uF16A',
+  /**
+   * Icon code with the value '\uEB28'.
+   */
   proHockey: '\uEB28',
-  projectCollection: '\uF363',
-  projectLogoInverse: '\uEDD4',
+  /**
+   * Icon code with the value '\uECDC'.
+   */
+  product: '\uECDC',
+  /**
+   * Icon code with the value '\uEDD4'.
+   */
+  projectLogo: '\uEDD4',
+  /**
+   * Icon code with the value '\uE8A6'.
+   */
   protectedDocument: '\uE8A6',
-  protectRestrict: '\uF22A',
+  /**
+   * Icon code with the value '\uEF6D'.
+   */
   publicCalendar: '\uEF6D',
+  /**
+   * Icon code with the value '\uEF6E'.
+   */
   publicContactCard: '\uEF6E',
+  /**
+   * Icon code with the value '\uEF6F'.
+   */
   publicEmail: '\uEF6F',
+  /**
+   * Icon code with the value '\uEF70'.
+   */
   publicFolder: '\uEF70',
-  publisherLogo: '\uF1ED',
-  publisherLogo16: '\uF3A0',
-  publisherLogoFill: '\uF1EE',
-  publisherLogoFill16: '\uF3A1',
-  publisherLogoInverse16: '\uF39F',
+  /**
+   * Icon code with the value '\uEA86'.
+   */
   puzzle: '\uEA86',
-  py: '\uF2F9',
-  pythonLanguage: '\uF2F8',
-  queryList: '\uF2B8',
+  /**
+   * Icon code with the value '\uEE19'.
+   */
   questionnaire: '\uEE19',
+  /**
+   * Icon code with the value '\uEE4B'.
+   */
   questionnaireMirrored: '\uEE4B',
+  /**
+   * Icon code with the value '\uE70B'.
+   */
   quickNote: '\uE70B',
-  quickNoteSolid: '\uF338',
-  radioBtnOff: '\uECCA',
+  /**
+   * Icon code with the value '\uECCB'.
+   */
   radioBtnOn: '\uECCB',
+  /**
+   * Icon code with the value '\uE915'.
+   */
   radioBullet: '\uE915',
+  /**
+   * Icon code with the value '\uE9C4'.
+   */
   rain: '\uE9C4',
+  /**
+   * Icon code with the value '\uE9C3'.
+   */
   rainShowersDay: '\uE9C3',
+  /**
+   * Icon code with the value '\uEA0F'.
+   */
   rainShowersNight: '\uEA0F',
+  /**
+   * Icon code with the value '\uE9C7'.
+   */
   rainSnow: '\uE9C7',
-  rawSource: '\uF299',
+  /**
+   * Icon code with the value '\uE8C3'.
+   */
   read: '\uE8C3',
+  /**
+   * Icon code with the value '\uE736'.
+   */
   readingMode: '\uE736',
-  readingModeSolid: '\uF33D',
+  /**
+   * Icon code with the value '\uEF5B'.
+   */
   receiptCheck: '\uEF5B',
+  /**
+   * Icon code with the value '\uEF59'.
+   */
   receiptForward: '\uEF59',
+  /**
+   * Icon code with the value '\uEF5A'.
+   */
   receiptReply: '\uEF5A',
+  /**
+   * Icon code with the value '\uE823'.
+   */
   recent: '\uE823',
-  record2: '\uEA3F',
+  /**
+   * Icon code with the value '\uEF5D'.
+   */
   recurringEvent: '\uEF5D',
+  /**
+   * Icon code with the value '\uEDB2'.
+   */
   recurringTask: '\uEDB2',
+  /**
+   * Icon code with the value '\uEF87'.
+   */
   recycleBin: '\uEF87',
-  redeploy: '\uF29E',
+  /**
+   * Icon code with the value '\uE7B3'.
+   */
   redEye: '\uE7B3',
+  /**
+   * Icon code with the value '\uE7A6'.
+   */
   redo: '\uE7A6',
+  /**
+   * Icon code with the value '\uE72C'.
+   */
   refresh: '\uE72C',
+  /**
+   * Icon code with the value '\uEBF8'.
+   */
   reminderGroup: '\uEBF8',
+  /**
+   * Icon code with the value '\uE738'.
+   */
   remove: '\uE738',
+  /**
+   * Icon code with the value '\uED8A'.
+   */
   removeEvent: '\uED8A',
+  /**
+   * Icon code with the value '\uEB08'.
+   */
   removeFilter: '\uEB08',
+  /**
+   * Icon code with the value '\uED90'.
+   */
   removeLink: '\uED90',
+  /**
+   * Icon code with the value '\uED9B'.
+   */
   removeOccurrence: '\uED9B',
+  /**
+   * Icon code with the value '\uE8AC'.
+   */
   rename: '\uE8AC',
+  /**
+   * Icon code with the value '\uED50'.
+   */
   reopenPages: '\uED50',
+  /**
+   * Icon code with the value '\uE90F'.
+   */
   repair: '\uE90F',
+  /**
+   * Icon code with the value '\uE97A'.
+   */
   reply: '\uE97A',
+  /**
+   * Icon code with the value '\uEE0A'.
+   */
   replyAll: '\uEE0A',
+  /**
+   * Icon code with the value '\uEF5F'.
+   */
   replyAllAlt: '\uEF5F',
+  /**
+   * Icon code with the value '\uEE36'.
+   */
   replyAllMirrored: '\uEE36',
+  /**
+   * Icon code with the value '\uEF5E'.
+   */
   replyAlt: '\uEF5E',
+  /**
+   * Icon code with the value '\uEE35'.
+   */
   replyMirrored: '\uEE35',
-  repo: '\uF2CB',
+  /**
+   * Icon code with the value '\uEEBB'.
+   */
   reportLibrary: '\uEEBB',
+  /**
+   * Icon code with the value '\uEEBC'.
+   */
   reportLibraryMirrored: '\uEEBC',
-  repoSolid: '\uF2CC',
+  /**
+   * Icon code with the value '\uED24'.
+   */
   returnToSession: '\uED24',
-  reviewRequestMirroredSolid: '\uF357',
-  reviewRequestSolid: '\uF356',
-  reviewResponseSolid: '\uF358',
-  reviewSolid: '\uF355',
+  /**
+   * Icon code with the value '\uE845'.
+   */
   revToggleKey: '\uE845',
-  rewind: '\uEB9E',
+  /**
+   * Icon code with the value '\uE9D1'.
+   */
   ribbon: '\uE9D1',
-  ribbonSolid: '\uF345',
+  /**
+   * Icon code with the value '\uE9B1'.
+   */
   rightDoubleQuote: '\uE9B1',
+  /**
+   * Icon code with the value '\uEA8F'.
+   */
   ringer: '\uEA8F',
-  ringerOff: '\uF2C5',
-  robot: '\uE99A',
-  rocket: '\uF3B3',
+  /**
+   * Icon code with the value '\uED9F'.
+   */
   room: '\uED9F',
+  /**
+   * Icon code with the value '\uE7AD'.
+   */
   rotate: '\uE7AD',
-  rowsChild: '\uF29C',
-  rowsGroup: '\uF29B',
+  /**
+   * Icon code with the value '\uEB2D'.
+   */
   rugby: '\uEB2D',
+  /**
+   * Icon code with the value '\uEADA'.
+   */
   running: '\uEADA',
+  /**
+   * Icon code with the value '\uE757'.
+   */
   sad: '\uE757',
-  sadSolid: '\uF33E',
+  /**
+   * Icon code with the value '\uE74E'.
+   */
   save: '\uE74E',
-  saveAll: '\uF203',
-  saveAndClose: '\uF038',
+  /**
+   * Icon code with the value '\uE792'.
+   */
   saveAs: '\uE792',
-  savings: '\uEB0B',
-  scheduleEventAction: '\uF1EF',
-  scopeTemplate: '\uF2B0',
-  script: '\uF03A',
-  scrollUpDown: '\uEC8F',
+  /**
+   * Icon code with the value '\uE721'.
+   */
   search: '\uE721',
-  searchAndApps: '\uE773',
+  /**
+   * Icon code with the value '\uEC0C'.
+   */
   section: '\uEC0C',
+  /**
+   * Icon code with the value '\uEF76'.
+   */
   sections: '\uEF76',
+  /**
+   * Icon code with the value '\uED85'.
+   */
   securityGroup: '\uED85',
+  /**
+   * Icon code with the value '\uE724'.
+   */
   send: '\uE724',
+  /**
+   * Icon code with the value '\uEA63'.
+   */
   sendMirrored: '\uEA63',
-  separator: '\uF35E',
-  server: '\uF201',
-  serverEnviroment: '\uF29F',
-  serverProcesses: '\uF1FE',
+  /**
+   * Icon code with the value '\uF071'.
+   */
   setAction: '\uF071',
+  /**
+   * Icon code with the value '\uE713'.
+   */
   settings: '\uE713',
+  /**
+   * Icon code with the value '\uE72D'.
+   */
   share: '\uE72D',
+  /**
+   * Icon code with the value '\uEF79'.
+   */
   shareiOs: '\uEF79',
-  sharepointLogo: '\uF27E',
-  sharepointLogoFill: '\uF27F',
-  sharepointLogoInverse: '\uED18',
+  /**
+   * Icon code with the value '\uED18'.
+   */
+  sharepointLogo: '\uED18',
+  /**
+   * Icon code with the value '\uEA18'.
+   */
   shield: '\uEA18',
-  shieldSolid: '\uF340',
+  /**
+   * Icon code with the value '\uE719'.
+   */
   shop: '\uE719',
+  /**
+   * Icon code with the value '\uE7BF'.
+   */
   shoppingCart: '\uE7BF',
-  shoppingCartSolid: '\uF342',
-  shopServer: '\uF2B6',
+  /**
+   * Icon code with the value '\uE8BC'.
+   */
   showResults: '\uE8BC',
+  /**
+   * Icon code with the value '\uEA65'.
+   */
   showResultsMirrored: '\uEA65',
+  /**
+   * Icon code with the value '\uEF52'.
+   */
   sidePanel: '\uEF52',
-  sidePanelMirrored: '\uF221',
-  signOut: '\uF3B1',
+  /**
+   * Icon code with the value '\uEDFF'.
+   */
   singleBookmark: '\uEDFF',
-  singleColumn: '\uF1D3',
-  singleColumnEdit: '\uF321',
+  /**
+   * Icon code with the value '\uE759'.
+   */
   sipMove: '\uE759',
+  /**
+   * Icon code with the value '\uEF80'.
+   */
   skypeCheck: '\uEF80',
+  /**
+   * Icon code with the value '\uEF7D'.
+   */
   skypeCircleCheck: '\uEF7D',
+  /**
+   * Icon code with the value '\uEF7E'.
+   */
   skypeCircleClock: '\uEF7E',
+  /**
+   * Icon code with the value '\uEF7F'.
+   */
   skypeCircleMinus: '\uEF7F',
+  /**
+   * Icon code with the value '\uEF81'.
+   */
   skypeClock: '\uEF81',
-  skypeForBusinessLogoFill: '\uF27D',
+  /**
+   * Icon code with the value '\uEB6F'.
+   */
   skypeLogo: '\uEB6F',
+  /**
+   * Icon code with the value '\uEF83'.
+   */
   skypeMessage: '\uEF83',
+  /**
+   * Icon code with the value '\uEF82'.
+   */
   skypeMinus: '\uEF82',
+  /**
+   * Icon code with the value '\uEC13'.
+   */
   sliderThumb: '\uEC13',
-  snow: '\uE9C8',
-  snowflake: '\uEB46',
+  /**
+   * Icon code with the value '\uEB46'.
+   */
+  snow: '\uEB46',
+  /**
+   * Icon code with the value '\uE9FD'.
+   */
   snowShowerDay: '\uE9FD',
+  /**
+   * Icon code with the value '\uEA11'.
+   */
   snowShowerNight: '\uEA11',
+  /**
+   * Icon code with the value '\uEB21'.
+   */
   soccer: '\uEB21',
+  /**
+   * Icon code with the value '\uED7C'.
+   */
   socialListeningLogo: '\uED7C',
+  /**
+   * Icon code with the value '\uE8CB'.
+   */
   sort: '\uE8CB',
+  /**
+   * Icon code with the value '\uEE69'.
+   */
   sortDown: '\uEE69',
+  /**
+   * Icon code with the value '\uE9D0'.
+   */
   sortLines: '\uE9D0',
+  /**
+   * Icon code with the value '\uEE68'.
+   */
   sortUp: '\uEE68',
+  /**
+   * Icon code with the value '\uE7F5'.
+   */
   speakers: '\uE7F5',
+  /**
+   * Icon code with the value '\uEC4A'.
+   */
   speedHigh: '\uEC4A',
+  /**
+   * Icon code with the value '\uEDBC'.
+   */
   split: '\uEDBC',
-  sprint: '\uF3B0',
+  /**
+   * Icon code with the value '\uE9CC'.
+   */
   squalls: '\uE9CC',
-  stackedBarChart: '\uF24D',
-  stackedLineChart: '\uF24E',
+  /**
+   * Icon code with the value '\uE7FF'.
+   */
   stackIndicator: '\uE7FF',
+  /**
+   * Icon code with the value '\uEF78'.
+   */
   starburst: '\uEF78',
-  starburstSolid: '\uF33C',
+  /**
+   * Icon code with the value '\uEB90'.
+   */
   statusErrorFull: '\uEB90',
+  /**
+   * Icon code with the value '\uEA82'.
+   */
   statusTriangle: '\uEA82',
-  step: '\uF241',
-  stepInsert: '\uF242',
-  stepShared: '\uF243',
-  stepSharedAdd: '\uF244',
-  stepSharedInsert: '\uF245',
+  /**
+   * Icon code with the value '\uEB0F'.
+   */
   stockDown: '\uEB0F',
+  /**
+   * Icon code with the value '\uEB11'.
+   */
   stockUp: '\uEB11',
-  stop: '\uE71A',
-  stopSolid: '\uEE95',
+  /**
+   * Icon code with the value '\uE916'.
+   */
   stopwatch: '\uE916',
+  /**
+   * Icon code with the value '\uEA96'.
+   */
   storeLogo: '\uEA96',
+  /**
+   * Icon code with the value '\uEA04'.
+   */
   storeLogoMed: '\uEA04',
-  storyboard: '\uF308',
-  streaming: '\uE93E',
-  streamingOff: '\uF2BB',
-  streamLogo: '\uF329',
+  /**
+   * Icon code with the value '\uEDE0'.
+   */
   strikethrough: '\uEDE0',
+  /**
+   * Icon code with the value '\uEDA1'.
+   */
   subscribe: '\uEDA1',
+  /**
+   * Icon code with the value '\uEDDF'.
+   */
   subscript: '\uEDDF',
+  /**
+   * Icon code with the value '\uEDD3'.
+   */
   suitcase: '\uEDD3',
+  /**
+   * Icon code with the value '\uEF69'.
+   */
   sunAdd: '\uEF69',
-  sunny: '\uE9BD',
+  /**
+   * Icon code with the value '\uEF6A'.
+   */
   sunQuestionMark: '\uEF6A',
+  /**
+   * Icon code with the value '\uE9BD'.
+   */
+  sunny: '\uE9BD',
+  /**
+   * Icon code with the value '\uEDDE'.
+   */
   superscript: '\uEDDE',
-  swayLogoInverse: '\uED29',
-  switch: '\uE8AB',
+  /**
+   * Icon code with the value '\uED29'.
+   */
+  swayLogo: '\uED29',
+  /**
+   * Icon code with the value '\uE8AB'.
+   */
+  switcher: '\uE8AB',
+  /**
+   * Icon code with the value '\uE810'.
+   */
   switcherStartEnd: '\uE810',
+  /**
+   * Icon code with the value '\uE895'.
+   */
   sync: '\uE895',
+  /**
+   * Icon code with the value '\uE8F7'.
+   */
   syncFolder: '\uE8F7',
+  /**
+   * Icon code with the value '\uEE6E'.
+   */
   syncToPc: '\uEE6E',
+  /**
+   * Icon code with the value '\uE770'.
+   */
   system: '\uE770',
+  /**
+   * Icon code with the value '\uE7E9'.
+   */
   tab: '\uE7E9',
+  /**
+   * Icon code with the value '\uED86'.
+   */
   table: '\uED86',
+  /**
+   * Icon code with the value '\uE70A'.
+   */
   tablet: '\uE70A',
+  /**
+   * Icon code with the value '\uEC74'.
+   */
   tabletSelected: '\uEC74',
+  /**
+   * Icon code with the value '\uE8EC'.
+   */
   tag: '\uE8EC',
-  taskboard: '\uF1C2',
-  taskGroup: '\uF2AE',
-  taskGroupMirrored: '\uF2AF',
+  /**
+   * Icon code with the value '\uEDB7'.
+   */
   taskManager: '\uEDB7',
+  /**
+   * Icon code with the value '\uEDB8'.
+   */
   taskManagerMirrored: '\uEDB8',
-  taskSolid: '\uF333',
-  teamFavorite: '\uF2AD',
-  teamsLogo: '\uF27B',
-  teamsLogoFill: '\uF27C',
-  teamsLogoInverse: '\uF27A',
+  /**
+   * Icon code with the value '\uEA12'.
+   */
   teamwork: '\uEA12',
+  /**
+   * Icon code with the value '\uEE58'.
+   */
   temporaryUser: '\uEE58',
+  /**
+   * Icon code with the value '\uEB33'.
+   */
   tennis: '\uEB33',
-  testAutoSolid: '\uF3A8',
-  testBeaker: '\uF3A5',
-  testBeakerSolid: '\uF3A6',
-  testCase: '\uF3AF',
-  testExploreSolid: '\uF3A7',
-  testImpactSolid: '\uF3AA',
-  testParameter: '\uF3AD',
-  testPlan: '\uF3AB',
-  testStep: '\uF3AC',
-  testSuite: '\uF3AE',
-  testUserSolid: '\uF3A9',
+  /**
+   * Icon code with the value '\uEDC2'.
+   */
   textBox: '\uEDC2',
-  textCallout: '\uF2A2',
-  textDocument: '\uF029',
+  /**
+   * Icon code with the value '\uEDC3'.
+   */
   textField: '\uEDC3',
+  /**
+   * Icon code with the value '\uE7B6'.
+   */
   thumbnailView: '\uE7B6',
+  /**
+   * Icon code with the value '\uEA67'.
+   */
   thumbnailViewMirrored: '\uEA67',
+  /**
+   * Icon code with the value '\uE9C6'.
+   */
   thunderstorms: '\uE9C6',
+  /**
+   * Icon code with the value '\uEB54'.
+   */
   ticket: '\uEB54',
-  tiles: '\uECA5',
+  /**
+   * Icon code with the value '\uEF7C'.
+   */
   tiles2: '\uEF7C',
+  /**
+   * Icon code with the value '\uECA5'.
+   */
+  tiles: '\uECA5',
+  /**
+   * Icon code with the value '\uED9C'.
+   */
   timeline: '\uED9C',
-  timelineDelivery: '\uF2AB',
-  timelineMatrixView: '\uF361',
-  timelineProgress: '\uF2AA',
+  /**
+   * Icon code with the value '\uE91E'.
+   */
   timer: '\uE91E',
+  /**
+   * Icon code with the value '\uEC12'.
+   */
   toggleBorder: '\uEC12',
+  /**
+   * Icon code with the value '\uEC11'.
+   */
   toggleFilled: '\uEC11',
+  /**
+   * Icon code with the value '\uEC14'.
+   */
   toggleThumb: '\uEC14',
+  /**
+   * Icon code with the value '\uE815'.
+   */
   touch: '\uE815',
+  /**
+   * Icon code with the value '\uE7C9'.
+   */
   touchPointer: '\uE7C9',
+  /**
+   * Icon code with the value '\uE7C0'.
+   */
   train: '\uE7C0',
+  /**
+   * Icon code with the value '\uEB4D'.
+   */
   trainSolid: '\uEB4D',
+  /**
+   * Icon code with the value '\uED95'.
+   */
   transferCall: '\uED95',
+  /**
+   * Icon code with the value '\uE74D'.
+   */
+  trash: '\uE74D',
+  /**
+   * Icon code with the value '\uEED1'.
+   */
   triangleDown12: '\uEED1',
+  /**
+   * Icon code with the value '\uEED2'.
+   */
   triangleLeft12: '\uEED2',
+  /**
+   * Icon code with the value '\uEED3'.
+   */
   triangleRight12: '\uEED3',
-  triangleSolid: '\uEA08',
+  /**
+   * Icon code with the value '\uEECD'.
+   */
   triangleSolidDown12: '\uEECD',
+  /**
+   * Icon code with the value '\uEECE'.
+   */
   triangleSolidLeft12: '\uEECE',
+  /**
+   * Icon code with the value '\uEECF'.
+   */
   triangleSolidRight12: '\uEECF',
+  /**
+   * Icon code with the value '\uEECC'.
+   */
   triangleSolidUp12: '\uEECC',
+  /**
+   * Icon code with the value '\uEED0'.
+   */
   triangleUp12: '\uEED0',
-  triggerApproval: '\uF3B2',
-  triggerAuto: '\uF24A',
-  triggerUser: '\uF24B',
-  tripleColumn: '\uF1D5',
-  tripleColumnEdit: '\uF323',
+  /**
+   * Icon code with the value '\uED3F'.
+   */
   trophy: '\uED3F',
-  trophy2Solid: '\uF337',
+  /**
+   * Icon code with the value '\uE7DB'.
+   */
   turnRight: '\uE7DB',
+  /**
+   * Icon code with the value '\uE7F4'.
+   */
   tvMonitor: '\uE7F4',
+  /**
+   * Icon code with the value '\uEC77'.
+   */
   tvMonitorSelected: '\uEC77',
-  typeScriptLanguage: '\uF2F7',
-  umbrella: '\uEC04',
+  /**
+   * Icon code with the value '\uE8DC'.
+   */
   underline: '\uE8DC',
+  /**
+   * Icon code with the value '\uE7A7'.
+   */
   undo: '\uE7A7',
+  /**
+   * Icon code with the value '\uE8D9'.
+   */
   unfavorite: '\uE8D9',
-  unknown: '\uE9CE',
+  /**
+   * Icon code with the value '\uED97'.
+   */
   unknownCall: '\uED97',
-  unknownMirroredSolid: '\uF2E2',
-  unknownSolid: '\uF2E1',
+  /**
+   * Icon code with the value '\uE785'.
+   */
   unlock: '\uE785',
-  unlockSolid: '\uF304',
+  /**
+   * Icon code with the value '\uE77A'.
+   */
   unpin: '\uE77A',
+  /**
+   * Icon code with the value '\uEDA0'.
+   */
   unsubscribe: '\uEDA0',
+  /**
+   * Icon code with the value '\uE8F6'.
+   */
   unsyncFolder: '\uE8F6',
+  /**
+   * Icon code with the value '\uE74A'.
+   */
   up: '\uE74A',
+  /**
+   * Icon code with the value '\uE898'.
+   */
   upload: '\uE898',
-  userFollowed: '\uF25C',
-  userPause: '\uF2BA',
-  userSync: '\uF2B9',
-  variable: '\uF305',
-  variableGroup: '\uF31B',
-  vb: '\uF2F2',
-  vennDiagram: '\uF273',
+  /**
+   * Icon code with the value '\uE714'.
+   */
   video: '\uE714',
+  /**
+   * Icon code with the value '\uEA0C'.
+   */
   videoSolid: '\uEA0C',
+  /**
+   * Icon code with the value '\uE890'.
+   */
   view: '\uE890',
-  viewAll: '\uE8A9',
+  /**
+   * Icon code with the value '\uEF56'.
+   */
   viewAll2: '\uEF56',
-  viewDashboard: '\uF246',
-  viewList: '\uF247',
-  viewListGroup: '\uF248',
-  viewListTree: '\uF249',
-  visioDiagram: '\uF2A0',
-  visioDocument: '\uF2A9',
-  visioLogo: '\uF2A7',
-  visioLogo16: '\uF3A3',
-  visioLogoFill: '\uF2A8',
-  visioLogoFill16: '\uF3A4',
-  visioLogoInverse: '\uED7D',
-  visioLogoInverse16: '\uF3A2',
-  visualBasicLanguage: '\uF2F1',
-  visualStudioLogo: '\uEC22',
+  /**
+   * Icon code with the value '\uE8A9'.
+   */
+  viewAll: '\uE8A9',
+  /**
+   * Icon code with the value '\uED7D'.
+   */
+  visioLogo: '\uED7D',
+  /**
+   * Icon code with the value '\uED87'.
+   */
   voicemailForward: '\uED87',
+  /**
+   * Icon code with the value '\uED88'.
+   */
   voicemailReply: '\uED88',
+  /**
+   * Icon code with the value '\uE992'.
+   */
   volume0: '\uE992',
+  /**
+   * Icon code with the value '\uE993'.
+   */
   volume1: '\uE993',
+  /**
+   * Icon code with the value '\uE994'.
+   */
   volume2: '\uE994',
+  /**
+   * Icon code with the value '\uE995'.
+   */
   volume3: '\uE995',
+  /**
+   * Icon code with the value '\uEA85'.
+   */
   volumeDisabled: '\uEA85',
-  vstsAltLogo1: '\uF382',
-  vstsAltLogo2: '\uF383',
-  vstsLogo: '\uF381',
+  /**
+   * Icon code with the value '\uED89'.
+   */
   waffle: '\uED89',
+  /**
+   * Icon code with the value '\uE7BA'.
+   */
   warning: '\uE7BA',
+  /**
+   * Icon code with the value '\uEB41'.
+   */
   website: '\uEB41',
+  /**
+   * Icon code with the value '\uEADB'.
+   */
   weights: '\uEADB',
-  wifiEthernet: '\uEE77',
+  /**
+   * Icon code with the value '\uEBE6'.
+   */
   windDirection: '\uEBE6',
+  /**
+   * Icon code with the value '\uE782'.
+   */
   windowsLogo: '\uE782',
+  /**
+   * Icon code with the value '\uED8D'.
+   */
   wipePhone: '\uED8D',
+  /**
+   * Icon code with the value '\uEF71'.
+   */
   wordDocument: '\uEF71',
-  wordLogo: '\uF1E3',
-  wordLogo16: '\uF391',
-  wordLogoFill: '\uF1E4',
-  wordLogoFill16: '\uF392',
-  wordLogoInverse: '\uEC29',
-  wordLogoInverse16: '\uF390',
+  /**
+   * Icon code with the value '\uEC29'.
+   */
+  wordLogo: '\uEC29',
+  /**
+   * Icon code with the value '\uE821'.
+   */
   work: '\uE821',
+  /**
+   * Icon code with the value '\uEA01'.
+   */
   workFlow: '\uEA01',
-  workItem: '\uF314',
-  workItemBar: '\uF35C',
-  workItemBarSolid: '\uF35D',
-  workItemBug: '\uF315',
-  world: '\uE909',
+  /**
+   * Icon code with the value '\uE918'.
+   */
   worldClock: '\uE918',
+  /**
+   * Icon code with the value '\uED19'.
+   */
   yammerLogo: '\uED19',
-  zipFolder: '\uF012',
+  /**
+   * Icon code with the value '\uE71E'.
+   */
   zoom: '\uE71E',
+  /**
+   * Icon code with the value '\uE8A3'.
+   */
   zoomIn: '\uE8A3',
+  /**
+   * Icon code with the value '\uE71F'.
+   */
   zoomOut: '\uE71F'
 };


### PR DESCRIPTION
This reverts commit #1925 due to concerns about the increased file size from adding new icons.