### PR TITLE
Breadcrumb: fixed menu icon showing up

### DIFF
--- a/common/changes/office-ui-fabric-react/breadcrumb-overflow-fix_2017-08-24-19-34.json
+++ b/common/changes/office-ui-fabric-react/breadcrumb-overflow-fix_2017-08-24-19-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Breadcrumb: Fixed extra dropdown icon",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -97,7 +97,7 @@ export class Breadcrumb extends BaseComponent<IBreadcrumbProps, any> {
                   iconProps={ { iconName: 'More' } }
                   role='button'
                   aria-haspopup='true'
-                  menuIconProps={ undefined }
+                  onRenderMenuIcon={ () => null }
                   menuProps={ {
                     items: contextualItems,
                     directionalHint: DirectionalHint.bottomLeftEdge


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2533
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Changed onRenderMenuIcon to suppress the menu icon


