### PR TITLE
ContextualMenu: Add ability to provide a role for a menu item

### DIFF
--- a/common/changes/office-ui-fabric-react/contextual-menu-role_2017-08-22-23-33.json
+++ b/common/changes/office-ui-fabric-react/contextual-menu-role_2017-08-22-23-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Add ability to override role on menu items",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -295,7 +295,7 @@ export interface IContextualMenuItem {
 
   /**
    * Optional accessibility label (aria-label) attribute that will be stamped on to the element.
-   * If none is specified, the arai-label attribute will contain the item name
+   * If none is specified, the aria-label attribute will contain the item name
    */
   ariaLabel?: string;
 
@@ -318,6 +318,12 @@ export interface IContextualMenuItem {
    * the commands. This should only be used in special cases when react and non-react are mixed.
    */
   onMouseDown?: (item: IContextualMenuItem, event: any) => void;
+
+  /**
+   * Optional override for the role attribute on the menu button. If one is not provided, it will
+   * have a value of menuitem or menuitemcheckbox.
+   */
+  role?: string;
 
   /**
    * Any additional properties to use when custom rendering menu items.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -388,6 +388,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
     const isChecked: boolean | null | undefined = getIsChecked(item);
     const canCheck: boolean = isChecked !== null;
+    const defaultRole = canCheck ? 'menuitemcheckbox' : 'menuitem';
 
     const itemButtonProperties = {
       className: css('ms-ContextualMenu-link', styles.link, {
@@ -408,7 +409,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       'aria-posinset': focusableElementIndex + 1,
       'aria-setsize': totalItemCount,
       'aria-disabled': item.isDisabled,
-      role: canCheck ? 'menuitemcheckbox' : 'menuitem',
+      role: item.role || defaultRole,
       style: item.style
     };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
There are some scenarios (such as a Pivot with an overflow menu) where we want to use a contextual menu with a custom role attribute of 'menuitemradio' instead of 'menuitem' or 'menuitemcheckbox'. This change adds the ability to specifically provide the role for a menu item, while still providing a default value when one is not provided. 
