### PR TITLE
TooltipHost: Specifying a className will no longer prevent innate Tooltip classes from being properly applied

### DIFF
--- a/common/changes/office-ui-fabric-react/2906-fix-tooltip-classname_2017-10-04-20-15.json
+++ b/common/changes/office-ui-fabric-react/2906-fix-tooltip-classname_2017-10-04-20-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TooltipHost: Specifying a className will no longer prevent innate Tooltip classes from being properly applied",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
@@ -44,18 +44,19 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
 
     return (
       <Callout
-        className={ mergeStyles(
-          'ms-Tooltip',
-          AnimationClassNames.fadeIn200,
-          styles.root,
-          (delay === TooltipDelay.medium) && styles.hasMediumDelay,
-          (maxWidth !== null) && { maxWidth: maxWidth }
-        )}
         target={ targetElement }
         directionalHint={ directionalHint }
         directionalHintForRTL={ directionalHintForRTL }
         {...calloutProps}
         { ...getNativeProps(this.props, divProperties) }
+        className={ mergeStyles(
+          'ms-Tooltip',
+          AnimationClassNames.fadeIn200,
+          styles.root,
+          (delay === TooltipDelay.medium) && styles.hasMediumDelay,
+          (maxWidth !== null) && { maxWidth: maxWidth },
+          this.props.className
+        ) }
       >
         <div className={ css('ms-Tooltip-content', styles.content) } id={ id } role='tooltip'>
           { onRenderContent(this.props, this._onRenderContent) }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2906 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Changed the ordering of properties on the `Callout` inside `Tooltip` so that a `className` prop passed in won't prevent all of the classes we would normally apply from being trampled on.

#### Focus areas to test

(optional)
