### PR TITLE
Fix focus issues on Mac OS

### DIFF
--- a/common/changes/office-ui-fabric-react/focus-issues_2017-07-27-00-10.json
+++ b/common/changes/office-ui-fabric-react/focus-issues_2017-07-27-00-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix focus issues for Safari and Firefox on Mac OS",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.scss
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.scss
@@ -26,6 +26,8 @@ $Callout-smallbeak-slant-width: 16px;
   position: absolute;
   box-sizing: border-box;
 
+  @include focus-clear();
+
   @media screen and (-ms-high-contrast: active) {
     border: 1px solid $ms-color-white;
   }

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -149,6 +149,8 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
               directionalClassName
             ) }
           style={ positions ? positions.calloutPosition : OFF_SCREEN_STYLE }
+          tabIndex={ -1 } // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
+          // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
           ref={ this._resolveRef('_calloutElement') }
         >
 
@@ -227,8 +229,8 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
     this._async.setTimeout(() => {
       this._events.on(this._targetWindow, 'scroll', this._dismissOnScroll, true);
       this._events.on(this._targetWindow, 'resize', this.dismiss, true);
-      this._events.on(this._targetWindow, 'focus', this._dismissOnLostFocus, true);
-      this._events.on(this._targetWindow, 'click', this._dismissOnLostFocus, true);
+      this._events.on(this._targetWindow.document.body, 'focus', this._dismissOnLostFocus, true);
+      this._events.on(this._targetWindow.document.body, 'click', this._dismissOnLostFocus, true);
     }, 0);
 
     if (this.props.onLayerMounted) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -430,7 +430,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   }
 
   private _onContentKeyDown(ev: React.KeyboardEvent<HTMLElement>) {
-    if (ev.which === KeyCodes.up) {
+    if (ev.which === KeyCodes.up && !ev.altKey) {
       if (this._header && this._header.focus()) {
         ev.preventDefault();
         ev.stopPropagation();


### PR DESCRIPTION
### Overview

This change fixes a bizarre focus bug in Safari and Firefox on Mac OS X.
This change also re

### Bug

To reproduce, host a `ContextualMenu` within an element that has `tabindex="-1"`. It is important that the final `<Layer>` produced by `ContextualMenu` be within that element.
When you click a button in the `ContextualMenu`, Safari will attempt to set focus not to the clicked `button`, but instead the closest ancestor with a `tabindex`. If this element happens to be outside the `Callout`, then the `Callout` will dismiss itself before the link is clicked.

The browser issues are known and documented here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus

### Solution

This change adds a `tabindex="-1"` to the root of the `Callout` component. This ensures that clicking within the `Callout` onto a `button` does not accidentally place focus outside the `Callout` and immediately dismiss it.

This change also modifies `DetailsList` to ignore arrow keys while `Alt` is held, so it does not interfere with navigation shortcuts which use `Alt+Arrow` combinations.