### PR TITLE
Mix native props to Nav items.

### DIFF
--- a/common/changes/office-ui-fabric-react/nav_2017-09-09-14-56.json
+++ b/common/changes/office-ui-fabric-react/nav_2017-09-09-14-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Mix native props to Nav items.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "s@warmsea.net"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -3,6 +3,8 @@ import {
   autobind,
   BaseComponent,
   css,
+  divProperties,
+  getNativeProps,
   getRTL
 } from '../../Utilities';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
@@ -182,6 +184,7 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
 
     return (
       <div
+        { ...getNativeProps(link, divProperties) }
         key={ link.key || linkIndex }
         className={ css(
           'ms-Nav-compositeLink',


### PR DESCRIPTION
This is to mix native properties to Nav items. For example, customers can put `data-link-key` into HTML tags.

This is to fix #1869.
This is a better but minimum fix as discussed in #2686.