### PR TITLE
Mirror DirectionalHints in RTL layouts

### DIFF
--- a/common/changes/office-ui-fabric-react/directional-hint-mirror-in-rtl_2017-07-21-19-17.json
+++ b/common/changes/office-ui-fabric-react/directional-hint-mirror-in-rtl_2017-07-21-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout/ContextualMenu/Tooltip: we now mirror DirectionalHints in RTL layouts by default. To override this behavior, specify `directionalHintForRtl`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -4,7 +4,7 @@ import { CalloutContent } from './CalloutContent';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import {
   IPoint,
-  IRectangle
+  IRectangle,
 } from '../../Utilities';
 
 export interface ICallout {
@@ -30,6 +30,12 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
    * @default DirectionalHint.BottomAutoEdge
    */
   directionalHint?: DirectionalHint;
+
+  /**
+   * How the element should be positioned in RTL layouts.
+   * If not specified, a mirror of `directionalHint` will be used instead
+   */
+  directionalHintForRtl?: DirectionalHint;
 
   /**
    * The gap between the Callout and the target

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -35,7 +35,7 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
    * How the element should be positioned in RTL layouts.
    * If not specified, a mirror of `directionalHint` will be used instead
    */
-  directionalHintForRtl?: DirectionalHint;
+  directionalHintForRTL?: DirectionalHint;
 
   /**
    * The gap between the Callout and the target

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -48,6 +48,12 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
   directionalHint?: DirectionalHint;
 
   /**
+   * How the element should be positioned in RTL layouts.
+   * If not specified, a mirror of `directionalHint` will be used instead
+   */
+  directionalHintForRtl?: DirectionalHint;
+
+  /**
    * The gap between the ContextualMenu and the target
    * @default 0
    */

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -51,7 +51,7 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * How the element should be positioned in RTL layouts.
    * If not specified, a mirror of `directionalHint` will be used instead
    */
-  directionalHintForRtl?: DirectionalHint;
+  directionalHintForRTL?: DirectionalHint;
 
   /**
    * The gap between the ContextualMenu and the target

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -175,6 +175,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       useTargetPoint,
       beakWidth,
       directionalHint,
+      directionalHintForRtl,
       gapSpace,
       coverTarget,
       ariaLabel,
@@ -216,6 +217,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
           isBeakVisible={ isBeakVisible }
           beakWidth={ beakWidth }
           directionalHint={ directionalHint }
+          directionalHintForRtl={ directionalHintForRtl }
           gapSpace={ gapSpace }
           coverTarget={ coverTarget }
           doNotLayer={ doNotLayer }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -175,7 +175,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       useTargetPoint,
       beakWidth,
       directionalHint,
-      directionalHintForRtl,
+      directionalHintForRTL,
       gapSpace,
       coverTarget,
       ariaLabel,
@@ -217,7 +217,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
           isBeakVisible={ isBeakVisible }
           beakWidth={ beakWidth }
           directionalHint={ directionalHint }
-          directionalHintForRtl={ directionalHintForRtl }
+          directionalHintForRTL={ directionalHintForRTL }
           gapSpace={ gapSpace }
           coverTarget={ coverTarget }
           doNotLayer={ doNotLayer }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
@@ -5,14 +5,13 @@ import { ContextualMenu, DirectionalHint, ContextualMenuItemType } from 'office-
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Slider } from 'office-ui-fabric-react/lib/Slider';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { autobind } from 'office-ui-fabric-react/lib/Utilities';
-import { getRTL } from '@uifabric/utilities';
+import { autobind, getRTL } from 'office-ui-fabric-react/lib/Utilities';
 import './ContextualMenuExample.scss';
 
 export interface IContextualMenuDirectionalExampleState {
   isContextualMenuVisible?: boolean;
   directionalHint?: DirectionalHint;
-  directionalHintForRtl?: DirectionalHint;
+  directionalHintForRTL?: DirectionalHint;
   useDirectionalHintForRtl?: boolean;
   isBeakVisible?: boolean;
   gapSpace?: number;
@@ -51,7 +50,7 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
       isContextualMenuVisible: false,
       isBeakVisible: false,
       directionalHint: DirectionalHint.bottomLeftEdge,
-      directionalHintForRtl: DirectionalHint.bottomLeftEdge,
+      directionalHintForRTL: DirectionalHint.bottomLeftEdge,
       useDirectionalHintForRtl: false,
       gapSpace: 0,
       beakWidth: 10,
@@ -63,7 +62,7 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
     let {
       beakWidth,
       directionalHint,
-      directionalHintForRtl,
+      directionalHintForRTL,
       edgeFixed,
       gapSpace,
       isBeakVisible,
@@ -100,7 +99,7 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
           { getRTL() &&
             <Dropdown
               label='Directional hint for RTL'
-              selectedKey={ DirectionalHint[directionalHintForRtl] }
+              selectedKey={ DirectionalHint[directionalHintForRTL] }
               options={ DIRECTION_OPTIONS }
               onChanged={ this._onDirectionalRtlChanged }
               disabled={ !useDirectionalHintForRtl } />
@@ -117,7 +116,7 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
             target={ this.refs.menuButton }
             isBeakVisible={ isBeakVisible }
             directionalHint={ directionalHint }
-            directionalHintForRtl={ useDirectionalHintForRtl ? directionalHintForRtl : undefined }
+            directionalHintForRTL={ useDirectionalHintForRtl ? directionalHintForRTL : undefined }
             gapSpace={ gapSpace }
             beakWidth={ beakWidth }
             directionalHintFixed={ edgeFixed }
@@ -233,7 +232,7 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
   @autobind
   private _onDirectionalRtlChanged(option: IDropdownOption) {
     this.setState({
-      directionalHintForRtl: (DirectionalHint as any)[option.key]
+      directionalHintForRTL: (DirectionalHint as any)[option.key]
     });
   }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
@@ -6,11 +6,14 @@ import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Slider } from 'office-ui-fabric-react/lib/Slider';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { getRTL } from '@uifabric/utilities';
 import './ContextualMenuExample.scss';
 
 export interface IContextualMenuDirectionalExampleState {
   isContextualMenuVisible?: boolean;
   directionalHint?: DirectionalHint;
+  directionalHintForRtl?: DirectionalHint;
+  useDirectionalHintForRtl?: boolean;
   isBeakVisible?: boolean;
   gapSpace?: number;
   beakWidth?: number;
@@ -48,6 +51,8 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
       isContextualMenuVisible: false,
       isBeakVisible: false,
       directionalHint: DirectionalHint.bottomLeftEdge,
+      directionalHintForRtl: DirectionalHint.bottomLeftEdge,
+      useDirectionalHintForRtl: false,
       gapSpace: 0,
       beakWidth: 10,
       edgeFixed: false
@@ -55,7 +60,16 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
   }
 
   public render() {
-    let { isContextualMenuVisible, isBeakVisible, directionalHint, gapSpace, beakWidth, edgeFixed } = this.state;
+    let {
+      beakWidth,
+      directionalHint,
+      directionalHintForRtl,
+      edgeFixed,
+      gapSpace,
+      isBeakVisible,
+      isContextualMenuVisible,
+      useDirectionalHintForRtl
+    } = this.state;
 
     return (
       <div className='ms-ContextualMenuDirectionalExample'>
@@ -80,6 +94,17 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
             selectedKey={ DirectionalHint[directionalHint] }
             options={ DIRECTION_OPTIONS }
             onChanged={ this._onDirectionalChanged } />
+          { getRTL() &&
+            <Checkbox label='Use RTL directional hint' checked={ useDirectionalHintForRtl } onChange={ this._onUseRtlHintChange } />
+          }
+          { getRTL() &&
+            <Dropdown
+              label='Directional hint for RTL'
+              selectedKey={ DirectionalHint[directionalHintForRtl] }
+              options={ DIRECTION_OPTIONS }
+              onChanged={ this._onDirectionalRtlChanged }
+              disabled={ !useDirectionalHintForRtl } />
+          }
         </div>
         <div className='ms-ContextualMenuDirectionalExample-buttonArea' ref='menuButton'>
           <DefaultButton
@@ -92,6 +117,7 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
             target={ this.refs.menuButton }
             isBeakVisible={ isBeakVisible }
             directionalHint={ directionalHint }
+            directionalHintForRtl={ useDirectionalHintForRtl ? directionalHintForRtl : undefined }
             gapSpace={ gapSpace }
             beakWidth={ beakWidth }
             directionalHintFixed={ edgeFixed }
@@ -184,6 +210,13 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
   }
 
   @autobind
+  private _onUseRtlHintChange(ev: React.FormEvent<HTMLElement>, isVisible: boolean) {
+    this.setState({
+      useDirectionalHintForRtl: isVisible
+    });
+  }
+
+  @autobind
   private _onShowMenuClicked() {
     this.setState({
       isContextualMenuVisible: !this.state.isContextualMenuVisible
@@ -194,6 +227,13 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
   private _onDirectionalChanged(option: IDropdownOption) {
     this.setState({
       directionalHint: (DirectionalHint as any)[option.key]
+    });
+  }
+
+  @autobind
+  private _onDirectionalRtlChanged(option: IDropdownOption) {
+    this.setState({
+      directionalHintForRtl: (DirectionalHint as any)[option.key]
     });
   }
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
@@ -49,6 +49,12 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
    * @default DirectionalHint.topCenter
    */
   directionalHint?: DirectionalHint;
+
+  /**
+   * How the element should be positioned in RTL layouts.
+   * If not specified, a mirror of `directionalHint` will be used instead
+   */
+  directionalHintForRtl?: DirectionalHint;
 }
 
 export enum TooltipDelay {

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.Props.ts
@@ -54,7 +54,7 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
    * How the element should be positioned in RTL layouts.
    * If not specified, a mirror of `directionalHint` will be used instead
    */
-  directionalHintForRtl?: DirectionalHint;
+  directionalHintForRTL?: DirectionalHint;
 }
 
 export enum TooltipDelay {

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
@@ -35,7 +35,7 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
       content,
       calloutProps,
       directionalHint,
-      directionalHintForRtl,
+      directionalHintForRTL,
       delay,
       id,
       onRenderContent = this._onRenderContent
@@ -52,7 +52,7 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
         ) }
         targetElement={ targetElement }
         directionalHint={ directionalHint }
