### PR TITLE
Search clear latest value

### DIFF
--- a/common/changes/office-ui-fabric-react/search-clear-latestValue_2017-08-02-16-39.json
+++ b/common/changes/office-ui-fabric-react/search-clear-latestValue_2017-08-02-16-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Searchbox: fixed bug when repeatedly entering a single character",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -97,6 +97,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
 
   @autobind
   private _onClearClick(ev?: any) {
+    this._latestValue = '';
     this.setState({
       value: ''
     });
@@ -149,6 +150,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
 
   @autobind
   private _onInputChange(ev: React.ChangeEvent<HTMLInputElement>) {
+
     const value = this._inputElement.value;
     if (value === this._latestValue) {
       return;

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -150,7 +150,6 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
 
   @autobind
   private _onInputChange(ev: React.ChangeEvent<HTMLInputElement>) {
-
     const value = this._inputElement.value;
     if (value === this._latestValue) {
       return;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2366
- [x] Include a change request file using `$ npm run change`

#### Description of changes

_onClearClick wasn't resetting latestValue which was used to compare against new keyboard input. So press 'a', clear, press 'a' again and the input thought there was already an 'a' in the search box and didn't print another. 

#### Focus areas to test

(optional)
