### PR TITLE
OveflowSet: Type of setState is incompatible with latest @typings/react

### DIFF
--- a/common/changes/office-ui-fabric-react/oveflowset-type-fix_2017-06-23-21-29.json
+++ b/common/changes/office-ui-fabric-react/oveflowset-type-fix_2017-06-23-21-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "OverflowSet: Fix type definition to be compatible with latest @types/react",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -10,7 +10,7 @@ import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import * as stylesImport from './OverflowSet.scss';
 const styles: any = stylesImport;
 
-export class OverflowSet extends BaseComponent<IOverflowSetProps, null> {
+export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> {
 
   public render() {
     let {


### PR DESCRIPTION
Changing BaseComponent<IOverflowSetProps, null> to BaseComponent<IOverflowSetProps, {}>