### PR TITLE
Dropdown/ContextualMenu: Adjust height of contextual menu and dropdown items

### DIFF
--- a/common/changes/office-ui-fabric-react/v-edwliu-dropdown-contextual-height_2017-06-29-18-05.json
+++ b/common/changes/office-ui-fabric-react/v-edwliu-dropdown-contextual-height_2017-06-29-18-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown/ContextualMenu: Adjust height of items to 32px",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.scss
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.scss
@@ -2,7 +2,7 @@
 
 
 
-$ContextualMenu-itemHeight: 36px;
+$ContextualMenu-itemHeight: 32px;
 $ContextualMenu-iconWidth: 14px;
 
 // component slots

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -10,7 +10,7 @@
 $Dropdown-selectedItem-bg: $ms-color-neutralQuaternaryAlt;
 $Dropdown-selectedItem-hover-bg: $ms-color-neutralLighter;
 $DropDown-height: 32px;
-$DropDown-item-height: 36px;
+$DropDown-item-height: 32px;
 
 // Mixin for high contrast mode link states
 @mixin highContrastListItemState {
@@ -203,7 +203,7 @@ $DropDown-item-height: 36px;
   height: auto;
   min-height: $DropDown-item-height;
   line-height: 20px;
-  padding: 5px 16px;
+  padding: 4px 16px;
   position: relative;
   border: 1px solid transparent;
   word-wrap: break-word;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2067
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adjust height of Contextual Menu and Dropdown items to 32px.

#### Focus areas to test

(optional)
