### PR TITLE
Fix row focus handling for DetailsList

### DIFF
--- a/common/changes/office-ui-fabric-react/row-focus_2017-06-21-23-34.json
+++ b/common/changes/office-ui-fabric-react/row-focus_2017-06-21-23-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix some focus issues in DetailsList",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -25,7 +25,12 @@ const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.butt
 const MOUSEMOVE_PRIMARY_BUTTON = 1; // for mouse move event we are using ev.buttons property, 1 means left button
 const INNER_PADDING = 16;
 
+export interface IDetailsHeader {
+  focus(): boolean;
+}
+
 export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
+  componentRef?: (component: IDetailsHeader) => void;
   columns: IColumn[];
   selection: ISelection;
   selectionMode: SelectionMode;
@@ -67,7 +72,7 @@ export interface IColumnResizeDetails {
   columnMinWidth: number;
 }
 
-export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHeaderState> {
+export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHeaderState> implements IDetailsHeader {
   public static defaultProps = {
     isSelectAllVisible: SelectAllVisibility.visible
   };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -129,8 +129,6 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
       onRenderColumnHeaderTooltip = this._onRenderColumnHeaderTooltip
     } = this.props;
 
-    const ColumnHeaderTooltip = (props: ITooltipHostProps) => onRenderColumnHeaderTooltip(props, this._onRenderColumnHeaderTooltip);
-
     return (
       <FocusZone
         role='row'
@@ -156,18 +154,22 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
             <span
               aria-label={ ariaLabelForSelectionColumn }
             ></span>
-            <ColumnHeaderTooltip
-              hostClassName={ css(styles.checkTooltip) }
-              id={ `${this._id}-checkTooltip` }
-              setAriaDescribedBy={ false }
-              content={ ariaLabelForSelectAllCheckbox }>
-              <DetailsRowCheck
-                aria-describedby={ `${this._id}-checkTooltip` }
-                selected={ isAllSelected }
-                anySelected={ false }
-                canSelect={ true }
-              />
-            </ColumnHeaderTooltip>
+            {
+              onRenderColumnHeaderTooltip({
+                hostClassName: css(styles.checkTooltip),
+                id: `${this._id}-checkTooltip`,
+                setAriaDescribedBy: false,
+                content: ariaLabelForSelectAllCheckbox,
+                children: (
+                  <DetailsRowCheck
+                    aria-describedby={ `${this._id}-checkTooltip` }
+                    selected={ isAllSelected }
+                    anySelected={ false }
+                    canSelect={ true }
+                  />
+                )
+              }, this._onRenderColumnHeaderTooltip)
+            }
           </div>
         ) : null }
         { groupNestingDepth > 0 ? (
@@ -211,51 +213,55 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                 data-automationid='ColumnsHeaderColumn'
                 data-item-key={ column.key }
               >
-                <ColumnHeaderTooltip
-                  hostClassName={ css(styles.cellTooltip) }
-                  id={ `${this._id}-${column.key}-tooltip` }
-                  setAriaDescribedBy={ false }
-                  content={ column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '' }
-                >
-                  <span
-                    className={ css('ms-DetailsHeader-cellTitle', styles.cellTitle) }
-                    data-is-focusable={ column.columnActionsMode !== ColumnActionsMode.disabled }
-                    role={ column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined }
-                    aria-describedby={ `${this._id}-${column.key}-tooltip` }
-                    onContextMenu={ this._onColumnContextMenu.bind(this, column) }
-                    onClick={ this._onColumnClick.bind(this, column) }
-                  >
-                    { column.isFiltered && (
-                      <Icon className={ styles.nearIcon } iconName='Filter' />
-                    ) }
+                {
+                  onRenderColumnHeaderTooltip({
+                    hostClassName: css(styles.cellTooltip),
+                    id: `${this._id}-${column.key}-tooltip`,
+                    setAriaDescribedBy: false,
+                    content: column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '',
+                    children: (
+                      <span
+                        className={ css('ms-DetailsHeader-cellTitle', styles.cellTitle) }
+                        data-is-focusable={ column.columnActionsMode !== ColumnActionsMode.disabled }
+                        role={ column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined }
+                        aria-describedby={ `${this._id}-${column.key}-tooltip` }
+                        onContextMenu={ this._onColumnContextMenu.bind(this, column) }
+                        onClick={ this._onColumnClick.bind(this, column) }
+                      >
+                        { column.isFiltered && (
+                          <Icon className={ styles.nearIcon } iconName='Filter' />
+                        ) }
 
-                    { column.isSorted && (
-                      <Icon className={ styles.nearIcon } iconName={ column.isSortedDescending ? 'SortDown' : 'SortUp' } />
-                    ) }
+                        { column.isSorted && (
+                          <Icon className={ styles.nearIcon } iconName={ column.isSortedDescending ? 'SortDown' : 'SortUp' } />
+                        ) }
 
-                    { column.isGrouped && (
-                      <Icon className={ styles.nearIcon } iconName='GroupedDescending' />
-                    ) }
+                        { column.isGrouped && (
+                          <Icon className={ styles.nearIcon } iconName='GroupedDescending' />
+                        ) }
 
-                    <span
-                      aria-label={ column.isIconOnly ? column.name : undefined }
-                      className={ css('ms-DetailsHeader-cellName', styles.cellName) }
-                    >
-                      { (column.iconName || column.iconClassName) && (
-                        <Icon className={ css(styles.nearIcon, column.iconClassName) } iconName={ column.iconName } />
-                      ) }
+                        <span
+                          aria-label={ column.isIconOnly ? column.name : undefined }
+                          className={ css('ms-DetailsHeader-cellName', styles.cellName) }
+                        >
+                          { (column.iconName || column.iconClassName) && (
+                            <Icon className={ css(styles.nearIcon, column.iconClassName) } iconName={ column.iconName } />
+                          ) }
 
-                      { !column.isIconOnly ? column.name : undefined }
-                    </span>
+                          { !column.isIconOnly ? column.name : undefined }
+                        </span>
 
-                    { column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
-                      <Icon
-                        className={ css('ms-DetailsHeader-filterChevron', styles.filterChevron) }
-                        iconName='ChevronDown'
-                      />
-                    ) }
-                  </span>
-                </ColumnHeaderTooltip>
+                        { column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
+                          <Icon
+                            className={ css('ms-DetailsHeader-filterChevron', styles.filterChevron) }
+                            iconName='ChevronDown'
+                          />
+                        ) }
+                      </span>
+
+                    )
+                  }, this._onRenderColumnHeaderTooltip)
+                }
               </div>,
               (column.isResizable) && this._renderColumnSizer(columnIndex)
             ]

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -250,8 +250,6 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       onRenderDetailsHeader = this._onRenderDetailsHeader
     } = this.props;
 
