### PR TITLE
Adding CSS to fix long words getting out of focus

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.scss
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.scss
@@ -80,6 +80,7 @@ $Dialog-default-max-width: 340px;
   color: $ms-color-neutralPrimary;
   font-weight: $ms-font-weight-semilight;
   line-height: 1.5;
+  word-wrap: break-word;
 }
 
 .actions {


### PR DESCRIPTION
Adding css styling to break a long word added as subtext in Dialog box in order to break word over multiple lines instead of getting a horizontal bar or out of view.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2073
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Adding css styling to break a long word added as subtext in Dialog box in order to break word over multiple lines instead of getting a horizontal bar or out of view.

#### Focus areas to test

Dialog box with subtext span having a long word extending multiple lines
https://codepen.io/anon/pen/eReerM