### PR TITLE
zhiliu: viewport perf optimization

### DIFF
--- a/common/changes/office-ui-fabric-react/zhiliu-viewPortReflow_2017-08-21-03-59.json
+++ b/common/changes/office-ui-fabric-react/zhiliu-viewPortReflow_2017-08-21-03-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "viewport perf optimization, remove unnecessary mreasurement and reflow",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "zhiliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -47,7 +47,6 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
         });
 
       this._events.on(window, 'resize', this._onAsyncResize);
-      this._updateViewport();
     }
 
     public componentWillUnmount() {
@@ -56,13 +55,10 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
 
     public render() {
       let { viewport } = this.state;
-      let isViewportVisible = viewport!.width > 0 && viewport!.height > 0;
 
       return (
         <div className='ms-Viewport' ref='root' style={ { minWidth: 1, minHeight: 1 } }>
-          { isViewportVisible && (
-            <ComposedComponent ref={ this._updateComposedComponentRef } viewport={ viewport } { ...this.props as any } />
-          ) }
+          <ComposedComponent ref={ this._updateComposedComponentRef } viewport={ viewport } { ...this.props as any } />
         </div>
       );
     }


### PR DESCRIPTION
#### Pull request checklist

- [* ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Viewport measuring before its component rendering is an expensive reflow and total waste of time because there is nothing rendered yet.

The fix is simple, we do not do viewport measurements at its componentDidMount(). It is ok to keep its init value zero and measure when resizing happening after page rendering to save time.

My benchmark shows 40 ms save on sharepoint page rendering on chrome after this change.  

#### Focus areas to test

(optional)
