### PR TITLE
FocusZone: respect home/end when in INPUT or TEXTAREA

### DIFF
--- a/common/changes/office-ui-fabric-react/focus-zonefix_2017-08-18-16-01.json
+++ b/common/changes/office-ui-fabric-react/focus-zonefix_2017-08-18-16-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: presssing home/end inside of an input/textarea element should respect cursor location.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -343,6 +343,11 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           return;
 
         case KeyCodes.home:
+          if (
+            this._isElementInput(ev.target as HTMLElement) &&
+            !this._shouldInputLoseFocus(ev.target as HTMLInputElement, false)) {
+            return false;
+          }
           const firstChild = this.refs.root.firstChild as HTMLElement;
           if (this.focusElement(getNextElement(this.refs.root, firstChild, true) as HTMLElement)) {
             break;
@@ -350,6 +355,12 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           return;
 
         case KeyCodes.end:
+          if (
+            this._isElementInput(ev.target as HTMLElement) &&
+            !this._shouldInputLoseFocus(ev.target as HTMLInputElement, true)) {
+            return false;
+          }
+
           const lastChild = this.refs.root.lastChild as HTMLElement;
           if (this.focusElement(getPreviousElement(this.refs.root, lastChild, true, true, true) as HTMLElement)) {
             break;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #2546 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

When pressing home/end we look now look at the cursor state. If when pressing home and the cursor is at the beginning, we will go to the first element in the zone, but if the cursor is not at the beginning, we let the input element take care of moving the cursor. (Same thing with the end keystroke on the reverse side.)