-        directionalHintForRtl={ directionalHintForRtl }
+        directionalHintForRTL={ directionalHintForRTL }
         {...calloutProps}
         { ...getNativeProps(this.props, divProperties) }
       >

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
@@ -35,10 +35,11 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
       content,
       calloutProps,
       directionalHint,
+      directionalHintForRtl,
       delay,
       id,
       onRenderContent = this._onRenderContent
-    } = this.props;
+  } = this.props;
 
     return (
       <Callout
@@ -51,6 +52,7 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
         ) }
         targetElement={ targetElement }
         directionalHint={ directionalHint }
+        directionalHintForRtl={ directionalHintForRtl }
         {...calloutProps}
         { ...getNativeProps(this.props, divProperties) }
       >

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
@@ -63,7 +63,7 @@ export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement |
    * How the element should be positioned in RTL layouts.
    * If not specified, a mirror of `directionalHint` will be used instead
    */
-  directionalHintForRtl?: DirectionalHint;
+  directionalHintForRTL?: DirectionalHint;
 
   /**
    * Only show if there is overflow. If set, the tooltip hosts observes  and only shows the tooltip if this element has overflow.

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.Props.ts
@@ -60,6 +60,12 @@ export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement |
   directionalHint?: DirectionalHint;
 
   /**
+   * How the element should be positioned in RTL layouts.
+   * If not specified, a mirror of `directionalHint` will be used instead
+   */
+  directionalHintForRtl?: DirectionalHint;
+
+  /**
    * Only show if there is overflow. If set, the tooltip hosts observes  and only shows the tooltip if this element has overflow.
    * It also uses the parent as target element for the tooltip.
    */

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -47,7 +47,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
       content,
       children,
       directionalHint,
