### PR TITLE
Experiment: `DataList` - `DetailsList` rendering without measurements

### DIFF
--- a/packages/experiments/.vscode/settings.json
+++ b/packages/experiments/.vscode/settings.json
@@ -8,7 +8,7 @@
   // Controls if the editor should automatically close brackets after opening them
   "editor.autoClosingBrackets": false,
   // Controls whether the editor should render whitespace characters
-  "editor.renderWhitespace": "all",
+  "editor.renderWhitespace": "none",
   // Controls if the editor will insert spaces for tabs. Accepted values:  "auto", true, false. If set to "auto", the value will be guessed when a file is opened.
   "editor.insertSpaces": true,
   "files.exclude": {
@@ -33,5 +33,6 @@
   // Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": true,
   "editor.formatOnSave": true,
+  "editor.autoIndent": true,
   "typescript.tsdk": "../../common/node_modules/typescript/lib"
 }

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -2,9 +2,9 @@
 
 ##### Experimental components for Office UI Fabric React
 
-These are not production ready components and __should never be used in product__. This experimental space is useful for testing new components whos API might change before final release.
+These are not production ready components and __should never be used in product__. This experimental space is useful for testing new components whose API might change before final release.
 
-To import experimantal components:
+To import experimental components:
 
 ```js
 import { ComponentName } from '@uifabric/experiments/lib/ComponentName';

--- a/packages/experiments/src/components/DataList/DataList.scss
+++ b/packages/experiments/src/components/DataList/DataList.scss
@@ -1,0 +1,3 @@
+.root {
+  // overflow: auto;
+}

--- a/packages/experiments/src/components/DataList/DataList.tsx
+++ b/packages/experiments/src/components/DataList/DataList.tsx
@@ -1,0 +1,149 @@
+import * as React from "react";
+import { BaseComponent, IBaseProps, css, IRenderFunction } from "office-ui-fabric-react/lib/Utilities";
+
+///
+
+export interface IList<TItem> {
+
+}
+
+export interface IListProps<TItem> {
+  className?: string;
+
+  items: TItem[];
+
+  onRenderItem: IRenderFunction<TItem>;
+}
+
+export interface IStaticListProps<TItem> extends IListProps<TItem> {
+
+}
+
+export class StaticList<TItem = any> extends React.PureComponent<IStaticListProps<TItem>> implements IList<TItem> {
+  render(): JSX.Element {
+    const { className, items, onRenderItem = this.onRenderItem } = this.props;
+
+    return <ul className={ css(className) }>
+      { items.map(item => onRenderItem(item, this.onRenderItem)) }
+    </ul>;
+  }
+
+  private onRenderItem(item: TItem): JSX.Element {
+    return <li>
+      { item }
+    </li>;
+  }
+}
+
+//
+
+export interface IVirtualizedListProps<TItem> extends IListProps<TItem>, IBaseProps {
+  initialViewportHeight?: number;
+
+  itemHeight: number;
+}
+
+export interface IVirtualizedListState<TItem> {
+  viewportHeight: number;
+
+  scrollTop: number;
+}
+
+export class VirtualizedList<TItem> extends BaseComponent<IVirtualizedListProps<TItem>, IVirtualizedListState<TItem>> implements IList<TItem> {
+  private root: HTMLElement;
+
+  constructor(props: IVirtualizedListProps<TItem>, context: any) {
+    super(props, context);
+
+    const { initialViewportHeight = window.innerHeight } = this.props;
+
+    this.state = {
+      viewportHeight: initialViewportHeight, // Start with the window height
+
+      scrollTop: 0
+    };
+
+    this.onScroll = this._async.debounce(this.onScroll, 100);
+  }
+
+  componentDidMount() {
+    // Start measurement timer, after delay measure actual surface
+    this._events.on(this.root, "scroll", this.onScroll);
+  }
+
+  componentWillUnmount() {
+    this._events.off(this.root, "scroll");
+  }
+
+  render() {
+    const { className } = this.props;
+
+    // TODO: Make element overflow auto, works better with how people use the list
+    return <div className={ css(className, "ms-VirtualizedList") } ref={ this._resolveRef("root") }>
+
+    </div>;
+  }
+
+  private renderItems(): (JSX.Element | null)[] {
+    const { itemHeight, items, onRenderItem = this.onRenderItem } = this.props;
+    const { scrollTop, viewportHeight } = this.state;
+
+    const numberOfElementsOverdraw = 2;
+
+    let result: (JSX.Element | null)[] = [];
+
+    const startIndex = scrollTop / itemHeight - numberOfElementsOverdraw;
+    const endIndex = startIndex + (numberOfElementsOverdraw * 2) + (viewportHeight / itemHeight);
+    for (let i = startIndex; i < endIndex; ++i) {
+      result.push(onRenderItem(items[i], this.onRenderItem));
+    }
+
+    // Generate spacer page
+    const spacerHeight = startIndex * itemHeight;
+    result.unshift(<li style={ { height: spacerHeight } } />)
+
+    return result;
+  }
+
+  private onScroll() {
+    this.setState({
+      scrollTop: this.root.scrollTop
+    });
+  }
+
+  private onRenderItem(item: TItem): JSX.Element {
+    return <li>
+      { item }
+    </li>;
+  }
+}
+
+/////
+
+export interface IColumn {
+  key: string;
+
+  text: string;
+}
+
+export interface IDataListProps<TItem> {
+  items: TItem[];
+
+  columns: IColumn[];
+
+  isVirtualized?: boolean;
+}
+
+export class DataList<TItem = any> extends React.PureComponent<IDataListProps<TItem> {
+  render() {
+    const { items, isVirtualized } = this.props;
+
+    // TODO: Header/Columns
+
+    if (isVirtualized) {
+      return <VirtualizedList items={ items } />;
+    } else {
+      return <StaticList items={ items } />;
+    }
+  }
+}

--- a/packages/experiments/src/components/DataList/DataListHeader.scss
+++ b/packages/experiments/src/components/DataList/DataListHeader.scss
@@ -1,0 +1,3 @@
+.header {
+  background: lightgray;
+}

--- a/packages/experiments/src/components/DataList/DataListHeader.tsx
+++ b/packages/experiments/src/components/DataList/DataListHeader.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { IItem } from './List';
+import { IColumn, ISizing } from './DataList';
+import { DataListRow } from './DataListRow';
+import * as stylesImport from './DataListHeader.scss';
+const styles: any = stylesImport;
+
+export interface IDataListHeaderProps {
+  columns: IColumn[];
+
+  itemHeight: number;
+
+  onColumnResize?: (column: IColumn, newWidth: number) => void;
+}
+
+export class DataListHeader extends React.PureComponent<IDataListHeaderProps> {
+  private headerItem: { [columnName: string]: string };
+
+  constructor(props: IDataListHeaderProps, context: any) {
+    super(props, context);
+
+    const { columns } = this.props;
+
+    this.headerItem = {};
+    for (const column of columns) {
+      this.headerItem[column.fieldName || column.key] = column.name;
+    }
+  }
+
+  public render() {
+    const { columns, itemHeight } = this.props;
+
+    return <DataListRow className={ styles.header } columns={ columns } index={ -1 } item={ this.headerItem } itemHeight={ itemHeight } />;
+  }
+}

--- a/packages/experiments/src/components/DataList/DataListPage.tsx
+++ b/packages/experiments/src/components/DataList/DataListPage.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import {
+  ExampleCard,
+  IComponentDemoPageProps,
+  ComponentPage,
+  PropertiesTableSet
+} from '@uifabric/example-app-base';
+import { DataListBasicExample } from './examples/DataList.Basic.Example';
+
+let DataListBasicExampleCode = require('!raw-loader!experiments/src/components/DataList/examples/DataList.Basic.Example.tsx') as string;
+
+export class DataListPage extends React.Component<IComponentDemoPageProps, {}> {
+  public render() {
+    return (
+      <ComponentPage
+        title='DataList'
+        componentName='DataListExample'
+        exampleCards={
+          <ExampleCard title='DataList' code={ DataListBasicExampleCode }>
+            <DataListBasicExample />
+          </ExampleCard>
+        }
+        propertiesTables={
+          <PropertiesTableSet
+            sources={ [] }
+          />
+        }
+        overview={
+          <div>
+            Stuff
+          </div>
+        }
+        bestPractices={
+          <div></div>
+        }
+        dos={
+          <div>
+            Stuff dos
+          </div>
+        }
+        donts={
+          <div>
+          </div>
+        }
+        related={
+          <a href='https://dev.office.com/fabric-js/Components/Link/Link.html'>Fabric JS</a>
+        }
+        isHeaderVisible={ this.props.isHeaderVisible }>
+      </ComponentPage>
+    );
+  }
+
+}

--- a/packages/experiments/src/components/DataList/DataListRow.scss
+++ b/packages/experiments/src/components/DataList/DataListRow.scss
@@ -1,0 +1,35 @@
+.row {
+  display: flex;
+  box-sizing: border-box;
+  min-width: 100%;
+
+  height: 30px;
+  border: 1px solid black;
+}
+
+.rowDropColumns {
+  flex-wrap: wrap;
+  overflow: hidden;
+}
+
+.rowSelected {
+  border: 1px solid blue;
+}
+
+.cell {
+  position: relative;
+  flex-grow: 1;
+  flex-basis: 100px;
+  box-sizing: border-box;
+}
+
+.text {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/packages/experiments/src/components/DataList/DataListRow.tsx
+++ b/packages/experiments/src/components/DataList/DataListRow.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { css, autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { IItem } from './List';
+import { IColumn, ISizing } from './DataList';
+
+import * as stylesImport from './DataListRow.scss';
+import { ISelection } from 'office-ui-fabric-react/lib/utilities/selection';
+const styles: any = stylesImport;
+
+export interface IDataListRowProps<TItem extends IItem = any> {
+  className?: string;
+
+  columns: IColumn[];
+
+  index: number;
+
+  item: TItem;
+
+  itemHeight: number;
+
+  dropColumns?: boolean;
+
+  selection?: ISelection;
+}
+
+export class DataListRow<TItem extends IItem = any> extends React.PureComponent<IDataListRowProps<TItem>> {
+  public render() {
+    const { className, dropColumns, item, selection, index } = this.props;
+
+    const isSelected = selection && selection.isKeySelected(item.key);
+
+    return <div
+      className={ css(
+        'ms-DataListRow',
+        styles.row,
+        dropColumns && styles.rowDropColumns,
+        isSelected && styles.rowSelected,
+        isSelected && 'ms-DataListRow--Selected',
+        className
+      ) }
+      data-selection-index={ index }>
+      { this.renderColumns() }
+    </div>;
+  }
+
+  private renderColumns(): JSX.Element[] {
+    const { className, columns, item, itemHeight, dropColumns } = this.props;
+
+    return columns.map(column => {
+      const {
+        key,
+        fieldName,
+        name,
+        sizing,
+        minWidth,
+        isCollapsable
+      } = column;
+
+      return <div
+        key={ key }
+        className={ css(
+          'ms-DataList--Cell',
+          styles.cell
+        ) }
+        style={ {
+          minWidth,
+          flexShrink: isCollapsable ? 1 : undefined,
+          height: itemHeight
+        } }>
+        <div className={ styles.text }>
+          { this.getValueFromColumn(item, fieldName || key) }
+        </div>
+      </div>;
+    });
+  }
+
+  private getValueFromColumn(item: TItem, key: string): string {
+    return (item as any)[key];
+  }
+
+  @autobind
+  private onClick() {
+    this.props.selection!.toggleKeySelected(this.props.item.key);
+  }
+}

--- a/packages/experiments/src/components/DataList/List.tsx
+++ b/packages/experiments/src/components/DataList/List.tsx
@@ -1,0 +1,16 @@
+import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+
+export interface IItem {
+  key: string;
+}
+
+export interface IList<TItem extends IItem> {
+}
+
+export interface IListProps<TItem extends IItem> {
+  className?: string;
+
+  items: TItem[];
+
+  onRenderItem: (index: number, item: TItem) => JSX.Element | null;
+}

--- a/packages/experiments/src/components/DataList/StaticList.tsx
+++ b/packages/experiments/src/components/DataList/StaticList.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { IItem, IListProps, IList } from './List';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+
+export interface IStaticListProps<TItem extends IItem> extends IListProps<TItem> {
+  listTagName?: string;
+}
+
+export class StaticList<TItem extends IItem = any> extends React.PureComponent<IStaticListProps<TItem>> implements IList<TItem> {
+  public render(): JSX.Element {
+    const {
+      className,
+      items,
+      onRenderItem,
+      listTagName: ListTag = 'ul'
+     } = this.props;
+
+    return <ListTag className={ css(className) }>
+      { items.map((item, index) => onRenderItem(index, item)) }
+    </ListTag>;
+  }
+}

--- a/packages/experiments/src/components/DataList/VirtualizedList.scss
+++ b/packages/experiments/src/components/DataList/VirtualizedList.scss
@@ -1,0 +1,10 @@
+.root {
+}
+
+.rootOverflow {
+  overflow: auto;
+}
+
+.item {
+  height: 30px;
+}

--- a/packages/experiments/src/components/DataList/VirtualizedList.tsx
+++ b/packages/experiments/src/components/DataList/VirtualizedList.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { IBaseProps, BaseComponent, css, findScrollableParent } from 'office-ui-fabric-react/lib/Utilities';
+import { IItem, IListProps, IList } from './List';
+
+import * as stylesImport from './VirtualizedList.scss';
+const styles: any = stylesImport;
+
+export interface IVirtualizedListProps<TItem extends IItem> extends IListProps<TItem>, IBaseProps {
+  initialViewportHeight?: number;
+
+  /** Height of individual item in pixels */
+  itemHeight: number;
+
+  /** Number of items to draw before/after viewport height */
+  itemOverdraw?: number;
+}
+
+export interface IVirtualizedListState<TItem extends IItem> {
+  viewportHeight: number;
+
+  scrollTop: number;
+}
+
+export class VirtualizedList<TItem extends IItem = any> extends BaseComponent<IVirtualizedListProps<TItem>, IVirtualizedListState<TItem>> {
+  private root: HTMLElement;
+  private scrollContainer: HTMLElement;
+
+  constructor(props: IVirtualizedListProps<TItem>, context: any) {
+    super(props, context);
+
+    const {
+      initialViewportHeight = window.innerHeight  // Start with the window height if not passed in props
+    } = this.props;
+
+    this.state = {
+      viewportHeight: initialViewportHeight,
+
+      scrollTop: 0
+    };
+
+    this.onScroll = this._async.debounce(this.onScroll, 100);
+  }
+
+  public componentDidMount() {
+    this.scrollContainer = findScrollableParent(this.root)!;
+
+    // Start measurement timer, after delay measure actual surface
+    this._events.on(this.scrollContainer, 'scroll', this.onScroll);
+  }
+
+  public componentWillUnmount() {
+    this._events.off(this.scrollContainer, 'scroll');
+
+    // test
+  }
+
+  public render() {
+    const { className } = this.props;
+
+    // TODO: Make element overflow auto, works better with how people use the list
+    return <div
+      className={ css(styles.root/*, hasExternalScrollContainer && styles.rootOverflow*/, className) }
+      ref={ this._resolveRef('root') }>
+      { this.renderItems() }
+    </div>;
+  }
+
+  private renderItems(): (JSX.Element | null)[] {
+    const {
+      itemHeight,
+      items,
+      onRenderItem,
+      itemOverdraw = 2
+    } = this.props;
+    const { scrollTop, viewportHeight } = this.state;
+
+    const result: (JSX.Element | null)[] = [];
+
+    // Calculate items to render
+    const startIndex = Math.floor(
+      Math.max(
+        scrollTop / itemHeight - itemOverdraw,
+        0)
+    );
+    const endIndex = Math.floor(
+      Math.min(
+        startIndex + (itemOverdraw * 2) + (viewportHeight / itemHeight),
+        items.length)
+    );
+    for (let i = startIndex; i < endIndex; ++i) {
+      result.push(onRenderItem(i, items[i]));
+    }
+
+    // Generate spacer items
+    const startSpacerHeight = startIndex * itemHeight;
+    result.unshift(<li key='spacer-item-start' style={ { height: startSpacerHeight } } />);
+
+    const endSpacerHeight = (items.length - endIndex) * itemHeight;
+    if (endSpacerHeight > 0) {
+      result.push(<li key='spacer-item-end' style={ { height: endSpacerHeight } } />);
+    }
+
+    return result;
+  }
+
+  private onScroll() {
+    // TODO: CS: Can we use intersectionobserver here?
+    requestAnimationFrame(() => {
+      let scrollTop = 0;
+      if (this.scrollContainer as any === window) {
+        scrollTop = (this.scrollContainer as any).scrollY;
+      } else {
+        scrollTop = this.scrollContainer.scrollTop;
+      }
+
+      this.setState({
+        scrollTop
+      });
+    });
+  }
+}

--- a/packages/experiments/src/components/DataList/examples/DataList.Basic.Example.tsx
+++ b/packages/experiments/src/components/DataList/examples/DataList.Basic.Example.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { } from 'react-addons-perf';
+import { DataList, IColumn } from '../DataList';
+import { IItem } from '../List';
+
+interface IListItem extends IItem {
+  name: string;
+  position: string;
+  office: string;
+  index: number;
+}
+
+// const items: IListItem[] = [];
+// for (let i = 0; i < 300; ++i) {
+//   items.push({
+//     key: `item-${i}`,
+
+//     column1: `Item ${i} c1`,
+//     column2: `Item ${i} c2`,
+//   });
+// }
+
+const positions = ['Accountant', 'Developer', 'Administrative Assistant', 'Vice President', 'Technical Fellow', 'Development Manager', 'Designer', 'Program Manager'];
+
+const offices = ['Seattle', 'New York', 'Tokyo', 'California'];
+
+function randWord(words: string[]) {
+  return words[Math.floor(Math.random() * words.length)];
+}
+
+const items: IListItem[] = [];
+
+for (let i = 0; i < 100; i++) {
+  items.push({
+    key: 'item' + i,
+    name: 'Item ' + i,
+    position: randWord(positions),
+    office: randWord(offices),
+    index: i
+  });
+}
+
+export class DataListBasicExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <div>
+        {
+          React.createElement(
+            DataList as any,
+            {
+              isVirtualized: true,
+              items,
+              itemHeight: 30,
+              columns: [
+                {
+                  key: 'name',
+                  name: 'Name',
+                  fieldName: 'name',
+                  minWidth: 200,
+                  maxWidth: 300,
+                  isResizable: true
+                },
+                {
+                  key: 'position',
+                  name: 'Position',
+                  fieldName: 'position',
+                  minWidth: 150,
+                  maxWidth: 300,
+                  isResizable: true
+                },
+                {
+                  key: 'office',
+                  name: 'Office',
+                  fieldName: 'office',
+                  minWidth: 100,
+                  maxWidth: 300,
+                  isCollapsable: true,
+                  isResizable: true
+                },
+              ] as IColumn[]
+            })
+        }
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -15,6 +15,13 @@ export const AppDefinition: IAppDefinition = {
           name: 'Link',
           url: '#/examples/link'
         },
+
+        {
+          component: require<any>('../components/DataList/DataListPage').DataListPage,
+          key: 'DataList',
+          name: 'DataList',
+          url: '#/examples/dataList'
+        },
       ]
     }
   ],

--- a/packages/experiments/src/demo/index.tsx
+++ b/packages/experiments/src/demo/index.tsx
@@ -10,6 +10,7 @@ import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 
 import './index.scss';
 import './ColorStyles.scss';
+import { DataListBasicExample } from '../components/DataList/examples/DataList.Basic.Example';
 
 setBaseUrl('./dist/');
 
@@ -36,9 +37,10 @@ function _onLoad() {
 
   ReactDOM.render(
     <Fabric>
-      <Router onNewRouteLoaded={ _scrollAnchorLink }>
+      {/*<Router onNewRouteLoaded={ _scrollAnchorLink }>
         { _getRoutes() }
-      </Router>
+      </Router>*/}
+      <DataListBasicExample />
     </Fabric>,
     rootElement);
 }

--- a/packages/experiments/src/index.ts
+++ b/packages/experiments/src/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './Link';
+export * from './components/DataList/DataList';


### PR DESCRIPTION
# No intention to merge in this form, want to start a discussion, will add some more details later

# Motivation

We've observed that the `DetailsList` causes a lot of layout thrashing and reflow even for the initial rendering. It happens because we measure the viewport, we measure every page after we have rendered it, and we render & measure the initial pages twice.

## Approach

1. No measurement for the initial render, use smart defaults or have the user pass in exact measurements
   - Either the user has to pass in the initial viewport height, **or** we default to `window.innerHeight`, which doesn't cause layout
   - For pages and items, we have the user pass in the height of a row. This makes it impossible/harder to support multi-line rows, but allows rendering without measuring anything
2. No measurements for columns, rely on flexbox to drop columns without enough horizontal space
3. No `pages` for virtualized list, reducing unwanted animations for example in grouped lists or tree controls built on `DetailsList`

# Benchmarking

For `DetailsList` I've used this pen:
https://codepen.io/cschleiden/pen/ayEXmE?editors=1000

For `DataList` I'ved a setup like this: 
https://codepen.io/cschleiden/pen/WEdLJB?editors=1000
(served the experiments bundle from localhost)

In both examples I render 100 items with 3 columns with the same display size. Reloaded each page four times and took the median:

| | `DataList` | `DetailsList` |
| ---| ---: |---: |
| Chrome - Median | **25.5ms** | 101ms |
| IE - Median | tbd | tbd |
| Edge - Median | tbd | tbd |


![image](https://user-images.githubusercontent.com/2201819/29640363-812aec4c-8813-11e7-95fa-ae5f136cb2c3.png)

![image](https://user-images.githubusercontent.com/2201819/29640371-891942f0-8813-11e7-9728-3a1ad432ffe5.png)

# Going forward

There are a number of options: 

## Finish up the `DataListXXX` and `VirtualizedList` components

### Pro
- Opt-in experience for consumers, don't need to be compatible with `DetailsList`
- Can keep the `DataList` without styling, making it easier for consumers to bring their own style (requirement for VSTS)

### Cons
- Duplicate work, we probably want to support single/multi selection, a11y etc. that `DetailsList` already provides

## Extend `DetailsList` with additional props 

Bring items 1, 2 and potentially 3 from Approach into `DetailsList`.

### Pro

- Potentially easier for consumers to opt-in, maybe just a prop?
- Everyone would be able to take advantage of improvements

### Cons
- `DetailsList` is already very heavy, adding even more props would bloat the interface
- Danger of breaking `DetailsList` consumers
- `List` is already complex, hard to make changes

## Build our `VirtualizedList`, allow replacing `List` in `DetailsList` with it

### Pro
- Would give us some of the perf benefits, without rebuilding `DetailsList` completely 

### Cons
- Wouldn't give us benefits of not measuring columns (could maybe be added with another layout mode?)
