### PR TITLE
Checkbox styling repairs.

### DIFF
--- a/common/changes/office-ui-fabric-react/checkbox-css_2017-07-28-17-11.json
+++ b/common/changes/office-ui-fabric-react/checkbox-css_2017-07-28-17-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Checkbox: Adjusting the default text color to not use default button color, removing click behavior for disabled checkboxes, fixing an rtl margin issue.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -19,10 +19,12 @@ export const getStyles = memoizeFunction((
   const checkmarkFontColor = semanticColors.inputForegroundChecked;
   const checkmarkFontColorCheckedDisabled = semanticColors.disabledBackground;
   const checkboxBorderColor = semanticColors.inputBorder;
+  const checkboxBorderColorDisabled = semanticColors.disabledText;
   const checkboxBorderHoveredColor = semanticColors.inputBorderHovered;
   const checkboxBackgroundChecked = semanticColors.inputBackgroundChecked;
   const checkboxBackgroundCheckedHovered = semanticColors.inputBackgroundCheckedHovered;
   const checkboxBackgroundDisabled = semanticColors.disabledText;
+  const checkboxTextColor = semanticColors.bodyText;
   const checkboxTextColorDisabled = semanticColors.disabledText;
 
   const styles: ICheckboxStyles = {
@@ -40,6 +42,7 @@ export const getStyles = memoizeFunction((
     ],
     label: {
       display: 'inline-flex',
+      margin: '0 -4px',
       alignItems: 'center',
       cursor: 'pointer',
       position: 'relative',
@@ -62,7 +65,7 @@ export const getStyles = memoizeFunction((
       borderWidth: '1px',
       borderStyle: 'solid',
       borderColor: checkboxBorderColor,
-      marginRight: '8px',
+      margin: '0 4px',
       boxSizing: 'border-box',
       transitionProperty: 'background, border, border-color',
       transitionDuration: MS_CHECKBOX_TRANSITION_DURATION,
@@ -82,9 +85,11 @@ export const getStyles = memoizeFunction((
     },
     checkboxDisabled: {
       background: checkboxBackgroundDisabled,
+      borderColor: checkboxBorderColorDisabled
     },
     checkboxCheckedDisabled: {
       background: checkboxBackgroundDisabled,
+      borderColor: checkboxBorderColorDisabled
     },
     checkmark: {
       opacity: '0',
@@ -100,7 +105,8 @@ export const getStyles = memoizeFunction((
       color: checkmarkFontColorCheckedDisabled,
     },
     text: {
-      marginRight: '8px',
+      color: checkboxTextColor,
+      margin: '0 4px',
       fontSize: FontSizes.medium
     },
     textHovered: {

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -153,15 +153,17 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
 
   @autobind
   private _onClick(ev: React.FormEvent<HTMLButtonElement>) {
-    const { onChange } = this.props;
-    let { isChecked } = this.state;
+    const { disabled, onChange } = this.props;
+    const { isChecked } = this.state;
 
-    if (onChange) {
-      onChange(ev, !isChecked);
-    }
+    if (!disabled) {
+      if (onChange) {
+        onChange(ev, !isChecked);
+      }
 
-    if (this.props.checked === undefined) {
-      this.setState({ isChecked: !isChecked });
+      if (this.props.checked === undefined) {
+        this.setState({ isChecked: !isChecked });
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Basic.Example.tsx
@@ -48,6 +48,12 @@ export class CheckboxBasicExample extends React.Component<{}, ICheckboxBasicExam
         />
 
         <Checkbox
+          label='Disabled uncontrolled checkbox'
+          disabled={ true }
+          styles={ styles }
+        />
+
+        <Checkbox
           label='Disabled uncontrolled checkbox with defaultChecked true'
           disabled={ true }
           defaultChecked={ true }


### PR DESCRIPTION
This change does a few things for Checkbox:

Before:

![image](https://user-images.githubusercontent.com/1110944/28728482-a9e93d3c-737d-11e7-8d44-d4bd28418896.png)

After:

![image](https://user-images.githubusercontent.com/1110944/28728392-59c97876-737d-11e7-9fcf-54bf5cb13f78.png)

1. The Checkbox now uses the correct font color for text, rather than default button color.
2. The disabled Checkbox no longer has a defined border. This was a regression.
3. Margins around the box and the text are no longer RTL sensitive and flow correctly when switching. Please don't use marginRight unless you absolutely know what you're doing! Use symmetrical paddings, they work in either direction.
4. Clicking on a disabled Checkbox now no-ops. For some reasons I'm seeing onClick executing on disabled buttons, which is causing uncontrolled instances to toggle state when disabled. 
