### PR TITLE
[Suggestions] Adds an ARIA label prop for Suggestions container

### DIFF
--- a/common/changes/office-ui-fabric-react/joem-suggestions-aria-label_2017-09-20-19-44.json
+++ b/common/changes/office-ui-fabric-react/joem-suggestions-aria-label_2017-09-20-19-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds ARIA label prop for Suggestions component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joem@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts
@@ -179,6 +179,10 @@ export interface IBasePickerSuggestionsProps {
    * Screen reader message to read when there are suggestions available.
    */
   suggestionsAvailableAlertText?: string;
+  /**
+   * An ARIA label for the container that is the parent of the suggestions.
+   */
+  suggestionsContainerAriaLabel?: string;
 }
 
 export enum ValidationState {

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -38,7 +38,8 @@ const suggestionProps: IBasePickerSuggestionsProps = {
   noResultsFoundText: 'No results found',
   loadingText: 'Loading',
   showRemoveButtons: true,
-  suggestionsAvailableAlertText: 'People Picker Suggestions available'
+  suggestionsAvailableAlertText: 'People Picker Suggestions available',
+  suggestionsContainerAriaLabel: 'Suggested contacts'
 };
 
 const limitedSearchAdditionalProps: IBasePickerSuggestionsProps = {

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.Props.ts
@@ -114,6 +114,10 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
    * A function that resets focus to the expected item in the suggestion list
    */
   refocusSuggestions?: (keyCode: KeyCodes) => void;
+  /**
+   * An ARIA label for the container that is the parent of the suggestions.
+   */
+  suggestionsContainerAriaLabel?: string;
 }
 
 export interface ISuggestionItemProps<T> {

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -174,7 +174,8 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, {}> {
       onRenderSuggestion,
       suggestionsItemClassName,
       resultsMaximumNumber,
-      showRemoveButtons } = this.props;
+      showRemoveButtons,
+      suggestionsContainerAriaLabel } = this.props;
     let TypedSuggestionsItem = this.SuggestionsItemOfProperType;
 
     if (resultsMaximumNumber) {
@@ -186,6 +187,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, {}> {
         className={ css('ms-Suggestions-container', styles.suggestionsContainer) }
         id='suggestion-list'
         role='menu'
+        aria-label={ suggestionsContainerAriaLabel }
       >
         { suggestions.map((suggestion, index) =>
           <div


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Adds `suggestionsContainerAriaLabel` prop to `Suggestions` component to add an ARIA label to the container that holds the suggestions
- Also adds a prop of the same name to `BasePicker` component, so it's settable via the `PeoplePicker` component
