### PR TITLE
Primary split button

### DIFF
--- a/common/changes/office-ui-fabric-react/primary-split-button_2017-09-14-16-39.json
+++ b/common/changes/office-ui-fabric-react/primary-split-button_2017-09-14-16-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SplitButton: Fixed primary theme, updated documentation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
@@ -27,6 +27,47 @@ export function standardStyles(theme: ITheme): IButtonStyles {
       backgroundColor: theme.palette.neutralTertiaryAlt,
       color: theme.palette.neutralDark
     },
+
+    // Split button styles
+    splitButtonContainer: {
+      ':hover': {
+        borderColor: theme.palette.neutralLight
+      },
+      ':focus': {
+        borderColor: theme.palette.neutralDark
+      }
+    },
+
+    splitButtonMenuButton: {
+      color: theme.palette.white,
+      backgroundColor: theme.palette.neutralLighter,
+      ':hover': {
+        backgroundColor: theme.palette.neutralLight
+      },
+    },
+
+    splitButtonMenuButtonDisabled: {
+      backgroundColor: theme.palette.neutralLighter,
+      ':hover': {
+        backgroundColor: theme.palette.neutralLighter,
+      }
+    },
+
+    splitButtonMenuButtonChecked: {
+      backgroundColor: theme.palette.themePrimary,
+    },
+
+    splitButtonMenuButtonExpanded: {
+      backgroundColor: theme.palette.neutralLight,
+    },
+
+    splitButtonMenuIcon: {
+      color: theme.palette.neutralPrimary
+    },
+
+    splitButtonMenuIconDisabled: {
+      color: theme.palette.neutralTertiary
+    },
   };
 }
 
@@ -48,7 +89,7 @@ export function primaryStyles(theme: ITheme): IButtonStyles {
     },
 
     rootExpanded: {
-      backgroundColor: theme.palette.themePrimary,
+      backgroundColor: theme.palette.themeDark,
       color: theme.palette.white
     },
 
