### PR TITLE
TextField/Fabric component: font fot TEXTAREA elements now inherits font family.

### DIFF
--- a/common/changes/office-ui-fabric-react/multiline-textfield-font_2017-07-24-17-37.json
+++ b/common/changes/office-ui-fabric-react/multiline-textfield-font_2017-07-24-17-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: multiline variant font now correct, assuming the Fabric component wraps the application. A new selector was added which will force TEXTAREA elements to inherit the font.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
@@ -23,7 +23,8 @@ export const getStyles = memoizeFunction((
       {
         color: theme.palette.neutralPrimary,
         '& button': inheritFont,
-        '& input': inheritFont
+        '& input': inheritFont,
+        '& textarea': inheritFont
       }
     ])
   };


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #2276 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Font defined for TEXTAREA elements is now inherited, like INPUT elements.

