### PR TITLE
Make SelectionMode intrinsic to Selection model

### DIFF
--- a/common/changes/office-ui-fabric-react/selection-mode_2017-08-23-17-57.json
+++ b/common/changes/office-ui-fabric-react/selection-mode_2017-08-23-17-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make SelectionMode intrinsic to Selection model",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -1,16 +1,20 @@
-import { IObjectWithKey, ISelection, SELECTION_CHANGE } from './interfaces';
+
+import { IObjectWithKey, ISelection, SELECTION_CHANGE, SelectionMode } from './interfaces';
 import { EventGroup } from '../../Utilities';
 
 export interface ISelectionOptions {
   onSelectionChanged?: () => void;
   getKey?: (item: IObjectWithKey, index?: number) => string | number;
   canSelectItem?: (item: IObjectWithKey) => boolean;
+  selectionMode?: SelectionMode;
 }
 
 export class Selection implements ISelection {
   public count: number;
-  public getKey: (item: IObjectWithKey, index?: number) => string | number;
-  public canSelectItem: (item: IObjectWithKey) => boolean;
+  public readonly mode: SelectionMode;
+
+  private _getKey: (item: IObjectWithKey, index?: number) => string | number;
+  private _canSelectItem: (item: IObjectWithKey) => boolean;
 
   private _changeEventSuppressionCount: number;
   private _items: IObjectWithKey[];
@@ -26,21 +30,34 @@ export class Selection implements ISelection {
   private _unselectableCount: number;
 
   constructor(options: ISelectionOptions = {}) {
-    let {
+    const {
       onSelectionChanged,
       getKey,
-      canSelectItem = (item: IObjectWithKey) => { return true; }
+      canSelectItem = (item: IObjectWithKey) => true,
+      selectionMode = SelectionMode.multiple
     } = options;
-    this.getKey = getKey || ((item: IObjectWithKey, index?: number) => ((item && item.key) ? item.key : String(index)));
+
+    this.mode = selectionMode;
+
+    this._getKey = getKey || defaultGetKey;
 
     this._changeEventSuppressionCount = 0;
     this._exemptedCount = 0;
     this._anchoredIndex = 0;
     this._unselectableCount = 0;
-    this.setItems([], true);
 
     this._onSelectionChanged = onSelectionChanged;
-    this.canSelectItem = canSelectItem;
+    this._canSelectItem = canSelectItem;
+
+    this.setItems([], true);
+  }
+
+  public canSelectItem(item: IObjectWithKey): boolean {
+    return this._canSelectItem(item);
+  }
+
+  public getKey(item: IObjectWithKey, index?: number): string {
+    return `${this._getKey(item, index)}`;
   }
 
   public setChangeEvents(isEnabled: boolean, suppressChange?: boolean) {
@@ -159,7 +176,7 @@ export class Selection implements ISelection {
   }
 
   public isAllSelected(): boolean {
-    let selectableCount = this._items.length - this._unselectableCount;
+    let selectableCount = Math.min(this.mode === SelectionMode.single ? 1 : Infinity, this._items.length - this._unselectableCount);
 
     return (
       (this.count > 0) &&
@@ -180,7 +197,11 @@ export class Selection implements ISelection {
       (!this._isAllSelected && this._exemptedIndices[index]));
   }
 
-  public setAllSelected(isAllSelected: boolean) {
+  public setAllSelected(isAllSelected: boolean): void {
+    if (isAllSelected && this.mode !== SelectionMode.multiple) {
+      return;
+    }
+
     let selectableCount = this._items ? (this._items.length - this._unselectableCount) : 0;
 
     if (selectableCount > 0 && (this._exemptedCount > 0 || isAllSelected !== this._isAllSelected)) {
@@ -191,7 +212,7 @@ export class Selection implements ISelection {
     }
   }
 
-  public setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean) {
+  public setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean): void {
     let index = this._keyToIndexMap[key];
 
     if (index >= 0) {
@@ -199,7 +220,11 @@ export class Selection implements ISelection {
     }
   }
 
-  public setIndexSelected(index: number, isSelected: boolean, shouldAnchor: boolean) {
+  public setIndexSelected(index: number, isSelected: boolean, shouldAnchor: boolean): void {
+    if (this.mode === SelectionMode.none) {
+      return;
+    }
+
     // Clamp the index.
     index = Math.min(Math.max(0, index), this._items.length - 1);
 
@@ -208,11 +233,18 @@ export class Selection implements ISelection {
       return;
     }
 
+    this.setChangeEvents(false);
+
     let isExempt = this._exemptedIndices[index];
     let hasChanged = false;
     let canSelect = !this._unselectableIndices[index];
 
     if (canSelect) {
+      if (isSelected && this.mode === SelectionMode.single) {
+        // If this is single-select, the previous selection should be removed.
+        this.setAllSelected(false);
+      }
+
       // Determine if we need to remove the exemption.
       if (isExempt && (
         (isSelected && this._isAllSelected) ||
@@ -241,13 +273,24 @@ export class Selection implements ISelection {
     if (hasChanged) {
       this._updateCount();
     }
+
+    this.setChangeEvents(true);
   }
 
-  public selectToKey(key: string, clearSelection?: boolean) {
+  public selectToKey(key: string, clearSelection?: boolean): void {
     this.selectToIndex(this._keyToIndexMap[key], clearSelection);
   }
 
-  public selectToIndex(index: number, clearSelection?: boolean) {
+  public selectToIndex(index: number, clearSelection?: boolean): void {
+    if (this.mode === SelectionMode.none) {
+      return;
+    }
+
+    if (this.mode === SelectionMode.single) {
+      this.setIndexSelected(index, true, true);
+      return;
+    }
+
     let anchorIndex = this._anchoredIndex || 0;
     let startIndex = Math.min(index, anchorIndex);
     let endIndex = Math.max(index, anchorIndex);
@@ -265,21 +308,29 @@ export class Selection implements ISelection {
     this.setChangeEvents(true);
   }
 
-  public toggleAllSelected() {
+  public toggleAllSelected(): void {
     this.setAllSelected(!this.isAllSelected());
   }
 
-  public toggleKeySelected(key: string) {
+  public toggleKeySelected(key: string): void {
     this.setKeySelected(key, !this.isKeySelected(key), true);
   }
 
-  public toggleIndexSelected(index: number) {
+  public toggleIndexSelected(index: number): void {
     this.setIndexSelected(index, !this.isIndexSelected(index), true);
   }
 
-  public toggleRangeSelected(fromIndex: number, count: number) {
+  public toggleRangeSelected(fromIndex: number, count: number): void {
+    if (this.mode === SelectionMode.none) {
+      return;
+    }
+
     let isRangeSelected = this.isRangeSelected(fromIndex, count);
     let endIndex = fromIndex + count;
+
+    if (this.mode === SelectionMode.single && count > 1) {
+      return;
+    }
 
     this.setChangeEvents(false);
     for (let i = fromIndex; i < endIndex; i++) {
@@ -288,12 +339,12 @@ export class Selection implements ISelection {
     this.setChangeEvents(true);
   }
 
-  private _updateCount() {
+  private _updateCount(): void {
     this.count = this.getSelectedCount();
     this._change();
   }
 
-  private _change() {
+  private _change(): void {
     if (this._changeEventSuppressionCount === 0) {
       this._selectedItems = null;
 
@@ -306,5 +357,10 @@ export class Selection implements ISelection {
       this._hasChanged = true;
     }
   }
+}
 
+function defaultGetKey(item: IObjectWithKey, index?: number): string | number {
+  return item && item.key ?
+    item.key :
+    `${index}`;
 }

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -176,8 +176,13 @@ export class Selection implements ISelection {
   }
 
   public isAllSelected(): boolean {
-    let selectableCount = Math.min(this.mode === SelectionMode.single ? 1 : Infinity, this._items.length - this._unselectableCount);
+    let selectableCount = this._items.length - this._unselectableCount;
 
+    // In single mode, we can only have a max of 1 item.
+    if (this.mode === SelectionMode.single) {
+      selectableCount = Math.min(selectableCount, 1);
+    }
+    
     return (
       (this.count > 0) &&
       (this._isAllSelected && this._exemptedCount === 0) ||

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -126,8 +126,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   @autobind
   private _onFocus(ev: React.FocusEvent<HTMLElement>) {
     let target = ev.target as HTMLElement;
-    let { selection, selectionMode } = this.props;
+    let { selection } = this.props;
     let isToggleModifierPressed = this._isCtrlPressed || this._isMetaPressed;
+
+    const selectionMode = this._getSelectionMode();
 
     if (this._shouldHandleFocus && selectionMode !== SelectionMode.none) {
       let isToggle = this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME);
@@ -253,8 +255,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
       return;
     }
 
-    let { selectionMode, onItemInvoked } = this.props;
+    let { onItemInvoked } = this.props;
     let itemRoot = this._findItemRoot(target);
+
+    const selectionMode = this._getSelectionMode();
 
     if (itemRoot && onItemInvoked && selectionMode !== SelectionMode.none && !this._isInputElement(target)) {
       let index = this._getItemIndex(itemRoot);
@@ -286,7 +290,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
       return;
     }
 
-    let { selection, selectionMode } = this.props;
+    let { selection } = this.props;
     let isSelectAllKey = ev.which === KeyCodes.a && (this._isCtrlPressed || this._isMetaPressed);
     let isClearSelectionKey = ev.which === KeyCodes.escape;
 
@@ -296,6 +300,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
       this._handleNextFocus(true);
       return;
     }
+
+    const selectionMode = this._getSelectionMode();
 
     // If ctrl-a is pressed, select all (if all are not already selected.)
     if (isSelectAllKey && selectionMode === SelectionMode.multiple && !selection.isAllSelected()) {
@@ -349,7 +355,9 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   }
 
   private _onToggleAllClick(ev: React.MouseEvent<HTMLElement>) {
-    let { selection, selectionMode } = this.props;
+    let { selection } = this.props;
+
+    const selectionMode = this._getSelectionMode();
 
     if (selectionMode === SelectionMode.multiple) {
       selection.toggleAllSelected();
@@ -359,7 +367,9 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   }
 
   private _onToggleClick(ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, index: number) {
-    let { selection, selectionMode } = this.props;
+    let { selection } = this.props;
+
+    const selectionMode = this._getSelectionMode();
 
     if (selectionMode === SelectionMode.multiple) {
       selection.toggleIndexSelected(index);
@@ -390,8 +400,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   }
 
   private _onItemSurfaceClick(ev: React.SyntheticEvent<HTMLElement>, index: number) {
-    let { selection, selectionMode } = this.props;
+    let { selection } = this.props;
     let isToggleModifierPressed = this._isCtrlPressed || this._isMetaPressed;
+
+    const selectionMode = this._getSelectionMode();
 
     if (selectionMode === SelectionMode.multiple) {
       if (this._isShiftPressed) {
@@ -517,5 +529,17 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         this._shouldHandleFocus = false;
       }, 100);
     }
+  }
+
+  private _getSelectionMode(): SelectionMode {
+    const {
+      selection
+    } = this.props;
+
+    const {
+      selectionMode = selection ? selection.mode : SelectionMode.none
+    } = this.props;
+
+    return selectionMode;
   }
 }

--- a/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx
@@ -43,9 +43,9 @@ export class SelectionItemExample extends React.Component<ISelectionItemExampleP
     }
 
     return (
-      <div className='ms-SelectionItemExample' data-selection-index={ itemIndex }>
-        { (selectionMode !== SelectionMode.none) && (
-          <div className='ms-SelectionItemExample-check' data-selection-toggle={ true } >
+      <div className='ms-SelectionItemExample' data-is-focusable={ true } data-selection-index={ itemIndex }>
+        { (selection && selection.canSelectItem(item) && selection.mode !== SelectionMode.none) && (
+          <div className='ms-SelectionItemExample-check' data-is-focusable={ true } data-selection-toggle={ true } >
             <Check checked={ isSelected } />
           </div>
         ) }
@@ -92,10 +92,9 @@ export class SelectionBasicExample extends React.Component<any, ISelectionBasicE
     return (
       <div className='ms-SelectionBasicExample'>
         <CommandBar items={ this._getCommandItems() } />
-        <MarqueeSelection selection={ selection } isEnabled={ selectionMode === SelectionMode.multiple } >
+        <MarqueeSelection selection={ selection } isEnabled={ selection.mode === SelectionMode.multiple } >
           <SelectionZone
             selection={ selection }
-            selectionMode={ selectionMode }
             onItemInvoked={ (item) => alert('item invoked: ' + item.name) }>
             { items.map((item, index) => (
               <SelectionItemExample
@@ -103,7 +102,6 @@ export class SelectionBasicExample extends React.Component<any, ISelectionBasicE
                 key={ item.key }
                 item={ item }
                 itemIndex={ index }
-                selectionMode={ selectionMode }
                 selection={ selection }
               />
             )) }
@@ -125,18 +123,30 @@ export class SelectionBasicExample extends React.Component<any, ISelectionBasicE
   }
 
   private _onSelectionModeChanged(ev: React.MouseEvent<HTMLElement>, menuItem: IContextualMenuItem) {
-    this.setState({
-      selectionMode: menuItem.data
+    this.setState((previousState: ISelectionBasicExampleState) => {
+      let newSelection = new Selection({
+        onSelectionChanged: this._onSelectionChanged,
+        canSelectItem: previousState.canSelect === 'vowels' ? this._canSelectItem : undefined,
+        selectionMode: menuItem.data
+      });
+      newSelection.setItems(previousState.items as IObjectWithKey[], false);
+
+      return {
+        selection: newSelection
+      };
     });
   }
 
   private _onCanSelectChanged(ev: React.MouseEvent<HTMLElement>, menuItem: IContextualMenuItem) {
     let canSelectItem = (menuItem.data === 'vowels') ? this._canSelectItem : undefined;
-    let newSelection = new Selection({ onSelectionChanged: this._onSelectionChanged, canSelectItem: canSelectItem });
-    newSelection.setItems(this.state.items as IObjectWithKey[], false);
-    this.setState({
-      selection: newSelection,
-      canSelect: (menuItem.data === 'vowels') ? 'vowels' : 'all'
+
+    this.setState((previousState: ISelectionBasicExampleState) => {
+      let newSelection = new Selection({ onSelectionChanged: this._onSelectionChanged, canSelectItem: canSelectItem, selectionMode: previousState.selection.mode });
+      newSelection.setItems(previousState.items as IObjectWithKey[], false);
+      return {
+        selection: newSelection,
+        canSelect: (menuItem.data === 'vowels') ? 'vowels' : 'all'
+      };
     });
   }
 
@@ -145,7 +155,7 @@ export class SelectionBasicExample extends React.Component<any, ISelectionBasicE
   }
 
   private _getCommandItems(): IContextualMenuItem[] {
-    let { selectionMode, canSelect } = this.state;
+    let { selection, canSelect } = this.state;
 
     return [
       {
@@ -156,7 +166,7 @@ export class SelectionBasicExample extends React.Component<any, ISelectionBasicE
             key: SelectionMode[SelectionMode.none],
             name: 'None',
             canCheck: true,
-            checked: selectionMode === SelectionMode.none,
+            checked: selection.mode === SelectionMode.none,
             onClick: this._onSelectionModeChanged,
             data: SelectionMode.none
 
@@ -165,7 +175,7 @@ export class SelectionBasicExample extends React.Component<any, ISelectionBasicE
             key: SelectionMode[SelectionMode.single],
             name: 'Single select',
             canCheck: true,
-            checked: selectionMode === SelectionMode.single,
+            checked: selection.mode === SelectionMode.single,
             onClick: this._onSelectionModeChanged,
             data: SelectionMode.single
           },
@@ -173,7 +183,7 @@ export class SelectionBasicExample extends React.Component<any, ISelectionBasicE
             key: SelectionMode[SelectionMode.multiple],
             name: 'Multi select',
             canCheck: true,
-            checked: selectionMode === SelectionMode.multiple,
+            checked: selection.mode === SelectionMode.multiple,
             onClick: this._onSelectionModeChanged,
             data: SelectionMode.multiple
           },

--- a/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
@@ -12,7 +12,9 @@ export enum SelectionMode {
 
 export interface ISelection {
   count: number;
-  canSelectItem?: (item: IObjectWithKey) => boolean;
+  mode: SelectionMode;
+
+  canSelectItem: (item: IObjectWithKey) => boolean;
 
   // Obesrvable methods.
   setChangeEvents(isEnabled: boolean, suppressChange?: boolean): void;


### PR DESCRIPTION
### Overview

This change moves responsibility of handling `SelectionMode` from the `SelectionZone` into the `Selection` model itself. The `Selection` model can then enforce that no items are selected, or only one item is selected, if necessary.

To preserve backwards-compatibility, this change assumes that the default `SelectionMode` for a `Selection` instance is `SelectionMode.multiple`. In addition, if `selectionMode` is passed to `SelectionZone` separately, `SelectionZone` will enforce the mode regardless of the setting of the provided `Selection` model. Note that the most restrictive `SelectionMode` between a `SelectionZone` and a `Selection` will be what is enforced overall.

### Details

- Fixed a bug in the `SelectionBasicExample` that was preventing using the checkboxes from actually selecting multiple items.
- Made sure `Selection` *always* has `canSelectItem` as a field so UX can use it reliably.
- Made the default `getKey` a free function so it can be reused.
- Updated `SelectionBasicExample` to create a new `Selection` instance each time the `SelectionMode` changes.

