### PR TITLE
Implement alwaysShowCheck behavior for Check component

### DIFF
--- a/common/changes/@uifabric/experiments/check-hover_2017-09-20-22-53.json
+++ b/common/changes/@uifabric/experiments/check-hover_2017-09-20-22-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Consume Check hover behavior in Tile",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/check-hover_2017-09-20-22-53.json
+++ b/common/changes/office-ui-fabric-react/check-hover_2017-09-20-22-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Implement hover and focus trigger behavior for Check component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -7,10 +7,12 @@ import { css, BaseComponent, autobind, getId } from 'office-ui-fabric-react/lib/
 import { ISize } from '@uifabric/utilities';
 import * as TileStylesModule from './Tile.scss';
 import * as SignalStylesModule from '../signals/Signals.scss';
+import * as CheckStylesModule from 'office-ui-fabric-react/lib/components/Check/Check.scss';
 
 // tslint:disable:no-any
 const TileStyles: any = TileStylesModule;
 const SignalStyles: any = SignalStylesModule;
+const CheckStyles: any = CheckStylesModule;
 // tslint:enable:no-any
 
 const enum TileLayoutValues {
@@ -332,12 +334,13 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     return (
       <button
         aria-label={ this.props.toggleSelectionAriaLabel }
-        className={ css('ms-Tile-check', TileStyles.check) }
+        className={ css('ms-Tile-check', TileStyles.check, CheckStyles.checkHost) }
         data-selection-toggle={ true }
         role='checkbox'
         aria-checked={ isSelected }
       >
         <Check
+          alwaysShowCheck={ false }
           checked={ isSelected }
         />
       </button>

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -340,7 +340,6 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         aria-checked={ isSelected }
       >
         <Check
-          alwaysShowCheck={ false }
           checked={ isSelected }
         />
       </button>

--- a/packages/office-ui-fabric-react/src/components/Check/Check.scss
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.scss
@@ -34,6 +34,21 @@ $checkBoxHeight: 18px;
     background: $ms-color-themePrimary;
     opacity: 1;
   }
+
+  .check {
+    opacity: 0;
+  }
+
+  &.alwaysHasCheck,
+  .checkHost:hover &,
+  .checkHost:focus &,
+  &:hover,
+  &:focus,
+  &.rootIsChecked {
+    .check {
+      opacity: 1;
+    }
+  }
 }
 
 .circle,

--- a/packages/office-ui-fabric-react/src/components/Check/Check.scss
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.scss
@@ -39,7 +39,6 @@ $checkBoxHeight: 18px;
     opacity: 0;
   }
 
-  &.alwaysHasCheck,
   .checkHost:hover &,
   .checkHost:focus &,
   &:hover,

--- a/packages/office-ui-fabric-react/src/components/Check/Check.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.tsx
@@ -34,7 +34,7 @@ export class Check extends BaseComponent<ICheckProps, {}> {
   }
 
   public render() {
-    let { isChecked, checked } = this.props;
+    let { isChecked, checked, alwaysShowCheck = true } = this.props;
 
     isChecked = isChecked || checked;
 
@@ -43,7 +43,10 @@ export class Check extends BaseComponent<ICheckProps, {}> {
         className={ css(
           'ms-Check',
           styles.root,
-          isChecked && ('is-checked ' + styles.rootIsChecked)
+          {
+            [`is-checked ${styles.rootIsChecked}`]: isChecked,
+            [`always-has-check ${styles.alwaysHasCheck}`]: alwaysShowCheck
+          }
         ) }
       >
         { Icon({

--- a/packages/office-ui-fabric-react/src/components/Check/Check.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.tsx
@@ -34,7 +34,7 @@ export class Check extends BaseComponent<ICheckProps, {}> {
   }
 
   public render() {
-    let { isChecked, checked, alwaysShowCheck = true } = this.props;
+    let { isChecked, checked } = this.props;
 
     isChecked = isChecked || checked;
 
@@ -44,8 +44,7 @@ export class Check extends BaseComponent<ICheckProps, {}> {
           'ms-Check',
           styles.root,
           {
-            [`is-checked ${styles.rootIsChecked}`]: isChecked,
-            [`always-has-check ${styles.alwaysHasCheck}`]: alwaysShowCheck
+            [`is-checked ${styles.rootIsChecked}`]: isChecked
           }
         ) }
       >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -3,7 +3,12 @@ import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 import { css } from '../../Utilities';
 import { Check } from '../../Check';
-import * as styles from './DetailsRowCheck.scss';
+import * as DetailsRowCheckStyles from './DetailsRowCheck.scss';
+import * as CheckStylesModule from '../Check/Check.scss';
+
+// tslint:disable:no-any
+const CheckStyles: any = CheckStylesModule;
+// tslint:enable:no-any
 
 export interface IDetailsRowCheckProps extends React.HTMLAttributes<HTMLElement> {
   selected?: boolean;
@@ -33,15 +38,19 @@ export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
       role='checkbox'
       className={ css(
         'ms-DetailsRow-check',
-        styles.check,
-        !props.canSelect && styles.isDisabled,
+        DetailsRowCheckStyles.check,
+        CheckStyles.checkHost,
+        !props.canSelect && DetailsRowCheckStyles.isDisabled,
         !props.canSelect && 'ms-DetailsRow-check--isDisabled'
       ) }
       aria-checked={ isPressed }
       data-selection-toggle={ true }
       data-automationid='DetailsRowCheck'
     >
-      <Check checked={ isPressed } />
+      <Check
+        alwaysShowCheck={ false }
+        checked={ isPressed }
+      />
     </button>
   );
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -48,7 +48,6 @@ export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
       data-automationid='DetailsRowCheck'
     >
       <Check
-        alwaysShowCheck={ false }
         checked={ isPressed }
       />
     </button>


### PR DESCRIPTION
### Overview

This change implements the intended behavior of the `alwaysShowCheck` prop in `Check`. By default, it is `true`. However, if callers set it to `false`, the checkmark within the `Check` will only show if the `Check` itself receives focus or hover (or if selected), or if a marked parent element receives hover or focus.
A parent component may use `.checkHost` on an element to indicate which element may also cause the checkmark to appear on hover or focus.

Modified `DetailsRow` and `Tile` to use the new behavior.