### PR TITLE
Round 2 of visual bug fixes for UHF for website

### DIFF
--- a/apps/fabric-website/src/pages/BlogPage/BlogItem.scss
+++ b/apps/fabric-website/src/pages/BlogPage/BlogItem.scss
@@ -52,7 +52,7 @@ $BlogItem-dateColumnWidth: 120px;
   .BlogItem-contentColumn {
     max-width: 50em;
     width: 100%;
-    padding-top: 60px;
+    padding-top: 108px;
   }
 
   .BlogItem-title {

--- a/apps/fabric-website/src/pages/BlogPage/BlogItem.scss
+++ b/apps/fabric-website/src/pages/BlogPage/BlogItem.scss
@@ -52,7 +52,11 @@ $BlogItem-dateColumnWidth: 120px;
   .BlogItem-contentColumn {
     max-width: 50em;
     width: 100%;
-    padding-top: 108px;
+    padding-top: 60px;
+
+    h2 {
+      margin: $uhf-h2-margin;
+    }
   }
 
   .BlogItem-title {

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.module.scss
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.module.scss
@@ -47,11 +47,13 @@
   background-color:$color-getStarted-darker;
   color: $ms-color-neutralLighter;
 
-  a, a:visited {
+  a, a:visited,
+  .uhfLinkOverride {
     border-bottom: 1px solid $ms-color-neutralLight;
   }
 
-  a, a:hover, a:active {
+  a, a:hover, a:active,
+  .uhfLinkOverride {
     color: $ms-color-neutralLight;
   }
 }
@@ -130,8 +132,17 @@
     font-size: $ms-font-size-l;
   }
 
-  a {
+  a,
+  .uhfLinkOverride {
     color: $color-getStarted-medium;
+  }
+
+  h3 {
+    margin: $uhf-h3-margin;
+  }
+
+  .trademark {
+    margin-top: 80px;
   }
 }
 

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.module.scss
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.module.scss
@@ -48,12 +48,12 @@
   color: $ms-color-neutralLighter;
 
   a, a:visited,
-  .uhfLinkOverride {
+  .getStartedLink {
     border-bottom: 1px solid $ms-color-neutralLight;
   }
 
   a, a:hover, a:active,
-  .uhfLinkOverride {
+  .getStartedLink {
     color: $ms-color-neutralLight;
   }
 }
@@ -133,7 +133,7 @@
   }
 
   a,
-  .uhfLinkOverride {
+  .getStartedLink {
     color: $color-getStarted-medium;
   }
 

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -64,7 +64,7 @@ export class GetStartedPage extends React.Component<any, any> {
           <div id='toolkit'>
             <span className={ styles.title }>Design Toolkit</span>
             <span className={ styles.descriptionLarge }>The toolkit is built with Adobe XD and provides controls and layout templates that enable you to create seamless, beautiful Offices experiences.</span>
-            <a className={ styles.uhfLinkOverride } href='#/resources'>Learn more</a>
+            <a className={ styles.getStartedLink } href='#/resources'>Learn more</a>
           </div>
         </div>
 
@@ -76,7 +76,7 @@ export class GetStartedPage extends React.Component<any, any> {
               <div className={ diagramStyles.text }>
                 <span className={ diagramStyles.headline }>Fabric Core Styles</span>
                 <span className={ diagramStyles.description }>Core elements of the design language, including icons, colors, type, and grid</span>
-                <a className={ styles.uhfLinkOverride } href='#/styles'>See styles</a>
+                <a className={ styles.getStartedLink } href='#/styles'>See styles</a>
               </div>
             </div>
             <div className={ diagramStyles.or }>or</div>
@@ -89,7 +89,7 @@ export class GetStartedPage extends React.Component<any, any> {
                 <div className={ diagramStyles.content }>
                   <span className={ diagramStyles.headline }>Fabric React</span>
                   <span className={ diagramStyles.description }>Robust, up-to-date components built with the React framework</span>
-                  <a className={ styles.uhfLinkOverride } href='#/components'>See components</a>
+                  <a className={ styles.getStartedLink } href='#/components'>See components</a>
                 </div>
               </li>
               <li className={ diagramStyles.component }>
@@ -100,7 +100,7 @@ export class GetStartedPage extends React.Component<any, any> {
                 <div className={ diagramStyles.content }>
                   <span className={ diagramStyles.headline }>AngularJS</span>
                   <span className={ diagramStyles.description }>Community-driven project to build components for Angular-based apps</span>
-                  <a className={ styles.uhfLinkOverride } href='#/angular-js'>Learn more</a>
+                  <a className={ styles.getStartedLink } href='#/angular-js'>Learn more</a>
                 </div>
               </li>
             </ul>
@@ -109,7 +109,7 @@ export class GetStartedPage extends React.Component<any, any> {
 
         <div className={ styles.instructionsSection }>
           <h2 id='react'>Get started with Fabric React</h2>
-          <p>Use NPM to get Fabric components and core styling. All you need is <a className={ styles.uhfLinkOverride } href='https://nodejs.org/en/'>node.js</a> and <a className={ styles.uhfLinkOverride } href='http://gulpjs.com/'>gulp</a>.</p>
+          <p>Use NPM to get Fabric components and core styling. All you need is <a className={ styles.getStartedLink } href='https://nodejs.org/en/'>node.js</a> and <a className={ styles.getStartedLink } href='http://gulpjs.com/'>gulp</a>.</p>
 
           <ol className={ styles.steps }>
             <li>
@@ -134,7 +134,7 @@ const MyPage = () => (<Fabric><DefaultButton>I am a button.</DefaultButton></Fab
 ReactDOM.render(<MyPage />, document.body.firstChild);`
                 }
               </CodeBlock>
-              <p>For more information about using components, check out the <a className={ styles.uhfLinkOverride } href='#/components/'>components page</a>.</p>
+              <p>For more information about using components, check out the <a className={ styles.getStartedLink } href='#/components/'>components page</a>.</p>
             </li>
             <li>
               <p>You can also reference type styles for any text element:</p>
@@ -151,15 +151,15 @@ ReactDOM.render(<MyPage />, document.body.firstChild);`
                   `<i class="ms-Icon ms-Icon--Mail" aria-hidden="true"></i>`
                 }
               </CodeBlock>
-              <p>Components, type, and icons are just a small part of what Fabric has to offer. To reference other assets, including colors, product symbols, and more, see the <a className={ styles.uhfLinkOverride } href='#/styles'>styles page</a>.</p>
+              <p>Components, type, and icons are just a small part of what Fabric has to offer. To reference other assets, including colors, product symbols, and more, see the <a className={ styles.getStartedLink } href='#/styles'>styles page</a>.</p>
             </li>
           </ol>
 
           <h3>Other ways to get Fabric React</h3>
-          <p>For advanced scenarios or alternatives to NPM see the <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/blob/master/ghdocs/ADVANCED.md'>advanced documentation in the Fabric React repository</a>.</p>
+          <p>For advanced scenarios or alternatives to NPM see the <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/blob/master/ghdocs/ADVANCED.md'>advanced documentation in the Fabric React repository</a>.</p>
 
           <h3>Need a component Fabric React doesn&rsquo;t have?</h3>
-          <p>First, check the <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
+          <p>First, check the <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
 
           <h2 id='core'>Get started with Fabric Core</h2>
           <p>With one reference to our CDN, you can access Fabric&rsquo;s fonts, icons, type styles, colors, grid, and more.</p>
@@ -180,17 +180,17 @@ ReactDOM.render(<MyPage />, document.body.firstChild);`
                   `<span class="ms-font-su ms-fontColor-themePrimary">Big blue text</span>`
                 }
               </CodeBlock>
-              <p>To reference all the assets available in Fabric Core, see the <a className={ styles.uhfLinkOverride } href='#/styles'>styles page</a>. To use components, see <a className={ styles.uhfLinkOverride } href='#/get-started#react'>Fabric React</a> or <a className={ styles.uhfLinkOverride } href='#/angular-js'>ngOfficeUIFabric</a>.</p>
+              <p>To reference all the assets available in Fabric Core, see the <a className={ styles.getStartedLink } href='#/styles'>styles page</a>. To use components, see <a className={ styles.getStartedLink } href='#/get-started#react'>Fabric React</a> or <a className={ styles.getStartedLink } href='#/angular-js'>ngOfficeUIFabric</a>.</p>
             </li>
           </ol>
 
           <h3>Other ways to get Fabric Core</h3>
-          <p>You can <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-core/releases'>download a copy of Fabric for your project</a> or <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-core/blob/master/ghdocs/PACKAGES.md'>add it through a package manager</a>. You can also <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-core/blob/master/ghdocs/BUILDING.md'>build your own copy from the source code</a>.</p>
+          <p>You can <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-core/releases'>download a copy of Fabric for your project</a> or <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-core/blob/master/ghdocs/PACKAGES.md'>add it through a package manager</a>. You can also <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-core/blob/master/ghdocs/BUILDING.md'>build your own copy from the source code</a>.</p>
 
           <h3>Need an icon or feature Fabric Core doesn&rsquo;t have?</h3>
-          <p>First, check the <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
+          <p>First, check the <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
 
-          <p className={ styles.trademark }>Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.uhfLinkOverride } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement</a>.</p>
+          <p className={ styles.trademark }>Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.getStartedLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement</a>.</p>
         </div>
 
       </div>

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -64,7 +64,7 @@ export class GetStartedPage extends React.Component<any, any> {
           <div id='toolkit'>
             <span className={ styles.title }>Design Toolkit</span>
             <span className={ styles.descriptionLarge }>The toolkit is built with Adobe XD and provides controls and layout templates that enable you to create seamless, beautiful Offices experiences.</span>
-            <a href='#/resources'>Learn more</a>
+            <a className={ styles.uhfLinkOverride } href='#/resources'>Learn more</a>
           </div>
         </div>
 
@@ -76,7 +76,7 @@ export class GetStartedPage extends React.Component<any, any> {
               <div className={ diagramStyles.text }>
                 <span className={ diagramStyles.headline }>Fabric Core Styles</span>
                 <span className={ diagramStyles.description }>Core elements of the design language, including icons, colors, type, and grid</span>
-                <a href='#/styles'>See styles</a>
+                <a className={ styles.uhfLinkOverride } href='#/styles'>See styles</a>
               </div>
             </div>
             <div className={ diagramStyles.or }>or</div>
@@ -89,7 +89,7 @@ export class GetStartedPage extends React.Component<any, any> {
                 <div className={ diagramStyles.content }>
                   <span className={ diagramStyles.headline }>Fabric React</span>
                   <span className={ diagramStyles.description }>Robust, up-to-date components built with the React framework</span>
-                  <a href='#/components'>See components</a>
+                  <a className={ styles.uhfLinkOverride } href='#/components'>See components</a>
                 </div>
               </li>
               <li className={ diagramStyles.component }>
@@ -100,7 +100,7 @@ export class GetStartedPage extends React.Component<any, any> {
                 <div className={ diagramStyles.content }>
                   <span className={ diagramStyles.headline }>AngularJS</span>
                   <span className={ diagramStyles.description }>Community-driven project to build components for Angular-based apps</span>
-                  <a href='#/angular-js'>Learn more</a>
+                  <a className={ styles.uhfLinkOverride } href='#/angular-js'>Learn more</a>
                 </div>
               </li>
             </ul>
@@ -109,7 +109,7 @@ export class GetStartedPage extends React.Component<any, any> {
 
         <div className={ styles.instructionsSection }>
           <h2 id='react'>Get started with Fabric React</h2>
-          <p>Use NPM to get Fabric components and core styling. All you need is <a href='https://nodejs.org/en/'>node.js</a> and <a href='http://gulpjs.com/'>gulp</a>.</p>
+          <p>Use NPM to get Fabric components and core styling. All you need is <a className={ styles.uhfLinkOverride } href='https://nodejs.org/en/'>node.js</a> and <a className={ styles.uhfLinkOverride } href='http://gulpjs.com/'>gulp</a>.</p>
 
           <ol className={ styles.steps }>
             <li>
@@ -134,7 +134,7 @@ const MyPage = () => (<Fabric><DefaultButton>I am a button.</DefaultButton></Fab
 ReactDOM.render(<MyPage />, document.body.firstChild);`
                 }
               </CodeBlock>
-              <p>For more information about using components, check out the <a href='#/components/'>components page</a>.</p>
+              <p>For more information about using components, check out the <a className={ styles.uhfLinkOverride } href='#/components/'>components page</a>.</p>
             </li>
             <li>
               <p>You can also reference type styles for any text element:</p>
@@ -151,15 +151,15 @@ ReactDOM.render(<MyPage />, document.body.firstChild);`
                   `<i class="ms-Icon ms-Icon--Mail" aria-hidden="true"></i>`
                 }
               </CodeBlock>
-              <p>Components, type, and icons are just a small part of what Fabric has to offer. To reference other assets, including colors, product symbols, and more, see the <a href='#/styles'>styles page</a>.</p>
+              <p>Components, type, and icons are just a small part of what Fabric has to offer. To reference other assets, including colors, product symbols, and more, see the <a className={ styles.uhfLinkOverride } href='#/styles'>styles page</a>.</p>
             </li>
           </ol>
 
           <h3>Other ways to get Fabric React</h3>
-          <p>For advanced scenarios or alternatives to NPM see the <a href='https://github.com/OfficeDev/office-ui-fabric-react/blob/master/ghdocs/ADVANCED.md'>advanced documentation in the Fabric React repository</a>.</p>
+          <p>For advanced scenarios or alternatives to NPM see the <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/blob/master/ghdocs/ADVANCED.md'>advanced documentation in the Fabric React repository</a>.</p>
 
           <h3>Need a component Fabric React doesn&rsquo;t have?</h3>
-          <p>First, check the <a href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
+          <p>First, check the <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
 
           <h2 id='core'>Get started with Fabric Core</h2>
           <p>With one reference to our CDN, you can access Fabric&rsquo;s fonts, icons, type styles, colors, grid, and more.</p>
@@ -180,18 +180,18 @@ ReactDOM.render(<MyPage />, document.body.firstChild);`
                   `<span class="ms-font-su ms-fontColor-themePrimary">Big blue text</span>`
                 }
               </CodeBlock>
-              <p>To reference all the assets available in Fabric Core, see the <a href='#/styles'>styles page</a>. To use components, see <a href='#/get-started#react'>Fabric React</a> or <a href='#/angular-js'>ngOfficeUIFabric</a>.</p>
+              <p>To reference all the assets available in Fabric Core, see the <a className={ styles.uhfLinkOverride } href='#/styles'>styles page</a>. To use components, see <a className={ styles.uhfLinkOverride } href='#/get-started#react'>Fabric React</a> or <a className={ styles.uhfLinkOverride } href='#/angular-js'>ngOfficeUIFabric</a>.</p>
             </li>
           </ol>
 
           <h3>Other ways to get Fabric Core</h3>
-          <p>You can <a href='https://github.com/OfficeDev/office-ui-fabric-core/releases'>download a copy of Fabric for your project</a> or <a href='https://github.com/OfficeDev/office-ui-fabric-core/blob/master/ghdocs/PACKAGES.md'>add it through a package manager</a>. You can also <a href='https://github.com/OfficeDev/office-ui-fabric-core/blob/master/ghdocs/BUILDING.md'>build your own copy from the source code</a>.</p>
+          <p>You can <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-core/releases'>download a copy of Fabric for your project</a> or <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-core/blob/master/ghdocs/PACKAGES.md'>add it through a package manager</a>. You can also <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-core/blob/master/ghdocs/BUILDING.md'>build your own copy from the source code</a>.</p>
 
           <h3>Need an icon or feature Fabric Core doesn&rsquo;t have?</h3>
-          <p>First, check the <a href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
-        </div>
+          <p>First, check the <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a className={ styles.uhfLinkOverride } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
 
-        <p>Usage of Fabric assets, such as fonts and icons, is subject to the <a href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement</a>.</p>
+          <p className={ styles.trademark }>Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.uhfLinkOverride } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement</a>.</p>
+        </div>
 
       </div>
     );

--- a/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
@@ -113,7 +113,7 @@
   }
 
   a,
-  .uhfLinkOverride {
+  .homePageLink {
     color: $color-home-lighter;
     font-size: $ms-font-size-m;
     transition: color $ms-animation-duration-2 $ms-animation-ease-1;
@@ -205,7 +205,7 @@
 .productDescription {
   font-size: $ms-font-size-l;
 
-  a, a:visited, .uhfLinkOverride {
+  a, a:visited, .homePageLink {
     color: $color-home-medium;
     transition: color $ms-animation-duration-2 $ms-animation-ease-1;
   }
@@ -328,7 +328,7 @@
 
   a,
   a:visited,
-  .uhfLinkOverride {
+  .homePageLink {
     color: $color-home-lighter;
   }
 }

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -27,19 +27,19 @@ export class HomePage extends React.Component<any, any> {
           <div className={ styles.flavor }>
             <span className={ styles.flavorTitle }>AngularJS</span>
             <span className={ styles.flavorDescription }>Community-driven project for Angular apps</span>
-            <a className={ styles.uhfLinkOverride } href='#/angular-js'>Learn more</a>
+            <a className={ styles.homePageLink } href='#/angular-js'>Learn more</a>
           </div>
           <div className={ styles.flavor }>
             <span className={ styles.flavorTitle }>Fabric iOS</span>
             <span className={ styles.flavorDescription }>Native iOS styling and components written in Swift</span>
-            <a className={ styles.uhfLinkOverride } href='#/fabric-ios'>Learn more</a>
+            <a className={ styles.homePageLink } href='#/fabric-ios'>Learn more</a>
           </div>
         </div>
 
         <div className={ css(styles.product, styles.productSharepoint) }>
           <div>
             <span className={ styles.productTitle }>SharePoint</span>
-            <span className={ styles.productDescription }>New SharePoint experiences are built with Fabric and the SharePoint Framework comes with it baked in to make things simple. <a className={ styles.uhfLinkOverride } href='https://dev.office.com/sharepoint/docs/spfx/web-parts/get-started/use-fabric-react-components'>Learn more</a></span>
+            <span className={ styles.productDescription }>New SharePoint experiences are built with Fabric and the SharePoint Framework comes with it baked in to make things simple. <a className={ styles.homePageLink } href='https://dev.office.com/sharepoint/docs/spfx/web-parts/get-started/use-fabric-react-components'>Learn more</a></span>
           </div>
           <img className={ styles.productImage } src={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-sharepoint.svg' } width='496' height='300' alt='Illustrated representation of the sharepoint page.' />
         </div>
@@ -47,7 +47,7 @@ export class HomePage extends React.Component<any, any> {
         <div className={ css(styles.product, styles.productAddins) }>
           <div>
             <span className={ styles.productTitle }>Office Add-ins</span>
-            <span className={ styles.productDescription }>Fabric is the official UX design framework for Office Add-ins. With Fabric, add-ins blend seamlessly with Word, Excel, PowerPoint, and Outlook. <a className={ styles.uhfLinkOverride } href='http://dev.office.com/docs/add-ins/design/add-in-design'>Learn more</a></span>
+            <span className={ styles.productDescription }>Fabric is the official UX design framework for Office Add-ins. With Fabric, add-ins blend seamlessly with Word, Excel, PowerPoint, and Outlook. <a className={ styles.homePageLink } href='http://dev.office.com/docs/add-ins/design/add-in-design'>Learn more</a></span>
           </div>
           <img className={ styles.productImage } src={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-addins.svg' } width='496' height='300' alt='Illustrated representation of an office add-in.' />
         </div>
@@ -81,9 +81,9 @@ export class HomePage extends React.Component<any, any> {
               </a>
             </li>
           </ul>
-          <span className={ styles.trademark }>All trademarks are the property of their respective owners. Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.uhfLinkOverride } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement</a>.</span>
+          <span className={ styles.trademark }>All trademarks are the property of their respective owners. Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.homePageLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement</a>.</span>
           <span className={ styles.featuredTitle }>Design Toolkit</span>
-          <span className={ styles.featuredDescription } id={ styles.toolkitDescription }>The toolkit is built with Adobe XD and provides controls and layout templates that enable you to create seamless, beautiful Offices experiences. <a className={ styles.uhfLinkOverride } href='#/resources'>Learn more</a></span>
+          <span className={ styles.featuredDescription } id={ styles.toolkitDescription }>The toolkit is built with Adobe XD and provides controls and layout templates that enable you to create seamless, beautiful Offices experiences. <a className={ styles.homePageLink } href='#/resources'>Learn more</a></span>
         </div>
       </div>
     );

--- a/apps/fabric-website/src/pages/ResourcesPage/ResourcesPage.module.scss
+++ b/apps/fabric-website/src/pages/ResourcesPage/ResourcesPage.module.scss
@@ -68,6 +68,7 @@
 
 .related {
   margin-bottom: 60px;
+  @include ms-padding-left($contentInGrid);
 
   h2 {
     color: $ms-color-neutralPrimary;

--- a/apps/fabric-website/src/styles/_typography.scss
+++ b/apps/fabric-website/src/styles/_typography.scss
@@ -19,13 +19,12 @@
   h2 {
     font-size: $font-size-big;
     font-weight: $ms-font-weight-light;
-    margin-bottom: 4px;
-    margin-top: 48px;
+    margin: $uhf-h2-margin;
   }
 
   h3 {
     font-size: $ms-font-size-l;
-    margin: 40px 0 8px 0;
+    margin: $uhf-h3-margin;
   }
 
   h4 {

--- a/apps/fabric-website/src/styles/_variables.scss
+++ b/apps/fabric-website/src/styles/_variables.scss
@@ -96,4 +96,8 @@ $uhf-screen-min-mobile: 768px;
 $uhf-screen-max-mobile: ($uhf-screen-min-mobile - 1);
 $uhf-screen-max-lg: 1083px;
 
+// These variables assist with overriding UHF styles
+$uhf-h3-margin: 40px 0 8px 0;
+$uhf-h2-margin: 48px 0 4px 0;
+
 $baseURL: ' https://static2.sharepointonline.com/files/fabric/';

--- a/common/changes/@uifabric/fabric-website/uhf-visual-bus-v2_2017-09-21-02-05.json
+++ b/common/changes/@uifabric/fabric-website/uhf-visual-bus-v2_2017-09-21-02-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Styling to fix UHF header overriding our styles.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- **_Fixed blog calendar overlap in mobile:_**
**Before**
![image](https://user-images.githubusercontent.com/16619843/30673632-583989b6-9e29-11e7-8026-bffc29ad2416.png)
**After**
Well, I can't get the blog page to render in the devlink. I used the same strategy that I used for the GetStartedPage h3 on the BlogPage h2 so I think the best bet is to hope it works, and check again tomorrow after the test link gets updated.

- **_Fixed spacing in ResourcePage:_**
**Before**
![image](https://user-images.githubusercontent.com/16619843/30673617-39c4a6e6-9e29-11e7-9412-0e0ab23fb61c.png)
**After**
![image](https://user-images.githubusercontent.com/16619843/30675260-6205df3e-9e34-11e7-875d-68724c7c2603.png)

- **_Fixed UHF margin and link color overrides on Get-StartedPage:_**
**Before**
![image](https://user-images.githubusercontent.com/16619843/30675763-2fc49c4c-9e37-11e7-9bbd-6398bf65b4e7.png)
**After**
![image](https://user-images.githubusercontent.com/16619843/30673733-0a94e696-9e2a-11e7-8b42-32ab8d8d0df7.png)

#### Focus areas to test

(optional)
