### PR TITLE
Dropdown: fix controlled component

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-fix-controlled-component_2017-06-21-17-20.json
+++ b/common/changes/office-ui-fabric-react/dropdown-fix-controlled-component_2017-06-21-17-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: fixed bug that didn't allow operating Dropdown as a controlled component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -187,16 +187,18 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   }
 
   public setSelectedIndex(index: number) {
-    let { onChanged, options } = this.props;
+    let { onChanged, options, selectedKey } = this.props;
     let { selectedIndex } = this.state;
 
     index = Math.max(0, Math.min(options.length - 1, index));
 
     if (index !== selectedIndex) {
-      // Set the selected option.
-      this.setState({
-        selectedIndex: index
-      });
+      if (selectedKey === undefined) {
+        // Set the selected option if this is an uncontrolled component
+        this.setState({
+          selectedIndex: index
+        });
+      }
 
       if (onChanged) {
         onChanged(options[index], index);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2036 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix Dropdown such that, if `selectedKey` is provided, it only updates the `selectedIndex` through the passed-in `selectedKey`

#### Focus areas to test

(optional)
