### PR TITLE
BaseButton: Added borderRadius:0 to fix new default styles in webkit

### DIFF
--- a/common/changes/office-ui-fabric-react/webkit-borderRadius-fix_2017-10-04-14-52.json
+++ b/common/changes/office-ui-fabric-react/webkit-borderRadius-fix_2017-10-04-14-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BaseButton: Added borderRadius:0 to fix new default styles in webkit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   background-color: #f4f4f4;
+                  border-radius: 0px;
                   border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
@@ -135,6 +136,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   background-color: #f4f4f4;
+                  border-radius: 0px;
                   border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
@@ -44,7 +44,8 @@ export const getStyles = memoizeFunction((
         textAlign: 'center',
         cursor: 'pointer',
         verticalAlign: 'top',
-        padding: '0 16px'
+        padding: '0 16px',
+        borderRadius: 0
       }
     ],
 


### PR DESCRIPTION
New webkit default button styles include rounded corners (Thanks iOS!)

![screen shot 2017-10-04 at 7 54 26 am](https://user-images.githubusercontent.com/1434956/31182657-54e410be-a8d9-11e7-9a85-8a0af0d70380.png)

![screen shot 2017-10-04 at 7 56 53 am](https://user-images.githubusercontent.com/1434956/31182753-9c7d9080-a8d9-11e7-9fa5-85815a9b8756.png)
