### PR TITLE
Enable forceConsistentCasingInFileNames tsconfig option

### DIFF
--- a/apps/component-demo/tsconfig.json
+++ b/apps/component-demo/tsconfig.json
@@ -8,6 +8,7 @@
     "experimentalDecorators": true,
     "noEmitOnError": true,
     "importHelpers": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "types": [
       "chai",

--- a/apps/fabric-website/tsconfig.json
+++ b/apps/fabric-website/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "experimentalDecorators": true,
     "importHelpers": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "types": [
       "chai",

--- a/apps/test-bundle-button/tsconfig.json
+++ b/apps/test-bundle-button/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "experimentalDecorators": true,
     "importHelpers": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "types": [
       "webpack-env"

--- a/apps/todo-app/tsconfig.json
+++ b/apps/todo-app/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "sourceMap": true,
     "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "types": [
       "chai",

--- a/common/changes/@uifabric/example-app-base/strict-casing_2017-06-23-22-51.json
+++ b/common/changes/@uifabric/example-app-base/strict-casing_2017-06-23-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Enable forceConsistentCasingInFileNames tsconfig option",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/@uifabric/fabric-website/strict-casing_2017-06-23-22-51.json
+++ b/common/changes/@uifabric/fabric-website/strict-casing_2017-06-23-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Enable forceConsistentCasingInFileNames tsconfig option",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/@uifabric/styling/strict-casing_2017-06-23-22-51.json
+++ b/common/changes/@uifabric/styling/strict-casing_2017-06-23-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Enable forceConsistentCasingInFileNames tsconfig option",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/@uifabric/utilities/strict-casing_2017-06-23-22-51.json
+++ b/common/changes/@uifabric/utilities/strict-casing_2017-06-23-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Enable forceConsistentCasingInFileNames tsconfig option",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/strict-casing_2017-06-23-22-51.json
+++ b/common/changes/office-ui-fabric-react/strict-casing_2017-06-23-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Enable forceConsistentCasingInFileNames tsconfig option",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/example-app-base/tsconfig.json
+++ b/packages/example-app-base/tsconfig.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "experimentalDecorators": true,
     "importHelpers": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "lib": [
       "es2017",

--- a/packages/example-component/tsconfig.json
+++ b/packages/example-component/tsconfig.json
@@ -7,6 +7,7 @@
     "strictNullChecks": true,
     "experimentalDecorators": true,
     "importHelpers": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "sourceMap": true,
     "jsx": "react",

--- a/packages/office-ui-fabric-react/tsconfig.json
+++ b/packages/office-ui-fabric-react/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "experimentalDecorators": true,
     "importHelpers": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "lib": [
       "es2017",

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -10,6 +10,7 @@
     "importHelpers": true,
     "moduleResolution": "node",
     "noImplicitAny": false,
+    "forceConsistentCasingInFileNames": true,
     "lib": [
       "es2017",
       "dom"

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -13,6 +13,7 @@
     "importHelpers": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "types": [
       "chai",


### PR DESCRIPTION
This should help prevent things from building on Windows machines but failing to build on Linux machines (like the CI machines). This option makes it a compiler break to be inconsistent in file name casing. 