### PR TITLE
Add missing typedefs to utilities pkg to pass tslint

### DIFF
--- a/packages/utilities/src/Async.ts
+++ b/packages/utilities/src/Async.ts
@@ -15,6 +15,7 @@ export class Async {
   private _immediateIds: any = null;
   private _intervalIds: any = null;
   private _animationFrameIds: { [id: number]: boolean } | null = null;
+  // tslint:disable-next-line:typedef
   private _isDisposed = false;
   private _parent: any;
   private _onErrorHandler: ((e: any) => void) | undefined;
@@ -29,7 +30,7 @@ export class Async {
   /**
    * Dispose function, clears all async operations.
    */
-  public dispose() {
+  public dispose(): void {
     let id;
 
     this._isDisposed = true;
@@ -172,7 +173,7 @@ export class Async {
    * Clears the immediate.
    * @param id - Id to cancel.
    */
-  public clearImmediate(id: number) {
+  public clearImmediate(id: number): void {
 
     if (this._immediateIds && this._immediateIds[id]) {
       /* tslint:disable:ban-native-functions */
@@ -219,7 +220,7 @@ export class Async {
    * Clears the interval.
    * @param id - Id to cancel.
    */
-  public clearInterval(id: number) {
+  public clearInterval(id: number): void {
     if (this._intervalIds && this._intervalIds[id]) {
       /* tslint:disable:ban-native-functions */
       clearInterval(id);
@@ -418,7 +419,7 @@ export class Async {
     return animationFrameId;
   }
 
-  public cancelAnimationFrame(id: number) {
+  public cancelAnimationFrame(id: number): void {
     if (this._animationFrameIds && this._animationFrameIds[id]) {
       /* tslint:disable:ban-native-functions */
       window.cancelAnimationFrame ? window.cancelAnimationFrame(id) : window.clearTimeout(id);
@@ -427,7 +428,7 @@ export class Async {
     }
   }
 
-  protected _logError(e: any) {
+  protected _logError(e: any): void {
     if (this._onErrorHandler) {
       this._onErrorHandler(e);
     }

--- a/packages/utilities/src/Async.ts
+++ b/packages/utilities/src/Async.ts
@@ -15,13 +15,13 @@ export class Async {
   private _immediateIds: any = null;
   private _intervalIds: any = null;
   private _animationFrameIds: { [id: number]: boolean } | null = null;
-  // tslint:disable-next-line:typedef
-  private _isDisposed = false;
+  private _isDisposed: boolean;
   private _parent: any;
   private _onErrorHandler: ((e: any) => void) | undefined;
   private _noop: any;
 
   constructor(parent?: any, onError?: (e: any) => void) {
+    this._isDisposed = false;
     this._parent = parent || null;
     this._onErrorHandler = onError;
     this._noop = () => { /* do nothing */ };

--- a/packages/utilities/src/AutoScroll.ts
+++ b/packages/utilities/src/AutoScroll.ts
@@ -41,22 +41,22 @@ export class AutoScroll {
     }
   }
 
-  public dispose() {
+  public dispose(): void {
     this._events.dispose();
     this._stopScroll();
   }
 
-  private _onMouseMove(ev: MouseEvent) {
+  private _onMouseMove(ev: MouseEvent): void {
     this._computeScrollVelocity(ev.clientY);
   }
 
-  private _onTouchMove(ev: TouchEvent) {
+  private _onTouchMove(ev: TouchEvent): void {
     if (ev.touches.length > 0) {
       this._computeScrollVelocity(ev.touches[0].clientY);
     }
   }
 
-  private _computeScrollVelocity(clientY: number) {
+  private _computeScrollVelocity(clientY: number): void {
     if (!this._scrollRect) {
       return;
     }
@@ -85,13 +85,13 @@ export class AutoScroll {
     }
   }
 
-  private _startScroll() {
+  private _startScroll(): void {
     if (!this._timeoutId) {
       this._incrementScroll();
     }
   }
 
-  private _incrementScroll() {
+  private _incrementScroll(): void {
     if (this._scrollableParent) {
       this._scrollableParent.scrollTop += Math.round(this._scrollVelocity);
     }
@@ -99,7 +99,7 @@ export class AutoScroll {
     this._timeoutId = setTimeout(this._incrementScroll, SCROLL_ITERATION_DELAY);
   }
 
-  private _stopScroll() {
+  private _stopScroll(): void {
     if (this._timeoutId) {
       clearTimeout(this._timeoutId);
       delete this._timeoutId;

--- a/packages/utilities/src/BaseComponent.test.tsx
+++ b/packages/utilities/src/BaseComponent.test.tsx
@@ -46,7 +46,7 @@ class TestComponent extends BaseComponent<{}, {}> {
     this._createNullRef();
   }
 
-  private _createNullRef() {
+  private _createNullRef(): void {
     let foo: any = null;
 
     // Calling a null
@@ -72,7 +72,7 @@ describe('BaseComponent', () => {
     class Foo extends BaseComponent<{}, {}> {
       public root: HTMLElement;
 
-      public render() {
+      public render(): JSX.Element {
         return <div ref={ this._resolveRef('root') } />;
       }
     }
@@ -85,11 +85,11 @@ describe('BaseComponent', () => {
   });
 });
 
-function _buildTestFor(methodName: string) {
+function _buildTestFor(methodName: string): void {
   it(`calls the error logger on ${methodName} exception`, () => {
     let lastErrorMessage = null;
 
-    BaseComponent.onError = (errorMessage, ex) => lastErrorMessage = errorMessage;
+    BaseComponent.onError = (errorMessage: string | undefined) => lastErrorMessage = errorMessage;
 
     let c = new TestComponent();
 

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -63,21 +63,21 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
   /**
    * When the component will receive props, make sure the componentRef is updated.
    */
-  public componentWillReceiveProps(newProps?: P, newContext?: any) {
+  public componentWillReceiveProps(newProps?: P, newContext?: any): void {
     this._updateComponentRef(this.props, newProps);
   }
 
   /**
    * When the component has mounted, update the componentRef.
    */
-  public componentDidMount() {
+  public componentDidMount(): void {
     this._updateComponentRef(undefined, this.props);
   }
 
   /**
    * If we have disposables, dispose them automatically on unmount.
    */
-  public componentWillUnmount() {
+  public componentWillUnmount(): void {
     if (this.__disposables) {
       for (let i = 0, len = this._disposables.length; i < len; i++) {
         let disposable = this.__disposables[i];
@@ -93,7 +93,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
   /**
    * Gets the object's class name.
    */
-  public get className() {
+  public get className(): string {
     if (!this.__className) {
       let funcNameRegex = /function (.{1,})\(/;
       let results = (funcNameRegex).exec((this).constructor.toString());
@@ -154,7 +154,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
       this.__resolves = {};
     }
     if (!this.__resolves[refName]) {
-      this.__resolves[refName] = (ref) => {
+      this.__resolves[refName] = (ref: any) => {
         return (this as any)[refName] = ref;
       };
     }
@@ -165,7 +165,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
   /**
    * Updates the componentRef (by calling it with "this" when necessary.)
    */
-  protected _updateComponentRef(currentProps: IBaseProps | undefined, newProps: IBaseProps = {}) {
+  protected _updateComponentRef(currentProps: IBaseProps | undefined, newProps: IBaseProps = {}): void {
     if (this._shouldUpdateComponentRef &&
       ((!currentProps && newProps.componentRef) ||
         (currentProps && currentProps.componentRef !== newProps.componentRef))) {
@@ -185,7 +185,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
    * @param deprecationMap - The map of deprecations, where key is the prop name and the value is
    * either null or a replacement prop name.
    */
-  protected _warnDeprecations(deprecationMap: ISettingsMap<P>) {
+  protected _warnDeprecations(deprecationMap: ISettingsMap<P>): void {
     warnDeprecations(this.className, this.props, deprecationMap);
   }
 
@@ -194,7 +194,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
    *
    * @param mutuallyExclusiveMap - The map of mutually exclusive props.
    */
-  protected _warnMutuallyExclusive(mutuallyExclusiveMap: ISettingsMap<P>) {
+  protected _warnMutuallyExclusive(mutuallyExclusiveMap: ISettingsMap<P>): void {
     warnMutuallyExclusive(this.className, this.props, mutuallyExclusiveMap);
   }
 
@@ -216,18 +216,18 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
  * ensures that the BaseComponent's methods are called before the subclass's. This ensures that
  * componentWillUnmount in the base is called and that things in the _disposables array are disposed.
  */
-function _makeAllSafe(obj: BaseComponent<any, any>, prototype: Object, methodNames: string[]) {
+function _makeAllSafe(obj: BaseComponent<any, any>, prototype: Object, methodNames: string[]): void {
   for (let i = 0, len = methodNames.length; i < len; i++) {
     _makeSafe(obj, prototype, methodNames[i]);
   }
 }
 
-function _makeSafe(obj: BaseComponent<any, any>, prototype: Object, methodName: string) {
+function _makeSafe(obj: BaseComponent<any, any>, prototype: Object, methodName: string): void {
   let classMethod = (obj as any)[methodName];
   let prototypeMethod = (prototype as any)[methodName];
 
   if (classMethod || prototypeMethod) {
-    (obj as any)[methodName] = function () {
+    (obj as any)[methodName] = function (): any {
       let retVal;
 
       try {
@@ -250,7 +250,7 @@ function _makeSafe(obj: BaseComponent<any, any>, prototype: Object, methodName: 
   }
 }
 
-BaseComponent.onError = (errorMessage) => {
+BaseComponent.onError = (errorMessage: string) => {
   console.error(errorMessage);
   throw errorMessage;
 };

--- a/packages/utilities/src/Customizer.tsx
+++ b/packages/utilities/src/Customizer.tsx
@@ -44,11 +44,15 @@ export interface ICustomizerState {
  * @public
  */
 export class Customizer extends BaseComponent<ICustomizerProps, ICustomizerState> {
-  public static contextTypes = {
+  public static contextTypes: {
+    injectedProps: PropTypes.Requireable<any>;
+  } = {
     injectedProps: PropTypes.object
   };
 
-  public static childContextTypes = Customizer.contextTypes;
+  public static childContextTypes: {
+    injectedProps: PropTypes.Requireable<any>;
+  } = Customizer.contextTypes;
 
   constructor(props: any, context: any) {
     super(props);
@@ -60,15 +64,19 @@ export class Customizer extends BaseComponent<ICustomizerProps, ICustomizerState
     return this.state;
   }
 
-  public componentWillReceiveProps(newProps: any, newContext: any) {
+  public componentWillReceiveProps(newProps: any, newContext: any): void {
     this.setState(this._getInjectedProps(newProps, newContext));
   }
 
-  public render() {
+  public render(): React.ReactElement<any> {
     return React.Children.only(this.props.children);
   }
 
-  private _getInjectedProps(props: ICustomizerProps, context: ICustomizerState) {
+  private _getInjectedProps(props: ICustomizerProps, context: ICustomizerState): {
+    injectedProps: {
+      [x: string]: any;
+    };
+  } {
     let { settings: injectedPropsFromSettings = {} as ISettings } = props;
     let { injectedProps: injectedPropsFromContext = {} as ISettings } = context;
 

--- a/packages/utilities/src/DelayedRender.tsx
+++ b/packages/utilities/src/DelayedRender.tsx
@@ -32,7 +32,8 @@ export interface IDelayedRenderState {
  * @public
  */
 export class DelayedRender extends React.Component<IDelayedRenderProps, IDelayedRenderState> {
-  public static defaultProps: { delay: number } = {
+  // tslint:disable-next-line:typedef
+  public static defaultProps = {
     delay: 0
   };
 

--- a/packages/utilities/src/DelayedRender.tsx
+++ b/packages/utilities/src/DelayedRender.tsx
@@ -32,7 +32,7 @@ export interface IDelayedRenderState {
  * @public
  */
 export class DelayedRender extends React.Component<IDelayedRenderProps, IDelayedRenderState> {
-  public static defaultProps = {
+  public static defaultProps: { delay: number } = {
     delay: 0
   };
 
@@ -45,7 +45,7 @@ export class DelayedRender extends React.Component<IDelayedRenderProps, IDelayed
     };
   }
 
-  public componentDidMount() {
+  public componentDidMount(): void {
     let { delay } = this.props;
     this._timeoutId = setTimeout(() => {
       this.setState({
@@ -54,13 +54,13 @@ export class DelayedRender extends React.Component<IDelayedRenderProps, IDelayed
     }, delay);
   }
 
-  public componentWillUnmount() {
+  public componentWillUnmount(): void {
     if (this._timeoutId) {
       clearTimeout(this._timeoutId);
     }
   }
 
-  public render() {
+  public render(): React.ReactElement<any> | null {
     return this.state.isRendered ? React.Children.only(this.props.children) : null;
   }
 }

--- a/packages/utilities/src/EventGroup.ts
+++ b/packages/utilities/src/EventGroup.ts
@@ -72,7 +72,7 @@ export class EventGroup {
     eventName: string,
     eventArgs?: any,
     bubbleEvent?: boolean
-  ): any {
+  ): boolean | undefined {
     let retVal;
 
     if (EventGroup._isElement(target)) {
@@ -137,9 +137,8 @@ export class EventGroup {
     }
   }
 
-  // tslint:disable-next-line:typedef
-  private static _isElement(target: HTMLElement) {
-    return !!target && (target.addEventListener || target instanceof HTMLElement);
+  private static _isElement(target: HTMLElement): boolean {
+    return !!target && (!!target.addEventListener || target instanceof HTMLElement);
   }
 
   /** parent: the context in which events attached to non-HTMLElements are called */

--- a/packages/utilities/src/EventGroup.ts
+++ b/packages/utilities/src/EventGroup.ts
@@ -54,10 +54,11 @@ export interface IDeclaredEventsByName {
  * @public
  */
 export class EventGroup {
-  private static _uniqueId = 0;
+  // tslint:disable-next-line:no-inferrable-types
+  private static _uniqueId: number = 0;
   private _parent: any;
   private _eventRecords: IEventRecord[];
-  private _id = EventGroup._uniqueId++;
+  private _id: number = EventGroup._uniqueId++;
   private _isDisposed: boolean;
 
   /** For IE8, bubbleEvent is ignored here and must be dealt with by the handler.
@@ -71,7 +72,7 @@ export class EventGroup {
     eventName: string,
     eventArgs?: any,
     bubbleEvent?: boolean
-  ) {
+  ): any {
     let retVal;
 
     if (EventGroup._isElement(target)) {
@@ -128,7 +129,7 @@ export class EventGroup {
     return !!declaredEvents && !!declaredEvents[eventName];
   }
 
-  public static stopPropagation(event: any) {
+  public static stopPropagation(event: any): void {
     if (event.stopPropagation) {
       event.stopPropagation();
     } else { // IE8
@@ -136,6 +137,7 @@ export class EventGroup {
     }
   }
 
+  // tslint:disable-next-line:typedef
   private static _isElement(target: HTMLElement) {
     return !!target && (target.addEventListener || target instanceof HTMLElement);
   }
@@ -146,7 +148,7 @@ export class EventGroup {
     this._eventRecords = [];
   }
 
-  public dispose() {
+  public dispose(): void {
     if (!this._isDisposed) {
       this._isDisposed = true;
 
@@ -156,7 +158,7 @@ export class EventGroup {
   }
 
   /** On the target, attach a set of events, where the events object is a name to function mapping. */
-  public onAll(target: any, events: { [key: string]: (args?: any) => void; }, useCapture?: boolean) {
+  public onAll(target: any, events: { [key: string]: (args?: any) => void; }, useCapture?: boolean): void {
     for (let eventName in events) {
       if (events.hasOwnProperty(eventName)) {
         this.on(target, eventName, events[eventName], useCapture);
@@ -167,7 +169,7 @@ export class EventGroup {
   /** On the target, attach an event whose handler will be called in the context of the parent
    * of this instance of EventGroup.
    */
-  public on(target: any, eventName: string, callback: (args?: any) => void, useCapture?: boolean) {
+  public on(target: any, eventName: string, callback: (args?: any) => void, useCapture?: boolean): void {
     if (eventName.indexOf(',') > -1) {
       let events = eventName.split(/[ ,]+/);
 
@@ -248,7 +250,7 @@ export class EventGroup {
     }
   }
 
-  public off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean) {
+  public off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void {
     for (let i = 0; i < this._eventRecords.length; i++) {
       let eventRecord = this._eventRecords[i];
       if ((!target || target === eventRecord.target) &&
@@ -293,7 +295,7 @@ export class EventGroup {
   }
 
   /** Declare an event as being supported by this instance of EventGroup. */
-  public declare(event: any) {
+  public declare(event: any): void {
     let declaredEvents = this._parent.__declaredEvents = this._parent.__declaredEvents || {};
 
     if (typeof event === 'string') {

--- a/packages/utilities/src/FabricPerformance.ts
+++ b/packages/utilities/src/FabricPerformance.ts
@@ -46,7 +46,7 @@ export class FabricPerformance {
    * @param name - The name of this measurement
    * @param func - The logic to be measured for execution time
    */
-  public static measure(name: string, func: () => void) {
+  public static measure(name: string, func: () => void): void {
     const start = now();
     func();
     const end = now();
@@ -65,7 +65,7 @@ export class FabricPerformance {
     FabricPerformance.summary[name] = measurement;
   }
 
-  public static reset() {
+  public static reset(): void {
     FabricPerformance.summary = {};
     clearTimeout(FabricPerformance._timeoutId);
     FabricPerformance.setPeriodicReset();

--- a/packages/utilities/src/array.test.ts
+++ b/packages/utilities/src/array.test.ts
@@ -5,21 +5,21 @@ describe('array utils tests', () => {
   describe('findIndex tests', () => {
     it('returns -1 when there is no match in the array', () => {
       const array = [0, 1, 2];
-      const index = findIndex(array, _ => false);
+      const index = findIndex(array, () => false);
 
       expect(index).equals(-1);
     });
 
     it('should return the correct index when the predicate satisfies the condition', () => {
       const array = [0, 1, 2];
-      const index = findIndex(array, elem => elem === 1);
+      const index = findIndex(array, (elem: number) => elem === 1);
 
       expect(index).equals(1);
     });
 
     it('should return the first index when repeated elements satisfy the predicate', () => {
       const array = [0, 1, 2, 2];
-      const index = findIndex(array, elem => elem === 2);
+      const index = findIndex(array, (elem: number) => elem === 2);
 
       expect(index).equals(2);
     });
@@ -28,21 +28,21 @@ describe('array utils tests', () => {
   describe('find tests', () => {
     it('returns -1 when there is no match in the array', () => {
       const array = [0, 1, 2];
-      const item = find(array, _ => false);
+      const item = find(array, () => false);
 
       expect(item).equals(undefined);
     });
 
     it('should return the correct item when the predicate satisfies the condition', () => {
       const array = [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }];
-      const item = find(array, elem => elem.id === 1);
+      const item = find(array, (elem: { id: number }) => elem.id === 1);
 
       expect(item).equals(array[1]);
     });
 
     it('should return the first index when repeated elements satisfy the predicate', () => {
       const array = [8, 9, 10, 11];
-      const item = find(array, elem => elem === 10);
+      const item = find(array, (elem: number) => elem === 10);
 
       expect(item).equals(10);
     });

--- a/packages/utilities/src/array.ts
+++ b/packages/utilities/src/array.ts
@@ -77,5 +77,5 @@ export function toMatrix<T>(items: T[], columnCount: number): T[][] {
  * @param index - The index of the element to remove
  */
 export function removeIndex<T>(array: T[], index: number): T[] {
-  return array.filter((_, i) => index !== i);
+  return array.filter((_: T, i: number) => index !== i);
 }

--- a/packages/utilities/src/autobind.test.ts
+++ b/packages/utilities/src/autobind.test.ts
@@ -2,7 +2,8 @@ let { expect } = chai;
 import { autobind } from './autobind';
 
 class Greeter {
-  private _hello = 'hello';
+  // tslint:disable-next-line:no-inferrable-types
+  private _hello: string = 'hello';
 
   @autobind
   public sayHello(): string {

--- a/packages/utilities/src/autobind.ts
+++ b/packages/utilities/src/autobind.ts
@@ -2,7 +2,7 @@
  * Autobind is a utility for binding methods in a class. This simplifies tagging methods as being "bound" to the this pointer
  * so that they can be used in scenarios that simply require a function callback.
  */
-export function autobind<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>) {
+export function autobind<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): any {
   let fn = descriptor.value;
 
   let defining = false;
@@ -10,7 +10,7 @@ export function autobind<T extends Function>(target: any, key: string, descripto
   return {
     configurable: true,
 
-    get() {
+    get(): any {
       if (defining || (fn && this === fn.prototype) || this.hasOwnProperty(key)) {
         return fn;
       }
@@ -30,7 +30,7 @@ export function autobind<T extends Function>(target: any, key: string, descripto
       return fnBound;
     },
 
-    set(newValue: any) {
+    set(newValue: any): void {
       Object.defineProperty(this, key, {
         configurable: true,
         writable: true,

--- a/packages/utilities/src/autobind.ts
+++ b/packages/utilities/src/autobind.ts
@@ -2,7 +2,11 @@
  * Autobind is a utility for binding methods in a class. This simplifies tagging methods as being "bound" to the this pointer
  * so that they can be used in scenarios that simply require a function callback.
  */
-export function autobind<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): any {
+export function autobind<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): {
+  configurable: boolean;
+  get(): T;
+  set(newValue: any): void;
+} | void {
   let fn = descriptor.value;
 
   let defining = false;
@@ -10,9 +14,9 @@ export function autobind<T extends Function>(target: any, key: string, descripto
   return {
     configurable: true,
 
-    get(): any {
+    get(): T {
       if (defining || (fn && this === fn.prototype) || this.hasOwnProperty(key)) {
-        return fn;
+        return fn as T;
       }
 
       // Bind method only once, and update the property to return the bound value from now on

--- a/packages/utilities/src/css.ts
+++ b/packages/utilities/src/css.ts
@@ -28,7 +28,7 @@ export type ICssInput = string | ISerializableObject | IDictionary | null | unde
  *
  * @public
  */
-export function css(...args: ICssInput[]) {
+export function css(...args: ICssInput[]): string {
   let classes = [];
 
   for (let arg of args) {

--- a/packages/utilities/src/customizable.test.tsx
+++ b/packages/utilities/src/customizable.test.tsx
@@ -10,7 +10,7 @@ let { expect } = chai;
 class Foo extends React.Component<{ field: string; }, {}> {
   public name: any;
 
-  public render() {
+  public render(): JSX.Element {
     return <div>{ (this.props as any)[this.props.field] }</div>;
   }
 }

--- a/packages/utilities/src/customizable.tsx
+++ b/packages/utilities/src/customizable.tsx
@@ -2,13 +2,15 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { GlobalSettings, IChangeDescription } from './GlobalSettings';
 
-export function customizable(fields: string[]) {
+export function customizable(fields: string[]): any {
   // tslint:disable-next-line:no-shadowed-variable
   return function customizableFactory<P, S>(
     ComposedComponent: (new (props: P, ...args: any[]) => React.Component<P, S>)
   ): any {
     return class ComponentWithInjectedProps extends React.Component<P, {}> {
-      public static contextTypes = {
+      public static contextTypes: {
+        injectedProps: PropTypes.Requireable<any>;
+      } = {
         injectedProps: PropTypes.object
       };
 
@@ -18,15 +20,15 @@ export function customizable(fields: string[]) {
         this._onSettingChanged = this._onSettingChanged.bind(this);
       }
 
-      public componentDidMount() {
+      public componentDidMount(): void {
         GlobalSettings.addChangeListener(this._onSettingChanged);
       }
 
-      public componentWillUnmount() {
+      public componentWillUnmount(): void {
         GlobalSettings.removeChangeListener(this._onSettingChanged);
       }
 
-      public render() {
+      public render(): JSX.Element {
         let defaultProps = {};
 
         for (let propName of fields) {

--- a/packages/utilities/src/customizable.tsx
+++ b/packages/utilities/src/customizable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { GlobalSettings, IChangeDescription } from './GlobalSettings';
 
-export function customizable(fields: string[]): any {
+export function customizable(fields: string[]): <P, S>(ComposedComponent: new (props: P, ...args: any[]) => React.Component<P, S>) => any {
   // tslint:disable-next-line:no-shadowed-variable
   return function customizableFactory<P, S>(
     ComposedComponent: (new (props: P, ...args: any[]) => React.Component<P, S>)

--- a/packages/utilities/src/dom.ts
+++ b/packages/utilities/src/dom.ts
@@ -17,7 +17,7 @@ interface IVirtualElement extends HTMLElement {
  *
  * @public
  */
-export function setVirtualParent(child: HTMLElement, parent: HTMLElement) {
+export function setVirtualParent(child: HTMLElement, parent: HTMLElement): void {
   let virtualChild = <IVirtualElement>child;
   let virtualParent = <IVirtualElement>parent;
 
@@ -119,7 +119,7 @@ let _isSSR = false;
  *
  * @public
  */
-export function setSSR(isEnabled: boolean) {
+export function setSSR(isEnabled: boolean): void {
   _isSSR = isEnabled;
 }
 
@@ -128,7 +128,7 @@ export function setSSR(isEnabled: boolean) {
  *
  * @public
  */
-export function getWindow(rootElement?: HTMLElement) {
+export function getWindow(rootElement?: HTMLElement): Window | undefined {
   if (_isSSR || typeof window === 'undefined') {
     return undefined;
   } else {
@@ -147,7 +147,7 @@ export function getWindow(rootElement?: HTMLElement) {
  *
  * @public
  */
-export function getDocument(rootElement?: HTMLElement) {
+export function getDocument(rootElement?: HTMLElement): Document | undefined {
   if (_isSSR || typeof document === 'undefined') {
     return undefined;
   } else {

--- a/packages/utilities/src/focus.test.tsx
+++ b/packages/utilities/src/focus.test.tsx
@@ -18,7 +18,7 @@ function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
   return renderedDOM as HTMLElement;
 }
 
-function _initialize() {
+function _initialize(): void {
   _hiddenElement = renderIntoDocument(
     <div data-is-visible={ false }>
       <button />

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -273,7 +273,7 @@ export function isElementFocusSubZone(element?: HTMLElement): boolean {
  *
  * @public
  */
-export function doesElementContainFocus(element: HTMLElement) {
+export function doesElementContainFocus(element: HTMLElement): boolean {
   let document = getDocument(element);
   let currentActiveElement: HTMLElement | undefined = document && document.activeElement as HTMLElement;
   if (currentActiveElement && elementContains(element, currentActiveElement)) {

--- a/packages/utilities/src/hoist.ts
+++ b/packages/utilities/src/hoist.ts
@@ -29,7 +29,7 @@ export function hoistMethods(destination: any, source: any, exclusions: string[]
     ) {
       hoisted.push(methodName);
       /* tslint:disable:no-function-expression */
-      destination[methodName] = function () { source[methodName].apply(source, arguments); };
+      destination[methodName] = function (): void { source[methodName].apply(source, arguments); };
       /* tslint:enable */
     }
   }
@@ -46,5 +46,5 @@ export function hoistMethods(destination: any, source: any, exclusions: string[]
  */
 export function unhoistMethods(source: any, methodNames: string[]): void {
   methodNames
-    .forEach((methodName) => delete source[methodName]);
+    .forEach((methodName: string) => delete source[methodName]);
 }

--- a/packages/utilities/src/language.ts
+++ b/packages/utilities/src/language.ts
@@ -39,7 +39,7 @@ export function getLanguage(): string | null {
  *
  * @public
  */
-export function setLanguage(language: string, avoidPersisting = false): void {
+export function setLanguage(language: string, avoidPersisting: boolean = false): void {
   let doc = getDocument();
 
   if (doc) {

--- a/packages/utilities/src/memoize.test.ts
+++ b/packages/utilities/src/memoize.test.ts
@@ -22,7 +22,7 @@ describe('memoizeFunction', () => {
 
   it('can return a cached result with a 2 arg function', () => {
     let _timesCalled = 0;
-    let combine = memoizeFunction((obj1, obj2) => (obj1.val + obj2.val + ++_timesCalled));
+    let combine = memoizeFunction((obj1: any, obj2: any) => (obj1.val + obj2.val + ++_timesCalled));
     let objA = { val: 'a' };
     let objB = { val: 'b' };
 
@@ -36,7 +36,7 @@ describe('memoizeFunction', () => {
 
   it('can return a cached result with falsy args', () => {
     let _timesCalled = 0;
-    let combine = memoizeFunction((obj1, obj2) => ((obj1 ? obj1.val : '') + (obj2 ? obj2.val : '') + ++_timesCalled));
+    let combine = memoizeFunction((obj1: any, obj2: any) => ((obj1 ? obj1.val : '') + (obj2 ? obj2.val : '') + ++_timesCalled));
     let objA = { val: 'a' };
     let objB = { val: 'b' };
 
@@ -109,7 +109,7 @@ describe('memoize', () => {
     class Foo {
 
       @memoize
-      public bar(val: string) {
+      public bar(val: string): string {
         return val + _count++;
       }
     }

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -34,7 +34,7 @@ export function memoize<T extends Function>(
   key: string,
   descriptor: TypedPropertyDescriptor<T>): {
     configurable: boolean;
-    get(): any;
+    get(): T;
   } {
 
   // We bind to "null" to prevent people from inadvertently pulling values from "this",
@@ -43,7 +43,7 @@ export function memoize<T extends Function>(
 
   return {
     configurable: true,
-    get(): any {
+    get(): T {
       return fn;
     }
   };
@@ -109,6 +109,8 @@ export function memoizeFunction<T extends (...args: any[]) => RET_TYPE, RET_TYPE
   } as any;
 }
 
+function _normalizeArg(val: null | undefined): { empty: boolean } | any;
+function _normalizeArg(val: object): any;
 function _normalizeArg(val: any): any {
   if (!val) {
     return _emptyObject;

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -32,7 +32,10 @@ export function setMemoizeWeakMap(weakMap: any): void {
 export function memoize<T extends Function>(
   target: any,
   key: string,
-  descriptor: TypedPropertyDescriptor<T>) {
+  descriptor: TypedPropertyDescriptor<T>): {
+    configurable: boolean;
+    get(): any;
+  } {
 
   // We bind to "null" to prevent people from inadvertently pulling values from "this",
   // rather than passing them in as input values which can be memoized.
@@ -40,7 +43,7 @@ export function memoize<T extends Function>(
 
   return {
     configurable: true,
-    get() {
+    get(): any {
       return fn;
     }
   };
@@ -106,7 +109,7 @@ export function memoizeFunction<T extends (...args: any[]) => RET_TYPE, RET_TYPE
   } as any;
 }
 
-function _normalizeArg(val: any) {
+function _normalizeArg(val: any): any {
   if (!val) {
     return _emptyObject;
   } else if (typeof val === 'object') {

--- a/packages/utilities/src/object.test.ts
+++ b/packages/utilities/src/object.test.ts
@@ -28,7 +28,7 @@ describe('filteredAssign', () => {
       a: 1,
       b: 'string'
     };
-    let result = filteredAssign((propName) => propName !== 'b', {}, source);
+    let result = filteredAssign((propName: string) => propName !== 'b', {}, source);
 
     expect(result.a).to.equal(1);
     expect(result.b).to.equal(undefined, 'b was not excluded');

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -9,7 +9,7 @@ if (_global[CURRENT_ID_PROPERTY] === undefined) {
   _global[CURRENT_ID_PROPERTY] = 0;
 }
 
-function checkProperties(a: any, b: any) {
+function checkProperties(a: any, b: any): boolean {
   for (let propName in a) {
     if (a.hasOwnProperty(propName)) {
       if (!b.hasOwnProperty(propName) || (b[propName] !== a[propName])) {
@@ -26,7 +26,7 @@ function checkProperties(a: any, b: any) {
  *
  * @public
  */
-export function shallowCompare(a: any, b: any) {
+export function shallowCompare(a: any, b: any): boolean {
   return checkProperties(a, b) && checkProperties(b, a);
 }
 
@@ -56,7 +56,7 @@ export function assign(target: any, ...args: any[]): any {
  * @param args - One or more objects that will be mixed into the target in the order they are provided.
  * @returns Resulting merged target.
  */
-export function filteredAssign(isAllowed: (propName: string) => boolean, target: any, ...args: any[]) {
+export function filteredAssign(isAllowed: (propName: string) => boolean, target: any, ...args: any[]): any {
   target = target || {};
 
   for (let sourceObject of args) {

--- a/packages/utilities/src/properties.ts
+++ b/packages/utilities/src/properties.ts
@@ -272,7 +272,7 @@ export const imageProperties = divProperties;
  * @returns The filtered props
  */
 export function getNativeProps<T>(props: any, allowedPropNames: string[], excludedPropNames?: string[]): T {
-  return filteredAssign((propName) => {
+  return filteredAssign((propName: string) => {
     return (
       (!excludedPropNames || excludedPropNames.indexOf(propName) < 0) && (
         (propName.indexOf('data-') === 0) ||

--- a/packages/utilities/src/resources.ts
+++ b/packages/utilities/src/resources.ts
@@ -1,11 +1,11 @@
 let _baseUrl = '';
 
 /** Sets the current base url used for fetching images. */
-export function getResourceUrl(url: string) {
+export function getResourceUrl(url: string): string {
   return _baseUrl + url;
 }
 
 /** Gets the current base url used for fetching images. */
-export function setBaseUrl(baseUrl: string) {
+export function setBaseUrl(baseUrl: string): void {
   _baseUrl = baseUrl;
 }

--- a/packages/utilities/src/rtl.ts
+++ b/packages/utilities/src/rtl.ts
@@ -27,7 +27,7 @@ export function getRTL(): boolean {
  *
  * @public
  */
-export function setRTL(isRTL: boolean) {
+export function setRTL(isRTL: boolean): void {
   let doc = typeof document === 'undefined' ? undefined : document;
 
   if (doc && doc.documentElement) {

--- a/packages/utilities/src/scroll.ts
+++ b/packages/utilities/src/scroll.ts
@@ -18,7 +18,7 @@ export const DATA_IS_SCROLLABLE_ATTRIBUTE = 'data-is-scrollable';
  *
  * @public
  */
-export function disableBodyScroll() {
+export function disableBodyScroll(): void {
   let doc = getDocument();
 
   if (doc && doc.body && !_bodyScrollDisabledCount) {
@@ -33,7 +33,7 @@ export function disableBodyScroll() {
  *
  * @public
  */
-export function enableBodyScroll() {
+export function enableBodyScroll(): void {
   if (_bodyScrollDisabledCount > 0) {
     let doc = getDocument();
 

--- a/packages/utilities/src/string.ts
+++ b/packages/utilities/src/string.ts
@@ -18,7 +18,7 @@ export function format(s: string, ...values: any[]): string {
 
   let args = values;
   // Callback match function
-  function replace_func(match: string) {
+  function replace_func(match: string): string {
     // looks up in the args
     let replacement = args[match.replace(FORMAT_ARGS_REGEX, '') as any];
 

--- a/packages/utilities/src/test/injectWrapperMethod.ts
+++ b/packages/utilities/src/test/injectWrapperMethod.ts
@@ -6,14 +6,14 @@ import { ReactWrapper } from 'enzyme';
  * @param methodName - The name of the method to modify on the wrapper
  * @param fn - The function to run prior to the call of the original method
  */
-export function injectWrapperMethod(wrapper: ReactWrapper<any, any>, methodName: string, fn: () => void) {
+export function injectWrapperMethod(wrapper: ReactWrapper<any, any>, methodName: string, fn: () => void): void {
   const originalMethod = (wrapper.instance() as any)[methodName];
 
   if (typeof originalMethod !== 'function') {
     throw new Error(`Tried to override the method ${methodName} on a ReactWrapper that does not have that function`);
   }
 
-  (wrapper.instance() as any)[methodName] = function (prevProps: any) {
+  (wrapper.instance() as any)[methodName] = function (prevProps: any): void {
     fn();
     originalMethod.call(this, prevProps);
   };

--- a/packages/utilities/src/warn.test.ts
+++ b/packages/utilities/src/warn.test.ts
@@ -11,7 +11,7 @@ let _lastWarning: string | undefined;
 describe('warnDeprecations', () => {
   beforeEach(() => {
     _lastWarning = undefined;
-    setWarningCallback(message => _lastWarning = message);
+    setWarningCallback((message: string) => _lastWarning = message);
   });
 
   afterEach(() => setWarningCallback(undefined));
@@ -35,7 +35,7 @@ describe('warnDeprecations', () => {
 describe('warnMutuallyExclusive', () => {
   beforeEach(() => {
     _lastWarning = undefined;
-    setWarningCallback(message => _lastWarning = message);
+    setWarningCallback((message: string) => _lastWarning = message);
   });
 
   afterEach(() => setWarningCallback(undefined));
@@ -54,7 +54,7 @@ describe('warnMutuallyExclusive', () => {
 describe('warnConditionallyRequiredProps', () => {
   beforeEach(() => {
     _lastWarning = undefined;
-    setWarningCallback(message => _lastWarning = message);
+    setWarningCallback((message: string) => _lastWarning = message);
   });
 
   afterEach(() => setWarningCallback(undefined));

--- a/packages/utilities/tslint.json
+++ b/packages/utilities/tslint.json
@@ -6,9 +6,6 @@
     "no-any": false,
     "variable-name": false,
     "no-internal-module": false,
-    "prefer-const": false,
-    "typedef": [
-      false
-    ]
+    "prefer-const": false
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Re-enable 'typedefs' rule and add missing typedefs to utilities pkg to pass tslint. Note: I made some types 'any' which will have to be changed or disabled line by line when 'no-any' rule is re-enabled.