### PR TITLE
Fix accessible labeling for DetailsList column headers

### DIFF
--- a/common/changes/office-ui-fabric-react/details-columns_2017-08-22-20-39.json
+++ b/common/changes/office-ui-fabric-react/details-columns_2017-08-22-20-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix aria-labeling for DetailsList column headers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -182,10 +182,5 @@ $isPaddedMargin: 24px;
 }
 
 .accessibleLabel {
-  position: absolute;
-  overflow: hidden;
-  width: 1px;
-  height: 1px;
-  text-indent: 1px;
-  white-space: nowrap;
+  @include ms-screenReaderOnly;
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -180,3 +180,12 @@ $isPaddedMargin: 24px;
 .cell .collapseButton {
   @include ms-padding-right(0);
 }
+
+.accessibleLabel {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  text-indent: 1px;
+  white-space: nowrap;
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -152,6 +152,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         { showCheckbox ? (
           [
             <div
+              key='__checkbox'
               className={ css(
                 'ms-DetailsHeader-cell',
                 'ms-DetailsHeader-cellIsCheck',
@@ -182,9 +183,10 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                   )
                 }, this._onRenderColumnHeaderTooltip)
               }
-            </div >,
+            </div>,
             ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip ? (
               <label
+                key='__checkboxLabel'
                 id={ `${this._id}-checkTooltip` }
                 className={ styles.accessibleLabel }
               >
@@ -291,13 +293,13 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                             />
                           ) }
                         </span>
-
                       )
                     }, this._onRenderColumnHeaderTooltip)
                   }
                 </div>,
                 column.ariaLabel && !this.props.onRenderColumnHeaderTooltip ? (
                   <label
+                    key={ `${column.key}_label` }
                     id={ `${this._id}-${column.key}-tooltip` }
                     className={ styles.accessibleLabel }
                   >
@@ -320,7 +322,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
             </Layer>
           )
         }
-      </FocusZone >
+      </FocusZone>
     );
   }
 
