### PR TITLE
Split Button: Separate disabled capability for menu from primary action

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-splitButtonDisable_2017-10-02-20-48.json
+++ b/common/changes/office-ui-fabric-react/malozano-splitButtonDisable_2017-10-02-20-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "\"Separate split menu disabled capability from primary action\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/malozano-splitButtonDisable_2017-10-02-20-48.json
+++ b/common/changes/office-ui-fabric-react/malozano-splitButtonDisable_2017-10-02-20-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "\"Separate split menu disabled capability from primary action\"",
+      "comment": "\"Buttons: adding `primaryDisabled` flag for disabling only the primary action of the split button, leaving the menu enabled.\"",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -77,6 +77,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       className,
       description,
       disabled,
+      primaryDisabled,
       href,
       iconProps,
       menuIconProps,
@@ -87,6 +88,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
          } = this.props;
 
     let { menuProps } = this.state;
+    // Button is disabled if the whole button (in case of splitbutton is disabled) or if the primary action is disabled
+    let isPrimaryButtonDisabled = (disabled || primaryDisabled);
 
     this._classNames = getClassNames(
       styles!,
@@ -94,7 +97,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       variantClassName!,
       iconProps && iconProps.className,
       menuIconProps && menuIconProps.className,
-      disabled!,
+      isPrimaryButtonDisabled!,
       checked!,
       !!this.state.menuProps && !this.props.split
     );
@@ -102,7 +105,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     const { _ariaDescriptionId, _labelId, _descriptionId } = this;
     // Anchor tag cannot be disabled hence in disabled state rendering
     // anchor button as normal button
