### PR TITLE
Detail list resize

### DIFF
--- a/common/changes/office-ui-fabric-react/detailList-resize_2017-09-12-16-09.json
+++ b/common/changes/office-ui-fabric-react/detailList-resize_2017-09-12-16-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "DetailList: Fixed collapsing logic to look at all items including first 2",
+      "comment": "DetailsList: Fixed collapsing logic to look at all items including first 2",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/detailList-resize_2017-09-12-16-09.json
+++ b/common/changes/office-ui-fabric-react/detailList-resize_2017-09-12-16-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailList: Fixed collapsing logic to look at all items including first 2",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -619,7 +619,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     let lastIndex = adjustedColumns.length - 1;
 
     // Remove collapsable columns.
-    while (lastIndex > 1 && totalWidth > availableWidth) {
+    while (lastIndex > -1 && totalWidth > availableWidth) {
       let column = adjustedColumns[lastIndex];
 
       if (column.isCollapsable) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2759 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Logic was stopping at the 2nd to last item, but all items should be iterated through. Items are only removed if isCollapseable is set to true. So you could collapse the 1st row while keeping the 3rd visible.

#### Focus areas to test

(optional)
