### PR TITLE
Add initial framework for a TilesList component

### DIFF
--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -64,7 +64,8 @@
     "webpack-notifier": "^1.5.0"
   },
   "dependencies": {
-    "office-ui-fabric-react": "4.34.0"
+    "office-ui-fabric-react": "4.34.0",
+    "office-ui-fabric-core": ">= 7.1.2 <8.0.0"
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.0.1-0 || ^16.0.0-0",

--- a/packages/experiments/src/Tile.ts
+++ b/packages/experiments/src/Tile.ts
@@ -1,0 +1,2 @@
+
+export * from './components/Tile/index';

--- a/packages/experiments/src/TilesList.ts
+++ b/packages/experiments/src/TilesList.ts
@@ -1,0 +1,2 @@
+
+export * from './components/TilesList/index';

--- a/packages/experiments/src/components/Tile/Tile.Props.ts
+++ b/packages/experiments/src/components/Tile/Tile.Props.ts
@@ -1,0 +1,71 @@
+
+import * as React from 'react';
+import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
+import { Tile } from './Tile';
+import { Selection } from 'office-ui-fabric-react/lib/utilities/selection/Selection';
+
+export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpanElement | HTMLAnchorElement> {
+  /**
+   * Index of the item in the selection controller.
+   *
+   * @type {number}
+   * @memberof ITileProps
+   */
+  selectionIndex?: number;
+  /**
+   * Selection controller for the item rendered in the tile.
+   *
+   * @type {Selection}
+   * @memberof ITileProps
+   */
+  selection?: Selection;
+  /**
+   * Name to use on the nameplate for the tile.
+   *
+   * @type {(React.ReactNode | React.ReactNode[])}
+   * @memberof ITileProps
+   */
+  itemName?: React.ReactNode | React.ReactNode[];
+  /**
+   * Activity to use on the nameplate for the tile.
+   *
+   * @type {(React.ReactNode | React.ReactNode[])}
+   * @memberof ITileProps
+   */
+  itemActivity?: React.ReactNode | React.ReactNode[];
+  /**
+   * Content to render as the full-size background of the tile.
+   *
+   * @type {(React.ReactNode | React.ReactNode[])}
+   * @memberof ITileProps
+   */
+  background?: React.ReactNode | React.ReactNode[];
+  /**
+   * Whether or not to frame the background.
+   *
+   * @type {boolean}
+   * @memberof ITileProps
+   */
+  showBackgroundFrame?: boolean;
+  /**
+   * Content to render as the foreground of the tile, bounded by padding and the nameplate.
+   *
+   * @type {(React.ReactNode | React.ReactNode[])}
+   * @memberof ITileProps
+   */
+  foreground?: React.ReactNode | React.ReactNode[];
+  /**
+   * Whether or not to frame the foreground.
+   *
+   * @type {boolean}
+   * @memberof ITileProps
+   */
+  showForegroundFrame?: boolean;
+  /**
+   * The accessible label for the selection checkbox.
+   *
+   * @type {boolean}
+   * @memberof ITileProps
+   */
+  toggleSelectionAriaLabel?: boolean;
+}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -1,0 +1,265 @@
+
+@import '../../../../office-ui-fabric-react/src/common/common';
+
+.tile {
+  @include focus-clear();
+
+  display: block;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: $ms-color-white;
+  transition: transform 0.1s linear;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  align-content: stretch;
+
+  text-decoration: none;
+  color: $ms-color-neutralPrimary;
+
+  &:hover {
+    background-color: $ms-color-neutralLighter;
+
+    &.selected {
+      background-color: $ms-color-neutralQuaternaryAlt;
+    }
+  }
+
+  &.selected {
+    background-color: $ms-color-neutralLight;
+  }
+
+  @include focus(true) {
+    background-color: $ms-color-neutralLighter;
+
+    &.selected {
+      background-color: $ms-color-neutralQuaternaryAlt; // Todo need a color variable.
+    }
+  }
+
+  @include focus(true) {
+    outline: 1px solid $ms-color-neutralSecondary;
+
+    &.selected {
+      outline: 1px solid $ms-color-themePrimary;
+    }
+  }
+
+  &.hasBackgroundFrame {
+    box-shadow: 0 1px 3px 1px rgba(1, 1, 0, 0.05);
+
+    &:hover {
+      outline: 1px solid $ms-color-neutralTertiaryAlt;
+    }
+
+    @include focus(true) {
+      outline: 1px solid $ms-color-neutralSecondary;
+
+      &.selected {
+        outline: 1px solid $ms-color-themePrimary;
+      }
+    }
+
+    &:after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      pointer-events: none;
+      border: 2px solid $ms-color-white;
+    }
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+.frame {
+  margin: auto;
+  position: relative;
+  overflow: hidden;
+  max-width: 100%;
+  max-height: 100%;
+
+  &.hasForegroundFrame {
+    margin: auto auto 0 auto;
+    background-color: $ms-color-white;
+    box-shadow: 0 1px 3px 1px rgba(1, 1, 0, 0.05);
+
+    &:after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      pointer-events: none;
+      border: 2px solid $ms-color-white;
+    }
+  }
+}
+
+.check {
+  @include focus-border($position: absolute);
+  display: none;
+  top: 0;
+  @include right(0);
+  border: none;
+  background: none;
+  opacity: 0;
+
+  .tile.selectable & {
+    display: block;
+  }
+
+  .tile.selected &,
+  .tile:hover & {
+    opacity: 1;
+  }
+
+  @include focus(true) {
+    opacity: 1;
+  }
+}
+
+.tile {
+  @include focus(true) {
+    .check {
+      opacity: 1;
+    }
+  }
+}
+
+button.check {
+  padding: 6px;
+}
+
+.content {
+  position: relative;
+  flex: 1;
+}
+
+.background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden;
+}
+
+.foreground {
+  top: 16px;
+  left: 16px;
+  right: 16px;
+  bottom: 0;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+}
+
+.nameplate {
+  display: block;
+  margin: auto 0 0 0;
+  padding: 12px 8px;
+  text-align: center;
+
+  .tile.hasBackgroundFrame & {
+    padding: 12px 10px;
+  }
+}
+
+.signal {
+  display: inline-block;
+
+  &.storageSignal {
+    @include margin-left(4px);
+  }
+
+  &.socialSignal {
+    @include margin-right(4px);
+  }
+
+  &.lifecycleSignal {
+    @include margin-right(4px);
+  }
+}
+
+@mixin preserveExtenders($topMargin: 0px) {
+  padding-top: 8px;
+  margin-top: $topMargin - 8px;
+  @include margin-left(-8px);
+  @include padding-left(8px);
+}
+
+.name {
+  display: block;
+  font-weight: $ms-font-weight-regular;
+  font-size: $ms-font-size-m;
+  color: $ms-color-neutralPrimary;
+  height: 20px;
+  line-height: 20px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  @include preserveExtenders();
+}
+
+.activity {
+  margin-top: 4px;
+  display: block;
+  font-weight: $ms-font-weight-regular;
+  font-size: $ms-font-size-s;
+  color: #767676;
+  height: 16px;
+  line-height: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  @include preserveExtenders(4px);
+}
+
+.hasBackgroundFrame {
+  .nameplate {
+    @include text-align(left);
+  }
+}
+
+.hasBackground {
+  .nameplate {
+    position: relative;
+    background-image: linear-gradient(to top, rgba(#000, 0.65) 0%, rgba(#000, 0.65 * 0.85) 70%, rgba(#000, 0.30 * 0.85) 100%);
+
+    &:before {
+      position: absolute;
+      content: '';
+      display: block;
+      height: 12px;
+      bottom: 100%;
+      left: 0;
+      right: 0;
+      background-image: linear-gradient(to top, rgba(#000, 0.30 * 0.85) 0%, rgba(#000, 0) 100%);
+    }
+  }
+
+  .name {
+    color: $ms-color-white;
+    text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
+  }
+
+  .activity {
+    color: $ms-color-white;
+    text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
+  }
+}

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -1,0 +1,260 @@
+
+import * as React from 'react';
+import { ITileProps } from './Tile.Props';
+import { Check } from 'office-ui-fabric-react/lib/Check';
+import { SELECTION_CHANGE } from 'office-ui-fabric-react/lib/utilities/selection/index';
+import { css, BaseComponent, autobind, getNativeProps, getId } from 'office-ui-fabric-react/lib/Utilities';
+import * as TileStylesModule from './Tile.scss';
+import * as SignalStylesModule from '../signals/Signals.scss';
+
+const TileStyles: any = TileStylesModule;
+const SignalStyles: any = SignalStylesModule;
+
+export interface ITileState {
+  isSelected?: boolean;
+}
+
+/**
+ * A tile provides a frame for a potentially-selectable item which displays its contents prominently.
+ *
+ * @export
+ * @class Tile
+ * @extends {React.Component<ITileProps, ITileState>}
+ */
+export class Tile extends BaseComponent<ITileProps, ITileState> {
+  private _nameId: string;
+  private _activityId: string;
+
+  constructor(props: ITileProps, context: any) {
+    super(props, context);
+
+    this._nameId = getId('Tile-name');
+    this._activityId = getId('Tile-activity');
+
+    const {
+      selectionIndex = -1,
+      selection
+    } = props;
+
+    const isSelected = !!selection && selectionIndex > -1 && selection.isIndexSelected(selectionIndex);
+
+    this.state = {
+      isSelected: isSelected
+    };
+  }
+
+  public componentWillReceiveProps(nextProps: ITileProps) {
+    const {
+      selection,
+      selectionIndex
+    } = this.props;
+
+    const {
+      selection: nextSelection,
+      selectionIndex: nextSelectionIndex = -1
+    } = nextProps;
+
+    if (selection !== nextSelection || selectionIndex !== nextSelectionIndex) {
+      const isSelected = !!nextSelection && nextSelectionIndex > -1 && nextSelection.isIndexSelected(nextSelectionIndex);
+
+      this.setState({
+        isSelected: isSelected
+      });
+    }
+  }
+
+  public componentDidMount() {
+    const {
+      selection
+    } = this.props;
+
+    if (selection) {
+      this._events.on(selection, SELECTION_CHANGE, this._onSelectionChange);
+    }
+  }
+
+  public componentDidUpdate(previousProps: ITileProps) {
+    const {
+      selection
+    } = this.props;
+
+    const {
+      selection: previousSelection
+    } = previousProps;
+
+    if (selection !== previousSelection) {
+      if (previousSelection) {
+        this._events.off(previousSelection);
+      }
+
+      if (selection) {
+        this._events.on(selection, SELECTION_CHANGE, this._onSelectionChange);
+      }
+    }
+  }
+
+  public render() {
+    const {
+      children,
+      selectionIndex = -1,
+      selection,
+      background,
+      foreground,
+      showBackgroundFrame = false,
+      showForegroundFrame = false,
+      itemName,
+      itemActivity,
+      componentRef,
+      className,
+      ...aProps
+    } = this.props;
+
+    const isSelectable = !!selection && selectionIndex > -1;
+
+    const {
+      isSelected = false
+    } = this.state;
+
+    const Tag = aProps.href ? 'a' : 'span';
+
+    return (
+      <Tag
+        { ...(aProps.href ? aProps : {}) }
+        aria-labelledby={ this._nameId }
+        aria-describedby={ this._activityId }
+        className={ css('ms-Tile', className, TileStyles.tile, {
+          [`ms-Tile--hasBackgroundFrame ${TileStyles.hasBackgroundFrame}`]: showBackgroundFrame,
+          [`ms-Tile--isSelected ${TileStyles.selected} ${SignalStyles.selected}`]: isSelected,
+          [`ms-Tile--isSelectable ${TileStyles.selectable}`]: isSelectable,
+          [`ms-Tile--hasBackground ${TileStyles.hasBackground} ${SignalStyles.dark}`]: !!background
+        }) }
+        data-is-focusable={ true }
+        data-is-sub-focuszone={ true }
+        data-selection-invoke={ (selectionIndex > -1) ? true : undefined }
+        data-selection-index={ (selectionIndex > -1) ? selectionIndex : undefined }>
+        {
+          background ? this._onRenderBackground({
+            background: background
+          }) : null
+        }
+        {
+          foreground ? this._onRenderForeground({
+            foreground: foreground,
+            showForegroundFrame: showForegroundFrame
+          }) : null
+        }
+        {
+          (itemName || itemActivity) ? this._onRenderNameplate({
+            name: itemName,
+            activity: itemActivity
+          }) : null
+        }
+        {
+          isSelectable ? this._onRenderCheck({
+            isSelected: isSelected
+          }) : null
+        }
+      </Tag>
+    );
+  }
+
+  private _onRenderBackground({
+    background
+  }: {
+      background: React.ReactNode | React.ReactNode[]
+    }) {
+    return (
+      <span className={ css('ms-Tile-background', TileStyles.background) }>
+        { background }
+      </span>
+    );
+  }
+
+  private _onRenderForeground({
+    foreground,
+    showForegroundFrame
+  }: {
+      foreground: React.ReactNode | React.ReactNode[];
+      showForegroundFrame: boolean;
+    }) {
+    return (
+      <span
+        role='presentation'
+        className={ css('ms-Tile-content', TileStyles.content) }>
+        <span
+          role='presentation'
+          className={ css('ms-Tile-foreground', TileStyles.foreground) }>
+          <span
+            role='presentation'
+            className={ css('ms-Tile-frame', TileStyles.frame, {
+              [`ms-Tile-frame--hasForegroundFrame ${TileStyles.hasForegroundFrame}`]: showForegroundFrame
+            }) }>
+            { foreground }
+          </span>
+        </span>
+      </span>
+    );
+  }
+
+  private _onRenderNameplate({
+    name,
+    activity
+  }: {
+      name: React.ReactNode | React.ReactNode[];
+      activity: React.ReactNode | React.ReactNode[];
+    }) {
+    return (
+      <span
+        className={ css('ms-Tile-nameplate', TileStyles.nameplate) }>
+        {
+          name ? (
+            <span
+              id={ this._nameId }
+              className={ css('ms-Tile-name', TileStyles.name) }>
+              { name }
+            </span>
+          ) : null
+        }
+        {
+          activity ? (
+            <span
+              id={ this._activityId }
+              className={ css('ms-Tile-activity', TileStyles.activity) }>
+              { activity }
+            </span>
+          ) : null
+        }
+      </span>
+    );
+  }
+
+  private _onRenderCheck({
+    isSelected
+  }: {
+      isSelected: boolean;
+    }) {
+    return (
+      <button
+        aria-label={ this.props.toggleSelectionAriaLabel }
+        className={ css('ms-Tile-check', TileStyles.check) }
+        data-selection-toggle={ true }
+        role='checkbox'>
+        <Check
+          checked={ isSelected }
+        />
+      </button>
+    );
+  }
+
+  @autobind
+  private _onSelectionChange() {
+    const {
+      selection,
+      selectionIndex = -1
+    } = this.props;
+
+    this.setState({
+      isSelected: selectionIndex > -1 && selection && selection.isIndexSelected(selectionIndex)
+    });
+  }
+}

--- a/packages/experiments/src/components/Tile/TilePage.tsx
+++ b/packages/experiments/src/components/Tile/TilePage.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { Link } from 'office-ui-fabric-react/lib/Link';
+import {
+  ExampleCard,
+  IComponentDemoPageProps,
+  ComponentPage,
+  PropertiesTableSet
+} from '@uifabric/example-app-base';
+
+import { TileMediaExample } from './examples/Tile.Media.Example';
+const TileMediaExampleCode = require('!raw-loader!experiments/src/components/Tile/examples/Tile.Media.Example.tsx') as string;
+
+import { TileDocumentExample } from './examples/Tile.Document.Example';
+const TileDocumentExampleCode = require('!raw-loader!experiments/src/components/Tile/examples/Tile.Document.Example.tsx') as string;
+
+export class TilePage extends React.Component<IComponentDemoPageProps, {}> {
+  public render() {
+    return (
+      <ComponentPage
+        title='Tile'
+        componentName='Tile'
+        exampleCards={
+          <div>
+            <ExampleCard title='Document Tile' isOptIn={ true } code={ TileDocumentExampleCode }>
+              <TileDocumentExample />
+            </ExampleCard>
+            <ExampleCard title='Media Tile' isOptIn={ true } code={ TileMediaExampleCode }>
+              <TileMediaExample />
+            </ExampleCard>
+          </div>
+        }
+        propertiesTables={
+          <PropertiesTableSet
+            sources={ [
+              require<string>('!raw-loader!experiments/src/components/Tile/Tile.Props.ts')
+            ] }
+          />
+        }
+        overview={
+          <div>
+          </div>
+        }
+        bestPractices={
+          <div></div>
+        }
+        dos={
+          <div>
+            <ul>
+              <li>Use them to represent a large collection of items visually.</li>
+            </ul>
+          </div>
+        }
+        donts={
+          <div>
+            <ul>
+              <li>Use them for general layout of components that are not part of the same set.</li>
+            </ul>
+          </div>
+        }
+        isHeaderVisible={ this.props.isHeaderVisible }>
+      </ComponentPage>
+    );
+  }
+}

--- a/packages/experiments/src/components/Tile/examples/Tile.Document.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Document.Example.tsx
@@ -1,0 +1,182 @@
+
+import * as React from 'react';
+import { Tile } from '../Tile';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import {
+  SignalField,
+  Signal,
+  NewSignal,
+  CommentsSignal,
+  TrendingSignal,
+  SharedSignal,
+  MentionSignal
+} from '../../signals/Signals';
+import { lorem } from '@uifabric/example-app-base';
+import * as TileExampleStylesModule from './Tile.Example.scss';
+
+const TileExampleStyles = TileExampleStylesModule as any;
+
+export class TileDocumentExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <div>
+        <h3>Tiny document thumbnail</h3>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <TrendingSignal />
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            itemActivity={
+              <SignalField
+                before={
+                  <CommentsSignal>{ '12' }</CommentsSignal>
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            foreground={
+              <img src={ `//placehold.it/40x40` } style={
+                {
+                  display: 'block'
+                }
+              } />
+            }
+            showForegroundFrame={ true }
+          />
+        </div>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <TrendingSignal />
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            itemActivity={
+              <SignalField
+                before={
+                  <CommentsSignal>{ '12' }</CommentsSignal>
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            foreground={
+              <img src={ `//placehold.it/80x120` } style={
+                {
+                  display: 'block'
+                }
+              } />
+            }
+            showForegroundFrame={ true }
+          />
+        </div>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <TrendingSignal />
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            itemActivity={
+              <SignalField
+                before={
+                  <CommentsSignal>{ '12' }</CommentsSignal>
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            foreground={
+              <img src={ `//placehold.it/168x96` } style={
+                {
+                  display: 'block'
+                }
+              } />
+            }
+            showForegroundFrame={ true }
+          />
+        </div>
+        <h3>Maximum-sized document thumbnail</h3>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <NewSignal />
+                }
+              >
+                { lorem(10) }
+              </SignalField>
+            }
+            foreground={
+              <img src={ `//placehold.it/168x120` } style={
+                {
+                  display: 'block'
+                }
+
+              } />
+            }
+            showForegroundFrame={ true }
+          />
+        </div>
+        <h3>Document icon</h3>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <NewSignal />
+                }
+              >
+                { lorem(1) }
+              </SignalField>
+            }
+            itemActivity={
+              (
+                <SignalField
+                  before={
+                    <SharedSignal />
+                  }
+                >
+                  { lorem(3) }
+                </SignalField>
+              )
+            }
+            foreground={
+              <img
+                src={
+                  `https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/docx_48x1.svg`
+                }
+                style={
+                  {
+                    display: 'block',
+                    width: '64px',
+                    height: '64px',
+                    margin: '16px'
+                  }
+                }
+              />
+            }
+            showForegroundFrame={ true }
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/components/Tile/examples/Tile.Example.scss
+++ b/packages/experiments/src/components/Tile/examples/Tile.Example.scss
@@ -1,0 +1,23 @@
+
+.tile {
+  display: inline-block;
+  position: relative;
+  margin: 4px;
+}
+
+.landscapeTile {
+  width: 250px;
+  height: 200px;
+}
+
+.portraitTile {
+  width: 175px;
+  height: 200px;
+}
+
+.squareTile {
+  display: inline-block;
+  position: relative;
+  width: 200px;
+  height: 200px;
+}

--- a/packages/experiments/src/components/Tile/examples/Tile.Media.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Media.Example.tsx
@@ -1,0 +1,118 @@
+
+import * as React from 'react';
+import { Tile } from '../Tile';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import {
+  SignalField,
+  Signal,
+  NewSignal,
+  CommentsSignal,
+  TrendingSignal,
+  SharedSignal,
+  MentionSignal
+} from '../../signals/Signals';
+import { lorem } from '@uifabric/example-app-base';
+import * as TileExampleStylesModule from './Tile.Example.scss';
+
+const TileExampleStyles = TileExampleStylesModule as any;
+
+export class TileMediaExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <div>
+        <h3>Landscape</h3>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.landscapeTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <NewSignal />
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            itemActivity={
+              <SignalField
+                before={
+                  [<Signal><Icon iconName='play' /></Signal>, <MentionSignal />]
+                }
+              >
+                { lorem(6) }
+              </SignalField>
+            }
+            background={
+              <img src={ `//placehold.it/250x200` } style={
+                {
+                  display: 'block'
+                }
+              } />
+            }
+            showBackgroundFrame={ true }
+          />
+        </div>
+        <h3>Portrait</h3>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.portraitTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <NewSignal />
+                }
+              >
+                { lorem(1) }
+              </SignalField>
+            }
+            itemActivity={
+              <SignalField
+                before={
+                  <CommentsSignal>{ '6' }</CommentsSignal>
+                }
+              >
+                { lorem(6) }
+              </SignalField>
+            }
+            background={
+              <img src={ `//placehold.it/175x200` } style={
+                {
+                  display: 'block'
+                }
+              } />
+            }
+            showBackgroundFrame={ true }
+          />
+        </div>
+        <h3>No preview</h3>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <NewSignal />
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            itemActivity={
+              (
+                <SignalField
+                  before={
+                    [<Signal><Icon iconName='play' /></Signal>, <SharedSignal />]
+                  }
+                >
+                  { lorem(8) }
+                </SignalField>
+              )
+            }
+            foreground={
+              <Icon iconName='play' style={ { margin: '11px', fontSize: '40px' } } />
+            }
+            showBackgroundFrame={ true }
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/components/Tile/index.ts
+++ b/packages/experiments/src/components/Tile/index.ts
@@ -1,0 +1,3 @@
+
+export * from './Tile.Props';
+export * from './Tile';

--- a/packages/experiments/src/components/TilesList/TilesList.Props.ts
+++ b/packages/experiments/src/components/TilesList/TilesList.Props.ts
@@ -1,0 +1,102 @@
+
+import * as React from 'react';
+import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
+import { TilesList } from './TilesList';
+import { Selection } from 'office-ui-fabric-react/lib/utilities/selection/Selection';
+
+export interface ITilesGridItem<TItem> {
+  /**
+   * A unique key to assign to the item within the grid.
+   * This is only used for reconciliation, not selection behavior.
+   */
+  key: string;
+  /**
+   * The content item to be rendered. This will be passed back to `onRender`.
+   */
+  content: TItem;
+  /**
+   * The desired dimensions of the item, used to compute aspect ratio.
+   * If not provided, this is assumed to be a square equivalent to the current row height.
+   */
+  desiredSize?: { width: number; height: number; };
+  /**
+   * Invoked to render the virtual DOM for the item.
+   * This content will be rendered inside the cell allocated for the item.
+   */
+  onRender: (content: TItem, finalSize?: ITileSize) => (React.ReactNode | React.ReactNode[]);
+}
+
+export const enum TilesGridMode {
+  /**
+   * Every item in the grid gets its own row.
+   */
+  none,
+  /**
+   * Items in the row are stacked without resizing until they overflow.
+   */
+  stack,
+  /**
+   * Items in the row are stretched if necessary to fill the row.
+   */
+  fill
+}
+
+export interface ITilesGridSegment<TItem> {
+  /**
+   * A unique key to assign to the grid segment.
+   * This will only be used for reconciliation.
+   */
+  key: string;
+  /**
+   * The items to render as part of a contiguous, flowing grid.
+   * All items will be rendered with the same base row height and margin.
+   */
+  items: ITilesGridItem<TItem>[];
+  /**
+   * The spacing to allocate between items.
+   */
+  spacing?: number;
+  /**
+   * The base height for each row.
+   */
+  minRowHeight: number;
+  /**
+   * The maximum scale factor to use when stretching items to fill a row.
+   */
+  maxScaleFactor?: number;
+  /**
+   * The mode for the grid.
+   */
+  mode: TilesGridMode;
+  /**
+   * The top margin for the grid.
+   */
+  marginTop?: number;
+  /**
+   * The bottom margin for the grid.
+   */
+  marginBottom?: number;
+}
+
+export interface ITileSize {
+  width: number;
+  height: number;
+}
+
+export interface ITilesListProps<TItem> extends IBaseProps, React.HTMLAttributes<TilesList<TItem>> {
+  /**
+   * An array of items to assign to the list.
+   * This should be complete and not contain any holes.
+   * The items may either be header row specifications, or grid specifications which each
+   * define their own items.
+   */
+  items: (ITilesGridItem<TItem> | ITilesGridSegment<TItem>)[];
+  /**
+   * The desired number of content cells to render per page.
+   */
+  cellsPerPage?: number;
+  /**
+   * The current selection model.
+   */
+  selection?: Selection;
+}

--- a/packages/experiments/src/components/TilesList/TilesList.scss
+++ b/packages/experiments/src/components/TilesList/TilesList.scss
@@ -1,0 +1,47 @@
+
+@import '../../../../office-ui-fabric-react/src/common/common';
+
+.listCell {
+  display: block;
+  margin: 0;
+}
+
+.listPage {
+  display: flex;
+  flex-direction: column;
+}
+
+.cell {
+  display: block;
+  position: relative;
+}
+
+.cellContent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+.cellFirstInRow {
+  display: block;
+}
+
+.sizer {
+  display: block;
+  visibility: hidden;
+}
+
+.grid {
+  display: flex;
+  flex-direction: row;
+  flex-flow: row wrap;
+  align-items: flex-start;
+  justify-content: flex-start;
+  align-content: flex-start;
+}
+
+.none {
+  display: block;
+}

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -1,0 +1,518 @@
+
+import * as React from 'react';
+import { ITilesListProps, ITilesGridItem, ITilesGridSegment, TilesGridMode, ITileSize } from './TilesList.Props';
+import { List, IPageProps } from 'office-ui-fabric-react/lib/List';
+import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
+import { SelectionZone, SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection/index';
+import { autobind, css, IRenderFunction, IRectangle } from 'office-ui-fabric-react/lib/Utilities';
+import * as TilesListStylesModule from './TilesList.scss';
+
+const TilesListStyles: any = TilesListStylesModule;
+
+const MAX_TILE_STRETCH = 1.5;
+const CELLS_PER_PAGE = 100;
+
+export interface ITilesListState<TItem> {
+  cells: ITileCell<TItem>[];
+}
+
+export interface ITileGrid {
+  minRowHeight: number;
+  mode: TilesGridMode;
+  spacing: number;
+  maxScaleFactor: number;
+  marginTop: number;
+  marginBottom: number;
+  key: string;
+}
+
+export interface ITileCell<TItem> {
+  key: string;
+  content: TItem;
+  aspectRatio: number;
+  grid: ITileGrid;
+  onRender(content: TItem, finalSize: { width: number; height: number; }): React.ReactNode | React.ReactNode[];
+}
+
+interface IRowData {
+  scaleFactor: number;
+  isLastRow?: boolean;
+}
+
+interface IPageData<TItem> {
+  pageWidths: {
+    [index: number]: number;
+  };
+  rows: {
+    [index: number]: IRowData;
+  };
+  cellSizes: {
+    [index: number]: ITileSize;
+  };
+  extraCells: ITileCell<TItem>[] | undefined;
+}
+
+interface IPageSpecification<TItem> {
+  itemCount: number;
+  data: IPageData<TItem>;
+}
+
+interface IPageSpecificationCache<TItem> {
+  byIndex: {
+    [index: number]: IPageSpecification<TItem>;
+  };
+  width: number;
+}
+
+export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, ITilesListState<TItem>> {
+  private _pageSpecificationCache: IPageSpecificationCache<TItem> | undefined;
+
+  constructor(props: ITilesListProps<TItem>, context: any) {
+    super(props, context);
+
+    this.state = {
+      cells: this._getCells(props.items)
+    };
+  }
+
+  public componentWillReceiveProps(nextProps: ITilesListProps<TItem>) {
+    if (nextProps.items !== this.props.items) {
+      this.setState({
+        cells: this._getCells(nextProps.items)
+      });
+    }
+  }
+
+  public componentWillUpdate(nextProps: ITilesListProps<TItem>, nextState: ITilesListState<TItem>) {
+    if (nextState.cells !== this.state.cells) {
+      this._pageSpecificationCache = undefined;
+    }
+  }
+
+  public render() {
+    const {
+      selection
+    } = this.props;
+
+    const {
+      cells
+    } = this.state;
+
+    const list = (
+      <List
+        items={ cells }
+        getPageSpecification={ this._getPageSpecification }
+        onRenderPage={ this._onRenderPage }
+      />
+    );
+
+    return (
+      <FocusZone
+        direction={ FocusZoneDirection.bidirectional }
+      >
+        {
+          selection ?
+            <SelectionZone
+              selection={ selection }
+              selectionMode={ SelectionMode.multiple }>
+              { list }
+            </SelectionZone> :
+            list
+        }
+      </FocusZone>
+    );
+  }
+
+  private _onRenderCell(item: ITileCell<TItem>, finalSize: ITileSize) {
+    if (item.grid.mode === TilesGridMode.none) {
+      return (
+        <div className={ css(TilesListStyles.header) }
+        >
+          { item.onRender(item.content, { width: 0, height: 0 }) }
+        </div>
+      );
+    }
+
+    const itemWidthOverHeight = item.aspectRatio;
+    const itemHeightOverWidth = 1 / itemWidthOverHeight;
+
+    return (
+      <div
+        role='presentation'
+        className={ css(TilesListStyles.cell) }
+        style={
+          {
+            paddingTop: `${(100 * itemHeightOverWidth).toFixed(2)}%`
+          }
+        }
+      >
+        <div
+          role='presentation'
+          className={ css(TilesListStyles.cellContent) }
+        >
+          { item.onRender(item.content, finalSize) }
+        </div>
+      </div>
+    );
+  }
+
+  @autobind
+  private _onRenderPage(pageProps: IPageProps, defaultRender?: IRenderFunction<IPageProps>) {
+    const {
+      page,
+      className: pageClassName,
+      ...divProps
+    } = pageProps;
+
+    const {
+      items
+    } = page;
+
+    const data: IPageData<TItem> = page.data;
+
+    const cells: ITileCell<TItem>[] = items || [];
+
+    let grids: React.ReactNode[] = [];
+
+    const previousCell = this.state.cells[page.startIndex - 1];
+    const nextCell = this.state.cells[page.startIndex + page.itemCount];
+
+    const endIndex = cells.length;
+
+    let currentRow: IRowData | undefined;
+
+    for (let i = 0; i < endIndex;) {
+      // For each cell at the start of a grid.
+      const grid = cells[i].grid;
+
+      const renderedCells: React.ReactNode[] = [];
+
+      const width = data.pageWidths[i];
+
+      for (; i < endIndex && cells[i].grid === grid; i++) {
+        // For each cell in the current grid.
+        const cell = cells[i];
+
+        const index = page.startIndex + i;
+        const cellAsFirstRow = data.rows[index];
+
+        if (cellAsFirstRow) {
+          currentRow = cellAsFirstRow;
+        }
+
+        let finalSize = data.cellSizes[index];
+
+        if (currentRow) {
+          const {
+            scaleFactor
+          } = currentRow;
+
+          if (!currentRow.isLastRow || scaleFactor <= grid.maxScaleFactor) {
+            const finalScaleFactor = Math.min(grid.maxScaleFactor, scaleFactor);
+
+            finalSize = {
+              width: finalSize.width * finalScaleFactor,
+              height: finalSize.height * finalScaleFactor
+            };
+          }
+        }
+
+        renderedCells.push(
+          <div
+            key={ `${grid.key}-item-${cell.key}` }
+            data-item-index={ index }
+            className={ css('ms-List-cell', this._onGetCellClassName(), {
+              [`ms-TilesList-cell--firstInRow ${TilesListStyles.cellFirstInRow}`]: !!cellAsFirstRow
+            }) }
+            style={
+              {
+                ...this._onGetCellStyle(cell, currentRow)
+              }
+            }
+          >
+            { this._onRenderCell(cell, finalSize) }
+          </div>
+        );
+      }
+
+      const isOpenStart = previousCell && previousCell.grid === grid;
+      const isOpenEnd = nextCell && nextCell.grid === grid;
+
+      const margin = grid.spacing / 2;
+
+      grids.push(
+        <div
+          key={ grid.key }
+          className={ css('ms-TilesList-grid', {
+            [`${TilesListStyles.grid}`]: grid.mode !== TilesGridMode.none
+          }) }
+          style={
+            {
+              width: `${width}px`,
+              margin: `${-margin}px`,
+              marginTop: isOpenStart ? '0' : `${grid.marginTop - margin}px`,
+              marginBottom: isOpenEnd ? '0' : `${grid.marginBottom - margin}px`
+            }
+          }>
+          { ...renderedCells }
+        </div>
+      );
+    }
+
+    return (
+      <div
+        { ...divProps }
+        className={ css(pageClassName, this._onGetPageClassName()) }
+      >
+        { grids }
+      </div>
+    );
+  }
+
+  @autobind
+  private _getPageSpecification(startIndex: number, bounds: IRectangle): {
+    itemCount: number;
+    data: IPageData<TItem>;
+  } {
+    if (this._pageSpecificationCache) {
+      if (this._pageSpecificationCache.width !== bounds.width) {
+        this._pageSpecificationCache = undefined;
+      }
+    }
+
+    if (!this._pageSpecificationCache) {
+      this._pageSpecificationCache = {
+        width: bounds.width,
+        byIndex: {}
+      };
+    }
+
+    const pageSpecificationCache = this._pageSpecificationCache;
+
+    if (pageSpecificationCache.byIndex[startIndex]) {
+      return pageSpecificationCache.byIndex[startIndex];
+    }
+
+    const {
+      cells
+    } = this.state;
+
+    const endIndex = Math.min(cells.length, startIndex + CELLS_PER_PAGE);
+
+    let rowWidth = 0;
+    let rowStart = 0;
+    let fillPercent = 0;
+    let i = startIndex;
+
+    let isAtGridEnd = true;
+
+    const startCells: IPageData<TItem>['rows'] = {};
+    let extraCells: IPageData<TItem>['extraCells'] | undefined;
+    const cellSizes: IPageData<TItem>['cellSizes'] = {};
+    const widths: IPageData<TItem>['pageWidths'] = {};
+
+    for (; i < endIndex;) {
+      // For each cell at the start of a grid.
+      const grid = cells[i].grid;
+
+      rowWidth = 0;
+      rowStart = i;
+
+      const boundsWidth = bounds.width + grid.spacing;
+
+      widths[i] = boundsWidth;
+
+      let currentRow: IRowData = startCells[i] = {
+        scaleFactor: 1
+      };
+
+      if (grid.mode === TilesGridMode.none) {
+        // The current "grid" just takes up the full width.
+        // No flex calculations necessary.
+        isAtGridEnd = true;
+        fillPercent = 1;
+        cellSizes[i] = {
+          width: bounds.width,
+          height: 0
+        };
+        i++;
+        continue;
+      }
+
+      for (; i < endIndex && cells[i].grid === grid; i++) {
+        // For each cell in the current grid.
+        const {
+          aspectRatio
+        } = cells[i];
+
+        const width = aspectRatio * grid.minRowHeight + grid.spacing;
+
+        if (rowWidth + width > boundsWidth && grid.mode === TilesGridMode.fill) {
+          const totalMargin = grid.spacing * (i - rowStart);
+          currentRow.scaleFactor = (boundsWidth - totalMargin) / (rowWidth - totalMargin);
+        }
+
+        rowWidth += width;
+        fillPercent = rowWidth / boundsWidth;
+
+        cellSizes[i] = {
+          // Assign the expected base size of the cell.
+          // Scaling will be handled at render time.
+          width: aspectRatio * grid.minRowHeight,
+          height: grid.minRowHeight
+        };
+
+        if (rowWidth > boundsWidth) {
+          rowWidth = width;
+          fillPercent = rowWidth / boundsWidth;
+          rowStart = i;
+          currentRow = startCells[i] = {
+            scaleFactor: 1
+          };
+        }
+      }
+
+      if (cells[i] && cells[i].grid === grid) {
+        // If the next cell is part of a different grid.
+        isAtGridEnd = false;
+      } else {
+        currentRow.isLastRow = true;
+      }
+
+      if (rowWidth < boundsWidth && grid.mode === TilesGridMode.fill) {
+        const totalMargin = grid.spacing * (i - rowStart);
+        currentRow.scaleFactor = (boundsWidth - totalMargin) / (rowWidth - totalMargin);
+      }
+
+      if (!isAtGridEnd && currentRow.scaleFactor > grid.maxScaleFactor) {
+        // If the last computed row is not the end of the grid, and the content cannot scale to fit the width,
+        // declare these cells as 'extra' and let them be pushed into the next page.
+        extraCells = cells.slice(rowStart, i);
+      }
+    }
+
+    const itemCount = extraCells ?
+      // If there are extra cells, cut off the page so the extra cells will be pushed into the next page.
+      rowStart - startIndex :
+      // Otherwise, take all the cells.
+      i - startIndex;
+
+    const pageSpecification: IPageSpecification<TItem> = {
+      itemCount: itemCount,
+      data: {
+        pageWidths: widths,
+        rows: startCells,
+        extraCells: extraCells,
+        cellSizes: cellSizes
+      }
+    };
+
+    pageSpecificationCache.byIndex[startIndex] = pageSpecification;
+
+    return pageSpecification;
+  }
+
+  @autobind
+  private _onGetCellClassName(): string {
+    return TilesListStyles.listCell;
+  }
+
+  @autobind
+  private _onGetPageClassName(): string {
+    return TilesListStyles.listPage;
+  }
+
+  @autobind
+  private _onGetCellStyle(item: ITileCell<TItem>, currentRow?: IRowData): React.CSSProperties {
+    const {
+      grid: {
+        mode: gridMode,
+      maxScaleFactor
+      },
+      grid
+    } = item;
+
+    if (gridMode === TilesGridMode.none) {
+      return {};
+    }
+
+    const itemWidthOverHeight = item.aspectRatio || 1;
+    const itemHeightOverWidth = 1 / itemWidthOverHeight;
+    const margin = grid.spacing / 2;
+
+    const isFill = gridMode === TilesGridMode.fill;
+
+    const width = itemWidthOverHeight * grid.minRowHeight;
+
+    return {
+      flex: isFill ? `${itemWidthOverHeight} ${itemWidthOverHeight} ${width}px` : `0 0 ${width}px`,
+      maxWidth: isFill && (!currentRow || !currentRow.isLastRow || currentRow.scaleFactor <= maxScaleFactor) ?
+        // Flexbox can scale the item to the maximum ratio.
+        `${width * maxScaleFactor}px` :
+        // The item must not be scaled.
+        `${width}px`,
+      margin: `${margin}px`
+    };
+  }
+
+  private _getCells(items: (ITilesGridSegment<TItem> | ITilesGridItem<TItem>)[]): ITileCell<TItem>[] {
+    const cells: ITileCell<TItem>[] = [];
+
+    for (const item of items) {
+      if (isGridSegment(item)) {
+        const {
+          spacing = 0,
+          maxScaleFactor = MAX_TILE_STRETCH,
+          marginBottom = 0,
+          marginTop = 0
+        } = item;
+
+        const grid: ITileGrid = {
+          minRowHeight: item.minRowHeight,
+          spacing: spacing,
+          mode: item.mode,
+          key: `grid-${item.key}`,
+          maxScaleFactor: maxScaleFactor,
+          marginTop: marginTop,
+          marginBottom: marginBottom
+        };
+
+        for (const gridItem of item.items) {
+          const {
+            desiredSize
+          } = gridItem;
+
+          cells.push({
+            aspectRatio: desiredSize && (desiredSize.width / desiredSize.height) || 1,
+            content: gridItem.content,
+            onRender: gridItem.onRender,
+            grid: grid,
+            key: gridItem.key
+          });
+        }
+      } else {
+        cells.push({
+          aspectRatio: 1,
+          content: item.content,
+          onRender: item.onRender,
+          grid: {
+            minRowHeight: 0,
+            spacing: 0,
+            mode: TilesGridMode.none,
+            key: `grid-header-${item.key}`,
+            maxScaleFactor: 1,
+            marginBottom: 0,
+            marginTop: 0
+          },
+          key: `header-${item.key}`
+        });
+      }
+    }
+
+    return cells;
+  }
+}
+
+function isGridSegment<TItem>(item: ITilesGridSegment<TItem> | ITilesGridItem<TItem>): item is ITilesGridSegment<TItem> {
+  return !!(item as ITilesGridSegment<TItem>).items;
+}

--- a/packages/experiments/src/components/TilesList/TilesListPage.tsx
+++ b/packages/experiments/src/components/TilesList/TilesListPage.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { Link } from 'office-ui-fabric-react/lib/Link';
+import {
+  ExampleCard,
+  IComponentDemoPageProps,
+  ComponentPage,
+  PropertiesTableSet
+} from '@uifabric/example-app-base';
+
+import { TilesListBasicExample } from './examples/TilesList.Basic.Example';
+const TilesListBasicExampleCode = require('!raw-loader!experiments/src/components/TilesList/examples/TilesList.Basic.Example.tsx') as string;
+
+import { TilesListDocumentExample } from './examples/TilesList.Document.Example';
+const TilesListDocumentExampleCode = require('!raw-loader!experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx') as string;
+
+import { TilesListMediaExample } from './examples/TilesList.Media.Example';
+const TilesListMediaExampleCode = require('!raw-loader!experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx') as string;
+
+export class TilesListPage extends React.Component<IComponentDemoPageProps, {}> {
+  public render() {
+    return (
+      <ComponentPage
+        title='TilesList'
+        componentName='TilesListExample'
+        exampleCards={
+          <div>
+            <ExampleCard title='TilesList with basic tiles' isOptIn={ true } code={ TilesListBasicExampleCode }>
+              <TilesListBasicExample />
+            </ExampleCard>
+            <ExampleCard title='TilesList with document tiles' isOptIn={ true } code={ TilesListDocumentExampleCode }>
+              <TilesListDocumentExample />
+            </ExampleCard>
+            <ExampleCard title='TilesList with media tiles' isOptIn={ true } code={ TilesListMediaExampleCode }>
+              <TilesListMediaExample />
+            </ExampleCard>
+          </div>
+        }
+        propertiesTables={
+          <PropertiesTableSet
+            sources={ [
+              require<string>('!raw-loader!experiments/src/components/TilesList/TilesList.Props.ts')
+            ] }
+          />
+        }
+        overview={
+          <div>
+            <p>
+              <code>TilesList</code> is a specialization of the <Link href='#/examples/List'><code>List</code></Link> component.
+              It is intended to represent items visual using a one or mote content-focused flowing grids.
+            </p>
+            <p>
+              <code>TilesList</code> is designed to be used in conjunction with the <code>Tile</code> component. The <code>Tile</code> component provides a standardized form of focusable and selectable content item.
+            </p>
+          </div>
+        }
+        bestPractices={
+          <div></div>
+        }
+        dos={
+          <div>
+            <ul>
+              <li>Use them to represent a large collection of items visually.</li>
+            </ul>
+          </div>
+        }
+        donts={
+          <div>
+            <ul>
+              <li>Use them for general layout of components that are not part of the same set.</li>
+            </ul>
+          </div>
+        }
+        isHeaderVisible={ this.props.isHeaderVisible }>
+      </ComponentPage>
+    );
+  }
+}

--- a/packages/experiments/src/components/TilesList/examples/ExampleHelpers.tsx
+++ b/packages/experiments/src/components/TilesList/examples/ExampleHelpers.tsx
@@ -1,0 +1,130 @@
+
+import { TilesGridMode, ITilesGridItem, ITilesGridSegment, ITileSize } from '../TilesList.Props';
+import { lorem } from '@uifabric/example-app-base';
+
+type IAspectRatioByProbability = { [probability: string]: number; };
+
+const PROBABILITIES: IAspectRatioByProbability = {
+  '0.95': 3,
+  '0.90': 1 / 3,
+  '0.80': 16 / 9,
+  '0.70': 9 / 16,
+  '0.40': 4 / 3,
+  '0.10': 3 / 4,
+  '0.00': 1
+};
+
+const ENTRIES = Object.keys(PROBABILITIES).map((key: keyof IAspectRatioByProbability) => ({
+  probability: Number(key),
+  aspectRatio: PROBABILITIES[key]
+}));
+
+export interface IExampleItem {
+  key: string;
+  name: string;
+  index: number;
+  aspectRatio: number;
+}
+
+export interface IExampleGroup {
+  items: IExampleItem[];
+  name: string;
+  index: number;
+  type: 'document' | 'media';
+  key: string;
+}
+
+export function createMediaItems(count: number, indexOffset: number) {
+  const items: IExampleItem[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const seed = Math.random();
+
+    items.push({
+      key: `item-${indexOffset + i}`,
+      name: lorem(4),
+      index: indexOffset + i,
+      aspectRatio: ENTRIES.filter((entry: { probability: number; aspectRatio: number; }) => seed >= entry.probability)[0].aspectRatio
+    });
+  }
+
+  return items;
+}
+
+export function createDocumentItems(count: number, indexOffset: number) {
+  const items: IExampleItem[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const seed = Math.random();
+
+    items.push({
+      key: `item-${indexOffset + i}`,
+      name: lorem(4),
+      index: indexOffset + i,
+      aspectRatio: 1
+    });
+  }
+
+  return items;
+}
+
+export function createGroup(items: IExampleItem[], type: 'document' | 'media', index: number): IExampleGroup {
+  return {
+    items: items,
+    index: index,
+    name: lorem(4),
+    type: type,
+    key: `group-${index}`
+  };
+}
+
+export function getTileCells(groups: IExampleGroup[], {
+  onRenderCell,
+  onRenderHeader
+}: {
+    onRenderHeader: (item: IExampleItem) => JSX.Element;
+    onRenderCell: (item: IExampleItem, finalSize?: ITileSize) => JSX.Element;
+  }) {
+  const items: (ITilesGridSegment<IExampleItem> | ITilesGridItem<IExampleItem>)[] = [];
+
+  for (const group of groups) {
+    const header: ITilesGridItem<IExampleItem> = {
+      key: `header-${group.key}`,
+      content: {
+        key: '',
+        aspectRatio: 1,
+        name: lorem(6),
+        index: group.index
+      },
+      onRender: onRenderHeader
+    };
+
+    items.push(header);
+
+    items.push({
+      items: group.items.map((item: IExampleItem): ITilesGridItem<IExampleItem> => {
+        return {
+          key: item.key,
+          content: item,
+          desiredSize: group.type === 'document' ? {
+            width: 176,
+            height: 171
+          } : {
+              width: 171 * item.aspectRatio,
+              height: 171
+            },
+          onRender: onRenderCell
+        };
+      }),
+      spacing: 8,
+      marginBottom: 40,
+      minRowHeight: 171,
+      mode: group.type === 'document' ?
+        TilesGridMode.stack :
+        TilesGridMode.fill,
+      key: group.key
+    });
+  }
+
+  return items;
+}

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Basic.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Basic.Example.tsx
@@ -1,0 +1,79 @@
+
+import * as React from 'react';
+import {
+  TilesList,
+  ITilesGridSegment,
+  ITilesGridItem,
+  TilesGridMode,
+  ITileSize
+} from '../../TilesList';
+
+export interface IBasicItem {
+  color: string;
+  key: string;
+}
+
+const ITEMS: IBasicItem[] = [];
+
+for (let i = 0; i < 500; i++) {
+  ITEMS.push({
+    color: ['red', 'blue', 'green', 'yellow', 'orange', 'brown', 'purple', 'gray'][Math.floor(Math.random() * 8)],
+    key: `item-${i}`
+  });
+}
+
+export interface ITilesListBasicExampleState {
+  items: ITilesGridItem<IBasicItem>[];
+}
+
+export class TilesListBasicExample extends React.Component<{}, ITilesListBasicExampleState> {
+  constructor() {
+    super();
+
+    this.state = {
+      items: ITEMS.map((item: IBasicItem): ITilesGridItem<IBasicItem> => {
+        return {
+          content: item,
+          desiredSize: { width: 100, height: 100 },
+          key: item.key,
+          onRender: renderItem
+        };
+      })
+    };
+  }
+
+  public render() {
+    const gridSegment: ITilesGridSegment<IBasicItem> = {
+      items: this.state.items,
+      key: 'grid',
+      mode: TilesGridMode.fill,
+      minRowHeight: 100,
+      spacing: 10
+    };
+
+    return (
+      <TilesList
+        items={
+          [gridSegment]
+        }
+      />
+    );
+  }
+}
+
+function renderItem(item: IBasicItem) {
+  return (
+    <div
+      style={
+        {
+          position: 'absolute',
+          top: '0',
+          left: '0',
+          bottom: '0',
+          right: '0',
+          backgroundColor: item.color
+        }
+      }
+    />
+  );
+}

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx
@@ -1,0 +1,109 @@
+
+import * as React from 'react';
+import {
+  TilesList,
+  ITilesGridSegment,
+  ITilesGridItem,
+  TilesGridMode,
+  ITileSize
+} from '../../TilesList';
+import { Tile } from '../../../Tile';
+import { Selection } from 'office-ui-fabric-react/lib/utilities/selection/Selection';
+import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { AnimationClassNames } from 'office-ui-fabric-react/lib/Styling';
+import { lorem } from '@uifabric/example-app-base';
+import { IExampleGroup, IExampleItem, createGroup, createDocumentItems, getTileCells } from './ExampleHelpers';
+
+function createGroups(): IExampleGroup[] {
+  let offset = 0;
+
+  const groups: IExampleGroup[] = [];
+
+  for (let i = 0; i < 20; i++) {
+    const items = createDocumentItems(50 + Math.ceil(Math.random() * 6) * 50, offset);
+
+    offset += items.length;
+
+    groups.push(createGroup(items, 'document', i));
+  }
+
+  return groups;
+}
+
+const GROUPS = createGroups();
+
+const ITEMS = ([] as IExampleItem[]).concat(...GROUPS.map((group: { items: IExampleItem[]; }) => group.items));
+
+declare class TilesListClass extends TilesList<IExampleItem> { }
+
+const TilesListType: typeof TilesListClass = TilesList;
+
+export class TilesListDocumentExample extends React.Component<any, any> {
+  private _selection: Selection;
+
+  constructor() {
+    super();
+
+    this._selection = new Selection({
+      getKey: (item: IExampleItem) => item.key,
+    });
+
+    this._selection.setItems(ITEMS);
+  }
+  public render() {
+    const items = getTileCells(GROUPS, {
+      onRenderCell: this._onRenderDocumentCell,
+      onRenderHeader: this._onRenderHeader
+    });
+
+    return (
+      <div style={ { padding: '4px' } }>
+        <MarqueeSelection selection={ this._selection }>
+          <TilesListType
+            selection={ this._selection }
+            items={ items }
+          />
+        </MarqueeSelection>
+      </div>
+    );
+  }
+
+  @autobind
+  private _onRenderDocumentCell(item: IExampleItem) {
+    return (
+      <Tile
+        className={ AnimationClassNames.fadeIn400 }
+        selection={ this._selection }
+        selectionIndex={ ITEMS.indexOf(item) }
+        foreground={
+          <img
+            src={
+              `https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/docx_48x1.svg`
+            }
+            style={
+              {
+                display: 'block',
+                width: '40px',
+                height: '40px',
+                margin: '11px'
+              }
+            }
+          />
+        }
+        showForegroundFrame={ true }
+        itemName={ item.name }
+        itemActivity={ item.key }
+      />
+    );
+  }
+
+  @autobind
+  private _onRenderHeader(item: IExampleItem) {
+    return (
+      <div>
+        <h3>{ item.name }</h3>
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
@@ -1,0 +1,99 @@
+
+import * as React from 'react';
+import {
+  TilesList,
+  ITilesGridSegment,
+  ITilesGridItem,
+  TilesGridMode,
+  ITileSize
+} from '../../TilesList';
+import { Tile } from '../../../Tile';
+import { Selection } from 'office-ui-fabric-react/lib/utilities/selection/Selection';
+import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { AnimationClassNames } from 'office-ui-fabric-react/lib/Styling';
+import { lorem } from '@uifabric/example-app-base';
+import { IExampleGroup, IExampleItem, createGroup, createMediaItems, getTileCells } from './ExampleHelpers';
+
+function createGroups(): IExampleGroup[] {
+  let offset = 0;
+
+  const groups: IExampleGroup[] = [];
+
+  for (let i = 0; i < 20; i++) {
+    const items = createMediaItems(50 + Math.ceil(Math.random() * 6) * 50, offset);
+
+    offset += items.length;
+
+    groups.push(createGroup(items, 'media', i));
+  }
+
+  return groups;
+}
+
+const GROUPS = createGroups();
+
+const ITEMS = ([] as IExampleItem[]).concat(...GROUPS.map((group: { items: IExampleItem[]; }) => group.items));
+
+declare class TilesListClass extends TilesList<IExampleItem> { }
+
+const TilesListType: typeof TilesListClass = TilesList;
+
+export class TilesListMediaExample extends React.Component<any, any> {
+  private _selection: Selection;
+
+  constructor() {
+    super();
+
+    this._selection = new Selection({
+      getKey: (item: IExampleItem) => item.key,
+    });
+
+    this._selection.setItems(ITEMS);
+  }
+  public render() {
+    const items = getTileCells(GROUPS, {
+      onRenderCell: this._onRenderMediaCell,
+      onRenderHeader: this._onRenderHeader
+    });
+
+    return (
+      <div style={ { padding: '4px' } }>
+        <MarqueeSelection selection={ this._selection }>
+          <TilesListType
+            selection={ this._selection }
+            items={ items }
+          />
+        </MarqueeSelection>
+      </div>
+    );
+  }
+
+  @autobind
+  private _onRenderMediaCell(item: IExampleItem, finalSize: ITileSize) {
+    return (
+      <Tile
+        className={ AnimationClassNames.fadeIn400 }
+        selection={ this._selection }
+        selectionIndex={ item.index }
+        background={
+          <img style={ { display: 'block' } } src={
+            `//placehold.it/${Math.round(finalSize.width)}x${Math.round(finalSize.height)}`
+          } />
+        }
+        showBackgroundFrame={ true }
+        itemName={ item.name }
+        itemActivity={ item.key }
+      />
+    );
+  }
+
+  @autobind
+  private _onRenderHeader(item: IExampleItem) {
+    return (
+      <div>
+        <h3>{ item.name }</h3>
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/components/TilesList/index.ts
+++ b/packages/experiments/src/components/TilesList/index.ts
@@ -1,0 +1,2 @@
+export * from './TilesList';
+export * from './TilesList.Props';

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -1,0 +1,103 @@
+
+@import '../../../../office-ui-fabric-react/src/common/common';
+
+.signal {
+  display: inline-block;
+  margin: 0 4px;
+
+  &:first-child {
+    @include margin-left(0);
+  }
+
+  &:last-child {
+    @include margin-right(0);
+  }
+}
+
+.new {
+  width: 0;
+  height: 1em;
+  position: relative;
+  @include margin-right(0);
+  line-height: 1em;
+  color: $ms-color-themePrimary;
+
+  .selected & {
+    color: $ms-color-themeDark;
+  }
+}
+
+.newIcon {
+  position: absolute;
+  bottom: 100%;
+  @include right(-1px);
+  font-size: 0.66em;
+  margin-bottom: -0.75em;
+}
+
+.comments {
+  color: $ms-color-themePrimary;
+
+  .selected & {
+    color: $ms-color-themeDark;
+  }
+}
+
+.commentsIcon {
+  vertical-align: middle;
+}
+
+.commentsCount {
+  @include margin-left(0.2em);
+  font-size: 0.9em;
+  font-weight: $ms-font-weight-semibold;
+  vertical-align: baseline;
+}
+
+.trending {
+  color: #006257;
+}
+
+.blocked {
+  color: #a80000;
+}
+
+.warning {
+  color: #cf3902;
+}
+
+.shared {
+  color: $ms-color-neutralSecondary;
+}
+
+.missingMetadata {
+  color: $ms-color-themeDarker;
+}
+
+.mention {
+  color: $ms-color-themePrimary;
+
+  .selected & {
+    color: $ms-color-themeDark;
+  }
+}
+
+.signal {
+  .dark &,
+  .dark.selected {
+    color: $ms-color-white;
+  }
+}
+
+.signalField {
+  display: inline-flex;
+  max-width: 100%;
+  flex-direction: row nowrap;
+}
+
+.signalFieldValue {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  text-align: left;
+}

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -1,0 +1,147 @@
+
+import * as React from 'react';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import * as SignalStylesModule from './Signals.scss';
+
+const SignalStyles = SignalStylesModule as any;
+
+export interface ISignalFieldProps extends React.HTMLAttributes<HTMLSpanElement> {
+  before?: React.ReactNode | React.ReactNode[];
+  after?: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * Renders a field flanked by signals.
+ * Pass `<Signal />` or related components in for the `before` and `after` fields.
+ * Pass the main value as the children.
+ */
+export const SignalField: React.StatelessComponent<ISignalFieldProps> = (props: ISignalFieldProps): JSX.Element => {
+  return (
+    <span className={ SignalStyles.signalField }>
+      { props.before }
+      <span className={ SignalStyles.signalFieldValue }>
+        { props.children }
+      </span>
+      { props.after }
+    </span>
+  );
+};
+
+export interface ISignalProps extends React.HTMLAttributes<HTMLSpanElement> {
+  ariaLabel?: string;
+}
+
+export type Signal = React.StatelessComponent<ISignalProps>;
+
+export const Signal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <span className={ css(SignalStyles.signal) }>{ props.children }</span>
+  );
+};
+
+export const YouCheckedOutSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.youCheckedOutl) } iconName='' /> // TODO get correct icon
+  );
+};
+
+export const BlockedSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.blocked) } iconName='blocked2' />
+  );
+};
+
+export const MissingMetadataSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.missingMetadata) } iconName='info' />
+  );
+};
+
+export const WarningSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.warning) } iconName='warning' />
+  );
+};
+
+export const AwaitingApprovalSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.awaitingApproval) } iconName='documentmanagement' /> // TODO get correct icon
+  );
+};
+
+export const TrendingSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.trending) } iconName='market' />
+  );
+};
+
+export const SomeoneCheckedOutSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.someoneCheckedOut) } iconName='navigateforward' /> // TODO get correct icon
+  );
+};
+
+/**
+ * Renders a signal marking the proceeding content as new.
+ */
+export const NewSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <span className={ css(SignalStyles.signal, SignalStyles.new) }>
+      <Icon className={ css(SignalStyles.newIcon) } iconName='glimmer' />
+    </span>
+  );
+};
+
+/**
+ * Renders a signal for a live-edit scenario.
+ */
+export const LiveEditSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <span className={ css(SignalStyles.signal, SignalStyles.liveEdit) }>
+      { props.children }
+    </span>
+  );
+};
+
+export const MentionSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.mention) } iconName='accounts' />
+  );
+};
+
+/**
+ * Renders a signal for a number of comments.
+ */
+export const CommentsSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <span className={ css(SignalStyles.signal, SignalStyles.comments) }>
+      <Icon className={ css(SignalStyles.commentsIcon) } iconName='MessageFill' />
+      {
+        props.children ? (
+          <span className={ css(SignalStyles.commentsCount) }>
+            { props.children }
+          </span>
+        ) : null
+      }
+    </span>
+  );
+};
+
+export const UnseenEditSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.unseenEdit) } iconName='edit' /> // TODO get correct icon
+  );
+};
+
+export const ReadOnlySignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.readOnly) } iconName='' /> // TODO get correct icon
+  );
+};
+
+export const SharedSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return (
+    <Icon className={ css(SignalStyles.signal, SignalStyles.shared) } iconName='people' />
+  );
+};

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -15,6 +15,12 @@ export const AppDefinition: IAppDefinition = {
           name: 'Link',
           url: '#/examples/link'
         },
