### PR TITLE
DetailsList: fixing alignment, horiz scroll issues.

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-check_2017-09-07-23-02.json
+++ b/common/changes/office-ui-fabric-react/fix-check_2017-09-07-23-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Fixing alignment issues due to recent changes in Check.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
@@ -18,8 +18,13 @@
 }
 
 button.check {
-  padding: 3px;
+  height: 20px;
+  width: 20px;
+  padding: 0;
   margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .owner {


### PR DESCRIPTION
This change fixes the Check rendered within DetailsRows to be fix sized rather than variable sized with padding. Anything fixed sized should not depend on padding to achieve a fixed size! :(

Narrow before:
![image](https://user-images.githubusercontent.com/1110944/30188997-7a8787c2-93e6-11e7-8ae4-c7b122a3a325.png)

Narrow after:
![image](https://user-images.githubusercontent.com/1110944/30188935-2e697a94-93e6-11e7-84a6-91f98d6b2c77.png)

Regular before:
![image](https://user-images.githubusercontent.com/1110944/30189009-82f18f8e-93e6-11e7-9989-9041cd6ced24.png)

Regular after.
![image](https://user-images.githubusercontent.com/1110944/30188939-3ab4e1bc-93e6-11e7-8681-ea2ee346184f.png)
