### PR TITLE
Andrescb/fix datepicker callback

### DIFF
--- a/common/changes/office-ui-fabric-react/andrescb-fix-datepicker-callback_2017-10-02-23-23.json
+++ b/common/changes/office-ui-fabric-react/andrescb-fix-datepicker-callback_2017-10-02-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker - make onSelectDate callback execute as part of SetState instead of after it. This ensures that selected date changes occur in the expected order",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "andrescb@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -153,11 +153,11 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       errorMessage: errorMessage
     });
 
-    // Issue# 1274: Check if the date value changed from old props value, i.e., if indeed a new date is being
+    // Issue# 1274: Check if the date value changed from old value, i.e., if indeed a new date is being
     // passed in or if the formatting function was modified. We only update the selected date if either of these
     // had a legit change. Note tha the bug will still repro when only the formatDate was passed in props and this
     // is the result of the onSelectDate callback, but this should be a rare scenario.
-    let oldValue = this.props.value;
+    let oldValue = this.state.selectedDate;
     if (!compareDates(oldValue!, value!) || this.props.formatDate !== formatDate) {
       this.setState({
         selectedDate: value || new Date(),

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -256,11 +256,11 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       selectedDate: date,
       isDatePickerShown: false,
       formattedDate: formatDate && date ? formatDate(date) : '',
+    }, () => {
+      if (onSelectDate) {
+        onSelectDate(date);
+      }
     });
-
-    if (onSelectDate) {
-      onSelectDate(date);
-    }
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Issue: Changes to the datepicker's props.value triggered from its on SelectDate callback are not being honored.

Cause: 

Per React's documentation: 
setState() does not always immediately update the component. It may batch or defer the update until later. This makes reading this.state right after calling setState() a potential pitfall. (https://reactjs.org/docs/react-component.html#setstate)

As a result from React's batching of updates, the effect of setState ocurrs -after- the one provided by the callback function. Nulling the later.

Fix:
Per the documentation's recommendations, move the calling of the callback from a separate statement to the second argument of setState. This guarantees that the callback is not performed until after the setState operation has completed.

Notes:
This change might be a better fix for the issue specified in code:

> Issue# 1274: Check if the date value changed from old value, i.e., if indeed a new date is being passed in or if the formatting function was modified. We only update the selected date if either of these had a legit change. Note tha the bug will still repro when only the formatDate was passed in props and this is the result of the onSelectDate callback, but this should be a rare scenario. 

For the time being I've updated it's oldValue check from props.value to state.selectedDate to make sure it plays well with the proposed change.

#### Focus areas to test
