### PR TITLE
SwatchColorPicker fix uncaught exception if colorCells array is empty (#2815)

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-SwatchColorPickerEmptyArrayFix_--2815-_2017-09-12-22-02.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-SwatchColorPickerEmptyArrayFix_--2815-_2017-09-12-22-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "[SwatchColorPicker] Fix uncaught exception when colorCells is empty",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -4,8 +4,7 @@ import {
   BaseComponent,
   css,
   findIndex,
-  getId,
-  warn
+  getId
 } from '../../Utilities';
 import {
   ISwatchColorPicker,
@@ -76,11 +75,6 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
     } = this.props;
 
     if (colorCells.length < 1 || columnCount < 1) {
-      warn(
-        'The SwatchColorPicker component should have colorCells with at least one item and ' +
-        'a positive, non-zero columnCount'
-      );
-
       return null;
     }
 

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -4,7 +4,8 @@ import {
   BaseComponent,
   css,
   findIndex,
-  getId
+  getId,
+  warn
 } from '../../Utilities';
 import {
   ISwatchColorPicker,
@@ -67,17 +68,26 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
   public render() {
     let {
       colorCells,
+      columnCount,
       positionInSet,
       setSize,
       shouldFocusCircularNavigate,
       className
     } = this.props;
 
+    if (colorCells.length < 1 || columnCount < 1) {
+      warn(
+        'The SwatchColorPicker component should have colorCells with at least one item and ' +
+        'a positive, non-zero columnCount'
+      );
+
+      return null;
+    }
+
     return (
       <Grid
-        key={ this._id + colorCells[0].id + '-grid' }
         items={ colorCells.map((item, index) => { return { ...item, index }; }) }
-        columnCount={ this.props.columnCount }
+        columnCount={ columnCount }
         onRenderItem={ this._renderOption }
         positionInSet={ positionInSet && positionInSet }
         setSize={ setSize && setSize }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #2815 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

An uncaught exception is thrown if an empty array is passed to the SwatchColorPicker. This PR handles this case as well as non-negative, positive columnCount numbers. Also, there did not need to be a key for the grid (if creators are creating more than one SwatchColorPicker in a loop, they should be setting the key)

#### Focus areas to test
Verified that the SwatchColorPicker no longer throws an exception for an empty colorCells array or if the columnCount is less than one, and we don't add useless dom when in this case
