### PR TITLE
Only initialize default theme once

### DIFF
--- a/common/changes/@uifabric/styling/styling-init-theme-once_2017-07-13-02-42.json
+++ b/common/changes/@uifabric/styling/styling-init-theme-once_2017-07-13-02-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Only initialize the default theme once, even if multiple instances of @uifabric/styling are executed.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -21,16 +21,18 @@ let _theme: ITheme = {
 
 export const ThemeSettingName = 'theme';
 
-let win = typeof window !== 'undefined' ? window : undefined;
+if (!GlobalSettings.getValue(ThemeSettingName)) {
+  let win = typeof window !== 'undefined' ? window : undefined;
 
-// tslint:disable:no-string-literal no-any
-if (win && (win as any)['FabricConfig'] && (win as any)['FabricConfig'].theme) {
-  _theme = createTheme((win as any)['FabricConfig'].theme);
+  // tslint:disable:no-string-literal no-any
+  if (win && (win as any)['FabricConfig'] && (win as any)['FabricConfig'].theme) {
+    _theme = createTheme((win as any)['FabricConfig'].theme);
+  }
+  // tslint:enable:no-string-literal no-any
+
+  // Set the default theme.
+  GlobalSettings.setValue(ThemeSettingName, _theme);
 }
-// tslint:enable:no-string-literal no-any
-
-// Set the default theme.
-GlobalSettings.setValue(ThemeSettingName, _theme);
 
 /**
  * Gets the theme object.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

In the event a second instance of `@uifabric/styling` is loaded after the initial boot of an app, the initialization code shouldn't trample any existing theme that has been set.

#### Focus areas to test

Due to ongoing issues in our development environment, I haven't been able to fully verify the issue before leaving for vacation. However, I did regression test it in the example app.
