### PR TITLE
New GroupedList footer in complement to Show All link

### DIFF
--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.scss
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.scss
@@ -2,7 +2,7 @@
 
 .root {
   position: relative;
-  padding: 10px 84px;
+  padding: 5px 38px;
 
   :global(.ms-Link) {
     font-size: $ms-font-size-s;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.tsx
@@ -12,24 +12,16 @@ const styles: any = stylesImport;
 
 export class GroupFooter extends BaseComponent<IGroupDividerProps, {}> {
   public render(): JSX.Element | null {
-    let { group, groupLevel, showAllLinkText } = this.props;
+    let { group, groupLevel, footerText } = this.props;
 
-    if (group) {
+    if (group && footerText) {
       return (
         <div className={ css('ms-groupFooter', styles.root) }>
           { GroupSpacer({ count: groupLevel! }) }
-          TODO: make group footer less prominent or only render when overridden
+          { footerText }
         </div>
       );
     }
     return null;
-  }
-
-  @autobind
-  private _onSummarizeClick(ev: React.MouseEvent<HTMLElement>) {
-    this.props.onToggleSummarize!(this.props.group!);
-
-    ev.stopPropagation();
-    ev.preventDefault();
   }
 }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.tsx
@@ -111,9 +111,9 @@ export class GroupHeader extends BaseComponent<IGroupDividerProps, IGroupHeaderS
           <div className={ css('ms-GroupHeader-title', styles.title) }>
             <span>{ group.name }</span>
             {
-              // hasMoreData flag is set when grouping is throttle by SPO server which in turn resorts to regular
+              // hasMoreData flag is set when grouping is throttled by SPO server which in turn resorts to regular
               // sorting to simulate grouping behaviors, in which case group count is the number of items returned
-              // so far. That's the reasons we need to use "+" to show we might have more items than count
+              // so far. That's the reason we need to use "+" to show we might have more items than count
               // indicates.
             }
             <span className={ styles.headerCount }>({ group.count }{ group.hasMoreData && '+' })</span>

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupShowAll.scss
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupShowAll.scss
@@ -3,6 +3,7 @@
 .root {
   position: relative;
   padding: 10px 84px;
+  cursor: pointer;
 
   :global(.ms-Link) {
     font-size: $ms-font-size-s;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupShowAll.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupShowAll.tsx
@@ -7,10 +7,10 @@ import {
 import { Link } from '../../Link';
 import { IGroupDividerProps } from './GroupedList.Props';
 import { GroupSpacer } from './GroupSpacer';
-import * as stylesImport from './GroupFooter.scss';
+import * as stylesImport from './GroupShowAll.scss';
 const styles: any = stylesImport;
 
-export class GroupFooter extends BaseComponent<IGroupDividerProps, {}> {
+export class GroupShowAll extends BaseComponent<IGroupDividerProps, {}> {
   public render(): JSX.Element | null {
     let { group, groupLevel, showAllLinkText } = this.props;
 
@@ -18,7 +18,7 @@ export class GroupFooter extends BaseComponent<IGroupDividerProps, {}> {
       return (
         <div className={ css('ms-groupFooter', styles.root) }>
           { GroupSpacer({ count: groupLevel! }) }
-          TODO: make group footer less prominent or only render when overridden
+          <Link onClick={ this._onSummarizeClick }>{ showAllLinkText }</Link>
         </div>
       );
     }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
@@ -185,6 +185,9 @@ export interface IGroupRenderProps {
   /** Information to pass in to the group header. */
   headerProps?: IGroupDividerProps;
 
+  /** Information to pass in to the group Show all footer. */
+  showAllProps?: IGroupDividerProps;
+
   /** Information to pass in to the group footer. */
   footerProps?: IGroupDividerProps;
 
@@ -194,7 +197,12 @@ export interface IGroupRenderProps {
   onRenderHeader?: IRenderFunction<IGroupDividerProps>;
 
   /**
-   * Override which allows the caller to provider a customer footer.
+   * Override which allows the caller to provide a custom Show All link.
+   */
+  onRenderShowAll?: IRenderFunction<IGroupDividerProps>;
+
+  /**
+   * Override which allows the caller to provide a custom footer.
    */
   onRenderFooter?: IRenderFunction<IGroupDividerProps>;
 
@@ -245,10 +253,10 @@ export interface IGroupDividerProps {
   /** The selection mode of the list the group lives within. */
   selectionMode?: SelectionMode;
 
-  /** Text to display for the group footer show all link. */
+  /** Text to display for the group "Show All" link. */
   showAllLinkText?: string;
 
-  /** Callback for when the "Show All" link in group footer is clicked */
+  /** Callback for when the group "Show All" link is clicked */
   onToggleSummarize?: (group: IGroup) => void;
 
   /** Callback for when the group header is clicked. */

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
@@ -253,6 +253,9 @@ export interface IGroupDividerProps {
   /** The selection mode of the list the group lives within. */
   selectionMode?: SelectionMode;
 
+  /** Text to display for the group footer. */
+  footerText?: string;
+
   /** Text to display for the group "Show All" link. */
   showAllLinkText?: string;
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -157,6 +157,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
     };
 
     let headerProps = assign({}, groupProps!.headerProps, dividerProps);
+    let showAllProps = assign({}, groupProps!.showAllProps, dividerProps);
     let footerProps = assign({}, groupProps!.footerProps, dividerProps);
     let groupNestingDepth = this._getGroupNestingDepth();
 
@@ -181,9 +182,11 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
         items={ items }
         onRenderCell={ onRenderCell }
         onRenderGroupHeader={ groupProps!.onRenderHeader }
+        onRenderGroupShowAll={ groupProps!.onRenderShowAll }
         onRenderGroupFooter={ groupProps!.onRenderFooter }
         selectionMode={ selectionMode }
         selection={ selection }
+        showAllProps={ showAllProps }
         viewport={ viewport }
       />
     );
@@ -254,7 +257,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
   @autobind
   private _onToggleSummarize(group: IGroup) {
     let { groupProps } = this.props;
-    let onToggleSummarize = groupProps && groupProps.footerProps && groupProps.footerProps.onToggleSummarize;
+    let onToggleSummarize = groupProps && groupProps.showAllProps && groupProps.showAllProps.onToggleSummarize;
 
     if (onToggleSummarize) {
       onToggleSummarize(group);

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -225,7 +225,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
                 this._onRenderGroup(renderCount)
             )
         }
-        { onRenderGroupShowAll(groupShowAllProps, this._onRenderGroupShowAll) }
+        { isShowAllVisible && onRenderGroupShowAll(groupShowAllProps, this._onRenderGroupShowAll) }
         { onRenderGroupFooter(groupFooterProps, this._onRenderGroupFooter) }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -23,8 +23,9 @@ import {
   SELECTION_CHANGE
 } from '../../utilities/selection/index';
 
-import { GroupFooter } from './GroupFooter';
 import { GroupHeader } from './GroupHeader';
+import { GroupShowAll } from './GroupShowAll';
+import { GroupFooter } from './GroupFooter';
 
 import {
   List
@@ -89,11 +90,17 @@ export interface IGroupedListSectionProps extends React.Props<GroupedListSection
   /** Controls how/if the details list manages selection. */
   selectionMode?: SelectionMode;
 
+  /** Information to pass in to the group Show All footer. */
+  showAllProps?: IGroupDividerProps;
+
   /** Optional Viewport, provided by the parent component. */
   viewport?: IViewport;
 
   /** Override for rendering the group header. */
   onRenderGroupHeader?: IRenderFunction<IGroupDividerProps>;
+
+  /** Override for rendering the group Show All link. */
+  onRenderGroupShowAll?: IRenderFunction<IGroupDividerProps>;
 
   /** Override for rendering the group footer. */
   onRenderGroupFooter?: IRenderFunction<IGroupDividerProps>;
@@ -169,15 +176,17 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
       group,
       groupIndex,
       headerProps,
+      showAllProps,
       footerProps,
       viewport,
       selectionMode,
       onRenderGroupHeader = this._onRenderGroupHeader,
+      onRenderGroupShowAll = this._onRenderGroupShowAll,
       onRenderGroupFooter = this._onRenderGroupFooter
     } = this.props;
     let { isSelected } = this.state;
     let renderCount = group && getGroupItemLimit ? getGroupItemLimit(group) : Infinity;
-    let isFooterVisible = group && !group.children && !group.isCollapsed && !group.isShowingAll &&
+    let isShowAllVisible = group && !group.children && !group.isCollapsed && !group.isShowingAll &&
       (group.count > renderCount || group.hasMoreData);
     let hasNestedGroups = group && group.children && group.children.length > 0;
 
@@ -190,6 +199,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
       selectionMode: selectionMode
     };
     let groupHeaderProps: IGroupDividerProps = assign({}, headerProps, dividerProps);
+    let groupShowAllProps: IGroupDividerProps = assign({}, showAllProps, dividerProps);
     let groupFooterProps: IGroupDividerProps = assign({}, footerProps, dividerProps);
 
     return (
@@ -215,7 +225,8 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
                 this._onRenderGroup(renderCount)
             )
         }
-        { isFooterVisible && onRenderGroupFooter(groupFooterProps, this._onRenderGroupFooter) }
+        { onRenderGroupShowAll(groupShowAllProps, this._onRenderGroupShowAll) }
+        { onRenderGroupFooter(groupFooterProps, this._onRenderGroupFooter) }
       </div>
     );
   }
@@ -254,6 +265,11 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
   @autobind
   private _onRenderGroupHeader(props: IGroupDividerProps) {
     return <GroupHeader { ...props } />;
+  }
+
+  @autobind
+  private _onRenderGroupShowAll(props: IGroupDividerProps) {
+    return <GroupShowAll { ...props } />;
   }
 
   @autobind
@@ -303,6 +319,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
       groupNestingDepth,
       items,
       headerProps,
+      showAllProps,
       footerProps,
       listProps,
       onRenderCell,
@@ -310,6 +327,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
       selectionMode,
       viewport,
       onRenderGroupHeader,
+      onRenderGroupShowAll,
       onRenderGroupFooter
     } = this.props;
 
@@ -331,8 +349,10 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
         onRenderCell={ onRenderCell }
         selection={ selection }
         selectionMode={ selectionMode }
+        showAllProps={ showAllProps }
         viewport={ viewport }
         onRenderGroupHeader={ onRenderGroupHeader }
+        onRenderGroupShowAll={ onRenderGroupShowAll }
         onRenderGroupFooter={ onRenderGroupFooter }
       />
     ) : null;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.scss
@@ -1,11 +1,17 @@
 :global {
 
   .ms-GroupedListExample-header,
+  .ms-GroupedListExample-showall,
   .ms-GroupedListExample-footer {
     min-width: 300px;
     min-height: 40px;
     line-height: 40px;
     padding-left: 16px;
+  }
+
+  .ms-GroupedListExample-showall {
+    cursor: pointer;
+    padding-left: 32px;
   }
 
   .ms-GroupedListExample-name {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.tsx
@@ -31,6 +31,7 @@ export class GroupedListCustomExample extends React.Component<any, any> {
         groupProps={
           {
             onRenderHeader: this._onRenderHeader,
+            onRenderShowAll: this._onRenderShowAll,
             onRenderFooter: this._onRenderFooter
           }
         }
@@ -58,9 +59,17 @@ export class GroupedListCustomExample extends React.Component<any, any> {
     );
   }
 
+  private _onRenderShowAll(props: IGroupDividerProps): JSX.Element {
+    return (
+      <div className={ css('ms-GroupedListExample-showall', FontClassNames.medium) }>
+        This is a custom <Link onClick={ () => props.onToggleSummarize }>Show All</Link> link for { props.group!.name }
+      </div>
+    );
+  }
+
   private _onRenderFooter(props: IGroupDividerProps): JSX.Element {
     return (
-      <div className={ css('ms-GroupedListExample-footer', FontClassNames.xLarge) }>
+      <div className={ css('ms-GroupedListExample-footer', FontClassNames.large) }>
         This is a custom footer for { props.group!.name }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.tsx
@@ -31,7 +31,6 @@ export class GroupedListCustomExample extends React.Component<any, any> {
         groupProps={
           {
             onRenderHeader: this._onRenderHeader,
-            onRenderShowAll: this._onRenderShowAll,
             onRenderFooter: this._onRenderFooter
           }
         }
@@ -55,14 +54,6 @@ export class GroupedListCustomExample extends React.Component<any, any> {
       <div className={ css('ms-GroupedListExample-header', FontClassNames.xLarge) }>
         This is a custom header for { props.group!.name }
         &nbsp;(<Link onClick={ () => props.onToggleCollapse!(props.group!) }>{ props.group!.isCollapsed ? 'Expand' : 'Collapse' }</Link>)
-      </div>
-    );
-  }
-
-  private _onRenderShowAll(props: IGroupDividerProps): JSX.Element {
-    return (
-      <div className={ css('ms-GroupedListExample-showall', FontClassNames.medium) }>
-        This is a custom <Link onClick={ () => props.onToggleSummarize }>Show All</Link> link for { props.group!.name }
       </div>
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #2727
- [ ] No change file needed according to  `npm run change`

#### Description of changes

Added footerText property to IGroupDividerProps. New GroupFooter component will be rendered only when this property is set. GroupFooter can still be overridden with custom rendering.

Added new GroupShowAll component with same behavior as previous GroupFooter. Can be overridden with custom rendering.

#### Focus areas to test

Try setting footerText and override group footer rendering.
