### PR TITLE
Add shadows to folder covers [experiments]

### DIFF
--- a/common/changes/@uifabric/experiments/folder-shadows_2017-09-14-23-43.json
+++ b/common/changes/@uifabric/experiments/folder-shadows_2017-09-14-23-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add folder cover shadows",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -20,6 +20,14 @@
   }
 }
 
+.shadow {
+  display: block;
+  position: absolute;
+  left: -3px;
+  right: -3px;
+  bottom: -4px;
+}
+
 .front {
   display: block;
   position: absolute;
@@ -41,11 +49,11 @@
   left: 4px;
   right: 4px;
   bottom: 4px;
+  top: 4px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  overflow: hidden;
-  box-shadow: 0 1px 3px 1px rgba(1, 1, 0, 0.05);
+  justify-content: center;
   opacity: 1;
 
   transition: opacity 0.2s linear;
@@ -53,15 +61,15 @@
   .hideContent & {
     opacity: 0;
   }
+}
 
-  &,
-  .isSmall & {
-    max-height: 52px - 8px;
-  }
-
-  .isLarge & {
-    max-height: 80px - 8px;
-  }
+.frame {
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+  max-width: 100%;
+  max-height: 100%;
+  box-shadow: 0 1px 3px 2px rgba(1, 1, 0, 0.2);
 }
 
 .metadata {

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -41,6 +41,7 @@ const SIZES: {
 const ASSETS: {
   [P in FolderCoverSize]: {
     [T in FolderCoverType]: {
+      shadow: string;
       back: string;
       front: string;
     };
@@ -48,20 +49,24 @@ const ASSETS: {
 } = {
     small: {
       default: {
+        shadow: `${ASSET_CDN_BASE_URL}/foldericons/72x52_shadow_empty.png`,
         back: `${ASSET_CDN_BASE_URL}/foldericons/s-ldefaultback.png`,
         front: `${ASSET_CDN_BASE_URL}/foldericons/s-ldefaultfront.png`
       },
       media: {
+        shadow: `${ASSET_CDN_BASE_URL}/foldericons/72x52_shadow_empty.png`,
         back: `${ASSET_CDN_BASE_URL}/foldericons/s-lphotoback.png`,
         front: `${ASSET_CDN_BASE_URL}/foldericons/s-lphotosfront.png`
       }
     },
     large: {
       default: {
+        shadow: `${ASSET_CDN_BASE_URL}/foldericons/112x80_shadow_empty.png`,
         back: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xldefaultback.png`,
         front: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xldefaultfront.png`
       },
       media: {
+        shadow: `${ASSET_CDN_BASE_URL}/foldericons/112x80_shadow_empty.png`,
         back: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xlphotoback.png`,
         front: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xlphotofront.png`
       }
@@ -89,13 +94,19 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
         }) }
       >
         <img
+          className={ css('ms-FolderCover-shadow', FolderCoverStyles.shadow) }
+          src={ assets.shadow }
+        />
+        <img
           className={ css('ms-FolderCover-back', FolderCoverStyles.back) }
           src={ assets.back }
         />
         {
           this.props.children ? (
             <span className={ css('ms-FolderCover-content', FolderCoverStyles.content) }>
-              { this.props.children }
+              <span className={ css('ms-FolderCover-frame', FolderCoverStyles.frame) }>
+                { this.props.children }
+              </span>
             </span>
           ) : null
         }

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -95,6 +95,7 @@
 }
 
 .foreground {
+  display: inline-block;
   position: relative;
   overflow: hidden;
   max-width: 100%;

--- a/packages/experiments/src/components/Tile/examples/Tile.Example.scss
+++ b/packages/experiments/src/components/Tile/examples/Tile.Example.scss
@@ -15,6 +15,10 @@
   height: 171px;
 }
 
+.tileFolder {
+  display: inline-block;
+  margin: 3px;
+}
 
 .tileImage {
   display: block;

--- a/packages/experiments/src/components/Tile/examples/Tile.Folder.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Folder.Example.tsx
@@ -86,14 +86,18 @@ const FolderTileWithThumbnail: React.StatelessComponent<IFolderTileWithThumbnail
             </SignalField>
           }
           foreground={
-            renderFolderCoverWithLayout(folderCover, {
-              children: (
-                <img
-                  src={ `//placehold.it/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}` }
-                  className={ css(TileExampleStyles.tileImage) }
-                />
-              )
-            })
+            <span className={ css(TileExampleStylesModule.tileFolder) }>
+              {
+                renderFolderCoverWithLayout(folderCover, {
+                  children: (
+                    <img
+                      src={ `//placehold.it/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}` }
+                      className={ css(TileExampleStyles.tileImage) }
+                    />
+                  )
+                })
+              }
+            </span>
           }
         />
       </div>


### PR DESCRIPTION
### Overview

This change adds shadows which extend outside the bounds of the `FolderCover` component.
This change also fixes the drop shadow behind the folder cover content and makes it more prominent.

![image](https://user-images.githubusercontent.com/6828233/30461532-fd0a9a08-9973-11e7-8c22-a9730fa25f70.png)
