### PR TITLE
DetailsList: Allow column resize outside maxWidth (4.0 backport)

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsList-resizeJustifiedColumnsPastMaxWidth-4.0_2017-09-28-10-21.json
+++ b/common/changes/office-ui-fabric-react/detailsList-resizeJustifiedColumnsPastMaxWidth-4.0_2017-09-28-10-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Allow resizing columns wider than maxWidth in justified layout",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-panu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -615,10 +615,6 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
         },
         this._columnOverrides[column.key]);
 
-      if (newColumn.maxWidth && newColumn.calculatedWidth > newColumn.maxWidth) {
-        newColumn.calculatedWidth = newColumn.maxWidth;
-      }
-
       totalWidth += newColumn.calculatedWidth + (i > 0 ? DEFAULT_INNER_PADDING : 0) + (column.isPadded ? ISPADDED_WIDTH : 0);
 
       return newColumn;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2902 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Backport of [PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/2904) to 4.0 branch.

Removes the check that prohibits resizing a column in a justified DetailsList beyond the maxWidth. Also, it relaxes the minimum width to be the smaller of the constant MIN_COLUMN_WIDTH or the specified minWidth.

#### Focus areas to test

DetailsList. The first sample (Documents). Notice that you currently cannot resize columns more than the max without the changes introduced with this PR.