-    const renderAsAnchor: boolean = !disabled && !!href;
+    const renderAsAnchor: boolean = !isPrimaryButtonDisabled && !!href;
     const tag = renderAsAnchor ? 'a' : 'button';
     const nativeProps = getNativeProps(
       assign(
@@ -146,7 +149,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       {
         className: this._classNames.root,
         ref: this._resolveRef('_buttonElement'),
-        'disabled': disabled,
+        'disabled': isPrimaryButtonDisabled,
         'aria-label': ariaLabel,
         'aria-labelledby': ariaLabelledBy,
         'aria-describedby': ariaDescribedBy,
@@ -371,16 +374,15 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     const {
       styles = {},
       disabled,
-      splitDisabled,
       checked
     } = this.props;
 
-    const classNames = styles && getSplitButtonClassNames(styles!, !!splitDisabled, !!this.state.menuProps, !!checked);
+    const classNames = styles && getSplitButtonClassNames(styles!, !!disabled, !!this.state.menuProps, !!checked);
 
     return (
       <div
         aria-labelledby={ buttonProps.ariaLabel }
-        aria-disabled={ disabled && splitDisabled }
+        aria-disabled={ disabled }
         aria-haspopup={ true }
         aria-expanded={ this._isExpanded }
         aria-pressed={ this.props.checked }
@@ -423,7 +425,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       <BaseButton
         styles={ classNames }
         checked={ this.props.checked }
-        disabled={ this.props.splitDisabled }
+        disabled={ this.props.disabled }
         onClick={ this._onToggleMenu }
         menuProps={ undefined }
         iconProps={ menuIconProps }

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -371,15 +371,16 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     const {
       styles = {},
       disabled,
+      splitDisabled,
       checked
     } = this.props;
 
-    const classNames = styles && getSplitButtonClassNames(styles!, !!disabled, !!this.state.menuProps, !!checked);
+    const classNames = styles && getSplitButtonClassNames(styles!, !!splitDisabled, !!this.state.menuProps, !!checked);
 
     return (
       <div
         aria-labelledby={ buttonProps.ariaLabel }
-        aria-disabled={ disabled }
+        aria-disabled={ disabled && splitDisabled }
         aria-haspopup={ true }
         aria-expanded={ this._isExpanded }
         aria-pressed={ this.props.checked }
@@ -422,7 +423,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       <BaseButton
         styles={ classNames }
         checked={ this.props.checked }
-        disabled={ this.props.disabled }
+        disabled={ this.props.splitDisabled }
         onClick={ this._onToggleMenu }
         menuProps={ undefined }
         iconProps={ menuIconProps }

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -101,6 +101,11 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
   split?: boolean;
 
   /**
+   * If set to true and if this is a splitButton (split == true) then the split menu part of the button is disabled. Defaults to false.
+   */
+  splitDisabled?: boolean;
+
+  /**
    * The props for the icon shown when providing a menu dropdown.
    */
   menuIconProps?: IIconProps;

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -48,6 +48,11 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
   disabled?: boolean;
 
   /**
+   * If set to true and if this is a splitButton (split == true) then the primary action of a split button is disabled.
+   */
+  primaryDisabled?: boolean;
+
+  /**
    * Custom styling for individual elements within the button DOM.
    */
   styles?: IButtonStyles;
@@ -99,11 +104,6 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
    * If set to true, and if menuProps and onClick are provided, the button will render as a SplitButton. Defaults to false.
    */
   split?: boolean;
-
-  /**
-   * If set to true and if this is a splitButton (split == true) then the split menu part of the button is disabled. Defaults to false.
-   */
-  splitDisabled?: boolean;
 
   /**
    * The props for the icon shown when providing a menu dropdown.

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -70,6 +70,34 @@ export class ButtonSplitExample extends React.Component<IButtonProps, {}> {
             } }
           />
         </div>
+        <div>
+          <Label>Primary Action Disabled</Label>
+          <DefaultButton
+            primary
+            data-automation-id='test'
+            disabled={ disabled }
+            primaryDisabled={ true }
+            checked={ checked }
+            text='Create account'
+            onClick={ alertClicked }
+            split={ true }
+            style={ { height: '35px' } }
+            menuProps={ {
+              items: [
+                {
+                  key: 'emailMessage',
+                  name: 'Email message',
+                  icon: 'Mail'
+                },
+                {
+                  key: 'calendarEvent',
+                  name: 'Calendar event',
+                  icon: 'Calendar'
+                }
+              ]
+            } }
+          />
+        </div>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -70,34 +70,6 @@ export class ButtonSplitExample extends React.Component<IButtonProps, {}> {
             } }
           />
         </div>
-        <div>
-          <Label>Split Disabled</Label>
-          <DefaultButton
-            primary
-            data-automation-id='test'
-            disabled={ disabled }
-            checked={ checked }
-            text='Create account'
-            onClick={ alertClicked }
-            split={ true }
-            splitDisabled={ false }
-            style={ { height: '35px' } }
-            menuProps={ {
-              items: [
-                {
-                  key: 'emailMessage',
-                  name: 'Email message',
-                  icon: 'Mail'
-                },
-                {
-                  key: 'calendarEvent',
-                  name: 'Calendar event',
-                  icon: 'Calendar'
-                }
-              ]
-            } }
-          />
-        </div>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -70,6 +70,34 @@ export class ButtonSplitExample extends React.Component<IButtonProps, {}> {
             } }
           />
         </div>
+        <div>
+          <Label>Split Disabled</Label>
+          <DefaultButton
+            primary
+            data-automation-id='test'
+            disabled={ disabled }
+            checked={ checked }
+            text='Create account'
+            onClick={ alertClicked }
+            split={ true }
+            splitDisabled={ false }
+            style={ { height: '35px' } }
+            menuProps={ {
+              items: [
+                {
+                  key: 'emailMessage',
+                  name: 'Email message',
+                  icon: 'Mail'
+                },
+                {
+                  key: 'calendarEvent',
+                  name: 'Calendar event',
+                  icon: 'Calendar'
+                }
+              ]
+            } }
+          />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Right now a split button is disabled if the primary action of the split button is disabled. We want to separate this capability to enable scenarios where even though the primary action is disabled, we can still access the other menu options.

![separate](https://user-images.githubusercontent.com/3754893/31098843-e087ac1e-a778-11e7-8081-7e916d700b24.gif)
