### PR TITLE
Add presentation hooks for Tile and FolderCover

### DIFF
--- a/common/changes/@uifabric/experiments/tile-states_2017-09-06-18-16.json
+++ b/common/changes/@uifabric/experiments/tile-states_2017-09-06-18-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add presentation hooks for Tile and FolderCover",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.Props.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.Props.ts
@@ -12,7 +12,33 @@ export type FolderCoverType =
   'media';
 
 export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<FolderCover> {
+  /**
+   * The breakpoint size of the folder cover.
+   *
+   * @type {FolderCoverSize}
+   * @memberof IFolderCoverProps
+   */
   folderCoverSize?: FolderCoverSize;
+  /**
+   * The display type of the folder cover.
+   *
+   * @type {FolderCoverType}
+   * @memberof IFolderCoverProps
+   */
   folderCoverType?: FolderCoverType;
+  /**
+   * Whether or not the content should be hidden, even if specified.
+   * Use this to "fade in" the content once it is loaded.
+   *
+   * @type {boolean}
+   * @memberof IFolderCoverProps
+   */
+  hideContent?: boolean;
+  /**
+   * A metadata value to display on the folder cover.
+   *
+   * @type {(React.ReactNode[] | React.ReactNode)}
+   * @memberof IFolderCoverProps
+   */
   metadata?: React.ReactNode[] | React.ReactNode;
 }

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -43,6 +43,14 @@
   flex-direction: column;
   align-items: center;
   overflow: hidden;
