### PR TITLE
Icon: adding data-icon-name attribute.

### DIFF
--- a/common/changes/office-ui-fabric-react/icon-attr_2017-06-23-17-57.json
+++ b/common/changes/office-ui-fabric-react/icon-attr_2017-06-23-17-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Icon: Adding `data-icon-name` attribute for debugging identification purposes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -48,7 +48,8 @@ export function Icon(props: IIconProps): JSX.Element {
         aria-label={ ariaLabel }
         { ...(ariaLabel ? {} : {
           role: 'presentation',
-          'aria-hidden': true
+          'aria-hidden': true,
+          'data-icon-name': iconName,
         }) }
         { ...getNativeProps(props, htmlElementProperties) }
         className={


### PR DESCRIPTION
When rendering icons, the removal of the icon name from the css class name hurt some testing scenarios, adding a data attribute to replace it.
