### PR TITLE
Fix BaseAutoFill's default displayValue

### DIFF
--- a/packages/office-ui-fabric-react/src/components/pickers/AutoFill/BaseAutoFill.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/AutoFill/BaseAutoFill.tsx
@@ -29,7 +29,7 @@ export class BaseAutoFill extends BaseComponent<IBaseAutoFillProps, IBaseAutoFil
     super(props);
     this._value = '';
     this.state = {
-      displayValue: props.defaultVisibleValue === null ? '' : props.defaultVisibleValue
+      displayValue: props.defaultVisibleValue || ''
     };
   }
 


### PR DESCRIPTION
#### Description of changes

Fix null check of `props.defaultVisibleValue` to default to empty string if falsey. Currently, with the strict check for `null`, if `props.defaultVisibleValue` is `undefined`, then `displayValue` will be set to `undefined`. When the value is undefined, the component is initialized as an uncontrolled input that then becomes a controlled input on user interaction. 