### PR TITLE
Button: Add the ability to hide the menu icon when menu props are provided

### DIFF
--- a/common/changes/office-ui-fabric-react/chrisgo-hide-menu-icon_2017-09-11-22-59.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-hide-menu-icon_2017-09-11-22-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button: Add the ability to hide the menu icon when menu props are provided",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -324,7 +324,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     return (
-      menuIconProps ?
+      !props.hideMenuIcon ?
         <Icon
           { ...menuIconProps }
           className={ this._classNames.menuIcon }

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -101,6 +101,12 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
   menuIconProps?: IIconProps;
 
   /**
+   * If set to true, there will be no separate menu icon added to this control.
+   * This should only be set when the icon for the button is able to communicate that it invokes a menu.
+   */
+  hideMenuIcon?: boolean;
+
+  /**
    * Custom render function for the icon
    */
   onRenderIcon?: IRenderFunction<IButtonProps>;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Currently, whenever menu props are provided to BaseButton, we render some kind of icon to denote that the button can launch a menu. That icon is by default a chevron:

![image](https://user-images.githubusercontent.com/1581488/30300660-bc3cb134-970a-11e7-95d0-22377b5f8bb6.png)

However, there are some buttons which do not need a separate menu icon because the icon of the button itself communicates that it launches a menu. An example of this is the ellipsis in command bar:
![image](https://user-images.githubusercontent.com/1581488/30300713-fabd4f04-970a-11e7-87c3-64a145f00282.png)



