### PR TITLE
ComboBox: Fixes to better account for some controlled cases

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxControlledFixes_2017-08-10-00-16.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxControlledFixes_2017-08-10-00-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Fix some functionality for when the comboBox is controlled",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -87,6 +87,45 @@ describe('ComboBox', () => {
     expect(inputElement.props().value).equals('1');
   });
 
+  it('New options are not automatically added when allowFreeform on in controlled case', () => {
+    let comboBoxRoot;
+    let inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any>;
+    let comboBoxComponent: any;
+    let wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        options={ DEFAULT_OPTIONS }
+        allowFreeform={ true }
+        onChanged={ () => { return; } }
+        componentRef={ ref => comboBoxComponent = ref }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+    inputElement = comboBoxRoot.find('input');
+    inputElement.simulate('change', { target: { value: 'f' } });
+    inputElement.simulate('keydown', { which: KeyCodes.enter });
+    expect((comboBoxComponent as React.Component<any, any>).state.currentOptions.length).equals(DEFAULT_OPTIONS.length);
+  });
+
+  it('New options are automatically added when allowFreeform on in uncontrolled case', () => {
+    let comboBoxRoot;
+    let inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any>;
+    let comboBoxComponent: any;
+    let wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        options={ DEFAULT_OPTIONS }
+        allowFreeform={ true }
+        componentRef={ ref => comboBoxComponent = ref }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+    inputElement = comboBoxRoot.find('input');
+    inputElement.simulate('change', { target: { value: 'f' } });
+    inputElement.simulate('keydown', { which: KeyCodes.enter });
+    let currentOptions = (comboBoxComponent as React.Component<any, any>).state.currentOptions;
+    expect(currentOptions.length).equals(DEFAULT_OPTIONS.length + 1);
+    expect(currentOptions[currentOptions.length - 1].text).equals('f');
+  });
+
   it('Renders a default value with options', () => {
     let wrapper = mount(
       <ComboBox

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -616,7 +616,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
       // Did the creator give us an onChanged callback?
       if (onChanged) {
-        onChanged(option);
+        onChanged(option, index);
       }
 
       // if we have a new selected index,

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -126,7 +126,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     let selectedKey = props.defaultSelectedKey !== undefined ? props.defaultSelectedKey : props.selectedKey;
     this._lastReadOnlyAutoCompleteChangeTimeoutId = -1;
 
-    let index: number = selectedKey !== undefined ? this._getSelectedIndex(props.options!, selectedKey) : -1;
+    let index: number = this._getSelectedIndex(props.options, selectedKey);
 
     this.state = {
       isOpen: false,
@@ -149,7 +149,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     // update the selectedIndex and currentOptions state if the selectedKey or options have changed
     if ((newProps.selectedKey || newProps.value) &&
       (newProps.selectedKey !== this.props.selectedKey || newProps.options !== this.props.options)) {
-      let index: number = newProps.selectedKey !== undefined ? this._getSelectedIndex(newProps.options!, newProps.selectedKey) : -1;
+      let index: number = this._getSelectedIndex(newProps.options, newProps.selectedKey);
       this.setState({
         selectedIndex: index,
         currentOptions: newProps.options
@@ -725,11 +725,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         // If we are not controlled, create a new option
         let newOption: IComboBoxOption = { key: currentPendingValue, text: currentPendingValue };
         let newOptions: IComboBoxOption[] = [...currentOptions, newOption];
-        let newSelectedIndex: number = this._getSelectedIndex(newOptions, currentPendingValue);
 
         this.setState({
           currentOptions: newOptions,
-          selectedIndex: newSelectedIndex
+          selectedIndex: newOptions.length - 1
         });
       }
     } else if (currentPendingValueValidIndex >= 0) {
@@ -928,8 +927,12 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * @param selectedKey - the known selected key to find
    * @returns {number} - the index of the selected option, -1 if not found
    */
-  private _getSelectedIndex(options: IComboBoxOption[], selectedKey: string | number): number {
-    return findIndex(options, (option => (option.isSelected || option.selected || (selectedKey !== null) && option.key === selectedKey)));
+  private _getSelectedIndex(options: IComboBoxOption[] | undefined, selectedKey: string | number | undefined): number {
+    if (options === undefined || selectedKey === undefined) {
+      return -1;
+    }
+
+    return findIndex(options, (option => (option.isSelected || option.selected || option.key === selectedKey)));
   }
 
   /**


### PR DESCRIPTION


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

It was discovered that the comboBox was taking some liberties around adding new options even when the component is controlled. Part of this change also deals with getting focus/selection right in this case. I've also added unit tests that leverage the code path where the bug was found

#### Focus areas to test

Verified the focus, selection, and new option creation is working as expected for both controlled (selectedKey/value and onChanged) and uncontrolled components