### PR TITLE
Fix up accessibility hooks for TilesList [experiments]

### DIFF
--- a/common/changes/@uifabric/experiments/tile-aria_2017-09-15-22-49.json
+++ b/common/changes/@uifabric/experiments/tile-aria_2017-09-15-22-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add accessibility hooks for Tile, TilesList, and FolderCover",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/tile-aria_2017-09-15-22-49.json
+++ b/common/changes/office-ui-fabric-react/tile-aria_2017-09-15-22-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Force Check to use the page background color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.Props.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.Props.ts
@@ -11,7 +11,7 @@ export type FolderCoverType =
   'default' |
   'media';
 
-export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<FolderCover> {
+export interface IFolderCoverProps extends IBaseProps, React.Props<FolderCover>, React.HTMLAttributes<HTMLDivElement> {
   /**
    * The breakpoint size of the folder cover.
    *

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -78,13 +78,16 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
     const {
       folderCoverSize: size = 'large',
       folderCoverType: type = 'default',
-      hideContent = false
+      hideContent = false,
+      ref,
+      ...divProps
     } = this.props;
 
     const assets = ASSETS[size][type];
 
     return (
       <div
+        { ...divProps }
         className={ css(FolderCoverStyles.root, {
           [`ms-FolderCover--isSmall ${FolderCoverStyles.isSmall}`]: size === 'small',
           [`ms-FolderCover--isLarge ${FolderCoverStyles.isLarge}`]: size === 'large',
@@ -94,10 +97,12 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
         }) }
       >
         <img
+          aria-hidden={ true }
           className={ css('ms-FolderCover-shadow', FolderCoverStyles.shadow) }
           src={ assets.shadow }
         />
         <img
+          aria-hidden={ true }
           className={ css('ms-FolderCover-back', FolderCoverStyles.back) }
           src={ assets.back }
         />
@@ -111,6 +116,7 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
           ) : null
         }
         <img
+          aria-hidden={ true }
           className={ css('ms-FolderCover-front', FolderCoverStyles.front) }
           src={ assets.front }
         />

--- a/packages/experiments/src/components/Tile/Tile.Props.ts
+++ b/packages/experiments/src/components/Tile/Tile.Props.ts
@@ -96,6 +96,20 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    */
   hideForeground?: boolean;
   /**
+   * The accessible label representing the tile and its content.
+   *
+   * @type {string}
+   * @memberof ITileProps
+   */
+  ariaLabel?: string;
+  /**
+   * The accessible label providing description or instructions for the tile.
+   *
+   * @type {string}
+   * @memberof ITileProps
+   */
+  descriptionAriaLabel?: string;
+  /**
    * The accessible label for the selection checkbox.
    *
    * @type {boolean}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -76,6 +76,14 @@
   }
 }
 
+.label {
+  @include ms-screenReaderOnly;
+}
+
+.description {
+  @include ms-screenReaderOnly;
+}
+
 .link {
   @include focus-clear();
 

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -62,6 +62,8 @@ const SIZES: {
 export class Tile extends BaseComponent<ITileProps, ITileState> {
   private _nameId: string;
   private _activityId: string;
+  private _labelId: string;
+  private _descriptionId: string;
 
   // tslint:disable-next-line:no-any
   constructor(props: ITileProps, context: any) {
@@ -69,6 +71,8 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
 
     this._nameId = getId('Tile-name');
     this._activityId = getId('Tile-activity');
+    this._labelId = getId('Tile-label');
+    this._descriptionId = getId('Tile-description');
 
     const {
       selectionIndex = -1,
@@ -149,7 +153,11 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
       className,
       tileSize = 'large',
       contentSize,
-      ...aProps
+      ariaLabel,
+      descriptionAriaLabel,
+      href,
+      onClick,
+      ...divProps
     } = this.props;
 
     const isSelectable = !!selection && selectionIndex > -1;
@@ -158,12 +166,12 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
       isSelected = false
     } = this.state;
 
-    const Tag = aProps.href ? 'a' : 'span';
-
     return (
       <div
-        aria-labelledby={ this._nameId }
-        aria-describedby={ this._activityId }
+        aria-selected={ isSelected }
+        { ...divProps }
+        aria-labelledby={ ariaLabel ? this._labelId : this._nameId }
+        aria-describedby={ descriptionAriaLabel ? this._descriptionId : this._activityId }
         className={ css('ms-Tile', className, TileStyles.tile, {
           [`ms-Tile--isSmall ${TileStyles.isSmall}`]: tileSize === 'small',
           [`ms-Tile--isLarge ${TileStyles.isLarge}`]: tileSize === 'large',
@@ -180,11 +188,22 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         data-disable-click-on-enter={ true }
         data-selection-index={ (selectionIndex > -1) ? selectionIndex : undefined }
       >
-        <Tag
-          { ...aProps }
+        <a
+          href={ href }
+          onClick={ onClick }
           data-selection-invoke={ (selectionIndex > -1) ? true : undefined }
           className={ css('ms-Tile-link', TileStyles.link) }
         >
+          {
+            ariaLabel ? (
+              <span
+                id={ this._labelId }
+                className={ css('ms-Tile-label', TileStylesModule.label) }
+              >
+                { ariaLabel }
+              </span>
+            ) : null
+          }
           {
             background ? this._onRenderBackground({
               background: background,
@@ -203,7 +222,17 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
               activity: itemActivity
             }) : null
           }
-        </Tag>
+        </a>
+        {
+          descriptionAriaLabel ? (
+            <span
+              id={ this._descriptionId }
+              className={ css('ms-Tile-description', TileStylesModule.description) }
+            >
+              { descriptionAriaLabel }
+            </span>
+          ) : null
+        }
         {
           isSelectable ? this._onRenderCheck({
             isSelected: isSelected
@@ -306,6 +335,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         className={ css('ms-Tile-check', TileStyles.check) }
         data-selection-toggle={ true }
         role='checkbox'
+        aria-checked={ isSelected }
       >
         <Check
           checked={ isSelected }

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -101,12 +101,14 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
       items,
       cellsPerPage,
       ref,
+      role,
       focusZoneComponentRef,
       ...divProps
     } = this.props;
 
     return (
       <FocusZone
+        role={ role }
         { ...divProps }
         ref={ ref as ((element: FocusZone | null) => void) }
         componentRef={ focusZoneComponentRef }
@@ -116,6 +118,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
       >
         <List
           items={ cells }
+          role={ role ? 'presentation' : undefined }
           getPageSpecification={ this._getPageSpecification }
           onRenderPage={ this._onRenderPage }
         />

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx
@@ -61,6 +61,7 @@ export class TilesListDocumentExample extends React.Component<{}, {}> {
             onItemInvoked={ this._onItemInvoked }
           >
             <TilesListType
+              role='list'
               items={ items }
             />
           </SelectionZone>
@@ -81,9 +82,12 @@ export class TilesListDocumentExample extends React.Component<{}, {}> {
   private _onRenderDocumentCell(item: IExampleItem): JSX.Element {
     return (
       <Tile
+        role='listitem'
+        aria-setsize={ ITEMS.length }
+        aria-posinset={ item.index }
         className={ AnimationClassNames.fadeIn400 }
         selection={ this._selection }
-        selectionIndex={ ITEMS.indexOf(item) }
+        selectionIndex={ item.index }
         foreground={
           <img
             src={
@@ -109,7 +113,7 @@ export class TilesListDocumentExample extends React.Component<{}, {}> {
   @autobind
   private _onRenderHeader(item: IExampleItem): JSX.Element {
     return (
-      <div>
+      <div role='presentation'>
         <h3>{ item.name }</h3>
       </div>
     );

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
@@ -66,6 +66,7 @@ export class TilesListMediaExample extends React.Component<{}, {}> {
             onItemInvoked={ this._onItemInvoked }
           >
             <TilesListType
+              role='list'
               items={ items }
             />
           </SelectionZone>
@@ -86,6 +87,9 @@ export class TilesListMediaExample extends React.Component<{}, {}> {
   private _onRenderMediaCell(item: IExampleItem, finalSize: ITileSize): JSX.Element {
     const tile = (
       <Tile
+        role='listitem'
+        aria-setsize={ ITEMS.length }
+        aria-posinset={ item.index }
         contentSize={ finalSize }
         className={ AnimationClassNames.fadeIn400 }
         selection={ this._selection }
@@ -118,7 +122,7 @@ export class TilesListMediaExample extends React.Component<{}, {}> {
   @autobind
   private _onRenderHeader(item: IExampleItem): JSX.Element {
     return (
-      <div>
+      <div role='presentation'>
         <h3>{ item.name }</h3>
       </div>
     );

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -45,50 +45,89 @@ export interface ISignalProps extends React.HTMLAttributes<HTMLSpanElement> {
 export type Signal = React.StatelessComponent<ISignalProps>;
 
 export const Signal: Signal = (props: ISignalProps): JSX.Element => {
+  const {
+    ariaLabel,
+    ...spanProps
+  } = props;
+
   return (
-    <span className={ css(SignalStyles.signal) }>{ props.children }</span>
+    <span
+      aria-label={ props.ariaLabel }
+      { ...spanProps }
+      className={ css(SignalStyles.signal) }
+    >
+      { props.children }
+    </span>
   );
 };
 
 export const YouCheckedOutSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.youCheckedOutl) } iconName='' /> // TODO get correct icon
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.youCheckedOutl) }
+      iconName=''
+    /> // TODO get correct icon
   );
 };
 
 export const BlockedSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.blocked) } iconName='blocked2' />
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.blocked) }
+      iconName='blocked2'
+    />
   );
 };
 
 export const MissingMetadataSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.missingMetadata) } iconName='info' />
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.missingMetadata) }
+      iconName='info'
+    />
   );
 };
 
 export const WarningSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.warning) } iconName='warning' />
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.warning) }
+      iconName='warning'
+    />
   );
 };
 
 export const AwaitingApprovalSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.awaitingApproval) } iconName='documentmanagement' /> // TODO get correct icon
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.awaitingApproval) }
+      iconName='documentmanagement'
+    /> // TODO get correct icon
   );
 };
 
 export const TrendingSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.trending) } iconName='market' />
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.trending) }
+      iconName='market'
+    />
   );
 };
 
 export const SomeoneCheckedOutSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.someoneCheckedOut) } iconName='navigateforward' /> // TODO get correct icon
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.someoneCheckedOut) }
+      iconName='navigateforward'
+    /> // TODO get correct icon
   );
 };
 
@@ -96,9 +135,21 @@ export const SomeoneCheckedOutSignal: Signal = (props: ISignalProps): JSX.Elemen
  * Renders a signal marking the proceeding content as new.
  */
 export const NewSignal: Signal = (props: ISignalProps): JSX.Element => {
+  const {
+    ariaLabel,
+    ...spanProps
+  } = props;
+
   return (
-    <span className={ css(SignalStyles.signal, SignalStyles.newItem) }>
-      <Icon className={ css(SignalStyles.newIcon) } iconName='glimmer' />
+    <span
+      { ...spanProps }
+      className={ css(SignalStyles.signal, SignalStyles.newItem) }
+    >
+      <Icon
+        ariaLabel={ props.ariaLabel }
+        className={ css(SignalStyles.newIcon) }
+        iconName='glimmer'
+      />
     </span>
   );
 };
@@ -107,8 +158,17 @@ export const NewSignal: Signal = (props: ISignalProps): JSX.Element => {
  * Renders a signal for a live-edit scenario.
  */
 export const LiveEditSignal: Signal = (props: ISignalProps): JSX.Element => {
+  const {
+    ariaLabel,
+    ...spanProps
+  } = props;
+
   return (
-    <span className={ css(SignalStyles.signal, SignalStyles.liveEdit) }>
+    <span
+      aria-label={ ariaLabel }
+      { ...spanProps }
+      className={ css(SignalStyles.signal, SignalStyles.liveEdit) }
+    >
       { props.children }
     </span>
   );
@@ -116,7 +176,11 @@ export const LiveEditSignal: Signal = (props: ISignalProps): JSX.Element => {
 
 export const MentionSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.mention) } iconName='accounts' />
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.mention) }
+      iconName='accounts'
+    />
   );
 };
 
