### PR TITLE
Add resize group to fabric-website

### DIFF
--- a/apps/fabric-website/src/components/App/AppState.tsx
+++ b/apps/fabric-website/src/components/App/AppState.tsx
@@ -291,6 +291,12 @@ export const AppState: IAppState = {
           getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/Components/RatingComponentPage').RatingComponentPage))
         },
         {
+          title: 'ResizeGroup',
+          url: '#/components/resizegroup',
+          component: () => <LoadingComponent title='ResizeGroup' />,
+          getComponent: cb => require.ensure([], (require) => cb(require<any>('../../pages/Components/ResizeGroupComponentPage').ResizeGroupComponentPage))
+        },
+        {
           title: 'SearchBox',
           url: '#/components/searchbox',
           component: () => <LoadingComponent title='SearchBox' />,

--- a/apps/fabric-website/src/pages/Components/ResizeGroupComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ResizeGroupComponentPage.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { ResizeGroupPage } from 'office-ui-fabric-react/lib/components/ResizeGroup/ResizeGroupPage';
+import { PageHeader } from '../../components/PageHeader/PageHeader';
+import { ComponentPage } from '../../components/ComponentPage/ComponentPage';
+
+export class ResizeGroupComponentPage extends React.Component<any, any> {
+  public render() {
+    return (
+      <div ref='pageElement'>
+        <ComponentPage>
+          <PageHeader pageTitle='ResizeGroupPage' backgroundColor='#038387'
+            links={
+              [
+                {
+                  'text': 'Overview',
+                  'location': 'Overview'
+                },
+                {
+                  'text': 'Variants',
+                  'location': 'Variants'
+                },
+                {
+                  'text': 'Implementation',
+                  'location': 'Implementation'
+                }
+              ]
+            } />
+          <ResizeGroupPage isHeaderVisible={ false } />
+        </ComponentPage>
+      </div>
+    );
+  }
+}

--- a/common/changes/@uifabric/fabric-website/add-resize-group-to-website_2017-08-31-20-40.json
+++ b/common/changes/@uifabric/fabric-website/add-resize-group-to-website_2017-08-31-20-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Publish resize group on fabric-website",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/add-resize-group-to-website_2017-08-31-20-40.json
+++ b/common/changes/office-ui-fabric-react/add-resize-group-to-website_2017-08-31-20-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Respect ths isHeader property on the ResizeGroup demo page",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroupPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroupPage.tsx
@@ -92,6 +92,7 @@ export class ResizeGroupPage extends React.Component<any, any> {
             </ul>
           </div>
         }
+        isHeaderVisible={ this.props.isHeaderVisible }
       />
     );
   }

--- a/scripts/tasks/webpack-resources.js
+++ b/scripts/tasks/webpack-resources.js
@@ -94,7 +94,7 @@ module.exports = {
             {
               test: [/\.json$/],
               enforce: 'pre',
-              loader: 'json',
+              loader: 'json-loader',
               exclude: [
                 /node_modules/
               ]

--- a/scripts/tasks/webpack-resources.js
+++ b/scripts/tasks/webpack-resources.js
@@ -94,7 +94,7 @@ module.exports = {
             {
               test: [/\.json$/],
               enforce: 'pre',
-              loader: 'json-loader',
+              loader: 'json',
               exclude: [
                 /node_modules/
               ]


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
* Adds resize group to the website
* Updates the resize group demo page to respect the isHeaderVisible property
