### PR TITLE
Tooltip on render fix

### DIFF
--- a/common/changes/office-ui-fabric-react/tooltip-onRender-fix_2017-07-12-16-53.json
+++ b/common/changes/office-ui-fabric-react/tooltip-onRender-fix_2017-07-12-16-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TooltipHost: Fixed check which kept onRenderContent from working",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -65,20 +65,19 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
         aria-describedby={ setAriaDescribedBy && isTooltipVisible && content ? tooltipId : undefined }
       >
         { children }
-        { isTooltipVisible &&
-          content ? (
-            <Tooltip
-              { ...tooltipProps }
-              id={ tooltipId }
-              delay={ delay }
-              content={ content }
-              targetElement={ this._getTargetElement() }
-              directionalHint={ directionalHint }
-              calloutProps={ assign(calloutProps, { onDismiss: this._onTooltipCallOutDismiss }) }
-              { ...getNativeProps(this.props, divProperties) }
-            >
-            </Tooltip>
-          ) : undefined }
+        { isTooltipVisible && (
+          <Tooltip
+            id={ tooltipId }
+            delay={ delay }
+            content={ content }
+            targetElement={ this._getTargetElement() }
+            directionalHint={ directionalHint }
+            calloutProps={ assign(calloutProps, { onDismiss: this._onTooltipCallOutDismiss }) }
+            { ...getNativeProps(this.props, divProperties) }
+            { ...tooltipProps }
+          >
+          </Tooltip>
+        ) }
       </div>
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2177 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
We were checking for content before rendering the tooltip. This broke simply using onRenderContent. Removed the check as it is really unnecessary. 

#### Focus areas to test

(optional)
