### PR TITLE
mergeStyleSets: Another fix to make type safety work

### DIFF
--- a/common/changes/@uifabric/merge-styles/another-fix_2017-09-30-00-41.json
+++ b/common/changes/@uifabric/merge-styles/another-fix_2017-09-30-00-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Found that adding `false` to the list of accepted typings in `mergeStyleSets` was breaking type safety. Removed it.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -9,7 +9,7 @@ import { IStyle } from './IStyle';
  * @public
  */
 export function mergeStyleSets<T>(
-  ...cssSets: ({[P in keyof T]?: IStyle } | false | null | undefined)[]
+  ...cssSets: ({[P in keyof T]?: IStyle } | null | undefined)[]
 ): T {
   const classNameSet: Partial<T> = {};
   let cssSet = cssSets[0];


### PR DESCRIPTION
It seems that after my changes yesterday, type safety still doesn't work because I added the `false` to the list of possible arguments, which for some odd reason makes TypeScript confused.

Removing it restores the type safety.

![image](https://user-images.githubusercontent.com/1110944/31040574-c0cee1d6-a53d-11e7-80a2-56703632fd94.png)
