### PR TITLE
ComboBox: Fixing role typo from header to heading

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxRoleTypoFix_2017-08-14-20-24.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxRoleTypoFix_2017-08-14-20-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Fix role typo to read heading instead of header",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -822,7 +822,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     let { onRenderOption = this._onRenderOption } = this.props;
 
     return (
-      <div key={ item.key } className={ this._classNames.header } role='header'>
+      <div key={ item.key } className={ this._classNames.header } role='heading'>
         { onRenderOption(item, this._onRenderOption) }
       </div>);
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

There's a typo in the combobox where header should actually be heading... fixing
#### Focus areas to test

verified that the element is now correctly being represented as a heading