-      directionalHintForRtl,
+      directionalHintForRTL,
       delay,
       id,
       setAriaDescribedBy = true,
@@ -73,7 +73,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
             content={ content }
             targetElement={ this._getTargetElement() }
             directionalHint={ directionalHint }
-            directionalHintForRtl={ directionalHintForRtl }
+            directionalHintForRTL={ directionalHintForRTL }
             calloutProps={ assign(calloutProps, { onDismiss: this._onTooltipCallOutDismiss }) }
             { ...getNativeProps(this.props, divProperties) }
             { ...tooltipProps }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -47,6 +47,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
       content,
       children,
       directionalHint,
+      directionalHintForRtl,
       delay,
       id,
       setAriaDescribedBy = true,
@@ -72,6 +73,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
             content={ content }
             targetElement={ this._getTargetElement() }
             directionalHint={ directionalHint }
+            directionalHintForRtl={ directionalHintForRtl }
             calloutProps={ assign(calloutProps, { onDismiss: this._onTooltipCallOutDismiss }) }
             { ...getNativeProps(this.props, divProperties) }
             { ...tooltipProps }

--- a/packages/office-ui-fabric-react/src/utilities/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning.ts
@@ -44,7 +44,7 @@ export interface IPositionProps {
    * How the element should be positioned in RTL layouts.
    * If not specified, a mirror of `directionalHint` will be used instead
    */
-  directionalHintForRtl?: DirectionalHint;
+  directionalHintForRTL?: DirectionalHint;
 
   /** The gap between the callout and the target */
   gapSpace?: number;
@@ -182,8 +182,8 @@ let OppositeEdgeDictionary: { [key: number]: number } = {
 
 function getDirectionalHintForLayout(props: IPositionProps): DirectionalHint {
   if (getRTL()) {
-    return props.directionalHintForRtl !== undefined ?
-      props.directionalHintForRtl :
+    return props.directionalHintForRTL !== undefined ?
+      props.directionalHintForRTL :
       MirrorDirectionalHintDictionary[props.directionalHint];
   } else {
     return props.directionalHint;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2278
- [x] Include a change request file using `$ npm run change`

#### Description of changes

All code which uses DirectionalHints now mirrors them in RTL layouts by default. All such components now also have `directionalHintForRtl` properties to use as an escape hatch to avoid this default behavior.

#### Focus areas to test

(optional)
