### PR TITLE
Update version from num to range

### DIFF
--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -3,7 +3,8 @@ import { css } from 'office-ui-fabric-react/lib/Utilities';
 import * as stylesImport from './HomePage.module.scss';
 const styles: any = stylesImport;
 
-const packageData = require('../../../package.json');
+const corePackageData = require('../../../node_modules/office-ui-fabric-core/package.json');
+const reactPackageData = require('../../../node_modules/office-ui-fabric-react/package.json');
 
 export class HomePage extends React.Component<any, any> {
   public render() {
@@ -13,7 +14,7 @@ export class HomePage extends React.Component<any, any> {
           <h1 className={ styles.title }>Office UI Fabric</h1>
           <span className={ styles.tagline }>The official front-end framework for building experiences that fit seamlessly into Office and Office 365.</span>
           <a href='#/get-started' className={ css(styles.button, styles.primaryButton) }>Get started</a>
-          <span className={ styles.version }>Fabric Core { packageData.dependencies['office-ui-fabric-core'] } and Fabric React { packageData.dependencies['office-ui-fabric-react'] }</span>
+          <span className={ styles.version }>Fabric Core { corePackageData.version } and Fabric React { reactPackageData.version }</span>
         </div>
 
         <div className={ styles.flavors }>

--- a/common/changes/@uifabric/fabric-website/update-version-from-num-to-range_2017-08-24-22-58.json
+++ b/common/changes/@uifabric/fabric-website/update-version-from-num-to-range_2017-08-24-22-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Changed where Fabric Core and Fabric React versions were drawing from so that they would appear as a number instead of a range.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
… so that it would appear as a number instead of a range

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1647
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In order to get Fabric Core and Fabric React versions to appear as a number instead as a range, changed where the data was pulling from.

#### Focus areas to test

(optional)
