### PR TITLE
SplitButton: Menu target should be the entire control instead

### DIFF
--- a/common/changes/office-ui-fabric-react/split-button-menu-anchor_2017-09-11-13-13.json
+++ b/common/changes/office-ui-fabric-react/split-button-menu-anchor_2017-09-11-13-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SplitButton: Update the menu launcher target for a split button to be the entire control instead of just the menu launching portion",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -46,7 +46,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   };
 
   private _buttonElement: HTMLElement;
-  private _splitButtonContainer: HTMLElement | null;
+  private _splitButtonContainer: HTMLElement;
   private _labelId: string;
   private _descriptionId: string;
   private _ariaDescriptionId: string;
@@ -342,7 +342,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         directionalHint={ DirectionalHint.bottomLeftEdge }
         {...menuProps}
         className={ 'ms-BaseButton-menuhost ' + menuProps.className }
-        target={ this._splitButtonContainer || this._buttonElement }
+        target={ this._isSplitButton ? this._splitButtonContainer : this._buttonElement }
         labelElementId={ this._labelId }
         onDismiss={ this._onToggleMenu }
       />
@@ -374,7 +374,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         className={ css(disabled ? styles!.splitButtonContainerDisabled : styles!.splitButtonContainer) }
         tabIndex={ 0 }
         onKeyDown={ this.props.disabled ? undefined : this._onSplitButtonKeyDown }
-        ref={ div => this._splitButtonContainer = div }
+        ref={ this._resolveRef('_splitButtonContainer') }
       >
         <span aria-hidden={ true } style={ { 'display': 'flex' } }>
           { this._onRenderContent(tag, buttonProps) }

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -46,6 +46,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   };
 
   private _buttonElement: HTMLElement;
+  private _splitButtonContainer: HTMLElement | null;
   private _labelId: string;
   private _descriptionId: string;
   private _ariaDescriptionId: string;
@@ -341,7 +342,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         directionalHint={ DirectionalHint.bottomLeftEdge }
         {...menuProps}
         className={ 'ms-BaseButton-menuhost ' + menuProps.className }
-        target={ this._buttonElement }
+        target={ this._splitButtonContainer || this._buttonElement }
         labelElementId={ this._labelId }
         onDismiss={ this._onToggleMenu }
       />
@@ -373,6 +374,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         className={ css(disabled ? styles!.splitButtonContainerDisabled : styles!.splitButtonContainer) }
         tabIndex={ 0 }
         onKeyDown={ this.props.disabled ? undefined : this._onSplitButtonKeyDown }
+        ref={ div => this._splitButtonContainer = div }
       >
         <span aria-hidden={ true } style={ { 'display': 'flex' } }>
           { this._onRenderContent(tag, buttonProps) }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
A split button is a component with two buttons in it. The button on the left invokes an action and the button on the right invokes a menu. Currently, the target passed to the contexutal menu created when the menu launcher is clicked is just the button element on the left. This results in a few bugs:

1. Clicking the menu launcher when the menu is already open causes the menu to be opened again rather than dismissed. 
![splitbuttonlauncher](https://user-images.githubusercontent.com/1581488/30276343-60effb3e-96b9-11e7-98d4-82633b3f7f16.gif)

2. The menu is positioned against the wrong element, this is most evident when using the rightTopEdge DirectionalHint on the menu
![splitbuttonbug2](https://user-images.githubusercontent.com/1581488/30276623-4c93672e-96ba-11e7-91d6-4e1d688594fe.gif)

This PR updates the target of the menu launched by a split button to be the div that wraps the two buttons, instead of just the button on the left. 
. 