+  box-shadow: 0 1px 3px 1px rgba(1, 1, 0, 0.05);
+  opacity: 1;
+
+  transition: opacity 0.2s linear;
+
+  .hideContent & {
+    opacity: 0;
+  }
 
   &,
   .isSmall & {

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -69,7 +69,8 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
   public render(): JSX.Element | null {
     const {
       folderCoverSize: size = 'large',
-      folderCoverType: type = 'default'
+      folderCoverType: type = 'default',
+      hideContent = false
     } = this.props;
 
     const assets = ASSETS[size][type];
@@ -77,27 +78,32 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
     return (
       <div
         className={ css(FolderCoverStyles.root, {
-          [FolderCoverStyles.isSmall]: size === 'small',
-          [FolderCoverStyles.isLarge]: size === 'large',
-          [FolderCoverStyles.isDefault]: type === 'default',
-          [FolderCoverStyles.isMedia]: type === 'media'
+          [`ms-FolderCover--isSmall ${FolderCoverStyles.isSmall}`]: size === 'small',
+          [`ms-FolderCover--isLarge ${FolderCoverStyles.isLarge}`]: size === 'large',
+          [`ms-FolderCover--isDefault ${FolderCoverStyles.isDefault}`]: type === 'default',
+          [`ms-FolderCover--isMedia ${FolderCoverStyles.isMedia}`]: type === 'media',
+          [`ms-FolderCover--hideContent ${FolderCoverStyles.hideContent}`]: hideContent
         }) }
       >
         <img
-          className={ css(FolderCoverStyles.back) }
+          className={ css('ms-FolderCover-back', FolderCoverStyles.back) }
           src={ assets.back }
         />
-        <span className={ css(FolderCoverStyles.content) }>
-          { this.props.children }
-        </span>
+        {
+          this.props.children ? (
+            <span className={ css('ms-FolderCover-content', FolderCoverStyles.content) }>
+              { this.props.children }
+            </span>
+          ) : null
+        }
         <img
-          className={ css(FolderCoverStyles.front) }
+          className={ css('ms-FolderCover-front', FolderCoverStyles.front) }
           src={ assets.front }
         />
         {
           this.props.metadata ?
             (
-              <span className={ css(FolderCoverStyles.metadata) }>
+              <span className={ css('ms-FolderCover-metadata', FolderCoverStyles.metadata) }>
                 { this.props.metadata }
               </span>
             ) :

--- a/packages/experiments/src/components/Tile/Tile.Props.ts
+++ b/packages/experiments/src/components/Tile/Tile.Props.ts
@@ -66,6 +66,14 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    */
   showBackgroundFrame?: boolean;
   /**
+   * Whether or not to hide the background, regardless of whether it is present.
+   * Use this to control when the background "fades in" if the content needs to be loaded.
+   *
+   * @type {boolean}
+   * @memberof ITileProps
+   */
+  hideBackground?: boolean;
+  /**
    * Content to render as the foreground of the tile, bounded by padding and the nameplate.
    *
    * @type {(React.ReactNode | React.ReactNode[])}
@@ -79,6 +87,14 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    * @memberof ITileProps
    */
   showForegroundFrame?: boolean;
+  /**
+   * Whether or not to hide the foreground, regardless of whether it is present.
+   * Use this to control when the foreground "fades in" if the content needs to be loaded.
+   *
+   * @type {boolean}
+   * @memberof ITileProps
+   */
+  hideForeground?: boolean;
   /**
    * The accessible label for the selection checkbox.
    *

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -178,13 +178,21 @@ button.check {
   }
 }
 
-.content {
-  margin: 16px 16px 0 16px;
+.aboveNameplate {
   flex: 1;
+  position: relative;
+  margin: 16px 16px 0 16px;
+}
+
+.content {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  position: relative;
 }
 
 .nameplate {
@@ -236,8 +244,8 @@ button.check {
   font-weight: $ms-font-weight-regular;
   font-size: $ms-font-size-m;
   color: $ms-color-neutralPrimary;
-  height: 20px;
-  line-height: 20px;
+  height: 17px;
+  line-height: 17px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -250,8 +258,8 @@ button.check {
   font-weight: $ms-font-weight-regular;
   font-size: $ms-font-size-s;
   color: #767676;
-  height: 16px;
-  line-height: 16px;
+  height: 14px;
+  line-height: 14px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -10,6 +10,7 @@
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: 0; // Reset the stacking context.
   background-color: $ms-color-white;
   transition: transform 0.1s linear;
   color: $ms-color-neutralPrimary;
@@ -93,12 +94,18 @@
   text-decoration: none;
 }
 
-.frame {
+.foreground {
   margin: auto;
   position: relative;
   overflow: hidden;
   max-width: 100%;
   max-height: 100%;
+  opacity: 1;
+  transition: opacity 0.2s linear;
+
+  &.foregroundHide {
+    opacity: 0;
+  }
 
   &.hasForegroundFrame {
     margin: auto auto 0 auto;
@@ -154,11 +161,6 @@ button.check {
   padding: 6px;
 }
 
-.content {
-  position: relative;
-  flex: 1;
-}
-
 .background {
   position: absolute;
   top: 0;
@@ -166,25 +168,40 @@ button.check {
   right: 0;
   bottom: 0;
   overflow: hidden;
+
+  opacity: 1;
+
+  transition: opacity 0.2s linear;
+
+  &.backgroundHide {
+    opacity: 0;
+  }
 }
 
-.foreground {
-  top: 16px;
-  left: 16px;
-  right: 16px;
-  bottom: 0;
-  flex-grow: 1;
+.content {
+  margin: 16px 16px 0 16px;
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  position: absolute;
+  position: relative;
 }
 
 .nameplate {
   display: block;
+  position: relative;
   margin: auto 0 0 0;
   padding: 12px 8px;
   text-align: center;
+  z-index: 0;
+
+  .name {
+    transition: color 0.2s linear;
+  }
+
+  .activity {
+    transition: color 0.2s linear;
+  }
 
   .tile.hasBackgroundFrame & {
     padding: 12px 10px;
@@ -249,28 +266,36 @@ button.check {
 
 .hasBackground {
   .nameplate {
-    position: relative;
-    background-image: linear-gradient(to top, rgba(#000, 0.65) 0%, rgba(#000, 0.65 * 0.85) 70%, rgba(#000, 0.30 * 0.85) 100%);
-
     &:before {
       position: absolute;
       content: '';
       display: block;
-      height: 12px;
-      bottom: 100%;
+      top: -12px;
+      bottom: 0;
       left: 0;
       right: 0;
-      background-image: linear-gradient(to top, rgba(#000, 0.30 * 0.85) 0%, rgba(#000, 0) 100%);
+      background-image: linear-gradient(to top, rgba(#000, 0.65) 0%, rgba(#000, 0.65 * 0.85) 55%, rgba(#000, 0.65 * 0.30) 80%, rgba(#000, 0) 100%);
+      z-index: -1;
+      transition: opacity 0.2s linear;
+      opacity: 0;
     }
   }
 
-  .name {
-    color: $ms-color-white;
-    text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
-  }
+  &.showBackground {
+    .name {
+      color: $ms-color-white;
+      text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
+    }
 
-  .activity {
-    color: $ms-color-white;
-    text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
+    .activity {
+      color: $ms-color-white;
+      text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
+    }
+
+    .nameplate {
+      &:before {
+        opacity: 1;
+      }
+    }
   }
 }

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -15,8 +15,9 @@ const SignalStyles: any = SignalStylesModule;
 
 const enum TileLayoutValues {
   nameplatePadding = 12,
-  nameplateNameHeight = 20,
-  nameplateActivityHeight = 20,
+  nameplateNameHeight = 17,
+  nameplateMargin = 4,
+  nameplateActivityHeight = 14,
   foregroundMargin = 16
 }
 
@@ -211,16 +212,21 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     return (
       <span
         role='presentation'
-        className={ css('ms-Tile-content', TileStyles.content) }
+        className={ css('ms-Tile-aboveNameplate', TileStyles.aboveNameplate) }
       >
         <span
           role='presentation'
-          className={ css('ms-Tile-foreground', TileStyles.foreground, {
-            [`ms-Tile-foreground--hasFrame ${TileStyles.hasForegroundFrame}`]: showForegroundFrame,
-            [`ms-Tile-foreground--hide ${TileStyles.foregroundHide}`]: hideForeground
-          }) }
+          className={ css('ms-Tile-content', TileStyles.content) }
         >
-          { foreground }
+          <span
+            role='presentation'
+            className={ css('ms-Tile-foreground', TileStyles.foreground, {
+              [`ms-Tile-foreground--hasFrame ${TileStyles.hasForegroundFrame}`]: showForegroundFrame,
+              [`ms-Tile-foreground--hide ${TileStyles.foregroundHide}`]: hideForeground
+            }) }
+          >
+            { foreground }
+          </span>
         </span>
       </span>
     );
@@ -319,7 +325,7 @@ export function getTileLayout(tileElement: JSX.Element): ITileLayout {
       nameplateHeight += TileLayoutValues.nameplateNameHeight;
     }
     if (tileProps.itemActivity) {
-      nameplateHeight += TileLayoutValues.nameplateActivityHeight;
+      nameplateHeight += TileLayoutValues.nameplateActivityHeight + TileLayoutValues.nameplateMargin;
     }
   }
 

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -113,6 +113,8 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
       foreground,
       showBackgroundFrame = false,
       showForegroundFrame = false,
+      hideBackground = false,
+      hideForeground = false,
       itemName,
       itemActivity,
       componentRef,
@@ -136,7 +138,9 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
           [`ms-Tile--hasBackgroundFrame ${TileStyles.hasBackgroundFrame}`]: showBackgroundFrame,
           [`ms-Tile--isSelected ${TileStyles.selected} ${SignalStyles.selected}`]: isSelected,
           [`ms-Tile--isSelectable ${TileStyles.selectable}`]: isSelectable,
-          [`ms-Tile--hasBackground ${TileStyles.hasBackground} ${SignalStyles.dark}`]: !!background
+          [`ms-Tile--hasBackground ${TileStyles.hasBackground}`]: !!background,
+          [SignalStyles.dark]: !!background && !hideBackground,
+          [`ms-Tile--showBackground ${TileStyles.showBackground}`]: !hideBackground
         }) }
         data-is-focusable={ true }
         data-is-sub-focuszone={ true }
@@ -150,13 +154,15 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         >
           {
             background ? this._onRenderBackground({
-              background: background
+              background: background,
+              hideBackground
             }) : null
           }
           {
             foreground ? this._onRenderForeground({
               foreground: foreground,
-              showForegroundFrame: showForegroundFrame
+              showForegroundFrame: showForegroundFrame,
+              hideForeground
             }) : null
           }
           {
@@ -176,12 +182,18 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
   }
 
   private _onRenderBackground({
-    background
+    background,
+    hideBackground
   }: {
-      background: React.ReactNode | React.ReactNode[]
+      background: React.ReactNode | React.ReactNode[];
+      hideBackground: boolean;
     }): JSX.Element {
     return (
-      <span className={ css('ms-Tile-background', TileStyles.background) }>
+      <span
+        className={ css('ms-Tile-background', TileStyles.background, {
+          [`ms-Tile-background--hide ${TileStyles.backgroundHide}`]: hideBackground
+        }) }
+      >
         { background }
       </span>
     );
@@ -189,10 +201,12 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
 
   private _onRenderForeground({
     foreground,
-    showForegroundFrame
+    showForegroundFrame,
+    hideForeground
   }: {
       foreground: React.ReactNode | React.ReactNode[];
       showForegroundFrame: boolean;
+      hideForeground: boolean;
     }): JSX.Element {
     return (
       <span
@@ -201,16 +215,12 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
       >
         <span
           role='presentation'
-          className={ css('ms-Tile-foreground', TileStyles.foreground) }
+          className={ css('ms-Tile-foreground', TileStyles.foreground, {
+            [`ms-Tile-foreground--hasFrame ${TileStyles.hasForegroundFrame}`]: showForegroundFrame,
+            [`ms-Tile-foreground--hide ${TileStyles.foregroundHide}`]: hideForeground
+          }) }
         >
-          <span
-            role='presentation'
-            className={ css('ms-Tile-frame', TileStyles.frame, {
-              [`ms-Tile-frame--hasForegroundFrame ${TileStyles.hasForegroundFrame}`]: showForegroundFrame
-            }) }
-          >
-            { foreground }
-          </span>
+          { foreground }
         </span>
       </span>
     );

--- a/packages/experiments/src/components/Tile/examples/Tile.Document.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Document.Example.tsx
@@ -1,7 +1,8 @@
 
 import * as React from 'react';
 import { Tile, getTileLayout, renderTileWithLayout } from '../Tile';
-import { css } from 'office-ui-fabric-react/lib/Utilities';
+import { css, autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import {
   SignalField,
   NewSignal,
@@ -16,8 +17,29 @@ import * as TileExampleStylesModule from './Tile.Example.scss';
 // tslint:disable-next-line:no-any
 const TileExampleStyles = TileExampleStylesModule as any;
 
+const ITEMS: { name: string; activity: string; }[] = [
+  {
+    name: lorem(2),
+    activity: lorem(6),
+  },
+  {
+    name: lorem(2),
+    activity: lorem(6),
+  },
+  {
+    name: lorem(2),
+    activity: lorem(6),
+  },
+  {
+    name: lorem(2),
+    activity: lorem(6),
+  }
+];
+
 interface IDocumentTileWithThumbnailProps {
   originalImageSize: ISize;
+  showForeground: boolean;
+  item: typeof ITEMS[0];
 }
 
 const DocumentTileWithThumbnail: React.StatelessComponent<IDocumentTileWithThumbnailProps> =
@@ -36,7 +58,7 @@ const DocumentTileWithThumbnail: React.StatelessComponent<IDocumentTileWithThumb
               <TrendingSignal />
             }
           >
-            { lorem(2) }
+            { props.item.name }
           </SignalField>
         }
         itemActivity={
@@ -45,12 +67,13 @@ const DocumentTileWithThumbnail: React.StatelessComponent<IDocumentTileWithThumb
               <CommentsSignal>{ '12' }</CommentsSignal>
             }
           >
-            { lorem(2) }
+            { props.item.activity }
           </SignalField>
         }
         foreground={
           <span />
         }
+        hideForeground={ !props.showForeground }
         showForegroundFrame={ true }
       />
     );
@@ -81,10 +104,31 @@ const DocumentTileWithThumbnail: React.StatelessComponent<IDocumentTileWithThumb
     );
   };
 
-export class TileDocumentExample extends React.Component<{}, {}> {
+export interface ITileDocumentExampleState {
+  imagesLoaded: boolean;
+}
+
+export class TileDocumentExample extends React.Component<{}, ITileDocumentExampleState> {
+  constructor() {
+    super();
+
+    this.state = {
+      imagesLoaded: true
+    };
+  }
+
   public render(): JSX.Element {
+    const {
+      imagesLoaded
+    } = this.state;
+
     return (
       <div>
+        <Checkbox
+          label='Show images as loaded'
+          checked={ imagesLoaded }
+          onChange={ this._onImagesLoadedChanged }
+        />
         <h3>Document thumbnail</h3>
         <DocumentTileWithThumbnail
           originalImageSize={
@@ -93,6 +137,8 @@ export class TileDocumentExample extends React.Component<{}, {}> {
               height: 40
             }
           }
+          showForeground={ imagesLoaded }
+          item={ ITEMS[0] }
         />
         <DocumentTileWithThumbnail
           originalImageSize={
@@ -101,6 +147,8 @@ export class TileDocumentExample extends React.Component<{}, {}> {
               height: 150
             }
           }
+          showForeground={ imagesLoaded }
+          item={ ITEMS[1] }
         />
         <DocumentTileWithThumbnail
           originalImageSize={
@@ -109,6 +157,8 @@ export class TileDocumentExample extends React.Component<{}, {}> {
               height: 200
             }
           }
+          showForeground={ imagesLoaded }
+          item={ ITEMS[2] }
         />
         <h3>Document icon</h3>
         <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
@@ -119,7 +169,7 @@ export class TileDocumentExample extends React.Component<{}, {}> {
                   <NewSignal />
                 }
               >
-                { lorem(1) }
+                { ITEMS[3].name }
               </SignalField>
             }
             itemActivity={
@@ -129,7 +179,7 @@ export class TileDocumentExample extends React.Component<{}, {}> {
                     <SharedSignal />
                   }
                 >
-                  { lorem(3) }
+                  { ITEMS[3].activity }
                 </SignalField>
               )
             }
@@ -153,5 +203,12 @@ export class TileDocumentExample extends React.Component<{}, {}> {
         </div>
       </div>
     );
+  }
+
+  @autobind
+  private _onImagesLoadedChanged(event: React.FormEvent<HTMLInputElement>, checked: boolean): void {
+    this.setState({
+      imagesLoaded: checked
+    });
   }
 }

--- a/packages/experiments/src/components/Tile/examples/Tile.Media.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Media.Example.tsx
@@ -2,7 +2,8 @@
 import * as React from 'react';
 import { Tile, getTileLayout, renderTileWithLayout } from '../Tile';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { css } from 'office-ui-fabric-react/lib/Utilities';
+import { css, autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { ISize, fitContentToBounds } from '@uifabric/utilities';
 import {
   SignalField,
@@ -14,12 +15,29 @@ import {
 import { lorem } from '@uifabric/example-app-base';
 import * as TileExampleStylesModule from './Tile.Example.scss';
 
+const ITEMS: { name: string; activity: string; }[] = [
+  {
+    name: lorem(2),
+    activity: lorem(6),
+  },
+  {
+    name: lorem(2),
+    activity: lorem(6),
+  },
+  {
+    name: lorem(2),
+    activity: lorem(6),
+  }
+];
+
 // tslint:disable-next-line:no-any
 const TileExampleStyles = TileExampleStylesModule as any;
 
 interface IImageTileProps {
   tileSize: ISize;
   originalImageSize: ISize;
+  showBackground: boolean;
+  item: typeof ITEMS[0];
 }
 
 const ImageTile: React.StatelessComponent<IImageTileProps> = (props: IImageTileProps): JSX.Element => {
@@ -32,7 +50,7 @@ const ImageTile: React.StatelessComponent<IImageTileProps> = (props: IImageTileP
             <NewSignal />
           }
         >
-          { lorem(2) }
+          { props.item.name }
         </SignalField>
       }
       itemActivity={
@@ -41,12 +59,13 @@ const ImageTile: React.StatelessComponent<IImageTileProps> = (props: IImageTileP
             [<Signal key={ 0 }><Icon iconName='play' /></Signal>, <MentionSignal key={ 1 } />]
           }
         >
-          { lorem(6) }
+          { props.item.activity }
         </SignalField>
       }
       background={
         <span /> // Placeholder content
       }
+      hideBackground={ !props.showBackground }
       showBackgroundFrame={ true }
     />
   );
@@ -86,10 +105,31 @@ const ImageTile: React.StatelessComponent<IImageTileProps> = (props: IImageTileP
   );
 };
 
-export class TileMediaExample extends React.Component<{}, {}> {
+export interface ITileMediaExampleState {
+  imagesLoaded: boolean;
+}
+
+export class TileMediaExample extends React.Component<{}, ITileMediaExampleState> {
+  constructor() {
+    super();
+
+    this.state = {
+      imagesLoaded: true
+    };
+  }
+
   public render(): JSX.Element {
+    const {
+      imagesLoaded
+    } = this.state;
+
     return (
       <div>
+        <Checkbox
+          label='Show images as loaded'
+          checked={ imagesLoaded }
+          onChange={ this._onImagesLoadedChanged }
+        />
         <h3>Landscape</h3>
         <ImageTile
           tileSize={
@@ -98,12 +138,14 @@ export class TileMediaExample extends React.Component<{}, {}> {
               height: 200
             }
           }
+          item={ ITEMS[0] }
           originalImageSize={
             {
               width: 400,
               height: 300
             }
           }
+          showBackground={ imagesLoaded }
         />
         <h3>Portrait</h3>
         <ImageTile
@@ -113,12 +155,14 @@ export class TileMediaExample extends React.Component<{}, {}> {
               height: 250
             }
           }
+          item={ ITEMS[1] }
           originalImageSize={
             {
               width: 300,
               height: 400
             }
           }
+          showBackground={ imagesLoaded }
         />
         <h3>No preview</h3>
         <div className={ css(TileExampleStyles.tile, TileExampleStyles.squareTile) }>
@@ -129,7 +173,7 @@ export class TileMediaExample extends React.Component<{}, {}> {
                   <NewSignal />
                 }
               >
-                { lorem(2) }
+                { ITEMS[2].name }
               </SignalField>
             }
             itemActivity={
@@ -142,7 +186,7 @@ export class TileMediaExample extends React.Component<{}, {}> {
                     ]
                   }
                 >
-                  { lorem(8) }
+                  { ITEMS[2].name }
                 </SignalField>
               )
             }
@@ -154,5 +198,12 @@ export class TileMediaExample extends React.Component<{}, {}> {
         </div>
       </div>
     );
+  }
+
+  @autobind
+  private _onImagesLoadedChanged(event: React.FormEvent<HTMLInputElement>, checked: boolean): void {
+    this.setState({
+      imagesLoaded: checked
+    });
   }
 }

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -85,6 +85,8 @@
 }
 
 .signal {
+  transition: color 0.2s linear;
+
   .dark &,
   .dark.selected {
     color: $ms-color-white;


### PR DESCRIPTION
### Overview

This change adds presentation hooks for transitions states for the `Tile` and `FolderCover` components.
These let consumers 'stage' content and then fade it in when needed within these components.