### PR TITLE
Dropdown: no longer scrolls body when arrowing beyond the menu edges.

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-fix_2017-08-14-17-13.json
+++ b/common/changes/office-ui-fabric-react/dropdown-fix_2017-08-14-17-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: no longer scrolls body when arrowing up down at the start/end of the menu. Also added `multSelectDelimiter` for tweaking how the title is rendered in a multi-select scenario.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
@@ -55,6 +55,14 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<HTMLDivEle
   selectedKeys?: string[] | number[];
 
   /**
+   * When multiple items are selected, this still will be used to separate values in
+   * the dropdown title.
+   *
+   * @defaultValue ", "
+   */
+  multiSelectDelimiter?: string;
+
+  /**
    * Deprecated at v0.52.0, use 'disabled' instead.
    * @deprecated
    */

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -308,10 +308,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   private _onRenderTitle(item: IDropdownOption | IDropdownOption[]): JSX.Element {
     let displayTxt: string = '';
     if (this.props.multiSelect && Array.isArray(item)) {
-      for (let i = 0; i < item.length; i++) {
-        displayTxt += item[i].text;
-        displayTxt += (i === item.length - 1) ? '' : ',';
-      }
+      displayTxt = item.map(i => i.text).join(', ');
     } else {
       displayTxt = (item as IDropdownOption).text;
     }
@@ -380,18 +377,20 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
     let { selectedIndex } = this.state;
 
     return (
-      <FocusZone
-        ref={ this._resolveRef('_focusZone') }
-        direction={ FocusZoneDirection.vertical }
-        defaultActiveElement={ '#' + id + '-list' + selectedIndex }
-        id={ id + '-list' }
-        className={ css('ms-Dropdown-items', styles.items) }
-        aria-labelledby={ id + '-label' }
-        onKeyDown={ this._onZoneKeyDown }
-        role='listbox'
-      >
-        { this.props.options.map((item: any, index: number) => onRenderItem({ ...item, index }, this._onRenderItem)) }
-      </FocusZone>
+      <div onKeyDown={ this._onZoneKeyDown }>
+        <FocusZone
+          ref={ this._resolveRef('_focusZone') }
+          direction={ FocusZoneDirection.vertical }
+          defaultActiveElement={ '#' + id + '-list' + selectedIndex }
+          id={ id + '-list' }
+          className={ css('ms-Dropdown-items', styles.items) }
+          aria-labelledby={ id + '-label' }
+
+          role='listbox'
+        >
+          { this.props.options.map((item: any, index: number) => onRenderItem({ ...item, index }, this._onRenderItem)) }
+        </FocusZone>
+      </div>
     );
   }
 
@@ -535,6 +534,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   }
 
   private _getSelectedIndex(options: IDropdownOption[], selectedKey: string | number): number {
+    // tslint:disable-next-line:triple-equals
     return findIndex(options, (option => (option.isSelected || option.selected || (selectedKey != null) && option.key === selectedKey)));
   }
 
@@ -645,10 +645,17 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       case KeyCodes.up:
         if (ev.altKey || ev.metaKey) {
           this.setState({ isOpen: false });
-          break;
         }
+        break;
 
-        return;
+      // All directional keystrokes should be canceled when the zone is rendered.
+      // This avoids the body scroll from reacting and thus dismissing the dropdown.
+      case KeyCodes.home:
+      case KeyCodes.end:
+      case KeyCodes.pageUp:
+      case KeyCodes.pageDown:
+      case KeyCodes.down:
+        break;
 
       case KeyCodes.escape:
         this.setState({ isOpen: false });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -307,8 +307,10 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   @autobind
   private _onRenderTitle(item: IDropdownOption | IDropdownOption[]): JSX.Element {
     let displayTxt: string = '';
+    let { multiSelectDelimiter = ', ' } = this.props;
+
     if (this.props.multiSelect && Array.isArray(item)) {
-      displayTxt = item.map(i => i.text).join(', ');
+      displayTxt = item.map(i => i.text).join(multiSelectDelimiter);
     } else {
       displayTxt = (item as IDropdownOption).text;
     }
@@ -385,7 +387,6 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           id={ id + '-list' }
           className={ css('ms-Dropdown-items', styles.items) }
           aria-labelledby={ id + '-label' }
-
           role='listbox'
         >
           { this.props.options.map((item: any, index: number) => onRenderItem({ ...item, index }, this._onRenderItem)) }


### PR DESCRIPTION
Expand dropdown menu on a page with body scroll.
Down arrow to the bottom of the list.
Press down arrow one more time.

Before:
Page would scroll, causing the menu to dismiss.

After:
Page stays put, and keystroke is soaked.

Also tweaking the multiselect delimiter to include a space by default, and to be overridable via prop.