### PR TITLE
mergeStyleSets type safety works better

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,17 +12,19 @@
   "files.exclude": {
     "**/.git": true,
     "**/.DS_Store": true,
-    "**/bower_components": true,
     "**/coverage": true,
     "**/*.scss.ts": true
   },
   "files.watcherExclude": {
-    "**/.git/objects/**": true,
-    "**/.git/subtree-cache/**": true,
-    "**/node_modules/**": true,
-    "**/tmp/**": true,
-    "**/bower_components/**": true,
-    "**/dist/**": true
+    "**/.git": true,
+    "**/node_modules": true,
+    "**/lib": true,
+    "**/lib-amd": true,
+    "/**lib-es6": true,
+    "**/temp": true,
+    "**/dist": true,
+    "**/*.scss.ts": true,
+    "**/coverage": true
   },
   // Configure glob patterns for excluding files and folders in searches. Inherits all glob patterns from the file.exclude setting.
   "search.exclude": {
@@ -30,6 +32,7 @@
     "**/node_modules": true,
     "**/lib": true,
     "**/lib-amd": true,
+    "**/lib-es6": true,
     "**/dist": true,
     "**/*.scss.ts": true
   },

--- a/common/changes/@uifabric/merge-styles/mergestylesets_2017-09-29-03-31.json
+++ b/common/changes/@uifabric/merge-styles/mergestylesets_2017-09-29-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "The `mergeStyleSets` method's type safety was not correct. Now with significantly better type safety.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/mergestylesets_2017-09-29-03-31.json
+++ b/common/changes/office-ui-fabric-react/mergestylesets_2017-09-29-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updating mergeStyleSets usage in various components to adhere to correct typing.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -14,9 +14,8 @@ describe('mergeStyleSets', () => {
   });
 
   it('can merge style sets', () => {
-
-    // tslint:disable-next-line:no-any
-    const result = mergeStyleSets<any>(
+    const result: { root: string, a: string, b: string } = mergeStyleSets(
+      {},
       {
         root: { background: 'red' },
         a: { background: 'green' }

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -8,10 +8,10 @@ import { IStyle } from './IStyle';
  *
  * @public
  */
-export function mergeStyleSets<T extends object>(
-  ...cssSets: (T | false | null | undefined)[]
-): {[P in keyof T]?: string } {
-  const classNameSet: {[P in keyof T]?: string } = {};
+export function mergeStyleSets<T>(
+  ...cssSets: ({[P in keyof T]?: IStyle } | false | null | undefined)[]
+): T {
+  const classNameSet: Partial<T> = {};
   let cssSet = cssSets[0];
 
   if (cssSet) {
@@ -20,10 +20,11 @@ export function mergeStyleSets<T extends object>(
     }
     for (const prop in cssSet) {
       if (cssSet.hasOwnProperty(prop)) {
-        classNameSet[prop] = mergeStyles(cssSet[prop] as IStyle);
+        // tslint:disable-next-line:no-any
+        (classNameSet as any)[prop] = mergeStyles(cssSet[prop] as IStyle);
       }
     }
   }
 
-  return classNameSet;
+  return classNameSet as T;
 }

--- a/packages/merge-styles/src/server.test.ts
+++ b/packages/merge-styles/src/server.test.ts
@@ -7,7 +7,7 @@ describe('staticRender', () => {
   it('can render content', () => {
 
     const { html, css } = renderStatic(() => {
-      const classNames = mergeStyleSets({
+      const classNames: { root: string } = mergeStyleSets({
         root: {
           background: 'red'
         }

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -1,7 +1,7 @@
 import { IButtonStyles } from '../Button.Props';
 import {
   ITheme,
-  mergeStyleSets,
+  concatStyleSets,
   getFocusStyle
 } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
@@ -69,5 +69,5 @@ export const getStyles = memoizeFunction((
     },
   };
 
-  return mergeStyleSets(splitButtonStyles, customStyles)!;
+  return concatStyleSets(splitButtonStyles, customStyles)!;
 });

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -5,7 +5,7 @@ import {
 import {
   ITheme,
   IRawStyle,
-  mergeStyleSets,
+  concatStyleSets,
   FontSizes,
   FontWeights,
   getFocusStyle
@@ -135,7 +135,7 @@ export const getOptionStyles = memoizeFunction((
     },
   };
 
-  return mergeStyleSets(optionStyles, customStylesForAllOptions, customOptionStylesForCurrentOption) as IComboBoxOptionStyles;
+  return concatStyleSets(optionStyles, customStylesForAllOptions, customOptionStylesForCurrentOption) as IComboBoxOptionStyles;
 });
 
 export const getCaretDownButtonStyles = memoizeFunction((
@@ -173,7 +173,7 @@ export const getCaretDownButtonStyles = memoizeFunction((
     },
     rootDisabled: getDisabledStyles(theme),
   };
-  return mergeStyleSets(styles, customStyles) as IButtonStyles;
+  return concatStyleSets(styles, customStyles) as IButtonStyles;
 });
 
 export const getStyles = memoizeFunction((
@@ -312,5 +312,5 @@ export const getStyles = memoizeFunction((
 
   };
 
-  return mergeStyleSets(styles, customStyles) as IComboBoxStyles;
+  return concatStyleSets(styles, customStyles) as IComboBoxStyles;
 });

--- a/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.styles.ts
@@ -1,7 +1,7 @@
 import { IExpandingCardStyles } from './ExpandingCard.Props';
 import { memoizeFunction } from '../../Utilities';
 import {
-  mergeStyleSets,
+  concatStyleSets,
   ITheme
 } from '../../Styling';
 
@@ -59,5 +59,5 @@ export const getStyles = memoizeFunction((
     }
   };
 
-  return mergeStyleSets(styles, customStyles)!;
+  return concatStyleSets(styles, customStyles)!;
 });

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.classNames.ts
@@ -14,18 +14,17 @@ export interface IIconClassNames {
 export const getClassNames = memoizeFunction((
   customStyles?: IIconStyles
 ): IIconClassNames => {
-  let iconStyles: IIconStyles = {
-    root: {
-      display: 'inline-block'
-    },
-
-    imageContainer: {
-      overflow: 'hidden'
-    }
-  };
 
   return mergeStyleSets(
-    iconStyles,
+    {
+      root: {
+        display: 'inline-block'
+      },
+
+      imageContainer: {
+        overflow: 'hidden'
+      }
+    },
     customStyles
   );
 });


### PR DESCRIPTION
Before, this would not fail:

```
let foo: { a: string, b: string } = mergeStyleSets({
  a: {
    background: 'red',
    foobar: 1
  }
});
```

Now `foobar` shows red squiggles in vscode.