+        {
+          component: require<any>('../components/Tile/TilePage').TilePage,
+          key: 'Tile',
+          name: 'Tile',
+          url: '#/examples/tile'
+        }
       ]
     }
   ],

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -20,6 +20,12 @@ export const AppDefinition: IAppDefinition = {
           key: 'Tile',
           name: 'Tile',
           url: '#/examples/tile'
+        },
+        {
+          component: require<any>('../components/TilesList/TilesListPage').TilesListPage,
+          key: 'TilesList',
+          name: 'TilesList',
+          url: '#/examples/tileslist'
         }
       ]
     }

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -108,21 +108,28 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
     let { rootProps, ariaDescribedBy, ariaLabelledBy, className } = this.props;
     let divProps = getNativeProps(this.props, divProperties);
 
-    return React.createElement(
-      this.props.elementType || 'div', {
-        role: 'presentation',
-        ...divProps,
-        ...rootProps,
-        className: css('ms-FocusZone', className),
-        ref: 'root',
-        'data-focuszone-id': this._id,
-        'aria-labelledby': ariaLabelledBy,
-        'aria-describedby': ariaDescribedBy,
-        onKeyDown: this._onKeyDown,
-        onFocus: this._onFocus,
-        ...{ onMouseDownCapture: this._onMouseDown }
-      },
-      this.props.children
+    const Tag = this.props.elementType || 'div';
+
+    return (
+      <Tag
+        role='presentation'
+        {
+        ...divProps
+        }
+        {
+        ...rootProps
+        }
+        className={ css('ms-FocusZone', className) }
+        ref='root'
+        data-focuszone-id={ this._id }
+        aria-labelledby={ ariaLabelledBy }
+        aria-describedby={ ariaDescribedBy }
+        onKeyDown={ this._onKeyDown }
+        onFocus={ this._onFocus }
+        onMouseDownCapture={ this._onMouseDown }
+      >
+        { this.props.children }
+      </Tag>
     );
   }
 


