### PR TITLE
DocumentCard: Deprecate accentColor prop, reduce thickness of divider line

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-documentcard-design-updates_2017-07-11-20-48.json
+++ b/common/changes/office-ui-fabric-react/miwhea-documentcard-design-updates_2017-07-11-20-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DocumentCard: Deprecate accentColor prop, reduce thickness of divider line",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mike@mikewheaton.ca"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
@@ -45,6 +45,9 @@ export interface IDocumentCardProps extends React.Props<DocumentCard> {
   /**
    * Hex color value of the line below the card, which should correspond to the document type.
    * This should only be supplied when using the 'compact' card layout.
+   *
+   * Deprecated at v4.17.1, to be removed at >= v5.0.0.
+   * @deprecated
    */
   accentColor?: string;
 }
@@ -118,6 +121,9 @@ export interface IDocumentCardPreviewImage {
 
   /**
    * Hex color value of the line below the preview, which should correspond to the document type.
+   *
+   * Deprecated at v4.17.1, to be removed at >= v5.0.0.
+   * @deprecated
    */
   accentColor?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.Props.ts
@@ -45,9 +45,6 @@ export interface IDocumentCardProps extends React.Props<DocumentCard> {
   /**
    * Hex color value of the line below the card, which should correspond to the document type.
    * This should only be supplied when using the 'compact' card layout.
-   *
-   * Deprecated at v4.17.1, to be removed at >= v5.0.0.
-   * @deprecated
    */
   accentColor?: string;
 }
@@ -121,9 +118,6 @@ export interface IDocumentCardPreviewImage {
 
   /**
    * Hex color value of the line below the preview, which should correspond to the document type.
-   *
-   * Deprecated at v4.17.1, to be removed at >= v5.0.0.
-   * @deprecated
    */
   accentColor?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
@@ -35,7 +35,6 @@
 
 // Modifier: Compact layout
 .rootIsCompact {
-  border-bottom: 2px solid $ms-color-neutralTertiary; // Default border color
   display: flex;
   max-width: 480px;
   height: 109px;
@@ -45,9 +44,9 @@
     flex: 1;
     justify-content: space-between;
   }
-  // Remove the usual accent color from the preview
+
   .preview {
-    border-bottom: none;
+    border-bottom: none;   // Remove the usual border from the preview
     max-height: 106px;
     max-width: 144px;
 
@@ -210,7 +209,7 @@ $ms-DocumentCardActivity-personaTextGutter: 8px;
 
 /** Preview **/
 .preview {
-  border-bottom: 2px solid $ms-color-neutralTertiary; // Default border color
+  border-bottom: 1px solid $ms-color-neutralLight;
   position: relative;
   background-color: $ms-color-neutralLighterAlt;
   overflow: hidden;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
@@ -15,8 +15,16 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
   };
 
   public render() {
-    let { onClick, onClickHref, children, className, type } = this.props;
+    let { onClick, onClickHref, children, className, type, accentColor } = this.props;
     let actionable = (onClick || onClickHref) ? true : false;
+
+    // Override the border color if an accent color was provided (compact card only)
+    let style;
+    if (type === DocumentCardType.compact && accentColor) {
+      style = {
+        borderBottomColor: accentColor
+      };
+    }
 
     // if this element is actionable it should have an aria role
     let role = actionable ? (onClick ? 'button' : 'link') : null;
@@ -38,7 +46,8 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
           )
         }
         onKeyDown={ actionable ? this._onKeyDown : null }
-        onClick={ actionable ? this._onClick : null }>
+        onClick={ actionable ? this._onClick : null }
+        style={ style }>
         { children }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
@@ -15,16 +15,8 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
   };
 
   public render() {
-    let { onClick, onClickHref, children, className, type, accentColor } = this.props;
+    let { onClick, onClickHref, children, className, type } = this.props;
     let actionable = (onClick || onClickHref) ? true : false;
-
-    // Override the border color if an accent color was provided (compact card only)
-    let style;
-    if (type === DocumentCardType.compact && accentColor) {
-      style = {
-        borderBottomColor: accentColor
-      };
-    }
 
     // if this element is actionable it should have an aria role
     let role = actionable ? (onClick ? 'button' : 'link') : null;
@@ -46,8 +38,7 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
           )
         }
         onKeyDown={ actionable ? this._onKeyDown : null }
-        onClick={ actionable ? this._onClick : null }
-        style={ style }>
+        onClick={ actionable ? this._onClick : null }>
         { children }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
@@ -14,6 +14,14 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
     type: DocumentCardType.normal
   };
 
+  constructor(props: IDocumentCardProps) {
+    super(props);
+
+    this._warnDeprecations({
+      accentColor: null
+    });
+  }
+
   public render() {
     let { onClick, onClickHref, children, className, type, accentColor } = this.props;
     let actionable = (onClick || onClickHref) ? true : false;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPage.visualtest.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPage.visualtest.tsx
@@ -11,7 +11,8 @@ export default class DocumentCardVPage extends React.Component<any, any> {
           previewImageSrc: 'dist/document-preview.png',
           iconSrc: 'dist/icon-ppt.png',
           width: 318,
-          height: 196
+          height: 196,
+          accentColor: '#ce4b1f'
         }
       ],
     };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPage.visualtest.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPage.visualtest.tsx
