### PR TITLE
Users/petdun/fix text field error announcement

### DIFF
--- a/common/changes/office-ui-fabric-react/users-petdun-fixTextFieldErrorAnnouncement_2017-09-26-19-57.json
+++ b/common/changes/office-ui-fabric-react/users-petdun-fixTextFieldErrorAnnouncement_2017-09-26-19-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Moved aria live attribute onto the actual text of an error message for text field component so that it is read aloud by narrator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "peterdunlop2519@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/users-petdun-fixTextFieldErrorAnnouncement_2017-09-26-19-57.json
+++ b/common/changes/office-ui-fabric-react/users-petdun-fixTextFieldErrorAnnouncement_2017-09-26-19-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Moved aria live attribute onto the actual text of an error message for text field component so that it is read aloud by narrator",
+      "comment": "TextField: Moved aria live attribute onto the actual text of an error message for text field component so that it is read aloud by narrator.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -170,7 +170,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
           <span id={ this._descriptionId }>
             { description && <span className={ css('ms-TextField-description', styles.description) }>{ description }</span> }
             { errorMessage &&
-              <div >
+              <div>
                 <DelayedRender>
                   <p
                     className={ css('ms-TextField-errorMessage', AnimationClassNames.slideDownIn20, styles.errorMessage) }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -170,13 +170,13 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
           <span id={ this._descriptionId }>
             { description && <span className={ css('ms-TextField-description', styles.description) }>{ description }</span> }
             { errorMessage &&
-              <div aria-live='assertive'>
+              <div >
                 <DelayedRender>
                   <p
                     className={ css('ms-TextField-errorMessage', AnimationClassNames.slideDownIn20, styles.errorMessage) }
                   >
                     { Icon({ iconName: 'Error', className: styles.errorIcon }) }
-                    <span className={ styles.errorText } data-automation-id='error-message'>{ errorMessage }</span>
+                    <span aria-live='assertive' className={ styles.errorText } data-automation-id='error-message'>{ errorMessage }</span>
                   </p>
                 </DelayedRender>
               </div>


### PR DESCRIPTION
#### Pull request checklist

- [ x] Addresses an existing issue: Fixes #1618
- [x ] Include a change request file using `$ npm run change`

#### Description of changes

Moving aria label onto actual text. This causes the error to be read aloud by narrator. Previously it was not. I have not tested with firefox and NVDA.

#### Focus areas to test

