### PR TITLE
Re-enable 'variable-name' rule in utilities

### DIFF
--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -32,11 +32,13 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
    */
   protected _shouldUpdateComponentRef: boolean;
 
+  // tslint:disable:variable-name
   private __async: Async;
   private __events: EventGroup;
   private __disposables: IDisposable[] | null;
   private __resolves: { [name: string]: (ref: any) => any };
   private __className: string;
+  // tslint:enable:variable-name
 
   /**
    * BaseComponent constructor

--- a/packages/utilities/tslint.json
+++ b/packages/utilities/tslint.json
@@ -4,9 +4,6 @@
   ],
   "rules": {
     "no-any": false,
-    "variable-name": false,
-    "no-internal-module": false,
-    "prefer-const": false,
     "typedef": [
       false
     ]


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Re-enabled 'variable-name' tslint rule in utilities and disabled rule in affected lines in BaseComponent. Also removed 'prefer-const' and 'no-internal-modules' suppression since there were no violations