### PR TITLE
Migrating experiments package to Jest, adding needed hooks to merge-styles

### DIFF
--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -38,6 +38,7 @@ export * from './Overlay';
 export * from './Panel';
 export * from './Pickers';
 export * from './Persona';
+export * from './PersonaCoin';
 export * from './Pivot';
 export * from './ProgressIndicator';
 export * from './Rating';


### PR DESCRIPTION
This change updates how we test in the `experiments` package to use Jest snapshot testing and removes the dependency on karma for experiments. This means:

1. You get jest snapshot testing, yay!
2. Merge-styles applied css gets auto expanded in the snapshot, woot!
3. You can run `npm run start-test` to have a test watch mode, YESSS
4. You can type debugger in a test and press f5 and vscode and it hits, holy macaroni!
