### PR TITLE
Fix icon images!

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-icon-images_2017-06-17-16-55.json
+++ b/common/changes/office-ui-fabric-react/fix-icon-images_2017-06-17-16-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Icon: image icons now have less random \"l\" characters. Sorry about that!",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -37,7 +37,7 @@ export function Icon(props: IIconProps): JSX.Element {
           styles.root
         ) }
       >
-        l  <Image { ...props.imageProps as any } />
+        <Image { ...props.imageProps as any } />
       </div>
     );
   } else {


### PR DESCRIPTION
Accidentally added an extraneous character in the Icon component in the last fix.