### PR TITLE
[ChoiceGroup] Fixing null reference exception caused by imageSize

### DIFF
--- a/common/changes/@uifabric/example-app-base/users-adsurang-dropdownscrollfix_2017-07-10-18-18.json
+++ b/common/changes/@uifabric/example-app-base/users-adsurang-dropdownscrollfix_2017-07-10-18-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "adsurang@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/users-adsurang-dropdownscrollfix_2017-07-10-18-18.json
+++ b/common/changes/@uifabric/fabric-website/users-adsurang-dropdownscrollfix_2017-07-10-18-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "adsurang@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/users-adsurang-dropdownscrollfix_2017-07-10-18-18.json
+++ b/common/changes/@uifabric/styling/users-adsurang-dropdownscrollfix_2017-07-10-18-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "adsurang@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/users-adsurang-dropdownscrollfix_2017-07-10-18-18.json
+++ b/common/changes/office-ui-fabric-react/users-adsurang-dropdownscrollfix_2017-07-10-18-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing null reference exception caused if user does not specify imageSize along with imageSrc in choiceGroup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "adsurang@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -168,8 +168,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
               >
                 <Image
                   src={ option.imageSrc }
-                  width={ option.imageSize.width }
-                  height={ option.imageSize.height }
+                  width={ option.imageSize ? option.imageSize.width : null }
+                  height={ option.imageSize ? option.imageSize.height : null }
                 />
               </div>
               <div className={ css(
@@ -181,8 +181,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
               >
                 <Image
                   src={ option.selectedImageSrc }
-                  width={ option.imageSize.width }
-                  height={ option.imageSize.height }
+                  width={ option.imageSize ? option.imageSize.width : null }
+                  height={ option.imageSize ? option.imageSize.height : null }
                 />
               </div>
             </div>


### PR DESCRIPTION
#### Pull request checklist

- Addresses an existing issue: Fixes #2149 
- Include a change request file using `$ npm run change`

#### Description of changes

Choice group was throwing null reference exception when user was not specifying imageSize along with imageSrc in choiceGroup.
Fix is to add check before calling the width and height from props.imageSize

#### Focus areas to test

ChoiceGroup