### PR TITLE
Persona: fixed missing presence

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -66,6 +66,7 @@ export class Persona extends BaseComponent<IPersonaProps, {}> {
       imageAlt,
       imageInitials,
       initialsColor,
+      presence,
       primaryText,
       imageShouldFadeIn,
       imageShouldStartVisible,


### PR DESCRIPTION
#### Description of changes

Presence wasn't showing up in Persona. Added `presence` to `personaCoinProps` to so that it gets passed down to `PersonaPresence`. 

#### Before
![persona before](https://user-images.githubusercontent.com/15041132/31157180-f4bb3728-a86d-11e7-9ff7-2944c1f6c4da.PNG)

#### After
![persona after](https://user-images.githubusercontent.com/15041132/31157181-f6a159a0-a86d-11e7-87aa-7cb743ac4d2e.PNG)
