### PR TITLE
Dropdown: Add positioning wrapper to caretDown

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-update_2017-09-22-21-30.json
+++ b/common/changes/office-ui-fabric-react/dropdown-update_2017-09-22-21-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Adds a positioning wrapper around the caretDown icon",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "brgisla@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -102,15 +102,18 @@ $DropDown-item-height: 32px;
   }
 }
 
-.caretDown {
-  color: $ms-color-neutralDark;
-  font-size: $ms-icon-size-s;
+.caretDownWrapper {
   position: absolute;
   top: 1px; // border
   @include ms-right(12px);
-  pointer-events: none;
   height: $DropDown-height;
   line-height: $DropDown-height - 2px; // height minus the border
+}
+
+.caretDown {
+  color: $ms-color-neutralDark;
+  font-size: $ms-icon-size-s;
+  pointer-events: none;
 }
 
 // Style the new, replacement component

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -196,7 +196,9 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
                 onRenderPlaceHolder(this.props, this._onRenderPlaceHolder)
             }
           </span>
-          { onRenderCaretDown(this.props, this._onRenderCaretDown) }
+          <span className={ css('ms-Dropdown-caretDownWrapper', styles.caretDownWrapper) }>
+            { onRenderCaretDown(this.props, this._onRenderCaretDown) }
+          </span>
         </div>
         { isOpen && (
           onRenderContainer(this.props, this._onRenderContainer)

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.scss
@@ -8,11 +8,4 @@
   .dropdownExample-placeholder {
     display: flex;
   }
-  .dropdownExample-caretDownIcon {
-    right: 12px;
-    position: absolute;
-    top: 1px;
-    height: 32px;
-    line-height: 30px;
-  }
 }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
@@ -80,7 +80,7 @@ export class DropdownCustomExample extends React.Component<any, any> {
 
   private _onRenderCaretDown = (props: IDropdownProps): JSX.Element => {
     return (
-      <Icon className='dropdownExample-caretDownIcon' iconName='CirclePlus' />
+      <Icon iconName='CirclePlus' />
     );
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x ] Include a change request file using `$ npm run change`

#### Description of changes

Dropdown: Adds a positioning wrapper around the caretDown icon. Includes the css positioning in the wrapper, so that users of the new onCaretDownRender method do not need to add css rules for positioning their custom icons.

#### Focus areas to test

(optional)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/officedev/office-ui-fabric-react/2930)
<!-- Reviewable:end -->
