### PR TITLE
Nav: Add more options for nav link groups

### DIFF
--- a/common/changes/office-ui-fabric-react/elcraig-nav_2017-08-08-19-47.json
+++ b/common/changes/office-ui-fabric-react/elcraig-nav_2017-08-08-19-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Nav: Add more options for nav link groups",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
@@ -100,12 +100,7 @@ export interface INavLinkGroup {
   /**
    * Callback invoked when a group header is clicked
    */
-  onClick?: (ev?: React.MouseEvent<HTMLElement>, isCollapsing?: boolean) => void;
-
-  /**
-   * Function callback invoked when a link in this group is clicked
-   */
-  onLinkClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
+  onHeaderClick?: (ev?: React.MouseEvent<HTMLElement>, isCollapsing?: boolean) => void;
 }
 
 export interface INavLink {
@@ -186,6 +181,12 @@ export interface INavLink {
    *   parent link vs vers.
    */
   parentId?: string;
+
+  /**
+   * (Optional) By default, any link with onClick defined will render as a button.
+   * Set this property to true to override that behavior.
+   */
+  isAnchor?: boolean;
 
   /**
    * (Optional) Any additional properties to apply to the rendered links.

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
@@ -126,7 +126,7 @@ export interface INavLink {
 
   /**
    * Callback invoked when this link is clicked. Providing this callback will cause the link
-   * to render as a button (rather than an anchor) unless isAnchor is set to true.
+   * to render as a button (rather than an anchor) unless forceAnchor is set to true.
    */
   onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
 
@@ -185,9 +185,10 @@ export interface INavLink {
 
   /**
    * (Optional) By default, any link with onClick defined will render as a button.
-   * Set this property to true to override that behavior.
+   * Set this property to true to override that behavior. (Links without onClick defined
+   * will render as anchors by default.)
    */
-  isAnchor?: boolean;
+  forceAnchor?: boolean;
 
   /**
    * (Optional) Any additional properties to apply to the rendered links.

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
@@ -91,6 +91,21 @@ export interface INavLinkGroup {
    * The name to use for functional automation tests
    */
   automationId?: string;
+
+  /**
+   * If true, the group should render collapsed by default
+   */
+  collapseByDefault?: boolean;
+
+  /**
+   * Callback invoked when a group header is clicked
+   */
+  onClick?: (ev?: React.MouseEvent<HTMLElement>, isCollapsing?: boolean) => void;
+
+  /**
+   * Function callback invoked when a link in this group is clicked
+   */
+  onLinkClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
 }
 
 export interface INavLink {

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
@@ -125,7 +125,8 @@ export interface INavLink {
   links?: INavLink[];
 
   /**
-   * Function callback invoked when a link in the navigation is clicked
+   * Callback invoked when this link is clicked. Providing this callback will cause the link
+   * to render as a button (rather than an anchor) unless isAnchor is set to true.
    */
   onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
 

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -174,7 +174,7 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
             />
           </button> : null
         ) }
-        { link.onClick && !link.isAnchor
+        { link.onClick && !link.forceAnchor
           ? this._renderButtonLink(link, linkIndex)
           : this._renderAnchorLink(link, linkIndex, nestingLevel) }
       </div>

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -108,7 +108,8 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
     const isRtl: boolean = getRTL();
     const paddingBefore: string = (_indentationSize * nestingLevel) +
       String(this._hasExpandButton ? _indentWithExpandButton : _indentNoExpandButton) + 'px';
-    const target = link.target || (isRelativeUrl(link.url) ? '_self' : '_blank');
+    // Prevent hijacking of the parent window if link.target is defined
+    const rel = link.url && link.target && !isRelativeUrl(link.url) ? 'noopener noreferrer' : undefined;
 
     return (
       <a
@@ -118,8 +119,8 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
         onClick={ this._onNavAnchorLinkClicked.bind(this, link) }
         aria-label={ link.ariaLabel }
         title={ link.title || link.name }
-        target={ target }
-        rel='noopener'
+        target={ link.target }
+        rel={ rel }
       >
         { link.iconClassName && (
           <Icon


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Added the following options:
- Nav link groups
  - Flag to render collapsed by default
  - Click handler for group header
- Nav links
  - Flag to force rendering as an anchor (not a button) even if a click handler is provided

Also includes a small security fix: use `rel=noopener` for links that will open in a target window so that the original window's location can't be hijacked.