### PR TITLE
Revised left nav to coordinate with new design for UHF adoption

### DIFF
--- a/apps/fabric-website/src/components/App/AppState.tsx
+++ b/apps/fabric-website/src/components/App/AppState.tsx
@@ -27,21 +27,21 @@ export const AppState: IAppState = {
       url: '#/',
       className: 'fabricPage',
       isHomePage: true,
-      isHeaderLink: true,
+      isTopNavHeader: true,
       component: require<any>('../../pages/HomePage/HomePage').HomePage,
     },
     {
       title: 'Get started',
       url: '#/get-started',
       className: 'getStartedPage',
-      isHeaderLink: true,
+      isTopNavHeader: true,
       component: require<any>('../../pages/GetStarted/GetStartedPage').GetStartedPage,
     },
     {
       title: 'Styles',
       url: '#/styles',
       className: 'stylesPage',
-      isHeaderLink: true,
+      isTopNavHeader: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/Overviews/StylesPage').StylesPage)),
       pages: [
         {
@@ -91,7 +91,7 @@ export const AppState: IAppState = {
       title: 'Components',
       url: '#/components',
       className: 'componentsPage',
-      isHeaderLink: true,
+      isTopNavHeader: true,
       component: require<any>('../../pages/Overviews/ComponentsPage').ComponentsPage,
       pages: [
         {
@@ -387,14 +387,14 @@ export const AppState: IAppState = {
       title: 'Resources',
       url: '#/resources',
       className: 'resourcesPage',
-      isHeaderLink: true,
+      isTopNavHeader: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/ResourcesPage/ResourcesPage').ResourcesPage))
     },
     {
       title: 'Blog',
       url: '#/blog',
       className: 'blogPage',
-      isHeaderLink: true,
+      isTopNavHeader: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/BlogPage/BlogPage').BlogPage))
     },
     {

--- a/apps/fabric-website/src/components/App/AppState.tsx
+++ b/apps/fabric-website/src/components/App/AppState.tsx
@@ -27,21 +27,21 @@ export const AppState: IAppState = {
       url: '#/',
       className: 'fabricPage',
       isHomePage: true,
-      isTopNavHeader: true,
+      isTopNavLink: true,
       component: require<any>('../../pages/HomePage/HomePage').HomePage,
     },
     {
       title: 'Get started',
       url: '#/get-started',
       className: 'getStartedPage',
-      isTopNavHeader: true,
+      isTopNavLink: true,
       component: require<any>('../../pages/GetStarted/GetStartedPage').GetStartedPage,
     },
     {
       title: 'Styles',
       url: '#/styles',
       className: 'stylesPage',
-      isTopNavHeader: true,
+      isTopNavLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/Overviews/StylesPage').StylesPage)),
       pages: [
         {
@@ -91,7 +91,7 @@ export const AppState: IAppState = {
       title: 'Components',
       url: '#/components',
       className: 'componentsPage',
-      isTopNavHeader: true,
+      isTopNavLink: true,
       component: require<any>('../../pages/Overviews/ComponentsPage').ComponentsPage,
       pages: [
         {
@@ -387,14 +387,14 @@ export const AppState: IAppState = {
       title: 'Resources',
       url: '#/resources',
       className: 'resourcesPage',
-      isTopNavHeader: true,
+      isTopNavLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/ResourcesPage/ResourcesPage').ResourcesPage))
     },
     {
       title: 'Blog',
       url: '#/blog',
       className: 'blogPage',
-      isTopNavHeader: true,
+      isTopNavLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/BlogPage/BlogPage').BlogPage))
     },
     {

--- a/apps/fabric-website/src/components/App/AppState.tsx
+++ b/apps/fabric-website/src/components/App/AppState.tsx
@@ -27,21 +27,21 @@ export const AppState: IAppState = {
       url: '#/',
       className: 'fabricPage',
       isHomePage: true,
-      isTopNavLink: true,
+      isUhfLink: true,
       component: require<any>('../../pages/HomePage/HomePage').HomePage,
     },
     {
       title: 'Get started',
       url: '#/get-started',
       className: 'getStartedPage',
-      isTopNavLink: true,
+      isUhfLink: true,
       component: require<any>('../../pages/GetStarted/GetStartedPage').GetStartedPage,
     },
     {
       title: 'Styles',
       url: '#/styles',
       className: 'stylesPage',
-      isTopNavLink: true,
+      isUhfLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/Overviews/StylesPage').StylesPage)),
       pages: [
         {
@@ -91,7 +91,7 @@ export const AppState: IAppState = {
       title: 'Components',
       url: '#/components',
       className: 'componentsPage',
-      isTopNavLink: true,
+      isUhfLink: true,
       component: require<any>('../../pages/Overviews/ComponentsPage').ComponentsPage,
       pages: [
         {
@@ -387,14 +387,14 @@ export const AppState: IAppState = {
       title: 'Resources',
       url: '#/resources',
       className: 'resourcesPage',
-      isTopNavLink: true,
+      isUhfLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/ResourcesPage/ResourcesPage').ResourcesPage))
     },
     {
       title: 'Blog',
       url: '#/blog',
       className: 'blogPage',
-      isTopNavLink: true,
+      isUhfLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/BlogPage/BlogPage').BlogPage))
     },
     {

--- a/apps/fabric-website/src/components/App/AppState.tsx
+++ b/apps/fabric-website/src/components/App/AppState.tsx
@@ -26,19 +26,22 @@ export const AppState: IAppState = {
       title: 'Fabric',
       url: '#/',
       className: 'fabricPage',
+      isHomePage: true,
+      isHeaderLink: true,
       component: require<any>('../../pages/HomePage/HomePage').HomePage,
-      isHomePage: true
     },
     {
       title: 'Get started',
       url: '#/get-started',
       className: 'getStartedPage',
+      isHeaderLink: true,
       component: require<any>('../../pages/GetStarted/GetStartedPage').GetStartedPage,
     },
     {
       title: 'Styles',
       url: '#/styles',
       className: 'stylesPage',
+      isHeaderLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/Overviews/StylesPage').StylesPage)),
       pages: [
         {
@@ -88,6 +91,7 @@ export const AppState: IAppState = {
       title: 'Components',
       url: '#/components',
       className: 'componentsPage',
+      isHeaderLink: true,
       component: require<any>('../../pages/Overviews/ComponentsPage').ComponentsPage,
       pages: [
         {
@@ -383,12 +387,14 @@ export const AppState: IAppState = {
       title: 'Resources',
       url: '#/resources',
       className: 'resourcesPage',
+      isHeaderLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/ResourcesPage/ResourcesPage').ResourcesPage))
     },
     {
       title: 'Blog',
       url: '#/blog',
       className: 'blogPage',
+      isHeaderLink: true,
       getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/BlogPage/BlogPage').BlogPage))
     },
     {

--- a/apps/fabric-website/src/components/Nav/Nav.Props.ts
+++ b/apps/fabric-website/src/components/Nav/Nav.Props.ts
@@ -58,5 +58,5 @@ export interface INavPage {
    * Whether this link appears in the UHF header nav.
    * @default false
    */
-  isTopNavLink?: boolean;
+  isUhfLink?: boolean;
 }

--- a/apps/fabric-website/src/components/Nav/Nav.Props.ts
+++ b/apps/fabric-website/src/components/Nav/Nav.Props.ts
@@ -55,8 +55,8 @@ export interface INavPage {
   isHomePage?: boolean;
 
   /**
-   * Whether this appears in the UHF header nav.
+   * Whether this link appears in the UHF header nav.
    * @default false
    */
-  isTopNavHeader?: boolean;
+  isTopNavLink?: boolean;
 }

--- a/apps/fabric-website/src/components/Nav/Nav.Props.ts
+++ b/apps/fabric-website/src/components/Nav/Nav.Props.ts
@@ -58,5 +58,5 @@ export interface INavPage {
    * Whether this appears in the UHF header nav.
    * @default false
    */
-  isHeaderLink?: boolean;
+  isTopNavHeader?: boolean;
 }

--- a/apps/fabric-website/src/components/Nav/Nav.Props.ts
+++ b/apps/fabric-website/src/components/Nav/Nav.Props.ts
@@ -53,4 +53,10 @@ export interface INavPage {
    * @default false
    */
   isHomePage?: boolean;
+
+  /**
+   * Whether this appears in the UHF header nav.
+   * @default false
+   */
+  isHeaderLink?: boolean;
 }

--- a/apps/fabric-website/src/components/Nav/Nav.module.scss
+++ b/apps/fabric-website/src/components/Nav/Nav.module.scss
@@ -6,7 +6,6 @@ $nav-group-header-height: 40px;
   padding-top: 20px;
   @include ms-padding-right(12px);
   padding-bottom: 60px;
-  @include ms-padding-left(36px);
 }
 
 .link {
@@ -29,40 +28,6 @@ $nav-group-header-height: 40px;
   &.hasActiveChild {
     color: $ms-color-white;
     position: relative;
-
-    &::before {
-      content: '';
-      width: 2px;
-      height: 20px;
-      background: $ms-color-neutralTertiary;
-      position: absolute;
-      top: 3px;
-      @include ms-left(-16px);
-    }
-
-    &.fabricPage::before {
-      background-color: $color-home-medium;
-    }
-
-    &.getStartedPage::before {
-      background-color: $color-getStarted-medium;
-    }
-
-    &.stylesPage::before {
-      background-color: $color-styles-medium;
-    }
-
-    &.componentsPage::before {
-      background-color: $color-components-darker;
-    }
-
-    &.resourcesPage::before {
-      background-color: $color-resources-medium;
-    }
-
-    &.resourcesPage::before {
-      background-color: $color-blog-medium;
-    }
   }
 
 

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -49,7 +49,7 @@ export class Nav extends React.Component<INavProps, INavState> {
         page.className ? styles[page.className] : ''
       ) } key={ linkIndex }>
 
-        { page.isHeaderLink ?
+        { page.isTopNavHeader ?
           '' : <a
             href={ page.url }
             onClick={ this.props.onLinkClick }

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -49,7 +49,7 @@ export class Nav extends React.Component<INavProps, INavState> {
         page.className ? styles[page.className] : ''
       ) } key={ linkIndex }>
 
-        { page.isTopNavLink ?
+        { page.isUhfLink ?
           '' : <a
             href={ page.url }
             onClick={ this.props.onLinkClick }

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -49,7 +49,7 @@ export class Nav extends React.Component<INavProps, INavState> {
         page.className ? styles[page.className] : ''
       ) } key={ linkIndex }>
 
-        { page.isTopNavHeader ?
+        { page.isTopNavLink ?
           '' : <a
             href={ page.url }
             onClick={ this.props.onLinkClick }

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -48,14 +48,17 @@ export class Nav extends React.Component<INavProps, INavState> {
         page.isHomePage ? styles.isHomePage : '',
         page.className ? styles[page.className] : ''
       ) } key={ linkIndex }>
-        <a
-          href={ page.url }
-          onClick={ this.props.onLinkClick }
-          title={ title }
-          aria-label={ ariaLabel }
-        >
-          { page.title }
-        </a>
+
+        { page.isHeaderLink ?
+          '' : <a
+            href={ page.url }
+            onClick={ this.props.onLinkClick }
+            title={ title }
+            aria-label={ ariaLabel }
+          >
+            { page.title }
+          </a> }
+
         { childLinks }
       </li>
     );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

I added a flag in Nav props / AppState to define which links will be in the new UHF header. The idea is that the we can flag those header links to not render in the left side navigation. 

#### Focus areas to test

(optional)
