### PR TITLE
DetailsList: Set button.check margin to 0

### DIFF
--- a/common/changes/office-ui-fabric-react/v-edwliu-detailsrow-check-margin_2017-08-23-20-11.json
+++ b/common/changes/office-ui-fabric-react/v-edwliu-detailsrow-check-margin_2017-08-23-20-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Set button.check margin to 0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
@@ -19,6 +19,7 @@
 
 button.check {
   padding: 3px;
+  margin: 0;
 }
 
 .owner {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Sets margin to 0 for DetailsList check button.  Safari applies margin by default browser styles. 

**BEFORE:**
<img width="1206" alt="screen shot 2017-08-23 at 1 12 26 pm" src="https://user-images.githubusercontent.com/1291968/29636272-db2cdfd4-8804-11e7-979c-617bc56f95be.png">

**AFTER**:
<img width="1199" alt="screen shot 2017-08-23 at 1 12 50 pm" src="https://user-images.githubusercontent.com/1291968/29636276-e078ab76-8804-11e7-8ec8-dfaab0bf2a11.png">


#### Focus areas to test

(optional)
