### PR TITLE
Fabric site: Fix link to Color Accessibility PDF

### DIFF
--- a/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.tsx
@@ -38,7 +38,7 @@ export class ColorsPage extends React.Component<any, any> {
         />
         <div className={ pageStyles.u_maxTextWidth }>
           <h2 id='Overview'>Overview</h2>
-          <p>Fabric includes 9 theme colors and 11 neutral colors. Each has helper classes for text, background, border, and hover states. When selecting colors, refer to the <a href={ baseURL + 'https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf' }>color accessibility guidance (PDF)</a> to ensure that your text can be ready by everyone.</p>
+          <p>Fabric includes 9 theme colors and 11 neutral colors. Each has helper classes for text, background, border, and hover states. When selecting colors, refer to the <a href={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf' }>color accessibility guidance (PDF)</a> to ensure that your text can be ready by everyone.</p>
         </div>
         <h2 id='implementation'>Implementation</h2>
         <p>Colors can be applied to text, backgrounds, or borders using the following class name conventions:</p>

--- a/common/changes/@uifabric/fabric-website/jahnp-site-fixes_2017-07-20-05-22.json
+++ b/common/changes/@uifabric/fabric-website/jahnp-site-fixes_2017-07-20-05-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Remove erroneous usage of baseUrl to fix link to color accessibility guide",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "pejahn@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Not tracked as an issue, but the link to the Color Accessibility PDF on the [Colors page](https://dev.office.com/fabric#/styles/colors) is broken. (Also see this Tweet: https://twitter.com/StfBauer/status/885507452862681088)
- [x ] Include a change request file using `$ npm run change`

#### Description of changes

Remove erroneous usage of baseUrl in link to color accessibility PDF.
