### PR TITLE
Move registering FocusZone instance to componentDidMount

### DIFF
--- a/common/changes/office-ui-fabric-react/focus-zone-cdm_2017-08-01-00-34.json
+++ b/common/changes/office-ui-fabric-react/focus-zone-cdm_2017-08-01-00-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Move registering FocusZone instance to componentDidMount",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rydelan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -62,7 +62,6 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
     this._warnDeprecations({ rootProps: undefined });
 
     this._id = getId('FocusZone');
-    _allInstances[this._id] = this;
 
     this._focusAlignment = {
       left: 0,
@@ -71,6 +70,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   }
 
   public componentDidMount() {
+    _allInstances[this._id] = this;
     const windowElement = this.refs.root.ownerDocument.defaultView;
 
     let parentElement = getParent(this.refs.root);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2348
- [x] Include a change request file using `$ npm run change`

#### Description of 

By having FocusZone register itself in `constructor` it creates a memory leak when run on the server.
See #2348 for more details.

This change delays registering an instance with `_allInstances` until `componentDidMount`. From the
[React Documentation](https://facebook.github.io/react/docs/react-component.html#componentwillmount):

> `componentWillMount()` is invoked immediately before mounting occurs. It is called before render(), therefore setting state synchronously in this method will not trigger a re-rendering. Avoid introducing any side-effects or subscriptions in this method.

This moves the side effect into `componentDidMount`.

#### Focus areas to test

FocusZone