### PR TITLE
DetailsList: Move background from .cell to .root in DetailsHeader

### DIFF
--- a/common/changes/office-ui-fabric-react/v-edwliu-detailsheader-background-fix_2017-08-18-20-44.json
+++ b/common/changes/office-ui-fabric-react/v-edwliu-detailsheader-background-fix_2017-08-18-20-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Move background color from .cell to .root for DetailsHeader",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -11,6 +11,7 @@ $isPaddedMargin: 24px;
 
 .root {
   display: inline-block;
+  background: $headerBackgroundColor;
   position: relative;
   min-width: 100%;
   vertical-align: top;
@@ -35,7 +36,6 @@ $isPaddedMargin: 24px;
 
 .cell {
   @include ms-font-s;
-  background: $headerBackgroundColor;
   color: $headerForegroundColor;
   @include focus-border();
   position: relative;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -45,7 +45,6 @@ $isPaddedMargin: 24px;
   border: none;
   line-height: inherit;
   margin: 0;
-  @include ms-text-align(left);
   height: $rowHeight;
   vertical-align: top;
   white-space: nowrap;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Move background property from .cell to .root in DetailsHeader so the background spans the whole width of DetailsList.
![detailsheader](https://user-images.githubusercontent.com/1291968/29477093-bac0b8e8-841b-11e7-92a3-a08c26cd2b20.png)


#### Focus areas to test

(optional)
