### PR TITLE
Fix filteredAssign function so it does not throw with a null isAllowed parameter

### DIFF
--- a/common/changes/@uifabric/utilities/filteredAssignBug_2017-07-20-21-02.json
+++ b/common/changes/@uifabric/utilities/filteredAssignBug_2017-07-20-21-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Fixing filteredAssign function",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "alebet@microsoft.com"
+}

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -62,8 +62,10 @@ export function filteredAssign(isAllowed: (propName: string) => boolean, target:
   for (let sourceObject of args) {
     if (sourceObject) {
       for (let propName in sourceObject) {
-        if (sourceObject.hasOwnProperty(propName) &&
-          !isAllowed || isAllowed(propName)) {
+        if (
+          sourceObject.hasOwnProperty(propName) &&
+          (!isAllowed || isAllowed(propName))
+        ) {
           target[propName] = sourceObject[propName];
         }
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2268
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updated precedence of boolean operators so the filteredAssign function will not throw.

#### Focus areas to test

(optional)
