### PR TITLE
MarqueeSelection: performance adjustments

### DIFF
--- a/common/changes/office-ui-fabric-react/marquee_2017-06-27-19-44.json
+++ b/common/changes/office-ui-fabric-react/marquee_2017-06-27-19-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MarqueeSelection: now with better performance in Edge.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -182,7 +182,6 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
 
     if (!this._dragOrigin) {
       this._dragOrigin = currentPoint;
-      console.log(this._dragOrigin);
     }
 
     if (ev.buttons !== undefined && ev.buttons === 0) {

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.scss
@@ -7,6 +7,7 @@
     margin: 0;
     padding: 10px;
     overflow: hidden;
+    user-select: none;
   }
 
   .ms-MarqueeSelectionBasicExample-photoCell {


### PR DESCRIPTION
MarqueeSelection now uses requestAnimationFrame to avoid unnecessary reflows during the measure operations.