### PR DESCRIPTION
## Overview

This change adds a new component, `TilesList`, which is intended do be a visual complement to `DetailsList`.
*Note:* This component is still a work in progress. However, it is useful to get the initial pieces in since they can be reused in other components.

## TilesList

Unlike `DetailsList`, which allocates one row per item, `TilesList` allocates a 'tile' for each item, forming them into rows of multiple tiles, and performing optional 'fill' logic.
`TilesList` internally uses a `List` for virtualization and render performance. It flattens the tree of headers and grid segments provided to its `props` into a list of 'cells', which it passes to `List`. This allows the number of cells per page to be fairly consistent, optimizing for render speed per page.
`TilesList` uses flex-box to perform the actual layout, so it is fast in the browser and does not rely on absolute position or manual sizing. However, `TilesList` pre-computes the results of the flexbox layout in order to determine the optimal packing of cells per page, and the final size of each tile.
`TilesList` currently does not provide a default representation of each item, simply allocating a proportionally-sized box for each item in a grid segment. It is designed to be used in conjunction with the new `Tile` component for a 'pretty' item representation.

## Tile

`Tile` provides a way to represent an item visually. Its main facility to provide a bordered rectangle that supports focus and selection, but it also supports a nameplate as well and foreground and background content.

## Signals

The `Signals` module provides a standardized set of item signals to be used when rendering items in `DetailsList` and in `Tile` components.