-    const DetailsHeader = (props: IDetailsHeaderProps) => onRenderDetailsHeader(props, this._onRenderDetailsHeader);
-
     return (
       // If shouldApplyApplicationRole is true, role application will be applied to make arrow keys work
       // with JAWS.
@@ -271,27 +269,25 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
           aria-colcount={ (selectAllVisibility !== SelectAllVisibility.none ? 1 : 0) + (adjustedColumns ? adjustedColumns.length : 0) }
           aria-readonly='true'>
           <div onKeyDown={ this._onHeaderKeyDown } role='presentation'>
-            { isHeaderVisible && (
-              <DetailsHeader
-                componentRef={ this._resolveRef('_header') }
-                selectionMode={ selectionMode }
-                layoutMode={ layoutMode }
-                selection={ selection }
-                columns={ adjustedColumns }
-                onColumnClick={ onColumnHeaderClick }
-                onColumnContextMenu={ onColumnHeaderContextMenu }
-                onColumnResized={ this._onColumnResized }
-                onColumnIsSizingChanged={ this._onColumnIsSizingChanged }
-                onColumnAutoResized={ this._onColumnAutoResized }
-                groupNestingDepth={ groupNestingDepth }
-                isAllCollapsed={ isCollapsed }
-                onToggleCollapseAll={ this._onToggleCollapse }
-                ariaLabel={ ariaLabelForListHeader }
-                ariaLabelForSelectAllCheckbox={ ariaLabelForSelectAllCheckbox }
-                ariaLabelForSelectionColumn={ ariaLabelForSelectionColumn }
-                selectAllVisibility={ selectAllVisibility }
-              />
-            ) }
+            { isHeaderVisible && onRenderDetailsHeader({
+              componentRef: this._resolveRef('_header'),
+              selectionMode: selectionMode,
+              layoutMode: layoutMode,
+              selection: selection,
+              columns: adjustedColumns,
+              onColumnClick: onColumnHeaderClick,
+              onColumnContextMenu: onColumnHeaderContextMenu,
+              onColumnResized: this._onColumnResized,
+              onColumnIsSizingChanged: this._onColumnIsSizingChanged,
+              onColumnAutoResized: this._onColumnAutoResized,
+              groupNestingDepth: groupNestingDepth,
+              isAllCollapsed: isCollapsed,
+              onToggleCollapseAll: this._onToggleCollapse,
+              ariaLabel: ariaLabelForListHeader,
+              ariaLabelForSelectAllCheckbox: ariaLabelForSelectAllCheckbox,
+              ariaLabelForSelectionColumn: ariaLabelForSelectionColumn,
+              selectAllVisibility: selectAllVisibility
+            }, this._onRenderDetailsHeader) }
           </div>
           <div onKeyDown={ this._onContentKeyDown } role='presentation'>
             <FocusZone

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -21,7 +21,7 @@ import {
   IDetailsList,
   IDetailsListProps,
 } from '../DetailsList/DetailsList.Props';
-import { DetailsHeader, SelectAllVisibility, IDetailsHeaderProps } from '../DetailsList/DetailsHeader';
+import { DetailsHeader, IDetailsHeader, SelectAllVisibility, IDetailsHeaderProps } from '../DetailsList/DetailsHeader';
 import { DetailsRow, IDetailsRowProps } from '../DetailsList/DetailsRow';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import {
@@ -70,7 +70,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
 
   // References
   private _root: HTMLElement;
-  private _header: DetailsHeader;
+  private _header: IDetailsHeader;
   private _groupedList: GroupedList;
   private _list: List;
   private _focusZone: FocusZone;
@@ -273,7 +273,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
           <div onKeyDown={ this._onHeaderKeyDown } role='presentation'>
             { isHeaderVisible && (
               <DetailsHeader
-                ref={ this._resolveRef('_header') }
+                componentRef={ this._resolveRef('_header') }
                 selectionMode={ selectionMode }
                 layoutMode={ layoutMode }
                 selection={ selection }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import {
   BaseComponent,
   IDisposable,
@@ -191,7 +192,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
       <FocusZone
         {...getNativeProps(this.props, divProperties) }
         direction={ FocusZoneDirection.horizontal }
-        ref='root'
+        ref={ this._onRootRef }
         role='row'
         aria-label={ ariaLabel }
         className={ css(
@@ -283,8 +284,12 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
   }
 
   public focus(): boolean {
-    if (this.refs.root) {
-      this.refs.root.focus();
+    const {
+      root
+    } = this.refs;
+
+    if (root) {
+      root.focus();
       return true;
     }
 
@@ -318,6 +323,19 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
     const { selection } = this.props;
 
     selection.toggleIndexSelected(this.props.itemIndex);
+  }
+
+  private _onRootRef(root: FocusZone) {
+    const {
+      refs
+    } = this;
+
+    if (root) {
+      // Need to resolve the actual DOM node, not the component. The element itself will be used for drag/drop and focusing.
+      refs.root = ReactDOM.findDOMNode(root) as HTMLElement;
+    } else {
+      refs.root = undefined;
+    }
   }
 
   private _getRowDragDropOptions(): IDragDropOptions {


### PR DESCRIPTION
This change fixes some issues impacting the `DetailsList` and keyboard focus:
1. Hitting up when focused on the top row was not moving focus to the header.
1. Reloading the list was not automatically setting focus to the first row.
1. Resizing columns was causing the entire header to re-render, disrupting the operation.

This also fixes #2051 by adjusting how the overrides for rendering are handled.