### PR TITLE
BaseButton: Set the right classname on the menu icon

### DIFF
--- a/common/changes/office-ui-fabric-react/chrisgo-basebutton_menu_icon_2017-08-31-22-13.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-basebutton_menu_icon_2017-08-31-22-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BaseButton: Put the right classname on the menu icon",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -337,7 +337,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       menuIconProps ?
         <Icon
           { ...menuIconProps }
-          className={ this._classNames.icon }
+          className={ this._classNames.menuIcon }
         />
         :
         null


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The menu icon currently can't be styled correctly because the classname is set to icon instead of menuIcon
