### PR TITLE
Re-enable tslint rule 'jsx-self-close' in Fabric pkg

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/BreadcrumbPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/BreadcrumbPage.tsx
@@ -55,7 +55,7 @@ export class BreadcrumbPage extends React.Component<IComponentDemoPageProps, any
           <a href='https://dev.office.com/fabric-js/Components/Breadcrumb/Breadcrumb.html'>Fabric JS</a>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -72,8 +72,7 @@ export class BreadcrumbPage extends React.Component<IComponentDemoPageProps, any
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonPage.tsx
@@ -112,7 +112,7 @@ export class ButtonPage extends React.Component<IComponentDemoPageProps, IButton
           <a href='https://dev.office.com/fabric-js/Components/Button/Button.html'>Fabric JS</a>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -143,8 +143,7 @@ export class ButtonPage extends React.Component<IComponentDemoPageProps, IButton
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonPage.visualtest.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonPage.visualtest.tsx
@@ -104,8 +104,7 @@ export default class ButtonVPage extends React.Component<any, any> {
             ]
           }
           }
-        >
-        </DefaultButton>
+        />
         <DefaultButton
           id='ContextualButtonToggled'
           checked={ true }
@@ -128,8 +127,7 @@ export default class ButtonVPage extends React.Component<any, any> {
             ]
           }
           }
-        >
-        </DefaultButton>
+        />
       </div >
     </div>;
   }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -29,8 +29,7 @@ export class ButtonContextualMenuExample extends React.Component<IButtonProps, {
               ]
             }
             }
-          >
-          </DefaultButton>
+          />
         </div>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarPage.tsx
@@ -95,7 +95,7 @@ export class CalendarPage extends React.Component<IComponentDemoPageProps, any> 
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -119,8 +119,7 @@ export class CalendarPage extends React.Component<IComponentDemoPageProps, any> 
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -119,8 +119,7 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
               firstDayOfWeek={ DayOfWeek.Sunday }
               strings={ DayPickerStrings }
               isDayPickerVisible={ this.props.isDayPickerVisible }
-            >
-            </Calendar>
+            />
           </Callout>
         )
         }

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -130,8 +130,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
           highlightCurrentMonth={ this.props.highlightCurrentMonth }
           isDayPickerVisible={ this.props.isDayPickerVisible }
           showMonthPickerAsOverlay={ this.props.showMonthPickerAsOverlay }
-        >
-        </Calendar>
+        />
         { this.props.showNavigateButtons &&
           <div>
             <DefaultButton style={ buttonStyle } onClick={ this._goPrevious } text='Previous' />

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutPage.tsx
@@ -64,7 +64,7 @@ export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
           <a href='https://dev.office.com/fabric-js/Components/Callout/Callout.html'>Fabric JS</a>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -93,8 +93,7 @@ export class CalloutPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/CheckboxPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/CheckboxPage.tsx
@@ -51,7 +51,7 @@ export class CheckboxPage extends React.Component<IComponentDemoPageProps, any> 
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -73,8 +73,7 @@ export class CheckboxPage extends React.Component<IComponentDemoPageProps, any> 
           <a href='https://dev.office.com/fabric-js/Components/CheckBox/CheckBox.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupPage.tsx
@@ -60,7 +60,7 @@ export class ChoiceGroupPage extends React.Component<IComponentDemoPageProps, {}
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -87,8 +87,7 @@ export class ChoiceGroupPage extends React.Component<IComponentDemoPageProps, {}
           <a href='https://dev.office.com/fabric-js/Components/ChoiceFieldGroup/ChoiceFieldGroup.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPickerPage.tsx
@@ -34,8 +34,7 @@ export class ColorPickerPage extends React.Component<IComponentDemoPageProps, {}
           <div>ColorPicker is used to allow a user to select a color</div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBoxPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBoxPage.tsx
@@ -42,7 +42,7 @@ export class ComboBoxPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -54,14 +54,13 @@ export class ComboBoxPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         donts={
-          <div></div>
+          <div />
         }
         related={
           <a href='https://dev.office.com/fabric-js/Components/ComboBox/ComboBox.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBarPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBarPage.tsx
@@ -57,7 +57,7 @@ export class CommandBarPage extends React.Component<IComponentDemoPageProps, {}>
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -83,8 +83,7 @@ export class CommandBarPage extends React.Component<IComponentDemoPageProps, {}>
           <a href='https://dev.office.com/fabric-js/Components/CommandBar/CommandBar.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -394,8 +394,7 @@ describe('ContextualMenu', () => {
             }
             menuMounted = true;
           } }
