### PR TITLE
Nav: Update isGroupCollapsed for new groups

### DIFF
--- a/common/changes/office-ui-fabric-react/nav_2017-08-10-02-04.json
+++ b/common/changes/office-ui-fabric-react/nav_2017-08-10-02-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Nav: update isGroupCollapsed for new groups",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -56,6 +56,7 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
       isLinkExpandStateChanged: false,
       selectedKey: props.initialSelectedKey || props.selectedKey,
     };
+
     if (props.groups) {
       for (let group of props.groups) {
         if (group.collapseByDefault && group.name) {
@@ -64,6 +65,28 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
       }
     }
     this._hasExpandButton = false;
+  }
+
+  public componentWillReceiveProps(newProps: INavProps) {
+    let newGroups = newProps.groups || [];
+    let isGroupCollapsed = this.state.isGroupCollapsed!;
+
+    // If the component's props were updated, new groups may have been added, which may have
+    // collapseByDefault set. Ensure that setting is respected for any new groups.
+    // (If isGroupCollapsed is already set for a group, don't overwrite that.)
+    let hasUpdated = false;
+    for (let newGroup of newGroups) {
+      if (newGroup.name && newGroup.collapseByDefault && !isGroupCollapsed.hasOwnProperty(newGroup.name)) {
+        isGroupCollapsed[newGroup.name] = true;
+        hasUpdated = true;
+      }
+    }
+
+    if (hasUpdated) {
+      this.setState({
+        isGroupCollapsed: isGroupCollapsed
+      });
+    }
   }
 
   public render(): JSX.Element | null {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When the nav receives updated props, it should ensure that `collapseByDefault` is respected for any new groups.