### PR TITLE
Add a FolderCover component to experiments

### DIFF
--- a/common/changes/@uifabric/experiments/folder-cover_2017-08-25-23-08.json
+++ b/common/changes/@uifabric/experiments/folder-cover_2017-08-25-23-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Implement FolderCover component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/gulpfile.js
+++ b/packages/experiments/gulpfile.js
@@ -7,6 +7,8 @@ let gulp = require('gulp');
 build.task('webpack', build.webpack);
 build.task('sass', build.sass);
 build.task('karma', build.karma);
+build.task('ts', build.typescript);
+build.task('tslist', build.tslint);
 
 // initialize tasks.
 build.initialize(gulp);

--- a/packages/experiments/src/FolderCover.ts
+++ b/packages/experiments/src/FolderCover.ts
@@ -1,0 +1,2 @@
+
+export * from './components/FolderCover';

--- a/packages/experiments/src/components/FolderCover/FolderCover.Props.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.Props.ts
@@ -1,0 +1,20 @@
+
+import * as React from 'react';
+import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
+import { FolderCover } from './FolderCover';
+
+export type FolderCoverSize = keyof {
+  small: 'small',
+  large: 'large'
+};
+
+export type FolderCoverType = keyof {
+  default: 'default',
+  media: 'media'
+};
+
+export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<FolderCover> {
+  size?: FolderCoverSize;
+  type?: FolderCoverType;
+  metadata?: React.ReactNode[] | React.ReactNode;
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.Props.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.Props.ts
@@ -3,18 +3,16 @@ import * as React from 'react';
 import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
 import { FolderCover } from './FolderCover';
 
-export type FolderCoverSize = keyof {
-  small: 'small',
-  large: 'large'
-};
+export type FolderCoverSize =
+  'small' |
+  'large';
 
-export type FolderCoverType = keyof {
-  default: 'default',
-  media: 'media'
-};
+export type FolderCoverType =
+  'default' |
+  'media';
 
 export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<FolderCover> {
-  size?: FolderCoverSize;
-  type?: FolderCoverType;
+  folderCoverSize?: FolderCoverSize;
+  folderCoverType?: FolderCoverType;
   metadata?: React.ReactNode[] | React.ReactNode;
 }

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -1,0 +1,85 @@
+
+@import '~office-ui-fabric-react/src/common/common';
+
+.root {
+  display: inline-flex;
+  position: relative;
+  vertical-align: bottom;
+
+  &,
+  &.isSmall {
+    width: 72px;
+    height: 52px;
+  }
+
+  &.isLarge {
+    width: 112px;
+    height: 80px;
+  }
+}
+
+.front {
+  display: block;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.back {
+  display: block;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.content {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  bottom: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: hidden;
+
+  &,
+  .isSmall & {
+    max-height: 52px - 8px;
+  }
+
+  .isLarge & {
+    max-height: 80px - 8px;
+  }
+}
+
+.metadata {
+  position: absolute;
+  display: block;
+  right: 8px;
+  left: 8px;
+  @include text-align(right);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-weight: $ms-font-weight-regular;
+  color: $ms-color-white;
+
+  &,
+  &.isSmall {
+    font-size: $ms-font-size-s;
+  }
+
+  .isLarge & {
+    font-size: $ms-font-size-m;
+  }
+
+  &,
+  &.isDefault {
+    bottom: 8px;
+  }
+
+  .isMedia & {
+    bottom: 4px;
+  }
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -46,8 +46,8 @@ const ASSETS: {
 export class FolderCover extends React.Component<IFolderCoverProps, IFolderCoverState> {
   public render(): JSX.Element | null {
     const {
-      size = 'large',
-      type = 'default'
+      folderCoverSize: size = 'large',
+      folderCoverType: type = 'default'
     } = this.props;
 
     const assets = ASSETS[size][type];

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -1,0 +1,87 @@
+
+import * as React from 'react';
+import { IFolderCoverProps, FolderCoverSize, FolderCoverType } from './FolderCover.Props';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import * as FolderCoverStylesModule from './FolderCover.scss';
+
+// tslint:disable-next-line:no-any
+const FolderCoverStyles = FolderCoverStylesModule as any;
+
+export interface IFolderCoverState {
+  // TODO Add animation support for drag/drop events.
+}
+
+const ASSET_CDN_BASE_URL = 'https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets';
+
+const ASSETS: {
+  [P in FolderCoverSize]: {
+    [T in FolderCoverType]: {
+      back: string;
+      front: string;
+    };
+  };
+} = {
+    small: {
+      default: {
+        back: `${ASSET_CDN_BASE_URL}/foldericons/s-ldefaultback.png`,
+        front: `${ASSET_CDN_BASE_URL}/foldericons/s-ldefaultfront.png`
+      },
+      media: {
+        back: `${ASSET_CDN_BASE_URL}/foldericons/s-lphotoback.png`,
+        front: `${ASSET_CDN_BASE_URL}/foldericons/s-lphotosfront.png`
+      }
+    },
+    large: {
+      default: {
+        back: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xldefaultback.png`,
+        front: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xldefaultfront.png`
+      },
+      media: {
+        back: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xlphotoback.png`,
+        front: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xlphotofront.png`
+      }
+    }
+  };
+
+export class FolderCover extends React.Component<IFolderCoverProps, IFolderCoverState> {
+  public render(): JSX.Element | null {
+    const {
+      size = 'large',
+      type = 'default'
+    } = this.props;
+
+    const assets = ASSETS[size][type];
+
+    return (
+      <div
+        className={ css(FolderCoverStyles.root, {
+          [FolderCoverStyles.isSmall]: size === 'small',
+          [FolderCoverStyles.isLarge]: size === 'large',
+          [FolderCoverStyles.isDefault]: type === 'default',
+          [FolderCoverStyles.isMedia]: type === 'media'
+        }) }
+      >
+        <img
+          className={ css(FolderCoverStyles.back) }
+          src={ assets.back }
+        />
+        <span className={ css(FolderCoverStyles.content) }>
+          { this.props.children }
+        </span>
+        <img
+          className={ css(FolderCoverStyles.front) }
+          src={ assets.front }
+        />
+        {
+          this.props.metadata ?
+            (
+              <span className={ css(FolderCoverStyles.metadata) }>
+                { this.props.metadata }
+              </span>
+            ) :
+            null
+        }
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/components/FolderCover/FolderCoverPage.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCoverPage.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {
+  ExampleCard,
+  IComponentDemoPageProps,
+  ComponentPage,
+  PropertiesTableSet
+} from '@uifabric/example-app-base';
+
+import { FolderCoverBasicExample } from './examples/FolderCover.Basic.Example';
+const FolderCoverBasicExampleCode =
+  require('!raw-loader!experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx') as string;
+
+export class FolderCoverPage extends React.Component<IComponentDemoPageProps, {}> {
+  public render(): JSX.Element {
+    return (
+      <ComponentPage
+        title='FolderCover'
+        componentName='FolderCover'
+        exampleCards={
+          <div>
+            <ExampleCard title='Folder Cover' isOptIn={ true } code={ FolderCoverBasicExampleCode }>
+              <FolderCoverBasicExample />
+            </ExampleCard>
+          </div>
+        }
+        propertiesTables={
+          <PropertiesTableSet
+            sources={ [
+              require<string>('!raw-loader!experiments/src/components/FolderCover/FolderCover.Props.ts')
+            ] }
+          />
+        }
+        overview={
+          <div />
+        }
+        bestPractices={
+          <div />
+        }
+        dos={
+          <div>
+            <ul>
+              <li>Use them to represent a folder which may contain visual content.</li>
+            </ul>
+          </div>
+        }
+        donts={
+          <div>
+            <ul>
+              <li>To represent the concept of a folder as opposed to an actual folder item.</li>
+            </ul>
+          </div>
+        }
+        isHeaderVisible={ this.props.isHeaderVisible }
+      />
+    );
+  }
+}

--- a/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
+++ b/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
@@ -1,0 +1,42 @@
+
+import * as React from 'react';
+import { FolderCover } from '../FolderCover';
+
+export class FolderCoverBasicExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    return (
+      <div>
+        <h3>Large Default Cover</h3>
+        <FolderCover
+          size='large'
+          metadata={ 20 }
+        >
+          <img src='//placehold.it/104x72' />
+        </FolderCover>
+        <h3>Small Default Cover</h3>
+        <FolderCover
+          size='small'
+          metadata={ 15 }
+        >
+          <img src='//placehold.it/64x44' />
+        </FolderCover>
+        <h3>Large Media Cover</h3>
+        <FolderCover
+          size='large'
+          type='media'
+          metadata={ 20 }
+        >
+          <img src='//placehold.it/104x72' />
+        </FolderCover>
+        <h3>Small Media Cover</h3>
+        <FolderCover
+          size='small'
+          type='media'
+          metadata={ 15 }
+        >
+          <img src='//placehold.it/64x44' />
+        </FolderCover>
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
+++ b/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
@@ -8,30 +8,30 @@ export class FolderCoverBasicExample extends React.Component<{}, {}> {
       <div>
         <h3>Large Default Cover</h3>
         <FolderCover
-          size='large'
+          folderCoverSize='large'
           metadata={ 20 }
         >
           <img src='//placehold.it/104x72' />
         </FolderCover>
         <h3>Small Default Cover</h3>
         <FolderCover
-          size='small'
+          folderCoverSize='small'
           metadata={ 15 }
         >
           <img src='//placehold.it/64x44' />
         </FolderCover>
         <h3>Large Media Cover</h3>
         <FolderCover
-          size='large'
-          type='media'
+          folderCoverSize='large'
+          folderCoverType='media'
           metadata={ 20 }
         >
           <img src='//placehold.it/104x72' />
         </FolderCover>
         <h3>Small Media Cover</h3>
         <FolderCover
-          size='small'
-          type='media'
+          folderCoverSize='small'
+          folderCoverType='media'
           metadata={ 15 }
         >
           <img src='//placehold.it/64x44' />

--- a/packages/experiments/src/components/FolderCover/index.ts
+++ b/packages/experiments/src/components/FolderCover/index.ts
@@ -1,0 +1,3 @@
+
+export * from './FolderCover.Props';
+export * from './FolderCover';

--- a/packages/experiments/src/components/Tile/TilePage.tsx
+++ b/packages/experiments/src/components/Tile/TilePage.tsx
@@ -6,6 +6,9 @@ import {
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 
+import { TileFolderExample } from './examples/Tile.Folder.Example';
+const TileFolderExampleCode = require('!raw-loader!experiments/src/components/Tile/examples/Tile.Folder.Example.tsx') as string;
+
 import { TileMediaExample } from './examples/Tile.Media.Example';
 const TileMediaExampleCode = require('!raw-loader!experiments/src/components/Tile/examples/Tile.Media.Example.tsx') as string;
 
@@ -20,6 +23,9 @@ export class TilePage extends React.Component<IComponentDemoPageProps, {}> {
         componentName='Tile'
         exampleCards={
           <div>
+            <ExampleCard title='Folder Tile' isOptIn={ true } code={ TileFolderExampleCode }>
+              <TileFolderExample />
+            </ExampleCard>
             <ExampleCard title='Document Tile' isOptIn={ true } code={ TileDocumentExampleCode }>
               <TileDocumentExample />
             </ExampleCard>

--- a/packages/experiments/src/components/Tile/examples/Tile.Folder.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Folder.Example.tsx
@@ -67,7 +67,7 @@ export class TileFolderExample extends React.Component<{}, {}> {
             }
             foreground={
               <FolderCover
-                type='media'
+                folderCoverType='media'
               >
                 <img src='//placehold.it/104x72' />
               </FolderCover>

--- a/packages/experiments/src/components/Tile/examples/Tile.Folder.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Folder.Example.tsx
@@ -1,0 +1,80 @@
+
+import * as React from 'react';
+import { Tile } from '../Tile';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import {
+  SignalField,
+  NewSignal,
+  CommentsSignal,
+  TrendingSignal
+} from '../../signals/Signals';
+import { FolderCover } from '../../FolderCover/FolderCover';
+import { lorem } from '@uifabric/example-app-base';
+import * as TileExampleStylesModule from './Tile.Example.scss';
+
+// tslint:disable-next-line:no-any
+const TileExampleStyles = TileExampleStylesModule as any;
+
+export class TileFolderExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    return (
+      <div>
+        <h3>Folder</h3>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <NewSignal />
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            itemActivity={
+              <SignalField
+                before={
+                  <CommentsSignal>{ '12' }</CommentsSignal>
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            foreground={
+              <FolderCover />
+            }
+          />
+        </div>
+        <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
+          <Tile
+            itemName={
+              <SignalField
+                before={
+                  <TrendingSignal />
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            itemActivity={
+              <SignalField
+                before={
+                  <CommentsSignal>{ '12' }</CommentsSignal>
+                }
+              >
+                { lorem(2) }
+              </SignalField>
+            }
+            foreground={
+              <FolderCover
+                type='media'
+              >
+                <img src='//placehold.it/104x72' />
+              </FolderCover>
+            }
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -17,6 +17,12 @@ export const AppDefinition: IAppDefinition = {
           url: '#/examples/commandbar'
         },
         {
+          component: require<any>('../components/FolderCover/FolderCoverPage').FolderCoverPage,
+          key: 'FolderCover',
+          name: 'FolderCover',
+          url: '#/examples/foldercover'
+        },
+        {
           component: require<any>('../components/Tile/TilePage').TilePage,
           key: 'Tile',
           name: 'Tile',


### PR DESCRIPTION
### Overview

This change adds a `FolderCover` component that can be used to decorate `Tile` components. The component is general-purpose, supporting two sizes, two modes, and optional content and metadata.