### PR TITLE
Added label to Persona example Component in website

### DIFF
--- a/common/changes/office-ui-fabric-react/add-persona-label_2017-08-25-18-24.json
+++ b/common/changes/office-ui-fabric-react/add-persona-label_2017-08-25-18-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added label to Persona example components.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
@@ -37,47 +37,62 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
             onChange={ (ev, checked) => { this.setState({ renderPersonaDetails: checked }); } } />
         </div>
 
+        <Label>Tiny Persona (12px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.tiny }
           presence={ PersonaPresence.offline }
           hidePersonaDetails={ !renderPersonaDetails }
         />
+
+        <Label>Extra Extra Small Persona (24px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.extraExtraSmall }
           presence={ PersonaPresence.none }
           hidePersonaDetails={ !renderPersonaDetails }
         />
+
+        <Label>Size 28 Persona (28px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.size28 }
           presence={ PersonaPresence.none }
           hidePersonaDetails={ !renderPersonaDetails }
         />
+
+        <Label>Extra Small Persona (32px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.extraSmall }
           presence={ PersonaPresence.online }
           hidePersonaDetails={ !renderPersonaDetails }
         />
+
+        <Label>Small Persona (40px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.small }
           presence={ PersonaPresence.away }
           hidePersonaDetails={ !renderPersonaDetails }
         />
+
+        <Label>Medium Persona (48px)</Label>
         <Persona
           { ...examplePersona }
           hidePersonaDetails={ !renderPersonaDetails }
           presence={ PersonaPresence.busy }
         />
+
+        <Label>Large Persona (72px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.large }
           presence={ PersonaPresence.dnd }
           hidePersonaDetails={ !renderPersonaDetails }
         />
+
+        <Label>Extra Large Persona (100px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.extraLarge }

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
@@ -37,7 +37,7 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
             onChange={ (ev, checked) => { this.setState({ renderPersonaDetails: checked }); } } />
         </div>
 
-        <Label>Tiny Persona (12px)</Label>
+        <Label className='example-label'>Tiny Persona (12px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.tiny }
@@ -45,7 +45,7 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
           hidePersonaDetails={ !renderPersonaDetails }
         />
 
-        <Label>Extra Extra Small Persona (24px)</Label>
+        <Label className='example-label'>Extra Extra Small Persona (24px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.extraExtraSmall }
@@ -53,7 +53,7 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
           hidePersonaDetails={ !renderPersonaDetails }
         />
 
-        <Label>Size 28 Persona (28px)</Label>
+        <Label className='example-label'>Size 28 Persona (28px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.size28 }
@@ -61,7 +61,7 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
           hidePersonaDetails={ !renderPersonaDetails }
         />
 
-        <Label>Extra Small Persona (32px)</Label>
+        <Label className='example-label'>Extra Small Persona (32px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.extraSmall }
@@ -69,7 +69,7 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
           hidePersonaDetails={ !renderPersonaDetails }
         />
 
-        <Label>Small Persona (40px)</Label>
+        <Label className='example-label'>Small Persona (40px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.small }
@@ -77,14 +77,14 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
           hidePersonaDetails={ !renderPersonaDetails }
         />
 
-        <Label>Medium Persona (48px)</Label>
+        <Label className='example-label'>Medium Persona (48px)</Label>
         <Persona
           { ...examplePersona }
           hidePersonaDetails={ !renderPersonaDetails }
           presence={ PersonaPresence.busy }
         />
 
-        <Label>Large Persona (72px)</Label>
+        <Label className='example-label'>Large Persona (72px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.large }
@@ -92,7 +92,7 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
           hidePersonaDetails={ !renderPersonaDetails }
         />
 
-        <Label>Extra Large Persona (100px)</Label>
+        <Label className='example-label'>Extra Large Persona (100px)</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.extraLarge }

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/PersonaExample.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/PersonaExample.scss
@@ -3,7 +3,7 @@
     margin-right: 5px;
   }
 
-  .ms-Label {
+  .example-label {
     margin: 10px 0;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/PersonaExample.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/PersonaExample.scss
@@ -2,4 +2,8 @@
   .ms-JobIconExample {
     margin-right: 5px;
   }
+
+  .ms-Label {
+    margin: 10px 0;
+  }
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #1265
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Labeled each of the Persona size variant examples and added space between the labels and examples.

#### Focus areas to test

(optional)
