### PR TITLE
Remove missing content from Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Fabric React is a responsive, mobile-first collection of robust components desig
 - [Get started](#get-started)
 - [Testing](#testing)
 - [Advanced usage](#advanced-usage)
-- [Roadmap](#roadmap)
-- [Trello board](#trello-board)
 - [Browser support](#browser-support)
 - [Contribute to Fabric React](#contribute-to-fabric-react)
 - [Licenses](#licenses)


### PR DESCRIPTION
The "Contents" index in README.md includes references to sections that do not exist.
