### PR TITLE
Details focus

### DIFF
--- a/common/changes/office-ui-fabric-react/details-focus_2017-06-26-19-46.json
+++ b/common/changes/office-ui-fabric-react/details-focus_2017-06-26-19-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed focusing first item in DetailsList",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -14,7 +14,7 @@ import { IColumn, CheckboxVisibility } from './DetailsList.Props';
 import { DetailsRowCheck, IDetailsRowCheckProps } from './DetailsRowCheck';
 import { GroupSpacer } from '../GroupedList/GroupSpacer';
 import { DetailsRowFields } from './DetailsRowFields';
-import { FocusZone, FocusZoneDirection } from '../../FocusZone';
+import { FocusZone, FocusZoneDirection, IFocusZone } from '../../FocusZone';
 import { ISelection, SelectionMode, SELECTION_CHANGE } from '../../utilities/selection/interfaces';
 import {
   IDragDropHelper,
@@ -72,6 +72,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
   };
 
   private _root: HTMLElement;
+  private _focusZone: IFocusZone;
   private _hasSetFocus: boolean;
   private _droppingClassNames: string;
   private _hasMounted: boolean;
@@ -194,6 +195,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
         {...getNativeProps(this.props, divProperties) }
         direction={ FocusZoneDirection.horizontal }
         ref={ this._onRootRef }
+        componentRef={ this._resolveRef('_focusZone') }
         role='row'
         aria-label={ ariaLabel }
         className={ css(
@@ -285,16 +287,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
   }
 
   public focus(): boolean {
-    const {
-      _root
-    } = this;
-
-    if (_root) {
-      _root.focus();
-      return true;
-    }
-
-    return false;
+    return !!this._focusZone && this._focusZone.focus();
   }
 
   protected _onRenderCheck(props: IDetailsRowCheckProps) {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -133,12 +133,19 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
    */
   public focus(forceIntoFirstElement: boolean = false): boolean {
     if (!forceIntoFirstElement && this.refs.root.getAttribute(IS_FOCUSABLE_ATTRIBUTE) === 'true' && this._isInnerZone) {
-      // The parent focus zone should take responsibility for focusing this element.
+      const ownerZoneElement = this._getOwnerZone(this.refs.root);
+
+      if (ownerZoneElement !== this.refs.root) {
+        const ownerZone = _allInstances[ownerZoneElement.getAttribute(FOCUSZONE_ID_ATTRIBUTE)];
+
+        return !!ownerZone && ownerZone.focusElement(this.refs.root);
+      }
+
+      return false;
+    } else if (this._activeElement && elementContains(this.refs.root, this._activeElement)
+      && isElementTabbable(this._activeElement)) {
+      this._activeElement.focus();
       return true;
-     } else if (this._activeElement && elementContains(this.refs.root, this._activeElement)
-        && isElementTabbable(this._activeElement)) {
-        this._activeElement.focus();
-        return true;
     } else {
       const firstChild = this.refs.root.firstChild as HTMLElement;
 
@@ -652,7 +659,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
       }
     }
 
-    // If active element changes state to disabled, set it to null. 
+    // If active element changes state to disabled, set it to null.
     // Otherwise, we lose keyboard accessibility to other elements in focus zone.
     if (this._activeElement && !isElementTabbable(this._activeElement)) {
       this._activeElement = null;


### PR DESCRIPTION
Made some changes to `FocusZone` so calling `.focus()` even works when the focus zone is itself focuasable and is a child zone.
Updated `DetailsRow` to use `componentRef` and get the `IFocusZone` interface and call `.focus()` on it instead of using the `HTMLElement` interface.

This should finish off the issues with `DetailsRow` and keyboard focus.