### PR TITLE
PeoplePicker: Fixing A11yMAS issue in selected picker items

### DIFF
--- a/common/changes/office-ui-fabric-react/v-krbrow-picker-uia-node-fixes_2017-08-18-22-51.json
+++ b/common/changes/office-ui-fabric-react/v-krbrow-picker-uia-node-fixes_2017-08-18-22-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "PeoplePicker: Fixing A11yMAS accessibility issue in selected items.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-krbrow@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -154,10 +154,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           direction={ FocusZoneDirection.bidirectional }
           isInnerZoneKeystroke={ this._isFocusZoneInnerKeystroke }>
           <SelectionZone selection={ this.selection } selectionMode={ SelectionMode.multiple }>
-            <div className={ css('ms-BasePicker-text', styles.pickerText) }>
-              <span role={ 'list' }>
-                { this.renderItems() }
-              </span>
+            <div className={ css('ms-BasePicker-text', styles.pickerText) } role={ 'list' }>
+              { this.renderItems() }
               <BaseAutoFill
                 { ...inputProps as any }
                 className={ css('ms-BasePicker-input', styles.pickerInput) }

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -155,7 +155,9 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           isInnerZoneKeystroke={ this._isFocusZoneInnerKeystroke }>
           <SelectionZone selection={ this.selection } selectionMode={ SelectionMode.multiple }>
             <div className={ css('ms-BasePicker-text', styles.pickerText) }>
-              { this.renderItems() }
+              <span role={ 'list' }>
+                { this.renderItems() }
+              </span>
               <BaseAutoFill
                 { ...inputProps as any }
                 className={ css('ms-BasePicker-input', styles.pickerInput) }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -1,7 +1,7 @@
 /* tslint:disable */
 import * as React from 'react';
 /* tslint:enable */
-import { css } from '../../../../Utilities';
+import { css, getId } from '../../../../Utilities';
 import { Persona, PersonaSize, PersonaPresence } from '../../../../Persona';
 import { IPeoplePickerItemProps } from './PeoplePickerItem.Props';
 import { ValidationState } from '../../BasePicker.Props';
@@ -17,6 +17,9 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
     selected,
     removeButtonAriaLabel
   } = peoplePickerItemProps;
+
+  const itemId = getId();
+
   return (
     <div
       className={ css(
@@ -27,8 +30,12 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
       ) }
       data-is-focusable={ true }
       data-is-sub-focuszone={ true }
-      data-selection-index={ index } >
-      <div className={ css('ms-PickerItem-content', styles.itemContent) } >
+      data-selection-index={ index }
+      role={ 'listitem' }
+      aria-labelledby={ 'selectedItemPersona-' + itemId } >
+      <div
+        className={ css('ms-PickerItem-content', styles.itemContent) }
+        id={ 'selectedItemPersona-' + itemId } >
         <Persona
           { ...item }
           presence={ item.presence !== undefined ? item.presence : PersonaPresence.none }

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
@@ -17,7 +17,7 @@ export const TagItem = (props: IPickerItemProps<ITag>) => (
     key={ props.index }
     data-selection-index={ props.index }
     data-is-focusable={ !props.disabled && true }>
-    <span className={ css('ms-TagItem-text', styles.tagItemText) }>{ props.children }</span>
+    <span className={ css('ms-TagItem-text', styles.tagItemText) } aria-label={ props.children }>{ props.children }</span>
     { !props.disabled &&
       <span className={ css('ms-TagItem-close', styles.tagItemClose) } onClick={ props.onRemoveItem }>
         <Icon iconName='Cancel' />


### PR DESCRIPTION
#### Pull request checklist
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Selected PeoplePicker items were not being read correctly when when focused in Edge/IE and were not getting the right role assigned in UIA. This PR causes the person's name to be read when the selected item is focused and gives them listitem roles. Also, fixes a similar issue in TagPicker by giving the tags aria-labels.

#### Focus areas to test

PeoplePicker, BasePicker