@@ -11,8 +11,7 @@ export default class DocumentCardVPage extends React.Component<any, any> {
           previewImageSrc: 'dist/document-preview.png',
           iconSrc: 'dist/icon-ppt.png',
           width: 318,
-          height: 196,
-          accentColor: '#ce4b1f'
+          height: 196
         }
       ],
     };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -24,13 +24,6 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
     } else if (previewImages.length === 1) {
       // Render a single preview
       preview = this._renderPreviewImage(previewImages[0]);
-
-      // Override the border color if an accent color was provided
-      if (previewImages[0].accentColor) {
-        style = {
-          borderBottomColor: previewImages[0].accentColor
-        };
-      }
     }
 
     return (

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -24,6 +24,13 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
     } else if (previewImages.length === 1) {
       // Render a single preview
       preview = this._renderPreviewImage(previewImages[0]);
+
+      // Override the border color if an accent color was provided
+      if (previewImages[0].accentColor) {
+        style = {
+          borderBottomColor: previewImages[0].accentColor
+        };
+      }
     }
 
     return (

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
@@ -20,7 +20,8 @@ export class DocumentCardBasicExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196
+          height: 196,
+          accentColor: '#ce4b1f'
         }
       ],
     };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
@@ -20,8 +20,7 @@ export class DocumentCardBasicExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196,
-          accentColor: '#ce4b1f'
+          height: 196
         }
       ],
     };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
@@ -47,7 +47,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
 
     return (
       <div>
-        <DocumentCard type={ DocumentCardType.compact } onClickHref='http://bing.com'>
+        <DocumentCard type={ DocumentCardType.compact } onClickHref='http://bing.com' accentColor='#ce4b1f'>
           <DocumentCardPreview { ...previewProps } />
           <div className='ms-DocumentCard-details'>
             <DocumentCardTitle
@@ -64,7 +64,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
           </div>
         </DocumentCard>
         <p />
-        <DocumentCard type={ DocumentCardType.compact } onClickHref='http://bing.com'>
+        <DocumentCard type={ DocumentCardType.compact } onClickHref='http://bing.com' accentColor='#ce4b1f'>
           <DocumentCardPreview previewImages={ [previewProps.previewImages[0]] } />
           <div className='ms-DocumentCard-details'>
             <DocumentCardTitle

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
@@ -47,7 +47,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
 
     return (
       <div>
-        <DocumentCard type={ DocumentCardType.compact } onClickHref='http://bing.com' accentColor='#ce4b1f'>
+        <DocumentCard type={ DocumentCardType.compact } onClickHref='http://bing.com'>
           <DocumentCardPreview { ...previewProps } />
           <div className='ms-DocumentCard-details'>
             <DocumentCardTitle
@@ -64,7 +64,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
           </div>
         </DocumentCard>
         <p />
-        <DocumentCard type={ DocumentCardType.compact } onClickHref='http://bing.com' accentColor='#ce4b1f'>
+        <DocumentCard type={ DocumentCardType.compact } onClickHref='http://bing.com'>
           <DocumentCardPreview previewImages={ [previewProps.previewImages[0]] } />
           <div className='ms-DocumentCard-details'>
             <DocumentCardTitle

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -23,7 +23,8 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196
+          height: 196,
+          accentColor: '#ce4b1f'
         },
         {
           name: 'New Contoso Collaboration for Conference Presentation Draft',
@@ -32,7 +33,8 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196
+          height: 196,
+          accentColor: '#ce4b1f'
         },
         {
           name: 'Spec Sheet for design',
@@ -41,7 +43,8 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196
+          height: 196,
+          accentColor: '#ce4b1f'
         },
         {
           name: 'Contoso Marketing Presentation',
@@ -50,7 +53,8 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196
+          height: 196,
+          accentColor: '#ce4b1f'
         },
         {
           name: 'Notes from Ignite conference',
@@ -59,7 +63,8 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196
+          height: 196,
+          accentColor: '#ce4b1f'
         },
         {
           name: 'FY17 Cost Projections',
@@ -68,7 +73,8 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196
+          height: 196,
+          accentColor: '#ce4b1f'
         }
       ],
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -23,8 +23,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196,
-          accentColor: '#ce4b1f'
+          height: 196
         },
         {
           name: 'New Contoso Collaboration for Conference Presentation Draft',
@@ -33,8 +32,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196,
-          accentColor: '#ce4b1f'
+          height: 196
         },
         {
           name: 'Spec Sheet for design',
@@ -43,8 +41,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196,
-          accentColor: '#ce4b1f'
+          height: 196
         },
         {
           name: 'Contoso Marketing Presentation',
@@ -53,8 +50,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196,
-          accentColor: '#ce4b1f'
+          height: 196
         },
         {
           name: 'Notes from Ignite conference',
@@ -63,8 +59,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196,
-          accentColor: '#ce4b1f'
+          height: 196
         },
         {
           name: 'FY17 Cost Projections',
@@ -73,8 +68,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
           width: 318,
-          height: 196,
-          accentColor: '#ce4b1f'
+          height: 196
         }
       ],
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates DocumentCard to match the latest designs, which call for a reducing the divider line from 2px to 1px. The `accentColor` prop has been deprecated, as the color of this line no longer varies for different document types.

Result:
![image](https://user-images.githubusercontent.com/1382445/28090068-eb1b9e58-663f-11e7-8252-d7d3616682e1.png)
![image](https://user-images.githubusercontent.com/1382445/28090081-f99a6aa4-663f-11e7-97bf-cdc0d16b56d0.png)
