### PR TITLE
Making jest always run serially, adding support to skip tasks.

### DIFF
--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -14,6 +14,11 @@
     "clean": "node ../../scripts/clean.js",
     "start-test": "node ../../scripts/start-test.js"
   },
+  "disabledTasks": [
+    "sass",
+    "copy",
+    "karma"
+  ],
   "devDependencies": {
     "@types/jest": "^20.0.8",
     "@types/es6-promise": "^0.0.32",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,7 +2,13 @@ const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
 const { logStartTask, logEndTask, logEndBuild } = require('./logging');
-const packageName = getPackageName();
+const package = getPackage();
+
+if (!package) {
+  return;
+}
+
+const packageName = package.name;
 const isProduction = process.argv.indexOf('--production') > -1;
 
 let tasks = [
@@ -14,6 +20,11 @@ let tasks = [
   'jest',
   'webpack'
 ];
+
+// Filter disabled tasks if specified in the package.json.
+if (package.disabledTasks) {
+  tasks = tasks.filter(task => package.disabledTasks.indexOf(task) < 0);
+}
 
 if (process.argv.length >= 3 && process.argv[2].indexOf('--') === -1) {
   tasks = [process.argv[2]];
@@ -48,12 +59,12 @@ function runTask(task) {
       }));
 }
 
-function getPackageName() {
+function getPackage() {
   let packagePath = path.resolve(process.cwd(), 'package.json');
 
   if (fs.existsSync(packagePath)) {
-    return JSON.parse(fs.readFileSync(packagePath, 'utf8')).name;
+    return JSON.parse(fs.readFileSync(packagePath, 'utf8'));
   }
 
-  return '';
+  return undefined;
 }

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -4,12 +4,18 @@ module.exports = function (options) {
   const execSync = require('../exec-sync');
   const findConfig = require('../find-config');
 
-  const jestPath = path.resolve(__dirname, '../node_modules/jest/bin/jest');
   const jestConfigPath = findConfig('jest.config.js');
-  const coverage = (options.isProduction) ? ' --coverage' : '';
 
   if (fs.existsSync(jestConfigPath)) {
-    const command = `node ${jestPath} --config ${jestConfigPath} ${coverage} ${options.args || ''}`;
+    const jestPath = path.resolve(__dirname, '../node_modules/jest/bin/jest');
+
+    const args = [
+      `--config ${jestConfigPath}`,
+      options.isProduction && '--coverage --runInBand',
+      options.args
+    ].filter(arg => !!arg).join(' ');
+
+    const command = `node ${jestPath} ${args}`;
 
     execSync(command, undefined, path.dirname(jestConfigPath));
   }

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -10,8 +10,16 @@ module.exports = function (options) {
     const jestPath = path.resolve(__dirname, '../node_modules/jest/bin/jest');
 
     const args = [
+      // Specify the config file.
       `--config ${jestConfigPath}`,
-      options.isProduction && '--coverage --runInBand',
+
+      // Run tests in serial (parallel builds seem to hang rush.)
+      `--runInBand`,
+
+      // In production builds, produce coverage information.
+      options.isProduction && '--coverage',
+
+      // Pass in custom arguments.
       options.args
     ].filter(arg => !!arg).join(' ');
 


### PR DESCRIPTION
We're seeing some hangs when using rush with jest parallel. Addressing this by having jest always run tests serially. Also adding support for task skipping.