### PR TITLE
Make BaseComponent consistent with React.Component typing

### DIFF
--- a/common/changes/@uifabric/utilities/users-cschleid-makeStateOptional_2017-08-24-16-23.json
+++ b/common/changes/@uifabric/utilities/users-cschleid-makeStateOptional_2017-08-24-16-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "BaseComponent: Make State type optional to be consistent with React.Component typing",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "cschleid@microsoft.com"
+}

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -18,7 +18,7 @@ export interface IBaseProps {
  *
  * @public
  */
-export class BaseComponent<P extends IBaseProps, S> extends React.Component<P, S> {
+export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component<P, S> {
   /**
    * External consumers should override BaseComponent.onError to hook into error messages that occur from
    * exceptions thrown from within components.


### PR DESCRIPTION
Make it easier to build stateless components inheriting from `BaseComponent`