### PR TITLE
Fix npm start inside of fabric-website

### DIFF
--- a/scripts/tasks/webpack-resources.js
+++ b/scripts/tasks/webpack-resources.js
@@ -94,7 +94,7 @@ module.exports = {
             {
               test: [/\.json$/],
               enforce: 'pre',
-              loader: 'json',
+              loader: 'json-loader',
               exclude: [
                 /node_modules/
               ]


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
When running npm start inside of fabric-website, you get the following error:
https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed 

This change makes npm start work again in fabric-website. 
