### PR TITLE
Dropdown: fixed logic in getSelectedIndex

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-selectedKey-bugfix_2017-10-02-21-17.json
+++ b/common/changes/office-ui-fabric-react/dropdown-selectedKey-bugfix_2017-10-02-21-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: fixed logic in getSelectedIndex to support controlled uses",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -571,8 +571,14 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   }
 
   private _getSelectedIndex(options: IDropdownOption[], selectedKey: string | number): number {
-    // tslint:disable-next-line:triple-equals
-    return findIndex(options, (option => ((option.isSelected || option.selected) || (selectedKey != null) && option.key === selectedKey)));
+    return findIndex(options, (option => {
+      // tslint:disable-next-line:triple-equals
+      if (selectedKey != null) {
+        return option.key === selectedKey;
+      } else {
+        return !!option.isSelected || !!option.selected;
+      }
+    }));
   }
 
   @autobind


### PR DESCRIPTION
A recent fixed introduced a bug where if selectedKey wasn't null, but it didn't equal option.key, true would still be passed if option.selected was true.

selectedKey (controlled) should take precedence over option.selected (uncontrolled) values. 