### PR TITLE
Check: Reduced size of background so blue does not extend outside of border.

### DIFF
--- a/common/changes/office-ui-fabric-react/betrue-selectionCheck_2017-06-21-18-54.json
+++ b/common/changes/office-ui-fabric-react/betrue-selectionCheck_2017-06-21-18-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Check: reduced size of selection check background by 2px",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "betrue@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Check/Check.scss
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.scss
@@ -11,8 +11,8 @@ $checkBoxHeight: 24px;
 
 .root {
   line-height: 1;
-  width: $checkBoxHeight;
-  height: $checkBoxHeight;
+  width: $checkBoxHeight - 2px;
+  height: $checkBoxHeight - 2px;
   vertical-align: top;
   position: relative;
   @include ms-user-select(none);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2024
- [x] Include a change request file using `$ npm run change`

#### Description of changes

I subtracted 2px from the selection background so the background does not show beyond the white borders and give it a blue tinge.

#### Focus areas to test

(optional)
