### PR TITLE
Adding react import to SpinButton.Props

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2017-08-21-21-28.json
+++ b/common/changes/office-ui-fabric-react/master_2017-08-21-21-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding react import to SpinButton.Props for classic module resolution.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "serkani@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.Props.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Position } from '../../utilities/positioning';
 import { IIconProps } from '../../Icon';
 import { ITheme, IStyle } from '../../Styling';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adding missing react import to SpinButton.Props which is causing build error for classic module resolution.

#### Focus areas to test

None
