### PR TITLE
Checkbox edge doubleclick

### DIFF
--- a/common/changes/office-ui-fabric-react/checkbox-edge-doubleclick_2017-08-01-16-42.json
+++ b/common/changes/office-ui-fabric-react/checkbox-edge-doubleclick_2017-08-01-16-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Checkbox: Fix Edge bug where 2nd click event was being fired",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -106,6 +106,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
         name={ name }
         id={ this._id }
         role='checkbox'
+        type='button'
         className={ classNames.root }
         onClick={ this._onClick }
         onFocus={ this._onFocus }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -155,6 +155,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
   private _onClick(ev: React.FormEvent<HTMLButtonElement>) {
     const { disabled, onChange } = this.props;
     const { isChecked } = this.state;
+    ev.preventDefault();
 
     if (!disabled) {
       if (onChange) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2355
- [x] Include a change request file using `$ npm run change`

#### Description of changes

A 2nd click event was being fired in Edge which turned the checkbox back off every time you clicked it. Would be great to figure out why this was happening, but a preventDefault seems to fix it. I was hoping that type='button' would do it, but I'll keep that in there anyway to prevent checkboxes from submitting forms.  

#### Focus areas to test

(optional)
