### PR TITLE
List: Fix grid example to read right to left in RTL mode

### DIFF
--- a/common/changes/office-ui-fabric-react/v-edwliu-fix-list-example-rtl_2017-09-27-20-21.json
+++ b/common/changes/office-ui-fabric-react/v-edwliu-fix-list-example-rtl_2017-09-27-20-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: Fix Grid example to read right to left in RTL mode",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.scss
@@ -14,7 +14,7 @@
     text-align: center;
     outline: none;
     position: relative;
-    float: left;
+    @include ms-float(left);
     background: $ms-color-neutralLighter;
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2848 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds rtl mixin to float so grid reads right to left in RTL mode.

#### Focus areas to test

(optional)
