### PR TITLE
Adding alt text to Persona image

### DIFF
--- a/common/changes/office-ui-fabric-react/persona-alt_2017-06-24-20-53.json
+++ b/common/changes/office-ui-fabric-react/persona-alt_2017-06-24-20-53.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Adding image alt to Persona, defaulting to empty string",
+      "comment": "Persona: Adding image alt, defaulting to empty string",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/persona-alt_2017-06-24-20-53.json
+++ b/common/changes/office-ui-fabric-react/persona-alt_2017-06-24-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding image alt to Persona, defaulting to empty string",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pjsw@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
@@ -47,6 +47,11 @@ export interface IPersonaProps extends React.HTMLAttributes<Persona> {
   imageUrl?: string;
 
   /**
+   * Alt text for the image to use. Defaults to an empty string.
+   */
+  imageAlt?: string;
+
+  /**
    * The user's initials to display in the image area when there is no image.
    * @defaultvalue [Derived from primaryText]
    */

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
@@ -8,14 +8,16 @@ import * as chai from 'chai';
 import * as stylesImport from './Persona.scss';
 const styles: any = stylesImport;
 
+const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
+
 const { expect } = chai;
 
 describe('Persona', () => {
-  describe('initials and colors', () => {
-    beforeEach(() => {
-      setRTL(false);
-    });
+  beforeEach(() => {
+    setRTL(false);
+  });
 
+  describe('initials and colors', () => {
     it('renders with expected initialsColor if none was provided', () => {
       const wrapper = shallow(<Persona primaryText='Kat Larrson' />);
       let result = wrapper.find('.' + styles.initialsIsRed);
@@ -75,4 +77,15 @@ describe('Persona', () => {
     });
   });
 
+  describe('image', () => {
+    it('renders empty alt text by default', () => {
+      const wrapper = shallow(<Persona primaryText='Kat Larrson' imageUrl={ testImage1x1 } />);
+      expect(wrapper.find('Image').props().alt).to.equal('');
+    });
+
+    it('renders its given alt text', () => {
+      const wrapper = shallow(<Persona primaryText='Kat Larrson' imageUrl={ testImage1x1 } imageAlt='ALT TEXT' />);
+      expect(wrapper.find('Image').props().alt).to.equal('ALT TEXT');
+    });
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -65,7 +65,8 @@ export class Persona extends BaseComponent<IPersonaProps, IPersonaState> {
   public static defaultProps: IPersonaProps = {
     primaryText: '',
     size: PersonaSize.regular,
-    presence: PersonaPresence.none
+    presence: PersonaPresence.none,
+    imageAlt: ''
   };
 
   constructor(props: IPersonaProps) {
@@ -81,6 +82,7 @@ export class Persona extends BaseComponent<IPersonaProps, IPersonaState> {
       className,
       size,
       imageUrl,
+      imageAlt,
       initialsColor,
       presence,
       primaryText,
@@ -173,6 +175,7 @@ export class Persona extends BaseComponent<IPersonaProps, IPersonaState> {
               src={ imageUrl }
               width={ SIZE_TO_PIXELS[size] }
               height={ SIZE_TO_PIXELS[size] }
+              alt={ imageAlt }
               shouldFadeIn={ imageShouldFadeIn }
               shouldStartVisible={ imageShouldStartVisible }
               onLoadingStateChange={ this._onPhotoLoadingStateChange } />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1974
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds `imageAlt` prop to Persona, which defaults to an empty string

#### Focus areas to test

Persona
