### PR TITLE
Experiments fabric export

### DIFF
--- a/common/changes/@uifabric/experiments/experiments-fabric-export_2017-09-06-20-01.json
+++ b/common/changes/@uifabric/experiments/experiments-fabric-export_2017-09-06-20-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Removed global fabric export",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "micahgodbolt@gmail.com"
+}

--- a/packages/experiments/src/index.ts
+++ b/packages/experiments/src/index.ts
@@ -1,2 +1,2 @@
-export * from 'office-ui-fabric-react';
+export { CommandBar } from './CommandBar';
 export { CommandBar as ExperimentCommandBar } from './CommandBar';


### PR DESCRIPTION
#### Pull request checklist

This export was unnecessary and broke our ability to have same named components exported in both experiments and OUFR

 `export { CommandBar as ExperimentCommandBar } from './CommandBar'` kept in there for backwards compat. Will remove later.
#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
