### PR TITLE
Exporting GlobalSettings from utilities

### DIFF
--- a/common/changes/@uifabric/utilities/export-global-settings_2017-07-05-16-58.json
+++ b/common/changes/@uifabric/utilities/export-global-settings_2017-07-05-16-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Adding export for GlobalSettings object.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -5,6 +5,7 @@ export * from './Customizer';
 export * from './DelayedRender';
 export * from './EventGroup';
 export * from './FabricPerformance';
+export * from './GlobalSettings';
 export * from './IDisposable';
 export * from './IPoint';
 export * from './IRectangle';


### PR DESCRIPTION
The GlobalSettings object needs to be exported from utilities. Otherwise it is inaccessible via the top level import.