### PR TITLE
Toggle: Fixed aria-label that was missing from button

### DIFF
--- a/common/changes/office-ui-fabric-react/toggle-aria-label_2017-07-03-16-50.json
+++ b/common/changes/office-ui-fabric-react/toggle-aria-label_2017-07-03-16-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: Fixed aria-label that was missing from button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
@@ -23,6 +23,19 @@ describe('Toggle', () => {
     expect(labelElement.textContent).to.equal('Label');
   });
 
+  it('renders aria-label', () => {
+    let component = ReactTestUtils.renderIntoDocument(
+      <Toggle
+        label='Label'
+        offAriaLabel='offLabel'
+      />
+    );
+    let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+    let labelElement = renderedDOM.querySelector('button');
+
+    expect(labelElement.getAttribute('aria-label')).to.equal('offLabel');
+  });
+
   it('can call the callback on a change of toggle', () => {
     let isToggledValue;
     let callback = (isToggled) => {

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -113,6 +113,7 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
             ref={ (c): HTMLButtonElement => this._toggleButton = c }
             aria-disabled={ disabled }
             aria-pressed={ isChecked }
+            aria-label={ ariaLabel }
             id={ this._id }
             onChange={ () => { /* no-op */ } }
             disabled={ disabled }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2119
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Fixed aria-label

![toggle](https://user-images.githubusercontent.com/1434956/27801813-f060ccf6-5fd4-11e7-9a51-3b5a23e25bad.gif)


#### Focus areas to test

Added test to verify attribute was printing to the button.
