### PR TITLE
ContextualMenu: Change the type of MenuSection title to string 

### DIFF
--- a/common/changes/office-ui-fabric-react/menu-section-title-type_2017-09-19-22-42.json
+++ b/common/changes/office-ui-fabric-react/menu-section-title-type_2017-09-19-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Update the type of the title property on a menu section to be of type string",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -368,7 +368,7 @@ export interface IContextualMenuSection extends React.Props<ContextualMenu> {
   /**
    * The optional section title.
    */
-  title?: IContextualMenuItem;
+  title?: string;
 
   /**
    * If set to true, the section will display a divider at the top of the section.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -309,7 +309,15 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       return;
     }
 
-    let headerItem = section.title && this._renderHeaderMenuItem(section.title, index, hasCheckmarks, hasIcons);
+    let headerItem;
+    if (section.title) {
+      const headerContextualMenuItem: IContextualMenuItem = {
+        key: `header-${section.title}`,
+        itemType: ContextualMenuItemType.Header,
+        name: section.title
+      };
+      headerItem = this._renderHeaderMenuItem(headerContextualMenuItem, index, hasCheckmarks, hasIcons);
+    }
 
     if (section.items && section.items.length > 0) {
       return (

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -312,7 +312,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     let headerItem;
     if (section.title) {
       const headerContextualMenuItem: IContextualMenuItem = {
-        key: `header-${section.title}`,
+        key: `section-${section.title}-title`,
         itemType: ContextualMenuItemType.Header,
         name: section.title
       };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
@@ -31,11 +31,7 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
                 sectionProps: {
                   topDivider: true,
                   bottomDivider: true,
-                  title: {
-                    key: 'Actions',
-                    itemType: ContextualMenuItemType.Header,
-                    name: 'Actions'
-                  },
+                  title: 'Actions',
                   items: [
                     {
                       key: 'newItem',
@@ -79,11 +75,7 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
                 key: 'section',
                 itemType: ContextualMenuItemType.Section,
                 sectionProps: {
-                  title: {
-                    key: 'Navigation',
-                    itemType: ContextualMenuItemType.Header,
-                    name: 'Social'
-                  },
+                  title: 'Social',
                   items: [
                     {
                       key: 'share',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Recently the concept of Menu Sections was introduced into ContextualMenus as a mechanism for creating menus organized into sections. These sections can be separated by including dividers and they can optionally have a title. The existing type of title is IContextualMenuItem, which doesn't seem right. It should instead be of type string and the code rendering the section should be responsible for creating the corresponding contextual menu item.
