### PR TITLE
Enable the ComboBox suggestions to always be displayed if the text box if focused

### DIFF
--- a/common/changes/office-ui-fabric-react/alwaysShowSuggestions_2017-10-03-20-35.json
+++ b/common/changes/office-ui-fabric-react/alwaysShowSuggestions_2017-10-03-20-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add alwaysShowSuggestionsProp to combobox",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "alebet@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
@@ -59,6 +59,11 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   autoComplete?: string;
 
   /**
+   * Whether the ComboBox suggestions should always be displayed if the textbox is focused
+   */
+  alwaysDisplaySuggestions?: boolean;
+
+  /**
    * Value to show in the input, does not have to map to a combobox option
    */
   value?: string;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -217,6 +217,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       required,
       errorMessage,
       onRenderContainer = this._onRenderContainer,
+      alwaysDisplaySuggestions,
       allowFreeform,
       autoComplete,
       buttonIconProps,
@@ -292,7 +293,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           />
         </div>
 
-        { isOpen && (
+        { isOpen || (alwaysDisplaySuggestions && focused) && (
           (onRenderContainer as any)({ ...this.props as any }, this._onRenderContainer)
         ) }
         {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3019 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds a property to ComboBox to enable always displaying the suggestions dropdown.
If the property is true, as long as the textbox is focused, the suggestions will be displayed

#### Focus areas to test

(optional)
