### PR TITLE
Tooltip page - removed duplicate header

### DIFF
--- a/common/changes/office-ui-fabric-react/tooltip-page_2017-10-02-18-24.json
+++ b/common/changes/office-ui-fabric-react/tooltip-page_2017-10-02-18-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed duplicate header on Tooltip page.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
@@ -4,6 +4,7 @@ import { LayerHost } from 'office-ui-fabric-react/lib/Layer';
 import {
   ExampleCard,
   ComponentPage,
+  IComponentDemoPageProps,
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 import { TooltipCustomExample } from './examples/Tooltip.Custom.Example';
@@ -18,7 +19,7 @@ const TooltipBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/
 const TooltipCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx') as string;
 const TooltipOverflowExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Overflow.Example.tsx') as string;
 
-export class TooltipPage extends React.Component<any, any> {
+export class TooltipPage extends React.Component<IComponentDemoPageProps, any> {
   public render() {
     return (
       <ComponentPage
@@ -52,6 +53,7 @@ export class TooltipPage extends React.Component<any, any> {
             <span> supplement content associated with a specific UI component.</span>
           </div>
         }
+        isHeaderVisible={ this.props.isHeaderVisible }
         componentStatus={
           <ComponentStatus
             {...TooltipStatus}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The tooltip was showing a duplicate header. Added reference to IComponentDemoPageProps like other pages have, which picks up the prop, "isHeaderVisible".

**Before**:
![image](https://user-images.githubusercontent.com/16619843/31092913-d28b1ff6-a764-11e7-9c96-4561a7fdbc11.png)

**After**:
![image](https://user-images.githubusercontent.com/16619843/31092934-e0e383ea-a764-11e7-9466-c848acfa065c.png)


#### Focus areas to test

(optional)
