### PR TITLE
Render empty GroupedList headers

### DIFF
--- a/common/changes/office-ui-fabric-react/grouped-list-empty_2017-09-05-18-20.json
+++ b/common/changes/office-ui-fabric-react/grouped-list-empty_2017-09-05-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow rendering empty GroupedList headers",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "spelliot@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
@@ -50,37 +50,6 @@ let _items = [
   }
 ];
 
-function groupBy(items: any[], fieldName: string) {
-  let groups = items.reduce((currentGroups, currentItem, index) => {
-    let lastCurrentGroup = currentGroups[currentGroups.length - 1];
-    let fieldValue = currentItem[fieldName];
-
-    if (!lastCurrentGroup || lastCurrentGroup.value !== fieldValue) {
-      currentGroups.push({
-        key: 'group' + fieldValue + index,
-        name: `By "${fieldValue}"`,
-        value: fieldValue,
-        startIndex: index,
-        level: 0,
-        count: 0
-      });
-    }
-    if (lastCurrentGroup) {
-      lastCurrentGroup.count = index - lastCurrentGroup.startIndex;
-    }
-    return currentGroups;
-  }, []);
-
-  // Fix last group count
-  let lastGroup = groups[groups.length - 1];
-
-  if (lastGroup) {
-    lastGroup.count = items.length - lastGroup.startIndex;
-  }
-
-  return groups;
-}
-
 export class DetailsListGroupedExample extends React.Component<any, any> {
   constructor() {
     super();
@@ -98,10 +67,32 @@ export class DetailsListGroupedExample extends React.Component<any, any> {
         <DefaultButton onClick={ () => this._addItem() } text='Add an item' />
         <DetailsList
           items={ items }
-          groups={ groupBy(items, 'color') }
+          groups={ [
+            {
+              key: 'groupred0',
+              name: 'By "red"',
+              startIndex: 0,
+              count: 2
+            },
+            {
+              key: 'groupgreen2',
+              name: 'By "green"',
+              startIndex: 2,
+              count: 0
+            },
+            {
+              key: 'groupblue2',
+              name: 'By "blue"',
+              startIndex: 2,
+              count: 3
+            }
+          ] }
           columns={ _columns }
           ariaLabelForSelectAllCheckbox='Toggle selection for all items'
           ariaLabelForSelectionColumn='Toggle selection'
+          groupProps={ {
+            showEmptyGroups: true
+          } }
         />
       </Fabric>
     );

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
@@ -203,6 +203,12 @@ export interface IGroupRenderProps {
    * @default CheckboxVisibility.visible
    */
   collapseAllVisibility?: CollapseAllVisibility;
+
+  /**
+   * Boolean indicating if empty groups are shown
+   * @defaultvalue false
+   */
+  showEmptyGroups?: boolean;
 }
 
 export interface IGroupDividerProps {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -100,8 +100,8 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
               items={ groups }
               onRenderCell={ this._renderGroup }
               getItemCountForPage={ () => 1 }
-              usePageCache = { usePageCache }
-              onShouldVirtualize = { onShouldVirtualize }
+              usePageCache={ usePageCache }
+              onShouldVirtualize={ onShouldVirtualize }
             />
           )
         }
@@ -160,7 +160,11 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
     let footerProps = assign({}, groupProps!.footerProps, dividerProps);
     let groupNestingDepth = this._getGroupNestingDepth();
 
-    return (!group || group.count > 0) ? (
+    if (!groupProps!.showEmptyGroups && group && group.count === 0) {
+      return null;
+    }
+
+    return (
       <GroupedListSection
         ref={ 'group_' + groupIndex }
         key={ this._getGroupKey(group, groupIndex) }
@@ -182,7 +186,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
         selection={ selection }
         viewport={ viewport }
       />
-    ) : null;
+    );
   }
 
   private _getGroupKey(group: IGroup, index: number): string {

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -172,6 +172,10 @@ export class Selection implements ISelection {
   }
 
   public isRangeSelected(fromIndex: number, count: number): boolean {
+    if (count === 0) {
+      return false;
+    }
+
     let endIndex = fromIndex + count;
 
     for (let i = fromIndex; i < endIndex; i++) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Enable empty group headers (i.e. groups where `group.count === 0`) to be rendered. For example:

![capture](https://user-images.githubusercontent.com/2177366/30076269-2adf5c6e-922d-11e7-8603-40442a956b97.PNG)

Currently, I think this would be a breaking change since it changes the behavior of GroupedList, so we'd probably need some kind of option to enable rendering of empty group headers. I can think of a couple ways:

1. Add a boolean prop to `GroupedList` and `DetailsList`, e.g. `showEmptyGroups`. Default: `false`
2. Add a boolean property to the `IGroup` interface, e.g. `showIfEmpty`. This way, users can choose to render some empty groups, but not others.