### PR TITLE
ContextualMenu: Add onRenderSubMenu prop.

### DIFF
--- a/common/changes/office-ui-fabric-react/onRenderSubMenu_2017-09-05-20-01.json
+++ b/common/changes/office-ui-fabric-react/onRenderSubMenu_2017-09-05-20-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add onRenderSubMenu prop to ContextualMenu.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dawilson@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/onRenderSubMenu_2017-09-05-20-01.json
+++ b/common/changes/office-ui-fabric-react/onRenderSubMenu_2017-09-05-20-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Add onRenderSubMenu prop to ContextualMenu.",
+      "comment": "ContextualMenu: `onRenderSubMenu` prop added to allow the overriding of submenu rendering.",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -6,7 +6,8 @@ import { IIconProps } from '../Icon/Icon.Props';
 import { ICalloutProps } from '../../Callout';
 import {
   IPoint,
-  IRectangle
+  IRectangle,
+  IRenderFunction
 } from '../../Utilities';
 import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
 export { DirectionalHint } from '../../common/DirectionalHint';
@@ -181,6 +182,9 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * Pass in custom callout props
    */
   calloutProps?: ICalloutProps;
+
+  /** Method to call when trying to render a submenu. */
+  onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
 }
 
 export interface IContextualMenuItem {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -192,7 +192,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       useTargetWidth,
       directionalHintFixed,
       shouldFocusOnMount,
-      calloutProps } = this.props;
+      calloutProps,
+      onRenderSubMenu = this._onRenderSubMenu } = this.props;
 
     let hasIcons = !!(items && items.some(item => !!item.icon || !!item.iconProps));
     let hasCheckmarks = !!(items && items.some(item => !!item.canCheck));
@@ -265,13 +266,17 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                 </ul>
               </FocusZone>
             ) : (null) }
-            { submenuProps && <ContextualMenu { ...submenuProps } /> }
+            { submenuProps && onRenderSubMenu(submenuProps, this._onRenderSubMenu) }
           </div>
         </Callout>
       );
     } else {
       return null;
     }
+  }
+
+  private _onRenderSubMenu(subMenuProps: IContextualMenuProps) {
+    return <ContextualMenu { ...subMenuProps } />;
   }
 
   private _renderMenuItem(item: IContextualMenuItem, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds an onRenderSubMenu prop to ContextualMenu. This uses the IRenderFunction pattern to allow users to override the rendering of submenus. 

We (VSTS) need this to support our extensibility model and provide some other back-compat support for legacy components.

#### Focus areas to test

(optional)
