### PR TITLE
Expand hit-target for Selection checkbox in DetailsList

### DIFF
--- a/common/changes/office-ui-fabric-react/details-tap_2017-08-04-00-17.json
+++ b/common/changes/office-ui-fabric-react/details-tap_2017-08-04-00-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Expand hit target of DetailsRow checkbox",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -229,6 +229,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
           <div
             role='gridcell'
             aria-colindex={ 0 }
+            data-selection-toggle={ true }
             className={ css('ms-DetailsRow-cell', 'ms-DetailsRow-cellCheck', checkStyles.owner, styles.cell, styles.checkCell) }
           >
             { onRenderCheck({


### PR DESCRIPTION
This change expands the hit-target for the selection checkbox in `DetailsList` to the fill width and height of the selection checkbox column.

This fixes a major usability issue where a touch user can miss the checkbox and cause deselection of other selected items.