### PR TITLE
Checkbox: Don't use non-prefixed class names.

### DIFF
--- a/common/changes/office-ui-fabric-react/checkbox-fix_2017-07-10-18-47.json
+++ b/common/changes/office-ui-fabric-react/checkbox-fix_2017-07-10-18-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Checkbox: reverting global class names to use ms-Checkbox-* prefixed values.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -91,8 +91,8 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
           aria-checked={ isChecked }
         />
         <label className={ css('ms-Checkbox-label', styles.label) } htmlFor={ this._id }>
-          <span className={ css('box', styles.box) }>
-            <span className={ css('checkbox', styles.checkbox) }>
+          <span className={ css('ms-Checkbox-box', styles.box) }>
+            <span className={ css('ms-Checkbox-checkbox', styles.checkbox) }>
               <Icon iconName='CheckMark' className={ styles.checkmark } />
             </span>
           </span>


### PR DESCRIPTION
A recent update caused checkboxes to have non-prefixed global class names which may collide with other class names.