### PR TITLE
Update cell index in Grid

### DIFF
--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
@@ -50,14 +50,14 @@ export class Grid extends BaseComponent<IGridProps, {}> {
                     role={ 'row' }
                     key={ this._id + '-' + rowIndex + '-row' }
                   >
-                    { rows.map((cell) => {
+                    { rows.map((cell, cellIndex) => {
                       return (
                         <td
                           role={ 'presentation' }
-                          key={ this._id + '-' + cell.index + '-cell' }
+                          key={ this._id + '-' + cellIndex + '-cell' }
                           style={ { padding: '0px' } }
                         >
-                          { onRenderItem(cell, cell.index) }
+                          { onRenderItem(cell, cellIndex) }
                         </td>
                       );
                     }) }


### PR DESCRIPTION
#### Description of changes

Use `index` from `map` callback in Grid cell because `cell.index` may be undefined. Or perhaps it should be something like `let idx = cell.index || index` in case cell.index is defined? 

SwatchColorPicker uses Grid and it passes an array that is mapped to explicitly include the index in the object. Is that a requirement of using Grid? https://github.com/OfficeDev/office-ui-fabric-react/blob/c5904b5a36fd58694f4d59d634610068b98a87b9/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx#L83