### PR TITLE
Switched some font colors to achieve minimum contrast requirement on website

### DIFF
--- a/apps/fabric-website/src/data/colors-neutral.json
+++ b/apps/fabric-website/src/data/colors-neutral.json
@@ -27,7 +27,7 @@
   {
     "name": "neutralTertiary",
     "value": "#a6a6a6",
-    "labelColorClass": "ms-fontColor-white"
+    "labelColorClass": "ms-fontColor-black"
   },
   {
     "name": "neutralTertiaryAlt",

--- a/apps/fabric-website/src/data/colors-theme.json
+++ b/apps/fabric-website/src/data/colors-theme.json
@@ -22,12 +22,12 @@
   {
     "name": "themeSecondary",
     "value": "#2b88d8",
-    "labelColorClass": "ms-fontColor-white"
+    "labelColorClass": "ms-fontColor-black"
   },
   {
     "name": "themeTertiary",
     "value": "#71afe5",
-    "labelColorClass": "ms-fontColor-white"
+    "labelColorClass": "ms-fontColor-black"
   },
   {
     "name": "themeLight",

--- a/common/changes/@uifabric/fabric-website/swatch-text-accessibility_2017-08-28-16-16.json
+++ b/common/changes/@uifabric/fabric-website/swatch-text-accessibility_2017-08-28-16-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Switched some font colors on theme and neutral color swatches from white to black to achieve minimum contrast requirement of 4.5:1 for accessibility.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #2017 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Switched some font colors on the website from white to black on our theme and neutral color swatches to achieve minimum contrast requirement for accessibility of 4.5:1.

#### Focus areas to test

(optional)
