### PR TITLE
ContextualMenu: Support checkable items within MenuSections

### DIFF
--- a/common/changes/office-ui-fabric-react/menu-section-checked_2017-09-28-01-23.json
+++ b/common/changes/office-ui-fabric-react/menu-section-checked_2017-09-28-01-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Make sure to check items within a menu section for the 'canCheck' property",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -10,7 +10,7 @@ import { FocusZoneDirection } from '../../FocusZone';
 
 let { expect } = chai;
 
-import { ContextualMenu } from './ContextualMenu';
+import { ContextualMenu, canAnyMenuItemsCheck } from './ContextualMenu';
 import { IContextualMenuItem, ContextualMenuItemType } from './ContextualMenu.Props';
 import { Layer } from '../Layer/Layer';
 
@@ -423,5 +423,52 @@ describe('ContextualMenu', () => {
     expect(menuMounted).to.be.equal(true, 'Menu opened callback was not properly called');
     expect(layerMountedFirst).to.be.equal(true, 'Menu Mounted First');
     expect(menuMountedFirst).to.be.equal(false, 'Layer Mounted first');
+  });
+
+  describe('canAnyMenuItemsCheck', () => {
+    it('returns false when there are no checkable menu items', () => {
+      const items: IContextualMenuItem[] = [
+        { name: 'Item 1', key: 'Item 1' },
+        { name: 'Item 2', key: 'Item 2' },
+        { name: 'Item 3', key: 'Item 3' }
+      ];
+
+      expect(canAnyMenuItemsCheck(items)).to.equal(false);
+    });
+
+    it('returns true when there is at least one checkable menu item', () => {
+      const items: IContextualMenuItem[] = [
+        { name: 'Item 1', key: 'Item 1' },
+        { name: 'Item 2', key: 'Item 2', canCheck: true },
+        { name: 'Item 3', key: 'Item 3' }
+      ];
+
+      expect(canAnyMenuItemsCheck(items)).to.equal(true);
+    });
+
+    it('returns true when there is a menu section with an item that can check', () => {
+      const items: IContextualMenuItem[] = [
+        {
+          name: 'Item 1',
+          key: 'Item 1'
+        },
+        {
+          name: 'Item 2',
+          key: 'Item 2'
+        },
+        {
+          name: 'Item 3',
+          key: 'Item 3',
+          sectionProps: {
+            items: [
+              { name: 'Item 1', key: 'Item 1' },
+              { name: 'Item 2', key: 'Item 2', canCheck: true },
+              { name: 'Item 3', key: 'Item 3' }
+            ]
+          }
+        }];
+
+      expect(canAnyMenuItemsCheck(items)).to.equal(true);
+    });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -69,6 +69,26 @@ function getIsChecked(item: IContextualMenuItem): boolean | null | undefined {
   return null;
 }
 
+/**
+ * Returns true if a list of menu items can contain a checkbox
+ */
+export function canAnyMenuItemsCheck(items: IContextualMenuItem[]): boolean {
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i];
+
+    if (item.canCheck) {
+      return true;
+    }
+
+    // If the item is a section, check if any of the items in the section can check.
+    if (item.sectionProps && item.sectionProps.items.some(submenuItem => submenuItem.canCheck === true)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 @customizable('ContextualMenu', ['theme'])
 @withResponsiveMode
 export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContextualMenuState> {
@@ -192,7 +212,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       return false;
     }
 
-    let hasCheckmarks = !!(items && items.some(item => !!item.canCheck));
+    let hasCheckmarks = canAnyMenuItemsCheck(items);
     const submenuProps = this.state.expandedMenuItemKey ? this._getSubmenuProps() : null;
 
     isBeakVisible = isBeakVisible === undefined ? this.props.responsiveMode! <= ResponsiveMode.medium : isBeakVisible;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -73,9 +73,7 @@ function getIsChecked(item: IContextualMenuItem): boolean | null | undefined {
  * Returns true if a list of menu items can contain a checkbox
  */
 export function canAnyMenuItemsCheck(items: IContextualMenuItem[]): boolean {
-  for (let i = 0; i < items.length; i += 1) {
-    const item = items[i];
-
+  return items.some(item => {
     if (item.canCheck) {
       return true;
     }
@@ -84,9 +82,9 @@ export function canAnyMenuItemsCheck(items: IContextualMenuItem[]): boolean {
     if (item.sectionProps && item.sectionProps.items.some(submenuItem => submenuItem.canCheck === true)) {
       return true;
     }
-  }
 
-  return false;
+    return false;
+  });
 }
 
 @customizable('ContextualMenu', ['theme'])


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Items defined within a submenu currently don't allocate the space necessary for rendering a menu item as a checkbox. This PR updates logic to make sure that the canCheck property is respected for items defined as children of the menu section. 
