### PR TITLE
Adding the ability to disable withViewport measuring to improve performance

### DIFF
--- a/common/changes/office-ui-fabric-react/zhiliu-viewportPerf_2017-08-23-19-56.json
+++ b/common/changes/office-ui-fabric-react/zhiliu-viewportPerf_2017-08-23-19-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "perf optimization in withViewport, do not need to do expensive measurement when list is fixed column layout",
+      "comment": "withViewport: adding the ability to disable measures to improve performance of rendering the DetailsList in fixed mode.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/zhiliu-viewportPerf_2017-08-23-19-56.json
+++ b/common/changes/office-ui-fabric-react/zhiliu-viewportPerf_2017-08-23-19-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "perf optimization in withViewport, do not need to do expensive measurement when list is fixed column layout",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "zhiliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -16,7 +16,7 @@ import {
 } from '../GroupedList/index';
 import { IDetailsRowProps } from '../DetailsList/DetailsRow';
 import { IDetailsHeaderProps } from './DetailsHeader';
-import { IViewport } from '../../utilities/decorators/withViewport';
+import { IWithViewportProps, IViewport } from '../../utilities/decorators/withViewport';
 import { IListProps } from '../List/index';
 
 export { IDetailsHeaderProps };
@@ -30,7 +30,7 @@ export interface IDetailsList {
   forceUpdate: () => void;
 }
 
-export interface IDetailsListProps extends React.Props<DetailsList> {
+export interface IDetailsListProps extends React.Props<DetailsList>, IWithViewportProps {
   /**
    * Optional callback to access the IDetailsList interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -66,7 +66,7 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
     public render() {
       let { viewport } = this.state;
       const {
-        noUpdateViewport
+        skipViewportMeasures
       } = this.props as IWithViewportProps;
       let isViewportVisible = skipViewportMeasures || (viewport!.width > 0 && viewport!.height > 0);
 

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -14,6 +14,10 @@ export interface IWithViewportState {
   viewport?: IViewport;
 }
 
+export interface IWithViewportProps {
+  noUpdateViewport?: boolean;
+}
+
 const RESIZE_DELAY = 500;
 const MAX_RESIZE_ATTEMPTS = 3;
 
@@ -47,7 +51,12 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
         });
 
       this._events.on(window, 'resize', this._onAsyncResize);
-      this._updateViewport();
+      const {
+        noUpdateViewport
+      } = this.props as IWithViewportProps;
+      if (!noUpdateViewport) {
+        this._updateViewport();
+      }
     }
 
     public componentWillUnmount() {
@@ -56,7 +65,10 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
 
     public render() {
       let { viewport } = this.state;
-      let isViewportVisible = viewport!.width > 0 && viewport!.height > 0;
+      const {
+        noUpdateViewport
+      } = this.props as IWithViewportProps;
+      let isViewportVisible = noUpdateViewport || (viewport!.width > 0 && viewport!.height > 0);
 
       return (
         <div className='ms-Viewport' ref='root' style={ { minWidth: 1, minHeight: 1 } }>

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -15,7 +15,7 @@ export interface IWithViewportState {
 }
 
 export interface IWithViewportProps {
-  noUpdateViewport?: boolean;
+  skipViewportMeasures?: boolean;
 }
 
 const RESIZE_DELAY = 500;
@@ -52,9 +52,9 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
 
       this._events.on(window, 'resize', this._onAsyncResize);
       const {
-        noUpdateViewport
+        skipViewportMeasures
       } = this.props as IWithViewportProps;
-      if (!noUpdateViewport) {
+      if (!skipViewportMeasures) {
         this._updateViewport();
       }
     }
@@ -68,7 +68,7 @@ export function withViewport<P extends { viewport?: IViewport }, S>(ComposedComp
       const {
         noUpdateViewport
       } = this.props as IWithViewportProps;
-      let isViewportVisible = noUpdateViewport || (viewport!.width > 0 && viewport!.height > 0);
+      let isViewportVisible = skipViewportMeasures || (viewport!.width > 0 && viewport!.height > 0);
 
       return (
         <div className='ms-Viewport' ref='root' style={ { minWidth: 1, minHeight: 1 } }>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
When list is in fixed layout, we do not rely on viewport to measure the width of the list to figure out the column width. In that case, we do the expensive measurement for no use. 

The fix is simple, we do not do viewport measurements at its componentDidMount() when list is in fixed layout. It is ok to keep its init value zero and measure when resizing happening after page rendering to save time.

My benchmark shows 40 ms save on sharepoint page rendering on chrome after this change.

(give an overview)

#### Focus areas to test

(optional)
