### PR TITLE
Split button: 2 tab stops, better focus rectangles, easier to use

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -394,8 +394,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
           style={ { 'display': 'flex' } }
         >
           { this._onRenderContent(tag, buttonProps) }
-          { this._onRenderSplitButtonDivider(classNames) }
           { this._onRenderSplitButtonMenuButton(classNames) }
+          { this._onRenderSplitButtonDivider(classNames) }
         </span>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -141,15 +141,12 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       }
     }
 
-    const tabIndex = (this.props.tabIndex === undefined) ? (this._isSplitButton ? -1 : 0) : this.props.tabIndex;
-
     const buttonProps = assign(
       nativeProps,
       {
         className: this._classNames.root,
         ref: this._resolveRef('_buttonElement'),
         'disabled': disabled,
-        tabIndex: tabIndex,
         'aria-label': ariaLabel,
         'aria-labelledby': ariaLabelledBy,
         'aria-describedby': ariaDescribedBy,
@@ -388,8 +385,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         aria-pressed={ this.props.checked }
         aria-describedby={ buttonProps.ariaDescription }
         className={ classNames && classNames.splitButtonContainer }
-        tabIndex={ 0 }
-        onKeyDown={ this.props.disabled ? undefined : this._onSplitButtonKeyDown }
+        onKeyDown={ this._onSplitButtonKeyDown }
         ref={ this._resolveRef('_splitButtonContainer') }
       >
         <span
@@ -424,7 +420,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
     return (
       <BaseButton
-        tabIndex={ -1 }
         styles={ classNames }
         checked={ this.props.checked }
         disabled={ this.props.disabled }
@@ -437,19 +432,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
   @autobind
   private _onSplitButtonKeyDown(ev: React.KeyboardEvent<HTMLElement>) {
-    switch (ev.which) {
-      case KeyCodes.enter:
-      case KeyCodes.space:
-        (this.props.onClick as any)(null);
-        return;
+    if (ev.which === KeyCodes.down) {
+      this._onToggleMenu();
+      ev.preventDefault();
+      ev.stopPropagation();
     }
 
-    if (ev.altKey) {
-      switch (ev.which) {
-        case KeyCodes.down:
-          this._onToggleMenu();
-          return;
-      }
-    }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -296,12 +296,13 @@ describe('DefaultButton', () => {
           } }
         />
       );
-      const menuButtonDOM: HTMLButtonElement = renderedDOM.getElementsByClassName('ms-Button--default')[0] as HTMLButtonElement;
+      const menuButtonDOM: HTMLButtonElement = renderedDOM.querySelectorAll('button')[0];
+
       ReactTestUtils.Simulate.click(menuButtonDOM);
       expect(didClick).to.equal(true);
     });
 
-    it('Pressing Enter on SplitButton triggers action', () => {
+    it('Pressing down on SplitButton triggers menu', () => {
       const renderedDOM: HTMLElement = renderIntoDocument(
         <DefaultButton
           data-automation-id='test'
@@ -324,79 +325,14 @@ describe('DefaultButton', () => {
           } }
         />
       );
-      const splitButtonDOM = ReactDOM.findDOMNode(renderedDOM as React.ReactInstance);
-      ReactTestUtils.Simulate.keyDown(splitButtonDOM,
-        {
-          which: KeyCodes.enter
-        });
-      expect(didClick).to.equal(true);
-    });
 
-    it('Pressing Alt+Down on SplitButton triggers menu', () => {
-      const renderedDOM: HTMLElement = renderIntoDocument(
-        <DefaultButton
-          data-automation-id='test'
-          text='Create account'
-          split={ true }
-          onClick={ setTrue }
-          menuProps={ {
-            items: [
-              {
-                key: 'emailMessage',
-                name: 'Email message',
-                icon: 'Mail'
-              },
-              {
-                key: 'calendarEvent',
-                name: 'Calendar event',
-                icon: 'Calendar'
-              }
-            ]
-          } }
-        />
-      );
-      const splitButtonDOM = ReactDOM.findDOMNode(renderedDOM as React.ReactInstance);
-      ReactTestUtils.Simulate.focus(splitButtonDOM);
-      ReactTestUtils.Simulate.keyDown(splitButtonDOM,
+      const menuButtonElement = renderedDOM.querySelectorAll('button')[1];
+
+      ReactTestUtils.Simulate.keyDown(menuButtonElement,
         {
-          altKey: true,
           which: KeyCodes.down
         });
       expect(renderedDOM.getAttribute('aria-expanded')).to.equal('true');
-    });
-
-    it('A disabled SplitButton does not respond to key presses', () => {
-      const renderedDOM: HTMLElement = renderIntoDocument(
-        <DefaultButton
-          disabled={ true }
-          data-automation-id='test'
-          text='Create account'
-          split={ true }
-          onClick={ setTrue }
-          menuProps={ {
-            items: [
-              {
-                key: 'emailMessage',
-                name: 'Email message',
-                icon: 'Mail'
-              },
-              {
-                key: 'calendarEvent',
-                name: 'Calendar event',
-                icon: 'Calendar'
-              }
-            ]
-          } }
-        />
-      );
-      const splitButtonDOM = ReactDOM.findDOMNode(renderedDOM as React.ReactInstance);
-      ReactTestUtils.Simulate.focus(splitButtonDOM);
-      ReactTestUtils.Simulate.keyDown(splitButtonDOM,
-        {
-          altKey: true,
-          which: KeyCodes.down
-        });
-      expect(renderedDOM.getAttribute('aria-expanded')).to.equal('false');
     });
 
     it('A disabled SplitButton does not respond to clicks', () => {
@@ -423,8 +359,9 @@ describe('DefaultButton', () => {
           } }
         />
       );
-      const menuButtonDOM: HTMLButtonElement = renderedDOM.getElementsByClassName('ms-Button--default')[0] as HTMLButtonElement;
-      ReactTestUtils.Simulate.click(menuButtonDOM);
+      const buttonElement = renderedDOM.querySelectorAll('button')[0];
+
+      ReactTestUtils.Simulate.click(buttonElement);
       expect(didClick).to.equal(false);
     });
   });

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
@@ -34,13 +34,7 @@ export function standardStyles(theme: ITheme): IButtonStyles {
     },
 
     // Split button styles
-    splitButtonContainer: {
-      selectors: {
-        ':focus': {
-          borderColor: theme.palette.neutralDark
-        }
-      }
-    },
+    splitButtonContainer: {},
 
     splitButtonMenuButton: {
       color: theme.palette.white,
@@ -59,6 +53,10 @@ export function standardStyles(theme: ITheme): IButtonStyles {
           backgroundColor: theme.palette.neutralLighter,
         }
       }
+    },
+
+    splitButtonDivider: {
+      backgroundColor: theme.palette.neutralTertiaryAlt
     },
 
     splitButtonMenuButtonChecked: {
@@ -112,12 +110,10 @@ export function primaryStyles(theme: ITheme): IButtonStyles {
     },
 
     // Split button styles
-    splitButtonContainer: {
-      selectors: {
-        ':focus': {
-          borderColor: theme.palette.neutralDark
-        }
-      }
+    splitButtonContainer: {},
+
+    splitButtonDivider: {
+      backgroundColor: theme.palette.themeLighter
     },
 
     splitButtonMenuButton: {

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -1,7 +1,8 @@
 import { IButtonStyles } from '../Button.Props';
 import {
   ITheme,
-  mergeStyleSets
+  mergeStyleSets,
+  getFocusStyle
 } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 
@@ -23,19 +24,30 @@ export const getStyles = memoizeFunction((
       }
     },
 
-    splitButtonMenuButton: {
-      padding: '6px',
-      height: 'auto',
-      boxSizing: 'border-box',
-      border: '1px solid transparent',
-      outline: 'transparent',
-      userSelect: 'none',
-      display: 'inline-block',
-      textDecoration: 'none',
-      textAlign: 'center',
-      cursor: 'pointer',
-      verticalAlign: 'top',
-      width: '32px'
+    splitButtonMenuButton: [
+      getFocusStyle(theme, -1),
+      {
+        padding: 6,
+        height: 'auto',
+        boxSizing: 'border-box',
+        border: '1px solid transparent',
+        outline: 'transparent',
+        userSelect: 'none',
+        display: 'inline-block',
+        textDecoration: 'none',
+        textAlign: 'center',
+        cursor: 'pointer',
+        verticalAlign: 'top',
+        width: 32
+      }
+    ],
+
+    splitButtonDivider: {
+      position: 'absolute',
+      width: 1,
+      right: 32,
+      top: 8,
+      bottom: 8
     },
 
     splitButtonMenuButtonDisabled: {

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -38,14 +38,15 @@ export const getStyles = memoizeFunction((
         textAlign: 'center',
         cursor: 'pointer',
         verticalAlign: 'top',
-        width: 32
+        width: 32,
+        marginLeft: -1
       }
     ],
 
     splitButtonDivider: {
       position: 'absolute',
       width: 1,
-      right: 32,
+      right: 31,
       top: 8,
       bottom: 8
     },

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.styles.ts
@@ -5,6 +5,6 @@ export const getCustomSplitButtonStyles = memoizeFunction((): IButtonStyles => {
   return {
     splitButtonMenuButton: { backgroundColor: 'white', width: '10px' },
     splitButtonMenuIcon: { fontSize: '7px' },
-    splitButtonDivider: { borderLeft: '1px solid #c8c8c8' }
+    splitButtonDivider: { borderLeft: '1px solid #c8c8c8', right: 12 }
   };
 });

--- a/packages/utilities/src/scroll.scss
+++ b/packages/utilities/src/scroll.scss
@@ -2,5 +2,4 @@
 // is coming from.
 .scrollDisabled {
   overflow: hidden !important;
-  user-select: none;
 }


### PR DESCRIPTION
* Pressing down arrow expands the menu, no modifier required
* 2 tab stops now
* divider added

Standard:

![image](https://user-images.githubusercontent.com/1110944/30885708-33f88b5c-a2c9-11e7-8673-55d6bedab165.png)
![image](https://user-images.githubusercontent.com/1110944/30885716-3dca98dc-a2c9-11e7-8890-b6d3c7ad6db9.png)
![image](https://user-images.githubusercontent.com/1110944/30886742-10ee6506-a2cd-11e7-825d-ab3c13a7e036.png)

Primary:

![image](https://user-images.githubusercontent.com/1110944/30885746-5aa5e4ac-a2c9-11e7-8cc8-dbfa3acdeada.png)
![image](https://user-images.githubusercontent.com/1110944/30886703-ee7001ec-a2cc-11e7-989b-8b5f6783d2f6.png)
![image](https://user-images.githubusercontent.com/1110944/30886719-f8caa642-a2cc-11e7-900e-ae5a5cd20dd1.png)

