### PR TITLE
Adding getIconClassName helper to Fabric 4 to make the Fabric 5 transition easier.

### DIFF
--- a/common/changes/@uifabric/styling/add-icon-helpers_2017-09-08-22-14.json
+++ b/common/changes/@uifabric/styling/add-icon-helpers_2017-09-08-22-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Adding the `getIconClassName` function, which will provide a way for partners to generate a given icon class name. This replaces the implicit `ms-Icon--*` pattern being used now, as well as using IconClassNames, which will go away in Fabric 5.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/add-icon-helpers_2017-09-08-22-14.json
+++ b/common/changes/office-ui-fabric-react/add-icon-helpers_2017-09-08-22-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Icon: tweaked `iconName` to take in a string, rather than IconCode. The type safety can't be enforced in Fabric 5 which will support whatever subsets the customer registers.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.Props.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { IconName } from './IconName';
 import { IImageProps } from '../Image/Image.Props';
 import { IStyle } from '../../Styling';
 
@@ -37,11 +36,8 @@ export interface IIconStyles {
 export interface IIconProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * The name of the icon to use from the icon font.
-   *
-   * @type {(IconName | string | null)}
-   * @memberOf IIconProps
    */
-  iconName?: IconName | string | null;
+  iconName?: string | null;
 
   /**
    * Optional styling for the elements within the Icon.

--- a/packages/office-ui-fabric-react/src/components/Icon/IconName.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/IconName.ts
@@ -1,4 +1,8 @@
-// Please keep alphabetized
+/**
+ * This is being removed from the styling package in Fabric 5 and moved into a dedicated
+ * icons package.
+ * @deprecated
+ */
 export type IconName =
   // These icons are not in the font.
   'CustomIcon' |

--- a/packages/styling/src/classNames/IconClassNames.ts
+++ b/packages/styling/src/classNames/IconClassNames.ts
@@ -4,7 +4,10 @@ import {
 } from '../utilities/index';
 
 /**
- * All class names for all Fabric icons.
+ * Deprecated: All class names for all Fabric icons.
+ * NOTE: This is deprecated, being replaced with a getIconClassName function.
+ *
+ * @deprecated
  */
 export const IconClassNames: {[key in keyof typeof IconCodes]?: string } = {};
 

--- a/packages/styling/src/styles/IconCodes.ts
+++ b/packages/styling/src/styles/IconCodes.ts
@@ -1,3 +1,9 @@
+/**
+ * This is being removed in Fabric 5 due to the need to support arbitrary icon names
+ * for variable subsetting. Please use getIconClassName if you need the icon code, or
+ * render an <Icon /> component which will abstract how the icon is rendered.
+ * @deprecated
+ */
 export const IconCodes = {
   /**
    * Icon code with the value '\uED68'.

--- a/packages/styling/src/utilities/getIconClassName.ts
+++ b/packages/styling/src/utilities/getIconClassName.ts
@@ -1,0 +1,33 @@
+import {
+  IconClassNames
+} from '../classNames/IconClassNames';
+
+let _lowerCaseIconMap: { [key: string]: string };
+
+/**
+ * Gets an icon classname, given an icon name (case insensitive.) The class name can be attached to
+ * an I tag with no additional classnames. This will render the icon code using a ::before pseudo-selector.
+ *
+ * @public
+ */
+export function getIconClassName(name: string): string {
+  if (!name) {
+    return '';
+  }
+
+  // Make the lookup case insensitive. Note that this implementation is different in Fabric 5, but this method
+  // is being added sooner to make it easier to transition products.
+  name = name.toLowerCase();
+
+  if (!_lowerCaseIconMap) {
+    _lowerCaseIconMap = {};
+
+    for (let iconName in IconClassNames) {
+      if (IconClassNames.hasOwnProperty(iconName)) {
+        _lowerCaseIconMap[iconName.toLowerCase()] = iconName;
+      }
+    }
+  }
+
+  return IconClassNames[_lowerCaseIconMap[name.toLowerCase()]] || '';
+}

--- a/packages/styling/src/utilities/index.ts
+++ b/packages/styling/src/utilities/index.ts
@@ -7,3 +7,6 @@ export {
 export {
   buildClassMap
 } from './buildClassMap';
+export {
+  getIconClassName
+} from './getIconClassName';


### PR DESCRIPTION
This change adds a `getIconClassName` helper to the styling package, which replaces access to the IconClassNames object. This allows a single, case-insensitive way to get icons by name.