@@ -124,9 +188,21 @@ export const MentionSignal: Signal = (props: ISignalProps): JSX.Element => {
  * Renders a signal for a number of comments.
  */
 export const CommentsSignal: Signal = (props: ISignalProps): JSX.Element => {
+  const {
+    ariaLabel,
+    ...spanProps
+  } = props;
+
   return (
-    <span className={ css(SignalStyles.signal, SignalStyles.comments) }>
-      <Icon className={ css(SignalStyles.commentsIcon) } iconName='MessageFill' />
+    <span
+      { ...spanProps }
+      className={ css(SignalStyles.signal, SignalStyles.comments) }
+    >
+      <Icon
+        ariaLabel={ props.ariaLabel }
+        className={ css(SignalStyles.commentsIcon) }
+        iconName='MessageFill'
+      />
       {
         props.children ? (
           <span className={ css(SignalStyles.commentsCount) }>
@@ -140,18 +216,30 @@ export const CommentsSignal: Signal = (props: ISignalProps): JSX.Element => {
 
 export const UnseenEditSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.unseenEdit) } iconName='edit' /> // TODO get correct icon
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.unseenEdit) }
+      iconName='edit'
+    /> // TODO get correct icon
   );
 };
 
 export const ReadOnlySignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.readOnly) } iconName='' /> // TODO get correct icon
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.readOnly) }
+      iconName=''
+    /> // TODO get correct icon
   );
 };
 
 export const SharedSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <Icon className={ css(SignalStyles.signal, SignalStyles.shared) } iconName='people' />
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalStyles.shared) }
+      iconName='people'
+    />
   );
 };

--- a/packages/office-ui-fabric-react/src/components/Check/Check.scss
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.scss
@@ -18,8 +18,7 @@ $checkBoxHeight: 18px;
 
   @include ms-user-select(none);
 
-  &.rootIsChecked:before {
-    background: $ms-color-themePrimary;
+  &:before {
     content: '';
     position: absolute;
     left: 1px;
@@ -27,13 +26,14 @@ $checkBoxHeight: 18px;
     bottom: 1px;
     top: 1px;
     border-radius: 50%;
+    opacity: 1;
+    background: $bodyBackgroundColor;
   }
-}
 
-.root:hover,
-.root:focus,
-.rootIsChecked {
-  opacity: 1;
+  &.rootIsChecked:before {
+    background: $ms-color-themePrimary;
+    opacity: 1;
+  }
 }
 
 .circle,


### PR DESCRIPTION
### Overview

This change improves the ability to add accessibility to `TilesList` and related components, by reducing the number of exposed elements and allowing `aria-label` and `role` values to be assigned correctly.

The hit-target for `Tile` is now always an `a` element.
The background for the `Check` component is now always `$bodyBackgroundColor`.
The default `listitem` role for `List` cells will be used unless `role` is specified.

The examples have been updated with some basic accessibility hooks.