### PR TITLE
List: Fix documentation examples - Set autobind to onRenderCell to fix context of 'this'

### DIFF
--- a/common/changes/office-ui-fabric-react/v-edwliu-fix-list-example_2017-09-27-20-00.json
+++ b/common/changes/office-ui-fabric-react/v-edwliu-fix-list-example_2017-09-27-20-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: Fix documentation examples. Adds autobind to onRenderCell of List Grid Example",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx
@@ -3,6 +3,7 @@ import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import { List } from 'office-ui-fabric-react/lib/List';
 import './List.Grid.Example.scss';
 import { IRectangle } from '../../../Utilities';
+import { autobind } from 'office-ui-fabric-react/lib/Utilities';
 
 export interface IListGridExampleProps {
   items: any[];
@@ -54,6 +55,7 @@ export class ListGridExample extends React.Component<IListGridExampleProps, any>
     return this._rowHeight * ROWS_PER_PAGE;
   }
 
+  @autobind
   private _onRenderCell(item: any, index: number | undefined): JSX.Element {
     return (
       <div


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2949
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds autobind to onrendercell so "this" is bound to component example instead of undefined.

#### Focus areas to test

(optional)
