### PR TITLE
Adjustments for focusing items in People Picker

### DIFF
--- a/common/changes/office-ui-fabric-react/people-picker-focus_2017-07-14-21-52.json
+++ b/common/changes/office-ui-fabric-react/people-picker-focus_2017-07-14-21-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow the X in a persona to receive focus and update focus when it is clicked",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -544,6 +544,11 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           return true;
       }
     }
+
+    if (ev.which === KeyCodes.enter) {
+      return true;
+    }
+
     return false;
   }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -26,6 +26,7 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
         { ['is-invalid ' + styles.validationError]: item.ValidationState === ValidationState.warning }
       ) }
       data-is-focusable={ true }
+      data-is-sub-focuszone={ true }
       data-selection-index={ index } >
       <div className={ css('ms-PickerItem-content', styles.itemContent) } >
         <Persona
@@ -38,7 +39,6 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
         onClick={ () => { if (onRemoveItem) { onRemoveItem(); } } }
         iconProps={ { iconName: 'Cancel', style: { fontSize: '12px' } } }
         className={ css('ms-PickerItem-removeButton', styles.removeButton) }
-        data-is-focusable={ false }
         ariaLabel={ removeButtonAriaLabel }
       />
     </div >


### PR DESCRIPTION
This change addresses some minor focus handling issues in the People Picker, notably:

- You cannot tab to the X button on a persona item that has been selected in the picker.
- Clicking on the X button in a persona to deleted loses the focus.

With this change, the following become possible:

- When a persona has focus, hitting Enter will tab within the persona, focusing the X button. Arrow keys still skip over the X unless you hit Enter.
- Deleting a persona using the X sets focus to the item which replaced it at its index.