### PR TITLE
Devx website updates and removing FocusZone on Nav

### DIFF
--- a/apps/fabric-website/index-devx.html
+++ b/apps/fabric-website/index-devx.html
@@ -29,11 +29,17 @@
   var date = today.getFullYear() + '-' + (today.getMonth() + 1) + '-' + today.getDate();
   var entryPointFilename = 'fabric-sitev5';
 
+  // Query params
+  var noCompress = getParameterByName('noCompress') === 'true';
+  var devUrl = getParameterByName('devUrl');
+  var dogfood = getParameterByName('isDogfood');
+  var production = getParameterByName('isProduction');
+
   switch (true) {
-    case location.hostname === 'dev.office.com':
+    case location.hostname === 'dev.office.com' || production:
       isProduction = true;
       break;
-    case location.hostname === 'officedevcentersite-devx.azurewebsites.net' || location.hostname === 'https://devx.microsoft-tst.com':
+    case location.hostname === 'officedevcentersite-devx.azurewebsites.net' || location.hostname === 'devx.microsoft-tst.com' || dogfood:
       isDogfood = true;
       break;
     case location.hostname === 'officedevcentersite-release.azurewebsites.net':
@@ -68,8 +74,6 @@
   var baseDogfoodUrl = 'https://static2df.sharepointonline.com/files/fabric/fabric-website/dist/';
 
   var scripts = [];
-  var noCompress = getParameterByName('noCompress') === 'true';
-  var devUrl = getParameterByName('devUrl');
 
   if (devUrl) {
     scripts.push(devUrl);

--- a/apps/fabric-website/index-devx.html
+++ b/apps/fabric-website/index-devx.html
@@ -1,0 +1,108 @@
+<style>
+  body,
+  html {
+    margin: 0;
+    padding: 0;
+  }
+
+  .loading {
+    align-items: center;
+    background-color: #212121;
+    border-top: 50px solid #000;
+    display: flex;
+    height: 100vh;
+    justify-content: center;
+  }
+</style>
+<div id="main">
+  <div class="loading">
+    <img class="loadingImage" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/loading.gif" alt="Loading"
+      width="32" height="32" />
+  </div>
+</div>
+
+<script type="text/javascript">
+  var isProduction = false;
+  var isDogfood = false;
+  var isLocal = false;
+  var today = new Date();
+  var date = today.getFullYear() + '-' + (today.getMonth() + 1) + '-' + today.getDate();
+
+  switch (true) {
+    case location.hostname === 'dev.office.com':
+      isProduction = true;
+      break;
+    case location.hostname === 'officedevcentersite-devx.azurewebsites.net' || location.hostname === 'https://devx.microsoft-tst.com':
+      isDogfood = true;
+      break;
+    case location.hostname === 'officedevcentersite-release.azurewebsites.net':
+      isProduction = true;
+      break;
+    case location.hostname === 'localhost':
+      isLocal = true;
+  }
+
+  function loadScript(n) {
+    for (var i = 0; i < n.length; i++) {
+      var s = document.createElement('script');
+      s.src = n[i];
+      s.async = false;
+      document.body.appendChild(s);
+    }
+  }
+
+  function getParameterByName(name, url) {
+    if (!url) {
+      url = window.location.href;
+    }
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+      results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+  }
+
+  var reactProduction = [
+    '//cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react.min.js',
+    '//cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react-dom.min.js'
+  ];
+
+  var reactDevelopment = [
+    '//cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react.js',
+    '//cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react-dom.js'
+  ];
+
+  var baseProductionUrl = 'https://static2.sharepointonline.com/files/fabric/fabric-website/dist/';
+  var baseDogfoodUrl = 'https://static2df.sharepointonline.com/files/fabric/fabric-website/dist/';
+
+  var scripts = [];
+  var noCompress = getParameterByName('noCompress') === 'true';
+  var devUrl = getParameterByName('devUrl');
+
+  if (devUrl) {
+    scripts.push(devUrl);
+  } else if (isLocal) {
+    scripts.push.apply(scripts, reactDevelopment);
+    scripts.push('fabric-site.js');
+  } else if (isDogfood) {
+    if (noCompress) {
+      scripts.push.apply(scripts, reactDevelopment);
+      scripts.push(baseDogfoodUrl + 'fabric-site.min.js?date=' + Date.now());
+    } else {
+      scripts.push.apply(scripts, reactProduction);
+      scripts.push(baseDogfoodUrl + 'fabric-site.js?date=' + Date.now());
+    }
+  } else {
+    if (noCompress) {
+      scripts.push.apply(scripts, reactDevelopment);
+      scripts.push(baseProductionUrl + 'fabric-site.js?date=' + date);
+    } else {
+      scripts.push.apply(scripts, reactProduction);
+      scripts.push(baseProductionUrl + 'fabric-site.min.js?date=' + date);
+    }
+  }
+
+  loadScript(scripts);
+
+</script>

--- a/apps/fabric-website/index-devx.html
+++ b/apps/fabric-website/index-devx.html
@@ -27,6 +27,7 @@
   var isLocal = false;
   var today = new Date();
   var date = today.getFullYear() + '-' + (today.getMonth() + 1) + '-' + today.getDate();
+  var entryPointFilename = 'fabric-sitev5';
 
   switch (true) {
     case location.hostname === 'dev.office.com':
@@ -63,16 +64,6 @@
     return decodeURIComponent(results[2].replace(/\+/g, " "));
   }
 
-  var reactProduction = [
-    '//cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react.min.js',
-    '//cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react-dom.min.js'
-  ];
-
-  var reactDevelopment = [
-    '//cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react.js',
-    '//cdnjs.cloudflare.com/ajax/libs/react/0.14.7/react-dom.js'
-  ];
-
   var baseProductionUrl = 'https://static2.sharepointonline.com/files/fabric/fabric-website/dist/';
   var baseDogfoodUrl = 'https://static2df.sharepointonline.com/files/fabric/fabric-website/dist/';
 
@@ -83,23 +74,18 @@
   if (devUrl) {
     scripts.push(devUrl);
   } else if (isLocal) {
-    scripts.push.apply(scripts, reactDevelopment);
-    scripts.push('fabric-site.js');
+    scripts.push(entryPointFilename + '.js');
   } else if (isDogfood) {
     if (noCompress) {
-      scripts.push.apply(scripts, reactDevelopment);
-      scripts.push(baseDogfoodUrl + 'fabric-site.min.js?date=' + Date.now());
+      scripts.push(baseDogfoodUrl + entryPointFilename + '.min.js?date=' + Date.now());
     } else {
-      scripts.push.apply(scripts, reactProduction);
-      scripts.push(baseDogfoodUrl + 'fabric-site.js?date=' + Date.now());
+      scripts.push(baseDogfoodUrl + entryPointFilename + '.js?date=' + Date.now());
     }
   } else {
     if (noCompress) {
-      scripts.push.apply(scripts, reactDevelopment);
-      scripts.push(baseProductionUrl + 'fabric-site.js?date=' + date);
+      scripts.push(baseProductionUrl + entryPointFilename + '.js?date=' + date);
     } else {
-      scripts.push.apply(scripts, reactProduction);
-      scripts.push(baseProductionUrl + 'fabric-site.min.js?date=' + date);
+      scripts.push(baseProductionUrl + entryPointFilename + '.min.js?date=' + date);
     }
   }
 

--- a/apps/fabric-website/src/components/App/App.scss
+++ b/apps/fabric-website/src/components/App/App.scss
@@ -13,7 +13,6 @@
     flex-direction: column;
     margin: 0 auto;
     max-width: $App-maximumWidth;
-    padding-top: $Header-height; // Keep content from being covered by the header
   }
 
   .App-mobileNavBar {

--- a/apps/fabric-website/src/components/Header/Header.scss
+++ b/apps/fabric-website/src/components/Header/Header.scss
@@ -6,7 +6,6 @@
 
 :global {
   .od-Header {
-    background-color: $ms-color-black;
     height: $od-Header-height;
     left: 0;
     padding: 0 8px;

--- a/apps/fabric-website/src/components/Header/Header.tsx
+++ b/apps/fabric-website/src/components/Header/Header.tsx
@@ -14,19 +14,6 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
   public render() {
     return (
       <header className='od-Header'>
-        <div className='od-Header-banner'>
-          <div className='od-Header-logo'>
-            <a className='od-Logo-link' href='http://dev.office.com/' aria-label='Back to Office Dev Center website'>
-              <img src={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/images/logo-office-dev.svg' } width='190' height='48' alt='Office dev center logo image' />
-            </a>
-          </div>
-          <div className='od-Header-searchContainer'>
-            <DOSearchBox />
-          </div>
-        </div>
-        <div className='od-Header-navigationContainer'>
-         <DONavigation />
-        </div>
         <button className='od-Header-hamburgerButton' role='menu' aria-label='Mobile menu, press enter to open'>
           <i className='ms-Icon ms-Icon--menu2' aria-hidden='true'></i>
         </button>

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import * as stylesImport from './Nav.module.scss';
 const styles: any = stylesImport;
 import {
@@ -25,11 +24,9 @@ export class Nav extends React.Component<INavProps, INavState> {
       : null;
 
     return (
-      <FocusZone direction={ FocusZoneDirection.vertical } >
-        <nav className={ styles.nav } role='navigation'>
-          { links }
-        </nav>
-      </FocusZone>
+      <nav className={ styles.nav } role='navigation'>
+        { links }
+      </nav>
     );
   }
 

--- a/apps/fabric-website/webpack.serve.config.js
+++ b/apps/fabric-website/webpack.serve.config.js
@@ -8,7 +8,7 @@ let plugins = [
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify('production')
   }),
-  new WebpackNotifierPlugin(),
+  new WebpackNotifierPlugin()
 ];
 
 const devServerConfig = {

--- a/apps/fabric-website/webpack.site.config.js
+++ b/apps/fabric-website/webpack.site.config.js
@@ -35,14 +35,14 @@ function createConfig(isProduction, publicPath) {
   let webpackConfig = {
 
     entry: {
-      'fabric-site': './lib/root.js'
+      'fabric-sitev5': './lib/root.js'
     },
 
     output: {
       path: path.join(__dirname, '/dist'),
       publicPath: publicPath,
       filename: `[name]${minFileNamePart}.js`,
-      chunkFilename: `fabric-site-${version}-[name]${minFileNamePart}.js`
+      chunkFilename: `fabric-sitev5-${version}-[name]${minFileNamePart}.js`
     },
 
     devServer: {

--- a/apps/fabric-website/webpack.uhf.serve.config.js
+++ b/apps/fabric-website/webpack.uhf.serve.config.js
@@ -1,5 +1,5 @@
 /**
- * NOTE: Use this config file is for when you want to build and serve the website
+ * NOTE: This config file is for when you want to build and serve the website
  * for the purpose of testing your local changes with the UHF.
  * Using this will considerably slow down the build and serve process
  * but will allow you to access the output file on your local machine.
@@ -25,6 +25,7 @@ serveConfig.devServer.host = HOST_NAME;
 serveConfig.devServer.disableHostCheck = true;
 serveConfig.output.path = path.join(__dirname, '/dist');
 serveConfig.output.publicPath = '/dist/';
+serveConfig.output.filename = entryPointFilename + '.js';
 serveConfig.output.chunkFilename = `${entryPointFilename}-${version}-[name]${minFileNamePart}.js`;
 
 module.exports = serveConfig;

--- a/apps/fabric-website/webpack.uhf.serve.config.js
+++ b/apps/fabric-website/webpack.uhf.serve.config.js
@@ -9,12 +9,18 @@ let WriteFilePlugin = require('write-file-webpack-plugin');
 const HOST_NAME = require('os').hostname();
 let serveConfig = require('./webpack.serve.config');
 let path = require('path');
+const entryPointFilename = 'fabric-sitev5';
 
 // Overwrite the main webpack.site.config properties
+serveConfig.entry = {
+  [entryPointFilename]: './lib/root.js'
+};
+
 serveConfig.plugins.push(new WriteFilePlugin());
 serveConfig.devServer.host = HOST_NAME;
 serveConfig.devServer.disableHostCheck = true;
 serveConfig.output.path = path.join(__dirname, '/dist');
 serveConfig.output.publicPath = '/dist/';
+serveConfig.output.chunkFilename = `${entryPointFilename}-${version}-[name]${minFileNamePart}.js`;
 
 module.exports = serveConfig;

--- a/apps/fabric-website/webpack.uhf.serve.config.js
+++ b/apps/fabric-website/webpack.uhf.serve.config.js
@@ -5,11 +5,15 @@
  * but will allow you to access the output file on your local machine.
  */
 
-let WriteFilePlugin = require('write-file-webpack-plugin');
+const WriteFilePlugin = require('write-file-webpack-plugin');
 const HOST_NAME = require('os').hostname();
-let serveConfig = require('./webpack.serve.config');
-let path = require('path');
+const serveConfig = require('./webpack.serve.config');
+const path = require('path');
 const entryPointFilename = 'fabric-sitev5';
+const version = require('./package.json').version;
+const isProduction = process.argv.indexOf('--production') > -1;
+const minFileNamePart = isProduction ? '.min' : '';
+
 
 // Overwrite the main webpack.site.config properties
 serveConfig.entry = {


### PR DESCRIPTION
### Devx website updates
1. Created a new html index file (index-devx.html) with no header and footer html tags. This was needed because our website will now be placed in the devx base webpage that includes the UHF.
2. Updated the entry point file in webpack to fabric-websitev5.
3. Updated the UHF webpack config to clean it up a bit.
4. Removed references to react and react-dom in index-devx.html because the devx environment is already referencing them.
5. Removed FocusZone from Nav because it was causing an error that was breaking the whole site, more info below.

### Removed FocusZone 
I removed this component from the Nav component becuase it was causing the following error.

```
Uncaught Error: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded 
```

After reading up quite a bit, i think that somehow the FocusZone is pulling in an extra copy of React or has some fancy ref's that might be causing this issue. I think it's propably the former based on the fact that our new devx environment is already pulling in all the React bits and i removed our references to React in the index-devx.html.



