### PR TITLE
Fixing AMD importing, which was busted by the no-implicit-anys fix.

### DIFF
--- a/common/changes/@uifabric/styling/fix-amd_2017-06-17-04-00.json
+++ b/common/changes/@uifabric/styling/fix-amd_2017-06-17-04-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Fixing amd import that was broken byt the no-implicit-anys fix.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/styling/src/glamorExports.ts
+++ b/packages/styling/src/glamorExports.ts
@@ -1,9 +1,7 @@
 import * as Glamor from 'glamor';
+import rtlify from 'rtl-css-js';
 import { IRawStyle, IProcessedStyle } from './interfaces/index';
 import { getRTL } from '@uifabric/utilities/lib/index';
-
-// tslint:disable-next-line:no-any
-let rtlify: any = require('rtl-css-js');
 
 interface IGlamorRulePair {
   selector: string;

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -9,7 +9,7 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "moduleResolution": "node",
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "lib": [
       "es2017",
       "dom"


### PR DESCRIPTION
Reverting some of the no-implicit-anys fix.