@@ -336,6 +338,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
 
     return (
       <div
+        key={ `${column.key}_sizer` }
         aria-hidden={ true }
         role='button'
         data-is-focusable={ false }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -150,38 +150,48 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         direction={ FocusZoneDirection.horizontal }
       >
         { showCheckbox ? (
-          <div
-            className={ css(
-              'ms-DetailsHeader-cell',
-              'ms-DetailsHeader-cellIsCheck',
-              styles.cell,
-              styles.cellIsCheck,
-              checkStyles.owner,
-              isAllSelected && checkStyles.isSelected
-            ) }
-            onClick={ this._onSelectAllClicked }
-            aria-colindex={ 0 }
-            role='columnheader' >
-            <span
-              aria-label={ ariaLabelForSelectionColumn }
-            ></span>
-            {
-              onRenderColumnHeaderTooltip({
-                hostClassName: css(styles.checkTooltip),
-                id: `${this._id}-checkTooltip`,
-                setAriaDescribedBy: false,
-                content: ariaLabelForSelectAllCheckbox,
-                children: (
-                  <DetailsRowCheck
-                    aria-describedby={ `${this._id}-checkTooltip` }
-                    selected={ isAllSelected }
-                    anySelected={ false }
-                    canSelect={ true }
-                  />
-                )
-              }, this._onRenderColumnHeaderTooltip)
-            }
-          </div >
+          [
+            <div
+              className={ css(
+                'ms-DetailsHeader-cell',
+                'ms-DetailsHeader-cellIsCheck',
+                styles.cell,
+                styles.cellIsCheck,
+                checkStyles.owner,
+                isAllSelected && checkStyles.isSelected
+              ) }
+              aria-labelledby={ `${this._id}-check` }
+              onClick={ this._onSelectAllClicked }
+              aria-colindex={ 0 }
+              role='columnheader' >
+              {
+                onRenderColumnHeaderTooltip({
+                  hostClassName: css(styles.checkTooltip),
+                  id: `${this._id}-checkTooltip`,
+                  setAriaDescribedBy: false,
+                  content: ariaLabelForSelectAllCheckbox,
+                  children: (
+                    <DetailsRowCheck
+                      id={ `${this._id}-check` }
+                      aria-label={ ariaLabelForSelectionColumn }
+                      aria-describedby={ `${this._id}-checkTooltip` }
+                      selected={ isAllSelected }
+                      anySelected={ false }
+                      canSelect={ true }
+                    />
+                  )
+                }, this._onRenderColumnHeaderTooltip)
+              }
+            </div >,
+            ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip ? (
+              <label
+                id={ `${this._id}-checkTooltip` }
+                className={ styles.accessibleLabel }
+              >
+                { ariaLabelForSelectAllCheckbox }
+              </label>
+            ) : null
+          ]
         ) : null
         }
         {
@@ -238,6 +248,9 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                       content: column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '',
                       children: (
                         <span
+                          id={ `${this._id}-${column.key}` }
+                          aria-label={ column.isIconOnly ? column.name : undefined }
+                          aria-labelledby={ column.isIconOnly ? undefined : `${this._id}-${column.key}-name ` }
                           className={ css('ms-DetailsHeader-cellTitle', styles.cellTitle) }
                           data-is-focusable={ column.columnActionsMode !== ColumnActionsMode.disabled }
                           role={ column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined }
@@ -246,7 +259,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                           onClick={ this._onColumnClick.bind(this, column) }
                         >
                           <span
-                            aria-label={ column.isIconOnly ? column.name : undefined }
+                            id={ `${this._id}-${column.key}-name` }
                             className={ css('ms-DetailsHeader-cellName',
                               styles.cellName, {
                                 [styles.iconOnlyHeader]: column.isIconOnly
@@ -283,6 +296,14 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                     }, this._onRenderColumnHeaderTooltip)
                   }
                 </div>,
+                column.ariaLabel && !this.props.onRenderColumnHeaderTooltip ? (
+                  <label
+                    id={ `${this._id}-${column.key}-tooltip` }
+                    className={ styles.accessibleLabel }
+                  >
+                    { column.ariaLabel }
+                  </label>
+                ) : null,
                 (column.isResizable) && this._renderColumnSizer(columnIndex)
               ]
             );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -12,10 +12,6 @@ import {
 import {
   IRenderFunction
 } from 'office-ui-fabric-react/lib/Utilities';
-import {
-  TooltipHost,
-  ITooltipHostProps
-} from 'office-ui-fabric-react/lib/Tooltip';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 
 let _items: any[] = [];
@@ -84,12 +80,6 @@ export class DetailsListBasicExample extends React.Component<any, any> {
             columns={ _columns }
             setKey='set'
             layoutMode={ DetailsListLayoutMode.fixedColumns }
-            onRenderDetailsHeader={
-              (detailsHeaderProps: IDetailsHeaderProps, defaultRender: IRenderFunction<IDetailsHeaderProps>) => defaultRender({
-                ...detailsHeaderProps,
-                onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => <TooltipHost { ...tooltipHostProps } />
-              })
-            }
             selection={ this._selection }
             selectionPreservedOnEmptyClick={ true }
             ariaLabelForSelectionColumn='Toggle selection'


### PR DESCRIPTION
### Overview

Ensured that the following work in Edge + Narrator (our accessibility standard target)

- Putting focus on the Select All checkbox reads `ariaLabelForSelectionColumn` followed by `ariaLabelForSelectAllCheckbox`.
- Putting focus on the column header button reads `column.name` followed by `column.ariaLabel`.
- Scanning on the selection column header reads only `ariaLabelForSelectionColumn`.
- Scanning on any other column header reads only `column.name`.

This was accomplished by adding invisible `<label>` elements outside the `<div role='columnheader' />` elements and using `aria-describedby` and `aria-labelledby` to the correct `id` values.

The ability to wrap column headers with a `TooltipHost` to use instead has been left in-place.