### PR TITLE
DONT MERGE YET: Fabric component: have text color theme

### DIFF
--- a/common/changes/office-ui-fabric-react/phkuo-msFabricColor_2017-08-15-18-14.json
+++ b/common/changes/office-ui-fabric-react/phkuo-msFabricColor_2017-08-15-18-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fabric component: have the text color theme",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
@@ -21,7 +21,8 @@ export const getStyles = memoizeFunction((
     root: mergeStyles([
       theme.fonts.medium,
       {
-        color: theme.palette.neutralPrimary,
+        color: theme.semanticColors.bodyText,
+        '&.ms-Fabric': { color: theme.semanticColors.bodyText } // overwrite default ms-Fabric's color with one that themes
         '& button': inheritFont,
         '& input': inheritFont,
         '& textarea': inheritFont

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
@@ -22,7 +22,7 @@ export const getStyles = memoizeFunction((
       theme.fonts.medium,
       {
         color: theme.semanticColors.bodyText,
-        '&.ms-Fabric': { color: theme.semanticColors.bodyText } // overwrite default ms-Fabric's color with one that themes
+        '&.ms-Fabric': { color: theme.semanticColors.bodyText }, // overwrite default ms-Fabric's color with one that themes
         '& button': inheritFont,
         '& input': inheritFont,
         '& textarea': inheritFont


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fabric component: have text color theme
Right now, the root Fabric component has both the .ms-Fabric class and the autogenerated class on it. Both define the color property. However, the .ms-Fabric class is not themable, but its specificity is equal to the autogenerated class. If it comes later in the page, its non-theming color will overwrite the themable color of the autogenerated class. The fix is to specifically override .ms-Fabric's color with something with higher specificity for the Fabric component.

#### Focus areas to test

(optional)
