### PR TITLE
New SearchBox "inline" prop and example, and other adjustments per toolkit

### DIFF
--- a/common/changes/office-ui-fabric-react/searchbox-toolkit_2017-09-29-20-03.json
+++ b/common/changes/office-ui-fabric-react/searchbox-toolkit_2017-09-29-20-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added new inline prop for SearchBox and corresonding new example. Adjested the SearchBoxPage to better reflect the current toolkit documentation.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
@@ -63,8 +63,8 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
   ariaLabel?: string;
 
   /**
-   * Whether or not the SearchBox is inline.
+   * Whether or not the SearchBox is underlined.
    * @default false
    */
-  inline?: boolean;
+  underlined?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.Props.ts
@@ -61,4 +61,10 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
    * @defaultvalue labelText
    */
   ariaLabel?: string;
+
+  /**
+   * Whether or not the SearchBox is inline.
+   * @default false
+   */
+  inline?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
@@ -74,7 +74,7 @@
 }
 
 // Modifier: Inline searchbox
-.root.rootIsInline {
+.root.rootIsUnderlined {
   border-width: 0px 0px 1px 0px;
 
   &.rootIsDisabled {

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.scss
@@ -28,12 +28,11 @@
   flex-direction: column;
   justify-content: center;
   flex-shrink: 0;
-  color: $ms-color-neutralSecondaryAlt;
   font-size: 16px;
   width: 32px;
   text-align: center;
   transition: width $ms-animation-duration-1;
-  color: $ms-color-themeDarkAlt;
+  color: $ms-color-themePrimary;
 }
 
 .icon {
@@ -74,6 +73,15 @@
   color: $ms-color-themePrimary;
 }
 
+// Modifier: Inline searchbox
+.root.rootIsInline {
+  border-width: 0px 0px 1px 0px;
+
+  &.rootIsDisabled {
+    background-color: transparent;
+  }
+}
+
 // State: Active searchbox
 .root.rootIsActive {
   border-color: $ms-color-themePrimary;
@@ -97,10 +105,10 @@
   pointer-events: none;
   cursor: default;
   .iconContainer {
-    color: $ms-color-neutralTertiaryAlt;
+    color: $ms-color-neutralTertiary;
   }
   .field {
-    color: $ms-color-neutralTertiaryAlt;
+    color: $ms-color-neutralTertiary;
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -47,7 +47,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
   }
 
   public render() {
-    let { labelText, className, disabled } = this.props;
+    let { labelText, className, disabled, inline } = this.props;
     let { value, hasFocus, id } = this.state;
     return (
       <div
@@ -56,6 +56,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
           ['is-active ' + styles.rootIsActive]: hasFocus,
           ['is-disabled ' + styles.rootIsDisabled]: disabled,
           ['can-clear ' + styles.rootCanClear]: value!.length > 0,
+          ['is-inline ' + styles.rootIsInline]: inline,
         }) }
         { ...{ onFocusCapture: this._onFocusCapture } }
       >

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -47,7 +47,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
   }
 
   public render() {
-    let { labelText, className, disabled, inline } = this.props;
+    let { labelText, className, disabled, underlined } = this.props;
     let { value, hasFocus, id } = this.state;
     return (
       <div
@@ -56,7 +56,7 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
           ['is-active ' + styles.rootIsActive]: hasFocus,
           ['is-disabled ' + styles.rootIsDisabled]: disabled,
           ['can-clear ' + styles.rootCanClear]: value!.length > 0,
-          ['is-inline ' + styles.rootIsInline]: inline,
+          ['is-underlined ' + styles.rootIsUnderlined]: underlined,
         }) }
         { ...{ onFocusCapture: this._onFocusCapture } }
       >

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
@@ -6,7 +6,7 @@ import {
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 import { SearchBoxFullSizeExample } from './examples/SearchBox.FullSize.Example';
-import { SearchBoxInlineExample } from './examples/SearchBox.Inline.Example';
+import { SearchBoxUnderlinedExample } from './examples/SearchBox.Underlined.Example';
 import { SearchBoxDisabledExample } from './examples/SearchBox.Disabled.Example';
 import { SearchBoxSmallExample } from './examples/SearchBox.Small.Example';
 import { FontClassNames } from '../../Styling';
@@ -14,7 +14,7 @@ import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { SearchBoxStatus } from './SearchBox.checklist';
 
 const SearchBoxFullSizeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.FullSize.Example.tsx') as string;
-const SearchBoxInlineExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Inline.Example.tsx') as string;
+const SearchBoxUnderlinedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Underlined.Example.tsx') as string;
 const SearchBoxDisabledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Disabled.Example.tsx') as string;
 const SearchBoxSmallExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx') as string;
 
@@ -33,10 +33,10 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> 
               <SearchBoxFullSizeExample />
             </ExampleCard>
             <ExampleCard
-              title='Inline SearchBox'
-              code={ SearchBoxInlineExampleCode }
+              title='Underlined SearchBox'
+              code={ SearchBoxUnderlinedExampleCode }
             >
-              <SearchBoxInlineExample />
+              <SearchBoxUnderlinedExample />
             </ExampleCard>
             <ExampleCard
               title='Disabled SearchBoxes'
@@ -124,7 +124,7 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> 
               <li>Provide autocomplete suggestions where there are strong matches to the user's query that the user may want to view immediately.</li>
               <li>Use a visual separator to define a group of a similar or conceptually aligned autocomplete suggestions.</li>
               <li>If possible, provide a preview (e.g. image, title, etc.) for autocomplete suggestions to help the user quickly determine if the suggested result is what they were searching for.</li>
-              <li>Use the Inline SearchBox for CommandBars.</li>
+              <li>Use the Underlined SearchBox for CommandBars.</li>
             </ul>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBoxPage.tsx
@@ -5,14 +5,18 @@ import {
   IComponentDemoPageProps,
   PropertiesTableSet
 } from '@uifabric/example-app-base';
-import { SearchBoxSmallExample } from './examples/SearchBox.Small.Example';
 import { SearchBoxFullSizeExample } from './examples/SearchBox.FullSize.Example';
+import { SearchBoxInlineExample } from './examples/SearchBox.Inline.Example';
+import { SearchBoxDisabledExample } from './examples/SearchBox.Disabled.Example';
+import { SearchBoxSmallExample } from './examples/SearchBox.Small.Example';
 import { FontClassNames } from '../../Styling';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { SearchBoxStatus } from './SearchBox.checklist';
 
-const SearchBoxSmallExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx') as string;
 const SearchBoxFullSizeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.FullSize.Example.tsx') as string;
+const SearchBoxInlineExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Inline.Example.tsx') as string;
+const SearchBoxDisabledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Disabled.Example.tsx') as string;
+const SearchBoxSmallExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx') as string;
 
 export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -22,11 +26,29 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> 
         componentName='SearchBoxExample'
         exampleCards={
           <div>
-            <ExampleCard title='Default SearchBox' code={ SearchBoxSmallExampleCode }>
-              <SearchBoxSmallExample />
-            </ExampleCard>
-            <ExampleCard title='SearchBox with no parent container' code={ SearchBoxFullSizeExampleCode }>
+            <ExampleCard
+              title='Default SearchBox'
+              code={ SearchBoxFullSizeExampleCode }
+            >
               <SearchBoxFullSizeExample />
+            </ExampleCard>
+            <ExampleCard
+              title='Inline SearchBox'
+              code={ SearchBoxInlineExampleCode }
+            >
+              <SearchBoxInlineExample />
+            </ExampleCard>
+            <ExampleCard
+              title='Disabled SearchBoxes'
+              code={ SearchBoxDisabledExampleCode }
+            >
+              <SearchBoxDisabledExample />
+            </ExampleCard>
+            <ExampleCard
+              title='SearchBox with fixed width and custom event handling'
+              code={ SearchBoxSmallExampleCode }
+            >
+              <SearchBoxSmallExample />
             </ExampleCard>
           </div>
         }
@@ -102,6 +124,7 @@ export class SearchBoxPage extends React.Component<IComponentDemoPageProps, {}> 
               <li>Provide autocomplete suggestions where there are strong matches to the user's query that the user may want to view immediately.</li>
               <li>Use a visual separator to define a group of a similar or conceptually aligned autocomplete suggestions.</li>
               <li>If possible, provide a preview (e.g. image, title, etc.) for autocomplete suggestions to help the user quickly determine if the suggested result is what they were searching for.</li>
+              <li>Use the Inline SearchBox for CommandBars.</li>
             </ul>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Disabled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Disabled.Example.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
+
+export class SearchBoxDisabledExample extends React.Component<any, any> {
+
+  public render() {
+    return (
+      <div>
+        <SearchBox
+          onFocus={ () => console.log('onFocus called') }
+          onBlur={ () => console.log('onBlur called') }
+          disabled
+        />
+
+        <SearchBox
+          onFocus={ () => console.log('onFocus called') }
+          onBlur={ () => console.log('onBlur called') }
+          inline={ true }
+          disabled
+        />
+      </div>
+    );
+  }
+
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Disabled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Disabled.Example.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
+import './SearchBox.Examples.scss';
 
 export class SearchBoxDisabledExample extends React.Component<any, any> {
 
   public render() {
     return (
-      <div>
+      <div className='ms-SearchBoxExample'>
         <SearchBox
           onFocus={ () => console.log('onFocus called') }
           onBlur={ () => console.log('onBlur called') }
@@ -15,7 +16,7 @@ export class SearchBoxDisabledExample extends React.Component<any, any> {
         <SearchBox
           onFocus={ () => console.log('onFocus called') }
           onBlur={ () => console.log('onBlur called') }
-          inline={ true }
+          underlined={ true }
           disabled
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Examples.scss
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Examples.scss
@@ -1,0 +1,5 @@
+:global {
+  .ms-SearchBoxExample .ms-SearchBox {
+    margin: 0 0 10px 0;
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Inline.Example.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
+
+export class SearchBoxInlineExample extends React.Component<any, any> {
+
+  public render() {
+    return (
+      <SearchBox
+        onFocus={ () => console.log('onFocus called') }
+        onBlur={ () => console.log('onBlur called') }
+        inline={ true }
+      />
+    );
+  }
+
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Underlined.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Underlined.Example.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 
-export class SearchBoxInlineExample extends React.Component<any, any> {
+export class SearchBoxUnderlinedExample extends React.Component<any, any> {
 
   public render() {
     return (
       <SearchBox
         onFocus={ () => console.log('onFocus called') }
         onBlur={ () => console.log('onBlur called') }
-        inline={ true }
+        underlined={ true }
       />
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Added new "inline" prop for SearchBox with styling that reflects the toolkit's guidance for showing bottom border only
- Added new example for Inline SearchBox, also added an example to show disabled states
- Adjusted the SearchBoxPage to better reflect the current toolkit documentation.

After:
![image](https://user-images.githubusercontent.com/16619843/31033974-f270bf88-a516-11e7-91d8-24c3e9e4d830.png)

#### Focus areas to test

(optional)
