### PR TITLE
Fix crash in highlight component

### DIFF
--- a/common/changes/@uifabric/example-app-base/fix-highlight_2017-07-12-20-44.json
+++ b/common/changes/@uifabric/example-app-base/fix-highlight_2017-07-12-20-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Highlight: Use correct import for highlightBlock",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/example-app-base/src/components/Highlight/Highlight.tsx
+++ b/packages/example-app-base/src/components/Highlight/Highlight.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { registerLanguage } from 'highlight.js';
+import { registerLanguage, highlightBlock } from 'highlight.js';
 import * as javascript from 'highlight.js/lib/languages/javascript';
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 
@@ -30,6 +30,6 @@ export class Highlight extends BaseComponent<IHighlightProps, {}> {
   }
 
   public componentDidMount() {
-    hljs.highlightBlock(this._codeElement);
+    highlightBlock(this._codeElement);
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

After switching to using the d.ts file for highlight.js, we shouldn't use hljs anymore. 