@@ -60,6 +101,48 @@ export function primaryStyles(theme: ITheme): IButtonStyles {
     rootCheckedHovered: {
       backgroundColor: theme.palette.neutralLight,
       color: theme.palette.black
-    }
+    },
+
+    // Split button styles
+    splitButtonContainer: {
+      ':hover': {
+        borderColor: theme.palette.neutralLight
+      },
+      ':focus': {
+        borderColor: theme.palette.neutralDark
+      }
+    },
+
+    splitButtonMenuButton: {
+      backgroundColor: theme.palette.themePrimary,
+      color: theme.palette.white,
+      ':hover': {
+        backgroundColor: theme.palette.themeDark
+      },
+    },
+
+    splitButtonMenuButtonDisabled: {
+      backgroundColor: theme.palette.neutralLighter,
+      ':hover': {
+        backgroundColor: theme.palette.neutralLighter,
+      }
+    },
+
+    splitButtonMenuButtonChecked: {
+      backgroundColor: theme.palette.themeDark,
+    },
+
+    splitButtonMenuButtonExpanded: {
+      backgroundColor: theme.palette.themeDark,
+    },
+
+    splitButtonMenuIcon: {
+      color: theme.palette.white
+    },
+
+    splitButtonMenuIconDisabled: {
+      color: theme.palette.neutralTertiary
+    },
+
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -15,52 +15,33 @@ export const getStyles = memoizeFunction((
       display: 'inline-block',
       border: '1px solid transparent',
       ':hover': {
-        border: '1px solid',
-        borderColor: theme.palette.neutralLight
+        border: '1px solid'
       },
       ':focus': {
         outline: 'none!important',
-        border: '1px solid',
-        borderColor: theme.palette.neutralDark
+        border: '1px solid'
       }
-    },
-
-    splitButtonContainerDisabled: {
     },
 
     splitButtonMenuButton: {
       padding: '6px',
       height: 'auto',
-      color: theme.palette.white,
       boxSizing: 'border-box',
       border: '1px solid transparent',
+      outline: 'transparent',
       userSelect: 'none',
       display: 'inline-block',
       textDecoration: 'none',
       textAlign: 'center',
       cursor: 'pointer',
       verticalAlign: 'top',
-      width: '32px',
-      backgroundColor: theme.palette.neutralLighter,
-      ':hover': {
-        backgroundColor: theme.palette.neutralLight
-      },
+      width: '32px'
     },
 
     splitButtonMenuButtonDisabled: {
-      backgroundColor: theme.palette.neutralLighter,
       ':hover': {
-        backgroundColor: theme.palette.neutralLighter,
         cursor: 'default'
       }
-    },
-
-    splitButtonMenuIcon: {
-      color: theme.palette.neutralPrimary
-    },
-
-    splitButtonMenuIconDisabled: {
-      color: theme.palette.neutralTertiary
     },
 
     splitButtonFlexContainer: {
@@ -69,13 +50,6 @@ export const getStyles = memoizeFunction((
       flexWrap: 'nowrap',
       justifyContent: 'center',
       alignItems: 'center'
-    },
-    splitButtonMenuButtonChecked: {
-      backgroundColor: theme.palette.themePrimary,
-    },
-
-    splitButtonMenuButtonExpanded: {
-      backgroundColor: theme.palette.neutralLight,
     },
   };
 

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Basic.Example.scss
@@ -7,5 +7,8 @@
     & > * {
       flex-grow: 1;
     }
+    .ms-Label {
+      margin-bottom: 10px;
+    }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Default.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Default.Example.tsx
@@ -7,7 +7,7 @@ export class ButtonDefaultExample extends React.Component<IButtonProps, {}> {
     let { disabled, checked } = this.props;
 
     return (
-      <div className='ms-BasicButtonsExample ms-BasicButtonsTwoUp'>
+      <div className='ms-BasicButtonsTwoUp'>
         <div>
           <Label>Standard</Label>
           <DefaultButton

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DefaultButton, IconButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { PrimaryButton, DefaultButton, IconButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { getCustomSplitButtonStyles } from './Button.Split.Example.styles';
 
@@ -12,30 +12,58 @@ export class ButtonSplitExample extends React.Component<IButtonProps, {}> {
     let { disabled, checked } = this.props;
 
     return (
-      <div>
-        <Label>Split button</Label>
-        <DefaultButton
-          data-automation-id='test'
-          disabled={ disabled }
-          checked={ checked }
-          text='Create account'
-          onClick={ () => alert('Clicked') }
-          split={ true }
-          menuProps={ {
-            items: [
-              {
-                key: 'emailMessage',
-                name: 'Email message',
-                icon: 'Mail'
-              },
-              {
-                key: 'calendarEvent',
-                name: 'Calendar event',
-                icon: 'Calendar'
-              }
-            ]
-          } }
-        />
+      <div className='ms-BasicButtonsTwoUp'>
+        <div>
+          <Label>Standard</Label>
+          <DefaultButton
+            data-automation-id='test'
+            disabled={ disabled }
+            checked={ checked }
+            text='Create account'
+            onClick={ () => alert('Clicked') }
+            split={ true }
+            menuProps={ {
+              items: [
+                {
+                  key: 'emailMessage',
+                  name: 'Email message',
+                  icon: 'Mail'
+                },
+                {
+                  key: 'calendarEvent',
+                  name: 'Calendar event',
+                  icon: 'Calendar'
+                }
+              ]
+            } }
+          />
+        </div>
+        <div>
+          <Label>Primary</Label>
+          <DefaultButton
+            primary
+            data-automation-id='test'
+            disabled={ disabled }
+            checked={ checked }
+            text='Create account'
+            onClick={ () => alert('Clicked') }
+            split={ true }
+            menuProps={ {
+              items: [
+                {
+                  key: 'emailMessage',
+                  name: 'Email message',
+                  icon: 'Mail'
+                },
+                {
+                  key: 'calendarEvent',
+                  name: 'Calendar event',
+                  icon: 'Calendar'
+                }
+              ]
+            } }
+          />
+        </div>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PrimaryButton, DefaultButton, IconButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton, IconButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { getCustomSplitButtonStyles } from './Button.Split.Example.styles';
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #2833
- [ ] Include a change request file using `$ npm run change`

Pulled the split button colors out of splitbutton.styles and moved them into the button themes. Also created the primary theme as well. 

![split](https://user-images.githubusercontent.com/1434956/30442367-12bb97c8-9931-11e7-960c-05b956a33c4a.gif)
