### PR TITLE
Fix CommandBar rendering commandText span when no item name is given:…

### DIFF
--- a/common/changes/office-ui-fabric-react/commandtextfix_2017-07-18-15-14.json
+++ b/common/changes/office-ui-fabric-react/commandtextfix_2017-07-18-15-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix CommandBar rendering commandText span when no item name is given: #2233.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "trgau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -228,8 +228,15 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
             aria-haspopup={ hasSubmenuItems(item) }
           >
             { (hasIcon) ? this._renderIcon(item) : (null) }
-            <span className={ css(
-              'ms-CommandBarItem-commandText', styles.itemCommandText) } aria-hidden='true' role='presentation'>{ item.name }</span>
+            { (!!item.name) && (
+              <span
+                className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
+                aria-hidden='true'
+                role='presentation'
+              >
+                { item.name }
+              </span>
+            ) }
           </div>;
         }
       })() }


### PR DESCRIPTION
… #2233.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2233 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

See title


