### PR TITLE
Removed duplicate header in ResizeGroup page

### DIFF
--- a/common/changes/office-ui-fabric-react/resize-group-header_2017-10-03-21-51.json
+++ b/common/changes/office-ui-fabric-react/resize-group-header_2017-10-03-21-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removed duplicate header in ResizeGroup.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroupPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroupPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { LayerHost } from 'office-ui-fabric-react/lib/Layer';
 import {
   ExampleCard,
+  IComponentDemoPageProps,
   ComponentPage,
   PropertiesTableSet
 } from '@uifabric/example-app-base';
@@ -14,7 +15,7 @@ const ResizeGroupBasicExampleCode = require('!raw-loader!office-ui-fabric-react/
 
 const ResizeGroupFlexBoxExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.FlexBox.Example.tsx') as string;
 
-export class ResizeGroupPage extends React.Component<any, any> {
+export class ResizeGroupPage extends React.Component<IComponentDemoPageProps, any> {
   public render() {
     return (
       <ComponentPage
@@ -93,6 +94,7 @@ export class ResizeGroupPage extends React.Component<any, any> {
             </ul>
           </div>
         }
+        isHeaderVisible={ this.props.isHeaderVisible }
         componentStatus={
           <ComponentStatus
             {...ResizeGroupStatus}

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroupPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroupPage.tsx
@@ -66,6 +66,9 @@ export class ResizeGroupPage extends React.Component<IComponentDemoPageProps, an
             </span>
           </div>
         }
+        bestPractices={
+          <div />
+        }
         dos={
           <div>
             <ul>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Found another duplicate header like in https://github.com/OfficeDev/office-ui-fabric-react/pull/2999.
It was also missing the Best Practices header.
![image](https://user-images.githubusercontent.com/16619843/31151021-a89e6afe-a84a-11e7-9241-00f1a6d96b3e.png)

#### Focus areas to test

(optional)
