### PR TITLE
Icon: ms-Icon--{name} classname added back to Icons

### DIFF
--- a/common/changes/office-ui-fabric-react/icon_2017-06-16-18-53.json
+++ b/common/changes/office-ui-fabric-react/icon_2017-06-16-18-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Icon: adding back ms-Icon--iconName className to avoid breaking backwards compatibility.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -54,7 +54,7 @@ export function Icon(props: IIconProps): JSX.Element {
         className={
           css(
             'ms-Icon',
-            'ms-Icon--' + iconMemberName,
+            this.props.iconType === IconType.default && 'ms-Icon--' + iconMemberName,
             IconClassNames[iconMemberName],
             styles.root,
             props.className

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -54,7 +54,7 @@ export function Icon(props: IIconProps): JSX.Element {
         className={
           css(
             'ms-Icon',
-            this.props.iconType === IconType.default && 'ms-Icon--' + iconMemberName,
+            this.props.iconType === IconType.default && ('ms-Icon--' + iconMemberName),
             IconClassNames[iconMemberName],
             styles.root,
             props.className

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -54,7 +54,7 @@ export function Icon(props: IIconProps): JSX.Element {
         className={
           css(
             'ms-Icon',
-            this.props.iconType === IconType.default && ('ms-Icon--' + iconMemberName),
+            props.iconType === IconType.default && ('ms-Icon--' + iconMemberName),
             IconClassNames[iconMemberName],
             styles.root,
             props.className

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -54,6 +54,7 @@ export function Icon(props: IIconProps): JSX.Element {
         className={
           css(
             'ms-Icon',
+            'ms-Icon--' + iconMemberName,
             IconClassNames[iconMemberName],
             styles.root,
             props.className


### PR DESCRIPTION
Avoiding a regression where partners need the icon class name for whichever reasons (targeting, automation.)
