### PR TITLE
Add Comment icon

### DIFF
--- a/common/changes/@uifabric/styling/bekaise-addCommentIcon_2017-08-21-22-08.json
+++ b/common/changes/@uifabric/styling/bekaise-addCommentIcon_2017-08-21-22-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "add Comment icon",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "bekaise@microsoft.com"
+}

--- a/packages/styling/src/styles/IconCodes.ts
+++ b/packages/styling/src/styles/IconCodes.ts
@@ -684,6 +684,10 @@ export const IconCodes = {
    */
   combine: '\uEDBB',
   /**
+   * Icon code with value '\uE90A'.
+   */
+  comment: '\uE90A',
+  /**
    * Icon code with the value '\uE942'.
    */
   compassNW: '\uE942',


### PR DESCRIPTION
We would like to consume the Comment icon through the
office-ui-fabric-react package but it currently does not have all the
neccessary parts in place.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2550 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added missing icon code in `IconCodes.ts`

#### Focus areas to test

`<Icon iconName='Comment' />`
