### PR TITLE
Collapse GroupedList if groupProps.initialAllGroupsCollapsed

### DIFF
--- a/common/changes/office-ui-fabric-react/isallgroupscollapsed_2017-09-06-21-46.json
+++ b/common/changes/office-ui-fabric-react/isallgroupscollapsed_2017-09-06-21-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Collapse GroupedList if groupProps.initialAllGroupsCollapsed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "spelliot@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.Props.ts
@@ -174,8 +174,16 @@ export interface IGroup {
 
 export interface IGroupRenderProps {
 
-  /** Boolean indicating if all groups are in collapsed state. */
+  /**
+   * Boolean indicating if all groups are in collapsed state.
+   * @deprecated
+   */
   isAllGroupsCollapsed?: boolean;
+
+  /**
+   * Boolean indicating if all groups are initially in collapsed state.
+   */
+  initialAllGroupsCollapsed?: boolean;
 
   /** Grouping item limit. */
   getGroupItemLimit?: (group: IGroup) => number;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -79,6 +79,14 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
     }
   }
 
+  public componentWillMount() {
+    const { groupProps } = this.props;
+
+    if (groupProps && groupProps.initialAllGroupsCollapsed) {
+      this.toggleCollapseAll(groupProps.initialAllGroupsCollapsed);
+    }
+  }
+
   public render() {
     let {
       className,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2176 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Previously, passing `groupProps={{ isAllGroupsCollapsed: true }}` did not collapse all groups as expected. Now, it correctly collapses all groups.

#### Before

![before](https://user-images.githubusercontent.com/2177366/30136304-345ecb08-9313-11e7-9a36-eee83ba4665e.PNG)

#### After

![after](https://user-images.githubusercontent.com/2177366/30136268-fd6f6c24-9312-11e7-8688-b0cd27a878d7.PNG)
