### PR TITLE
Prevent touch input from starting a Marquee Selection

### DIFF
--- a/common/changes/office-ui-fabric-react/touch-marquee_2017-09-14-23-42.json
+++ b/common/changes/office-ui-fabric-react/touch-marquee_2017-09-14-23-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Prevent touch events from triggering marquee selection",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}


### PR DESCRIPTION
### Overview

This change fixes a bug in which Internet Explorer sees `pointerdown` events from touch input and routes them to the `mousedown` events which starts a marquee. Since `MarqueeSelection` does not invoke `preventDefault` during the `mousedown`, it allows scrolling, which can cause a phantom marquee to start selecting items.

This change adds a hook for `pointerdown` and `touchstart` to disable the handling for the subsequent `mousedown`, preventing marquee selection when the user touch-scrolls in IE and Edge.