-        >
-        </ContextualMenu>
+        />
       </div>
     );
     expect(menuMounted).to.be.equal(true, 'Menu opened callback was not properly called');

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
@@ -69,7 +69,7 @@ export class ContextualMenuPage extends React.Component<IComponentDemoPageProps,
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -95,8 +95,7 @@ export class ContextualMenuPage extends React.Component<IComponentDemoPageProps,
           <a href='https://dev.office.com/fabric-js/Components/ContextualMenu/ContextualMenu.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -230,8 +230,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
               firstDayOfWeek={ firstDayOfWeek }
               strings={ strings! }
               ref={ this._resolveRef('_calendar') }
-            >
-            </Calendar>
+            />
           </Callout>
         ) }
       </div>

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePickerPage.tsx
@@ -47,7 +47,7 @@ export class DatePickerPage extends React.Component<IComponentDemoPageProps, {}>
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -74,8 +74,7 @@ export class DatePickerPage extends React.Component<IComponentDemoPageProps, {}>
           <a href='https://dev.office.com/fabric-js/Components/DatePicker/DatePicker.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsListPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsListPage.tsx
@@ -97,7 +97,7 @@ export class DetailsListPage extends React.Component<IComponentDemoPageProps, {}
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -119,8 +119,7 @@ export class DetailsListPage extends React.Component<IComponentDemoPageProps, {}
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogPage.tsx
@@ -53,7 +53,7 @@ export class DialogPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -83,8 +83,7 @@ export class DialogPage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/Dialog/Dialog.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPage.tsx
@@ -56,7 +56,7 @@ export class DocumentCardPage extends React.Component<IComponentDemoPageProps, {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -76,8 +76,7 @@ export class DocumentCardPage extends React.Component<IComponentDemoPageProps, {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/DropdownPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/DropdownPage.tsx
@@ -45,7 +45,7 @@ export class DropdownPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -57,14 +57,13 @@ export class DropdownPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         donts={
-          <div></div>
+          <div />
         }
         related={
           <a href='https://dev.office.com/fabric-js/Components/Dropdown/Dropdown.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Facepile/FacepilePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/FacepilePage.tsx
@@ -76,7 +76,7 @@ export class FacepilePage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -100,8 +100,7 @@ export class FacepilePage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/FacePile/FacePile.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZonePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZonePage.tsx
@@ -56,8 +56,7 @@ export class FocusTrapZonePage extends React.Component<IComponentDemoPageProps, 
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -600,7 +600,7 @@ describe('FocusZone', () => {
     let buttonB: any;
     const component = ReactTestUtils.renderIntoDocument(
       <div { ...{ onFocusCapture: _onFocus } }>
-        <textarea className='t'></textarea>
+        <textarea className='t' />
         <FocusZone ref={ (focus) => { focusZone = focus; } }>
           <button className='a' ref={ (button) => { buttonA = button; } }>a</button>
           <button className='b' ref={ (button) => { buttonB = button; } }>b</button>

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZonePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZonePage.tsx
@@ -47,8 +47,7 @@ export class FocusZonePage extends React.Component<IComponentDemoPageProps, {}> 
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListPage.tsx
@@ -38,8 +38,7 @@ export class GroupedListPage extends React.Component<IComponentDemoPageProps, {}
           <p>Allows you to render a set of items as multiple lists with various grouping properties.</p>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Icon/IconPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/IconPage.tsx
@@ -47,7 +47,7 @@ export class IconPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -66,8 +66,7 @@ export class IconPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Image/ImagePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/ImagePage.tsx
@@ -61,8 +61,7 @@ export class ImagePage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Label/LabelPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/LabelPage.tsx
@@ -35,7 +35,7 @@ export class LabelPage extends React.Component<IComponentDemoPageProps, any> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -58,8 +58,7 @@ export class LabelPage extends React.Component<IComponentDemoPageProps, any> {
           <a href='https://dev.office.com/fabric-js/Components/Label/Label.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerPage.tsx
@@ -49,7 +49,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -69,8 +69,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Link/LinkPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/LinkPage.tsx
@@ -39,7 +39,7 @@ export class LinkPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -64,8 +64,7 @@ export class LinkPage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/Link/Link.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/List/ListPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/ListPage.tsx
@@ -65,8 +65,7 @@ export class ListPage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/List/List.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelectionPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelectionPage.tsx
@@ -39,8 +39,7 @@ export class MarqueeSelectionPage extends React.Component<IComponentDemoPageProp
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBarPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBarPage.tsx
@@ -38,7 +38,7 @@ export class MessageBarPage extends React.Component<IComponentDemoPageProps, {}>
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -63,8 +63,7 @@ export class MessageBarPage extends React.Component<IComponentDemoPageProps, {}>
           <a href='https://dev.office.com/fabric-js/Components/MessageBar/MessageBar.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Modal/ModalPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/ModalPage.tsx
@@ -41,7 +41,7 @@ export class ModalPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -59,8 +59,7 @@ export class ModalPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Nav/NavPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/NavPage.tsx
@@ -52,7 +52,7 @@ export class NavPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -74,8 +74,7 @@ export class NavPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Overlay/OverlayPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Overlay/OverlayPage.tsx
@@ -42,7 +42,7 @@ export class OverlayPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -63,8 +63,7 @@ export class OverlayPage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/Overlay/Overlay.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Panel/PanelPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/PanelPage.tsx
@@ -98,7 +98,7 @@ export class PanelPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -120,8 +120,7 @@ export class PanelPage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/Panel/Panel.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPage.tsx
@@ -52,7 +52,7 @@ export class PersonaPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -75,8 +75,7 @@ export class PersonaPage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/Persona/Persona.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotPage.tsx
@@ -94,7 +94,7 @@ export class PivotPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -117,8 +117,7 @@ export class PivotPage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/Pivot/Pivot.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -45,7 +45,7 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
       <div className={ css('ms-ProgressIndicator', styles.root, className) }>
         <div className={ css('ms-ProgressIndicator-itemName', styles.itemName) }>{ label }</div>
         <div className={ css('ms-ProgressIndicator-itemProgress', styles.itemProgress) }>
-          <div className={ css('ms-ProgressIndicator-progressTrack', styles.progressTrack) }></div>
+          <div className={ css('ms-ProgressIndicator-progressTrack', styles.progressTrack) } />
           <div
             className={ css(
               'ms-ProgressIndicator-progressBar',
@@ -58,8 +58,7 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
             aria-valuemax='100'
             aria-valuenow={ percentComplete.toFixed().toString() }
             aria-valuetext={ ariaValueText }
-          >
-          </div>
+          />
         </div>
         <div className={ css('ms-ProgressIndicator-itemDescription', styles.itemDescription) }>{ description }</div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicatorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicatorPage.tsx
@@ -55,7 +55,7 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -81,8 +81,7 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
           <a href='https://dev.office.com/fabric-js/Components/ProgressIndicator/ProgressIndicator.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Rating/RatingPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/RatingPage.tsx
@@ -35,7 +35,7 @@ export class RatingPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -52,8 +52,7 @@ export class RatingPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
@@ -43,7 +43,7 @@ export class ScrollablePanePage extends React.Component<IComponentDemoPageProps,
           </div>
         }
         bestPractices={
-          <div></div>
+          <div/>
         }
         dos={
           <div>
@@ -62,8 +62,7 @@ export class ScrollablePanePage extends React.Component<IComponentDemoPageProps,
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
@@ -87,7 +87,7 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> 
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -121,8 +121,7 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> 
           <a href='https://dev.office.com/fabric-js/Components/SearchBox/SearchBox.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Slider/SliderPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/SliderPage.tsx
@@ -38,7 +38,7 @@ export class SliderPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -62,8 +62,7 @@ export class SliderPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -153,7 +153,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
     return (
       <div className={ classNames.root }>
         { labelPosition !== Position.bottom && <div className={ classNames.labelWrapper }>
-          { iconProps && <Icon iconName={ iconProps.iconName } className={ classNames.icon } aria-hidden='true'></Icon> }
+          { iconProps && <Icon iconName={ iconProps.iconName } className={ classNames.icon } aria-hidden='true' /> }
           { label &&
             <Label
               id={ this._labelId }
@@ -218,7 +218,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
           </span>
         </div>
         { labelPosition === Position.bottom && <div className={ classNames.labelWrapper }>
-          { iconProps && <Icon iconName={ iconProps.iconName } className={ classNames.icon } aria-hidden='true'></Icon> }
+          { iconProps && <Icon iconName={ iconProps.iconName } className={ classNames.icon } aria-hidden='true' /> }
           { label &&
             <Label
               id={ this._labelId }

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButtonPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButtonPage.tsx
@@ -80,7 +80,7 @@ export class SpinButtonPage extends React.Component<IComponentDemoPageProps, {}>
           </div>
         }
         bestPractices={
-          <div></div>
+          <div/>
         }
         dos={
           <div>
@@ -104,8 +104,7 @@ export class SpinButtonPage extends React.Component<IComponentDemoPageProps, {}>
           <a href='https://dev.office.com/fabric-js/Components/SpinButton/SpinButton.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.tsx
@@ -27,8 +27,7 @@ export class Spinner extends BaseComponent<ISpinnerProps, any> {
               ['ms-Spinner--large ' + styles.circleIsTypeLarge]: type === SpinnerType.large // TODO remove deprecated value at >= 2.0.0
             })
           }
-        >
-        </div>
+        />
         {
           label && <div className={ css('ms-Spinner-label', styles.label) }>{ label }</div>
         }

--- a/packages/office-ui-fabric-react/src/components/Spinner/SpinnerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/SpinnerPage.tsx
@@ -38,7 +38,7 @@ export class SpinnerPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -63,8 +63,7 @@ export class SpinnerPage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/Spinner/Spinner.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPickerPage.tsx
@@ -53,8 +53,7 @@ export class SwatchColorPickerPage extends React.Component<IComponentDemoPagePro
           <a href='https://dev.office.com/fabric-js/Components/SwatchColorPicker/SwatchColorPicker.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextFieldPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextFieldPage.tsx
@@ -42,7 +42,7 @@ export class TextFieldPage extends React.Component<IComponentDemoPageProps, {}> 
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -77,8 +77,7 @@ export class TextFieldPage extends React.Component<IComponentDemoPageProps, {}> 
           <a href='https://dev.office.com/fabric-js/Components/TextField/TextField.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Toggle/TogglePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/TogglePage.tsx
@@ -48,7 +48,7 @@ export class TogglePage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         bestPractices={
-          <div></div>
+          <div />
         }
         dos={
           <div>
@@ -70,8 +70,7 @@ export class TogglePage extends React.Component<IComponentDemoPageProps, {}> {
           <a href='https://dev.office.com/fabric-js/Components/Toggle/Toggle.html'>Fabric JS</a>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -77,8 +77,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
             calloutProps={ assign(calloutProps, { onDismiss: this._onTooltipCallOutDismiss }) }
             { ...getNativeProps(this.props, divProperties) }
             { ...tooltipProps }
-          >
-          </Tooltip>
+          />
         ) }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerPage.tsx
@@ -62,8 +62,7 @@ export class PeoplePickerPage extends React.Component<IComponentDemoPageProps, {
             </ul>
           </div>
         }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/PickersPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PickersPage.tsx
@@ -42,8 +42,7 @@ export class PickersPage extends React.Component<IComponentDemoPageProps, {}> {
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionPage.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionPage.tsx
@@ -54,8 +54,7 @@ export class SelectionPage extends React.Component<IComponentDemoPageProps, {}> 
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }
-      >
-      </ComponentPage>
+      />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
@@ -54,7 +54,7 @@ function _initializeSelection(selectionMode = SelectionMode.multiple) {
         <button id='toggle2' data-selection-toggle={ true }>Toggle</button>
       </div>
 
-      <div id='surface3' data-selection-index='3'></div>
+      <div id='surface3' data-selection-index='3' />
 
     </SelectionZone>
   );

--- a/packages/office-ui-fabric-react/tslint.json
+++ b/packages/office-ui-fabric-react/tslint.json
@@ -8,7 +8,6 @@
     "jsx-boolean-value": false,
     "jsx-no-multiline-js": false,
     "jsx-wrap-multiline": false,
-    "jsx-self-close": false,
     "jsx-no-lambda": false,
     "jsx-ban-props": false,
     "max-line-length": [


### PR DESCRIPTION
#### Description of changes

Re-enable tslint rule 'jsx-self-close' and self-closed all JSX elements without children. Lots of files changed here but they all had similar fixes.