### PR TITLE
Updating rtlify to use @noflip

### DIFF
--- a/packages/merge-styles/src/transforms/rtlifyRules.test.ts
+++ b/packages/merge-styles/src/transforms/rtlifyRules.test.ts
@@ -34,7 +34,9 @@ describe('rtlifyRules', () => {
       [['cursor', 'w-resize'], ['cursor', 'e-resize']],
       [['cursor', 'sw-resize'], ['cursor', 'se-resize']],
       [['cursor', 'nw-resize'], ['cursor', 'ne-resize']],
-      [['left', '42px /*noflip*/'], ['left', '42px /*noflip*/']],
+      [['left', '42px /* @noflip */'], ['left', '42px']],
+      [['left', '42px @noflip'], ['left', '42px']],
+      [['left', '42px /*@noflip*/'], ['left', '42px']],
       [['box-shadow', '42px 0 red'], ['box-shadow', '-42px 0 red']],
       [['box-shadow', '-42px 0 red'], ['box-shadow', '42px 0 red']]
     ].forEach((test: string[][]) => {

--- a/packages/merge-styles/src/transforms/rtlifyRules.ts
+++ b/packages/merge-styles/src/transforms/rtlifyRules.ts
@@ -9,7 +9,7 @@ const _valueReplacements: { [key: string]: string } = {
   'nw-resize': 'ne-resize'
 };
 
-const NO_FLIP = 'noflip';
+const NO_FLIP = '@noflip';
 
 let _rtl = getRTL();
 
@@ -36,7 +36,7 @@ export function rtlifyRules(
     const value = rulePairs[index + 1] as string;
 
     if (value.indexOf(NO_FLIP) >= 0) {
-      return;
+      rulePairs[index + 1] = value.replace(/\s*(?:\/\*\s*)?\@noflip\b(?:\s*\*\/)?\s*?/g, '');
     } else if (name.indexOf('left') >= 0) {
       rulePairs[index] = name.replace('left', 'right');
     } else if (name.indexOf('right') >= 0) {


### PR DESCRIPTION
Minor change per discussion to how we disable rtl flipping in merge-styles.

Now you can provide:

```tsx
{
  left: '42px @noflip',
  right: '42px /* @noflip */',
  marginLeft: '42px /*@noflip*/'
}
```
They will all avoid flipping and will be reduced to just '42px'