### PR TITLE
Pass in hideSearchIcon as prop in search box, and primaryCommandsClassName and sideCommandsClassName for CommandBar

### DIFF
--- a/common/changes/@uifabric/example-app-base/chuli-cmdAndSearchFix_2017-07-11-22-47.json
+++ b/common/changes/@uifabric/example-app-base/chuli-cmdAndSearchFix_2017-07-11-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "chuli@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/chuli-cmdAndSearchFix_2017-07-11-22-47.json
+++ b/common/changes/@uifabric/fabric-website/chuli-cmdAndSearchFix_2017-07-11-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "chuli@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/chuli-cmdAndSearchFix_2017-07-11-22-47.json
+++ b/common/changes/@uifabric/styling/chuli-cmdAndSearchFix_2017-07-11-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "chuli@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/chuli-cmdAndSearchFix_2017-07-11-22-47.json
+++ b/common/changes/@uifabric/utilities/chuli-cmdAndSearchFix_2017-07-11-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "chuli@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/chuli-cmdAndSearchFix_2017-07-11-22-47.json
+++ b/common/changes/office-ui-fabric-react/chuli-cmdAndSearchFix_2017-07-11-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pass in hideSearchIcon as prop in search box, and primaryCommandsClassName and sideCommandsClassName for CommandBar",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chuli@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts
@@ -51,4 +51,15 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * @defaultvalue undefined
    */
   className?: string;
+
+  /**
+   * Additional css class to apply to the command bar primary command container
+   * @defaultvalue undefined
+   */
+  primaryCommandsClassName?: string;
+  /**
+   * Additional css class to apply to the command bar side command container
+   * @defaultvalue undefined
+   */
+  sideCommandsClassName?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -82,7 +82,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
   }
 
   public render() {
-    const { isSearchBoxVisible, searchPlaceholderText, className } = this.props;
+    const { isSearchBoxVisible, searchPlaceholderText, className, primaryCommandsClassName, sideCommandsClassName } = this.props;
     const { renderedItems, contextualMenuProps, expandedMenuItemKey, expandedMenuId, renderedOverflowItems, contextualMenuTarget, renderedFarItems } = this.state;
     let searchBox;
 
@@ -111,7 +111,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
       <div className={ css('ms-CommandBar', styles.root, className) } ref='commandBarRegion'>
         { searchBox }
         <FocusZone ref='focusZone' className={ styles.container } direction={ FocusZoneDirection.horizontal } role='menubar' >
-          <div className={ css('ms-CommandBar-primaryCommands', styles.primaryCommands) } ref='commandSurface'>
+          <div className={ css('ms-CommandBar-primaryCommands', styles.primaryCommands, primaryCommandsClassName) } ref='commandSurface'>
             { renderedItems.map((item, index) => (
               this._renderItemInCommandBar(item, index, expandedMenuItemKey)
             )).concat((renderedOverflowItems && renderedOverflowItems.length) ? [
@@ -133,7 +133,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
               </div>
             ] : []) }
           </div>
-          <div className={ css('ms-CommandBar-sideCommands', styles.sideCommands) } ref='farCommandSurface'>
+          <div className={ css('ms-CommandBar-sideCommands', styles.sideCommands, sideCommandsClassName) } ref='farCommandSurface'>
             { renderedFarItems.map((item, index) => (
               this._renderItemInCommandBar(item, index, expandedMenuItemKey, true)
             )) }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Customization.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Customization.Example.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { CommandButton } from 'office-ui-fabric-react/lib/Button';
 import { CommandBar } from 'office-ui-fabric-react/lib/CommandBar';
+import { CommandButton } from 'office-ui-fabric-react/lib/Button';
+import { farItems } from './data';
+import { IContextualMenuItem } from '../../ContextualMenu';
 import { css, autobind, } from 'office-ui-fabric-react/lib/Utilities';
 import styles = require('./CommandBar.Example.scss');
-import { IContextualMenuItem } from '../../ContextualMenu';
 
 export interface ISplitDropDownButtonState {
   isContextMenuShown: boolean;
@@ -21,6 +22,8 @@ export class CommandBarCustomizationExample extends React.Component<any, ISplitD
     return (
       <div>
         <CommandBar
+          primaryCommandsClassName={ styles.primaryCommands }
+          sideCommandsClassName={ styles.sideCommands }
           isSearchBoxVisible={ false }
           items={
             [
@@ -48,6 +51,7 @@ export class CommandBarCustomizationExample extends React.Component<any, ISplitD
               },
             ]
           }
+          farItems={ farItems }
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Example.scss
@@ -44,5 +44,13 @@
 }
 
 .darkerBG {
-  background: #d0d0d0
+  background: #d0d0d0;
+}
+
+.primaryCommands {
+  margin: 0 8px;
+}
+
+.sideCommands {
+  margin: 0 10px;
 }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
@@ -52,4 +52,9 @@ export interface ISearchBoxProps extends React.Props<SearchBox> {
    * @defaultvalue labelText
    */
   ariaLabel?: string;
+
+  /**
+   * The boolean which indicates whether to hide search icon.
+   */
+  hideSearchIcon?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -47,7 +47,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
   }
 
   public render() {
-    let { labelText, className } = this.props;
+    let { labelText, className, hideSearchIcon } = this.props;
     let { value, hasFocus, id } = this.state;
     return (
       <div
@@ -58,11 +58,14 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
         }) }
         { ...{ onFocusCapture: this._onFocusCapture } }
       >
