### PR TITLE
Remove Tooltip from DetailsList, allowing optional override

### DIFF
--- a/common/changes/office-ui-fabric-react/details-tooltip_2017-06-16-20-13.json
+++ b/common/changes/office-ui-fabric-react/details-tooltip_2017-06-16-20-13.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Remove Tooltip by default from DetailsList, allowing optional override",
+      "comment": "DetailsList: Remove Tooltip by defaul, allowing optional override.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/details-tooltip_2017-06-16-20-13.json
+++ b/common/changes/office-ui-fabric-react/details-tooltip_2017-06-16-20-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove Tooltip by default from DetailsList, allowing optional override",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -148,6 +148,7 @@ $resizerColor: $ms-color-neutralTertiaryAlt;
 }
 
 .cellTooltip {
+  display: block;
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -6,7 +6,8 @@ import {
   css,
   getRTL,
   getId,
-  KeyCodes
+  KeyCodes,
+  IRenderFunction
 } from '../../Utilities';
 import { IColumn, DetailsListLayoutMode, ColumnActionsMode } from './DetailsList.Props';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
@@ -14,7 +15,7 @@ import { Icon } from '../../Icon';
 import { Layer } from '../../Layer';
 import { GroupSpacer } from '../GroupedList/GroupSpacer';
 import { DetailsRowCheck } from './DetailsRowCheck';
-import { TooltipHost } from '../../Tooltip';
+import { ITooltipHostProps } from '../../Tooltip';
 import * as checkStyles from './DetailsRowCheck.scss';
 import { ISelection, SelectionMode, SELECTION_CHANGE } from '../../utilities/selection/interfaces';
 import * as stylesImport from './DetailsHeader.scss';
@@ -34,6 +35,7 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
   onColumnAutoResized?: (column: IColumn, columnIndex: number) => void;
   onColumnClick?: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void;
   onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => void;
+  onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
   groupNestingDepth?: number;
   isAllCollapsed?: boolean;
   onToggleCollapseAll?: (isAllCollapsed: boolean) => void;
@@ -118,6 +120,12 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
 
     const showCheckbox = selectAllVisibility !== SelectAllVisibility.none;
 
+    const {
+      onRenderColumnHeaderTooltip = this._onRenderColumnHeaderTooltip
+    } = this.props;
+
+    const ColumnHeaderTooltip = (props: ITooltipHostProps) => onRenderColumnHeaderTooltip(props, this._onRenderColumnHeaderTooltip);
+
     return (
       <FocusZone
         role='row'
@@ -143,7 +151,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
             <span
               aria-label={ ariaLabelForSelectionColumn }
             ></span>
-            <TooltipHost
+            <ColumnHeaderTooltip
               hostClassName={ css(styles.checkTooltip) }
               id={ `${this._id}-checkTooltip` }
               setAriaDescribedBy={ false }
@@ -154,7 +162,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                 anySelected={ false }
                 canSelect={ true }
               />
-            </TooltipHost>
+            </ColumnHeaderTooltip>
           </div>
         ) : null }
         { groupNestingDepth > 0 ? (
@@ -198,7 +206,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                 data-automationid='ColumnsHeaderColumn'
                 data-item-key={ column.key }
               >
-                <TooltipHost
+                <ColumnHeaderTooltip
                   hostClassName={ css(styles.cellTooltip) }
                   id={ `${this._id}-${column.key}-tooltip` }
                   setAriaDescribedBy={ false }
@@ -242,7 +250,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                       />
                     ) }
                   </span>
-                </TooltipHost>
+                </ColumnHeaderTooltip>
               </div>,
               (column.isResizable) && this._renderColumnSizer(columnIndex)
             ]
@@ -289,6 +297,13 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         onDoubleClick={ this._onSizerDoubleClick.bind(this, columnIndex) }
       />
     );
+  }
+
+  @autobind
+  private _onRenderColumnHeaderTooltip(tooltipHostProps: ITooltipHostProps, defaultRender?: IRenderFunction<ITooltipHostProps>) {
+    return <span className={ tooltipHostProps.hostClassName }>{
+      tooltipHostProps.children
+    }</span>;
   }
 
   /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -15,7 +15,10 @@ import {
   IGroupRenderProps
 } from '../GroupedList/index';
 import { IDetailsRowProps } from '../DetailsList/DetailsRow';
