### PR TITLE
Fix FocusZone to stop eating spacebars in textarea

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-focuszone-textarea_2017-06-22-22-19.json
+++ b/common/changes/office-ui-fabric-react/fix-focuszone-textarea_2017-06-22-22-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix FocusZone stop eating spacebar presses in textarea fields",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "frolov.anton@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -367,7 +367,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
     }
 
     do {
-      if (target.tagName === 'BUTTON' || target.tagName === 'A' || target.tagName === 'INPUT') {
+      if (target.tagName === 'BUTTON' || target.tagName === 'A' || target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
         return false;
       }
 
@@ -700,7 +700,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   }
 
   private _isElementInput(element: HTMLElement): boolean {
-    if (element && element.tagName && element.tagName.toLowerCase() === 'input') {
+    if (element && element.tagName && (element.tagName.toLowerCase() === 'input' || element.tagName.toLowerCase() === 'textarea')) {
       return true;
     }
     return false;


### PR DESCRIPTION
#### Pull request checklist

Addresses an existing issue: Fixes #2053

#### Description of changes

FocusZone._tryInvokeClickForFocusable should abort not only for <input> tags, but also for <textarea> tag targets.
Modified _isElementInput which should treat textarea as input element also.

#### Focus areas to test

Check that spaces are inserted into textarea: https://codepen.io/antonf/pen/RgZbpO