-        <div
-          className={ css('ms-SearchBox-iconContainer', styles.iconContainer) }
-        >
-          <Icon className={ css('ms-SearchBox-icon', styles.icon) } iconName='Search' />
-        </div>
+        {
+          !hideSearchIcon &&
+          <div
+            className={ css('ms-SearchBox-iconContainer', styles.iconContainer) }
+          >
+            <Icon className={ css('ms-SearchBox-icon', styles.icon) } iconName='Search' />
+          </div>
+        }
         <input
           id={ id }
           className={ css('ms-SearchBox-field', styles.field) }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
@@ -6,10 +6,12 @@ import {
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 import { SearchBoxSmallExample } from './examples/SearchBox.Small.Example';
+import { SearchBoxHideSearchIconExample } from './examples/SearchBox.HideSearchIcon.Example';
 import { SearchBoxFullSizeExample } from './examples/SearchBox.FullSize.Example';
 import { FontClassNames } from '../../Styling';
 
 const SearchBoxSmallExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx') as string;
+const SearchBoxHideSearchIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.HideSearchIcon.Example.tsx') as string;
 const SearchBoxFullSizeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.FullSize.Example.tsx') as string;
 
 export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> {
@@ -22,6 +24,9 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> 
           <div>
             <ExampleCard title='SearchBox' code={ SearchBoxSmallExampleCode }>
               <SearchBoxSmallExample />
+            </ExampleCard>
+            <ExampleCard title='SearchBox - With search icon hidden' code={ SearchBoxHideSearchIconExampleCode }>
+              <SearchBoxHideSearchIconExample />
             </ExampleCard>
             <ExampleCard title='SearchBox - No Parent Container' code={ SearchBoxFullSizeExampleCode }>
               <SearchBoxFullSizeExample />

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.HideSearchIcon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.HideSearchIcon.Example.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import {
+  SearchBox
+} from 'office-ui-fabric-react/lib/SearchBox';
+import './SearchBox.Small.Example.scss';
+
+export class SearchBoxHideSearchIconExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <div className='ms-SearchBoxSmallExample'>
+        <SearchBox
+          hideSearchIcon={ true }
+          onChange={ (newValue) => console.log('SearchBox onChange fired: ' + newValue) }
+          onSearch={ (newValue) => console.log('SearchBox onSearch fired: ' + newValue) }
+        />
+      </div>
+    );
+  }
+
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2182 #2183
- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Pass in hideSearchIcon in SearchBox as optional prop. Default value is false. 
This is needed in OWA, because as soon as we show the search box in dropdown, we are going to focus on it. It makes the icon especially annoying because it disappears immediately.

- Pass in customizable css for primaryCommands and sideCommands for CommandBar control
Currently there is a 20px default margin to the left of the primaryCommands. However, we need a smaller margin in OWA to have it align with other components.

#### Focus areas to test

(optional)
