### PR TITLE
Re-enabling sass theme token pre-processing in build.

### DIFF
--- a/common/changes/office-ui-fabric-react/sass_2017-08-25-23-55.json
+++ b/common/changes/office-ui-fabric-react/sass_2017-08-25-23-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updating sass build to pre-process theming again for better registration performance.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,6 +7,7 @@
     "build": "node -v"
   },
   "devDependencies": {
+    "@microsoft/load-themed-styles": "^1.5.1",
     "autoprefixer": "^7.1.2",
     "chalk": "^2.1.0",
     "cpx": "^1.5.0",

--- a/scripts/tasks/sass.js
+++ b/scripts/tasks/sass.js
@@ -5,6 +5,7 @@ module.exports = function (options) {
   const path = require('path');
   const fs = require('fs');
   const postcss = require('postcss');
+  const { splitStyles } = require("@microsoft/load-themed-styles");
   const autoprefixer = require('autoprefixer')({ browsers: ['> 1%', 'last 2 versions', 'ie >= 11'] });
   const modules = require('postcss-modules')({
     getJSON,
@@ -66,8 +67,9 @@ module.exports = function (options) {
     const source = [
       `/* tslint:disable */`,
       `import { loadStyles } from \'@microsoft/load-themed-styles\';`,
-      `loadStyles(${JSON.stringify(css)});`
+      `loadStyles(${JSON.stringify(splitStyles(css))});`
     ];
+
     const map = _fileNameToClassMap[fileName];
 
     for (let prop in map) {


### PR DESCRIPTION
The sass output is raw string, but should be a processed string output.