### PR TITLE
comboBox/Dropdown: Remove unneeded onChanged index param

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxRemoveOnChangedIndexParam_2017-08-09-15-30.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxRemoveOnChangedIndexParam_2017-08-09-15-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox/Dropdown: Remove unneeded index parameter from the onChangedCallback",
+      "type": "major"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
@@ -39,7 +39,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * 2) a manually edited value is submitted. In this case there may not be a matched option if allowFreeform is also true
    *    (and hence only value would be true, the other parameter would be null in this case)
    */
-  onChanged?: (option?: IComboBoxOption, index?: number, value?: string) => void;
+  onChanged?: (option?: IComboBoxOption, value?: string) => void;
 
   /**
    * Callback issued when the options should be resolved, if they have been updated or

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -611,7 +611,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
       // Did the creator give us an onChanged callback?
       if (onChanged) {
-        onChanged(option, index);
+        onChanged(option);
       }
 
       // if we have a new selected index,
@@ -725,7 +725,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       });
 
       if (onChanged) {
-        onChanged(undefined, undefined, currentPendingValue);
+        onChanged(undefined, currentPendingValue);
       }
     } else if (currentPendingValueValidIndex >= 0) {
       // Since we are not allowing freeform, we must have a matching

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -212,15 +212,10 @@ export class ComboBoxBasicExample extends React.Component<any, any> {
   }
 
   @autobind
-  private _onChanged(option: IComboBoxOption, index: number, value: string) {
+  private _onChanged(option: IComboBoxOption, value: string) {
     if (option !== undefined) {
       this.setState({
         selectedOptionKey: option.key,
-        value: null
-      });
-    } else if (index !== undefined && index >= 0 && index < this.state.options.length) {
-      this.setState({
-        selectedOptionKey: this.state.options[index].key,
         value: null
       });
     } else if (value !== undefined) {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
@@ -18,7 +18,7 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<HTMLDivEle
   /**
    * Callback issues when the selected option changes
    */
-  onChanged?: (option: IDropdownOption, index?: number) => void;
+  onChanged?: (option: IDropdownOption) => void;
 
   /**
    * Optional custom renderer for placeholder text

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -249,7 +249,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
         // for multi-select, flip the checked value
         let changedOpt = options[index];
         changedOpt.selected = this.props.multiSelect ? !checked : true;
-        onChanged(changedOpt, index);
+        onChanged(changedOpt);
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.Props.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.Props.ts
@@ -49,7 +49,7 @@ export interface ISelectableDroppableTextProps<T> extends React.HTMLAttributes<T
   /**
    * Callback issues when the selected option changes
    */
-  onChanged?: (option: ISelectableOption, index?: number) => void;
+  onChanged?: (option: ISelectableOption) => void;
 
   /**
     * Optional custom renderer for the ISelectableDroppableText container


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The onChanged callback for Dropdown and ComboBox included an unneeded index parameter (since the option is also included when the index is uncluded). This PR removes that index

#### Focus areas to test

Verified that there is no functionality changes internal to the components
