### PR TITLE
Dropdown: Change order of native props so className prop will overwrite properly

### DIFF
--- a/common/changes/office-ui-fabric-react/v-edwliu-dropdown-classfix_2017-07-17-18-42.json
+++ b/common/changes/office-ui-fabric-react/v-edwliu-dropdown-classfix_2017-07-17-18-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: List native props at top of div element",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -127,15 +127,9 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           <Label className={ css('ms-Dropdown-label') } id={ id + '-label' } ref={ this._resolveRef('_dropdownLabel') } required={ required }>{ label }</Label>
         ) }
         <div
-          { ...divProps }
           data-is-focusable={ !disabled }
           ref={ this._resolveRef('_dropDown') }
           id={ id }
-          className={ css('ms-Dropdown', styles.root, className, {
-            'is-open': isOpen,
-            ['is-disabled ' + styles.rootIsDisabled]: disabled,
-            'is-required ': required,
-          }) }
           tabIndex={ disabled ? -1 : 0 }
           aria-expanded={ isOpen ? 'true' : 'false' }
           role='combobox'
@@ -145,6 +139,12 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           aria-activedescendant={ isOpen && selectedIndex >= 0 ? (this._id + '-list' + selectedIndex) : null }
           aria-disabled={ disabled }
           aria-owns={ isOpen ? id + '-list' : null }
+          { ...divProps }
+          className={ css('ms-Dropdown', styles.root, className, {
+            'is-open': isOpen,
+            ['is-disabled ' + styles.rootIsDisabled]: disabled,
+            'is-required ': required,
+          }) }
           onBlur={ this._onDropdownBlur }
           onKeyDown={ this._onDropdownKeyDown }
           onKeyUp={ this._onDropdownKeyUp }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -127,6 +127,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           <Label className={ css('ms-Dropdown-label') } id={ id + '-label' } ref={ this._resolveRef('_dropdownLabel') } required={ required }>{ label }</Label>
         ) }
         <div
+          { ...divProps }
           data-is-focusable={ !disabled }
           ref={ this._resolveRef('_dropDown') }
           id={ id }
@@ -144,7 +145,6 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           aria-activedescendant={ isOpen && selectedIndex >= 0 ? (this._id + '-list' + selectedIndex) : null }
           aria-disabled={ disabled }
           aria-owns={ isOpen ? id + '-list' : null }
-          { ...divProps }
           onBlur={ this._onDropdownBlur }
           onKeyDown={ this._onDropdownKeyDown }
           onKeyUp={ this._onDropdownKeyUp }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2221
- [x] Include a change request file using `$ npm run change`

#### Description of changes

insert native props at top of Dropdown div element so className prop will overwrite properly

#### Focus areas to test

Dropdown
