### PR TITLE
[Accessibility] Use 'menuitemcheckbox' role for checkable menu items

### DIFF
--- a/common/changes/office-ui-fabric-react/menuitem-check_2017-07-27-21-44.json
+++ b/common/changes/office-ui-fabric-react/menuitem-check_2017-07-27-21-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Update accessibility for checkable menu items",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dmichon@microsoft.com"
+}


### PR DESCRIPTION
Fixes #2306

#### Description of changes

Adds `aria-checked` attribute to context menu items when `canCheck` property is `true` or when `isChecked` has a value of type `boolean` (for backwards compatibility).