+import { IDetailsHeaderProps } from './DetailsHeader';
 import { IViewport } from '../../utilities/decorators/withViewport';
+
+export { IDetailsHeaderProps };
 
 export interface IDetailsList {
   /**
@@ -130,6 +133,11 @@ export interface IDetailsListProps extends React.Props<DetailsList> {
 
   /** Callback for what to render when the item is missing. */
   onRenderMissingItem?: (index?: number) => React.ReactNode;
+
+  /**
+   * An override to render the details header.
+   */
+  onRenderDetailsHeader?: IRenderFunction<IDetailsHeaderProps>;
 
   /** Viewport, provided by the withViewport decorator. */
   viewport?: IViewport;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -10,6 +10,7 @@ import {
   autobind,
   css,
   getRTLSafeKeyCode,
+  IRenderFunction
 } from '../../Utilities';
 import {
   CheckboxVisibility,
@@ -20,7 +21,7 @@ import {
   IDetailsList,
   IDetailsListProps,
 } from '../DetailsList/DetailsList.Props';
-import { DetailsHeader, SelectAllVisibility } from '../DetailsList/DetailsHeader';
+import { DetailsHeader, SelectAllVisibility, IDetailsHeaderProps } from '../DetailsList/DetailsHeader';
 import { DetailsRow, IDetailsRowProps } from '../DetailsList/DetailsRow';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import {
@@ -247,6 +248,12 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       selectAllVisibility = SelectAllVisibility.none;
     }
 
+    const {
+      onRenderDetailsHeader = this._onRenderDetailsHeader
+    } = this.props;
+
+    const DetailsHeader = (props: IDetailsHeaderProps) => onRenderDetailsHeader(props, this._onRenderDetailsHeader);
+
     return (
       // If shouldApplyApplicationRole is true, role application will be applied to make arrow keys work
       // with JAWS.
@@ -345,6 +352,11 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   @autobind
   protected _onRenderRow(props: IDetailsRowProps, defaultRender?: any) {
     return <DetailsRow { ...props } />;
+  }
+
+  @autobind
+  private _onRenderDetailsHeader(detailsHeaderProps: IDetailsHeaderProps, defaultRender?: IRenderFunction<IDetailsHeaderProps>) {
+    return <DetailsHeader { ...detailsHeaderProps } />;
   }
 
   private _onRenderCell(nestingDepth: number, item: any, index: number): React.ReactNode {
@@ -677,7 +689,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     if (index >= 0) {
       onActiveItemChanged(items[index], index, ev);
     }
-  };
+  }
 }
 
 export function buildColumns(

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -5,9 +5,17 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import {
   DetailsList,
   DetailsListLayoutMode,
+  IDetailsHeaderProps,
   Selection,
   IColumn
 } from 'office-ui-fabric-react/lib/DetailsList';
+import {
+  IRenderFunction
+} from 'office-ui-fabric-react/lib/Utilities';
+import {
+  TooltipHost,
+  ITooltipHostProps
+} from 'office-ui-fabric-react/lib/Tooltip';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 
 let _items = [];
@@ -76,6 +84,12 @@ export class DetailsListBasicExample extends React.Component<any, any> {
             columns={ _columns }
             setKey='set'
             layoutMode={ DetailsListLayoutMode.fixedColumns }
+            onRenderDetailsHeader={
+              (detailsHeaderProps: IDetailsHeaderProps, defaultRender: IRenderFunction<IDetailsHeaderProps>) => defaultRender({
+                ...detailsHeaderProps,
+                onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => <TooltipHost { ...tooltipHostProps } />
+              })
+            }
             selection={ this._selection }
             selectionPreservedOnEmptyClick={ true }
             ariaLabelForSelectionColumn='Toggle selection'


### PR DESCRIPTION
This change removes the addition of `TooltipHost` to `DetailsList`, replacing it with a way to override the render behavior of the `DetailsHeader` to insert a tooltip wrapper if needed.

This fixes potential bundling issues should applications wish to defer tooltips, and also prevents any regressions in visuals experienced by applications consuming the recent accessibility changes.
