### PR TITLE
Handle null or undefined values in Selection getKey param

### DIFF
--- a/common/changes/office-ui-fabric-react/selection-key_2017-08-28-19-11.json
+++ b/common/changes/office-ui-fabric-react/selection-key_2017-08-28-19-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Handle case where getKey is null or undefined in Selection",
+      "comment": "Selection: Adding better handling around a case where getKey returns null or undefined.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/selection-key_2017-08-28-19-11.json
+++ b/common/changes/office-ui-fabric-react/selection-key_2017-08-28-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Handle case where getKey is null or undefined in Selection",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -57,7 +57,11 @@ export class Selection implements ISelection {
   }
 
   public getKey(item: IObjectWithKey, index?: number): string {
-    return `${this._getKey(item, index)}`;
+    const key = this._getKey(item, index);
+
+    return (typeof key === 'number' || key) ?
+      `${key}` :
+      '';
   }
 
   public setChangeEvents(isEnabled: boolean, suppressChange?: boolean) {
@@ -93,7 +97,11 @@ export class Selection implements ISelection {
       let item = items[i];
 
       if (item) {
-        newKeyToIndexMap[this.getKey(item, i)] = i;
+        const key = this.getKey(item, i);
+
+        if (key) {
+          newKeyToIndexMap[key] = i;
+        }
       }
 
       newUnselectableIndices[i] = item && !this.canSelectItem(item);
@@ -182,7 +190,7 @@ export class Selection implements ISelection {
     if (this.mode === SelectionMode.single) {
       selectableCount = Math.min(selectableCount, 1);
     }
-    
+
     return (
       (this.count > 0) &&
       (this._isAllSelected && this._exemptedCount === 0) ||


### PR DESCRIPTION
### Overview

This change fixes a minor bug in which if `getKey` passed to `Selection` returned `null` or `undefined`, such a value was being converted to a `string` (e.g. `'null'` or `'undefined'`) instead of being left alone. Such a value is unexpected, but without consuming projects using `--strictNullChecks` it is difficult to detect.