### PR TITLE
Style menuIcon according to root styles for the following states hove…

### DIFF
--- a/common/changes/office-ui-fabric-react/button_menuIcon_2017-10-04-20-33.json
+++ b/common/changes/office-ui-fabric-react/button_menuIcon_2017-10-04-20-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Style ms-Button-menuIcon according to root styles for the following states - hovered, pressed, expanded  ande expandedHovered.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "maxvay@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/button_menuIcon_2017-10-04-20-33.json
+++ b/common/changes/office-ui-fabric-react/button_menuIcon_2017-10-04-20-33.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Style ms-Button-menuIcon according to root styles for the following states - hovered, pressed, expanded  ande expandedHovered.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.classNames.ts
@@ -108,16 +108,16 @@ export const getClassNames = memoizeFunction((
       !expanded &&
       !checked && {
         selectors: {
-          ':hover': styles.rootHovered,
-          ':active': styles.rootPressed,
+          ':hover': styles.menuIconHovered,
+          ':active': styles.menuIconPressed,
         },
       },
       expanded && [
         'is-expanded',
-        styles.rootExpanded,
+        styles.menuIconExpanded,
         {
           selectors: {
-            ':hover': styles.rootExpandedHovered,
+            ':hover': styles.menuIconExpandedHovered,
           },
         },
       ]

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.classNames.ts
@@ -53,12 +53,12 @@ export const getClassNames = memoizeFunction((
           ':hover': styles.rootHovered,
           ':hover .ms-Button-icon': styles.iconHovered,
           ':hover .ms-Button-description': styles.descriptionHovered,
-          ':hover .ms-Button-menuIcon': styles.rootHovered,
+          ':hover .ms-Button-menuIcon': styles.menuIconHovered,
           ':focus': styles.rootFocused,
           ':active': styles.rootPressed,
           ':active .ms-Button-icon': styles.iconPressed,
           ':active .ms-Button-description': styles.descriptionPressed,
-          ':active .ms-Button-menuIcon': styles.rootPressed
+          ':active .ms-Button-menuIcon': styles.menuIconPressed
         }
       },
       disabled && checked && [

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.classNames.ts
@@ -39,6 +39,7 @@ export const getClassNames = memoizeFunction((
         {
           selectors: {
             ':hover .ms-Button-icon': styles.iconExpandedHovered,
+            ':hover .ms-Button-menuIcon': styles.rootExpandedHovered,
             ':hover': styles.rootExpandedHovered
           }
         }
@@ -52,10 +53,12 @@ export const getClassNames = memoizeFunction((
           ':hover': styles.rootHovered,
           ':hover .ms-Button-icon': styles.iconHovered,
           ':hover .ms-Button-description': styles.descriptionHovered,
+          ':hover .ms-Button-menuIcon': styles.rootHovered,
           ':focus': styles.rootFocused,
           ':active': styles.rootPressed,
           ':active .ms-Button-icon': styles.iconPressed,
-          ':active .ms-Button-description': styles.descriptionPressed
+          ':active .ms-Button-description': styles.descriptionPressed,
+          ':active .ms-Button-menuIcon': styles.rootPressed
         }
       },
       disabled && checked && [
@@ -100,7 +103,24 @@ export const getClassNames = memoizeFunction((
       menuIconClassName,
       styles.menuIcon,
       checked && styles.menuIconChecked,
-      disabled && styles.menuIconDisabled
+      disabled && styles.menuIconDisabled,
+      !disabled &&
+      !expanded &&
+      !checked && {
+        selectors: {
+          ':hover': styles.rootHovered,
+          ':active': styles.rootPressed,
+        },
+      },
+      expanded && [
+        'is-expanded',
+        styles.rootExpanded,
+        {
+          selectors: {
+            ':hover': styles.rootExpandedHovered,
+          },
+        },
+      ]
     ),
 
     description: mergeStyles(

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -316,6 +316,26 @@ export interface IButtonStyles {
   menuIcon?: IStyle;
 
   /**
+   * Style for the menu chevron on hover.
+   */
+  menuIconHovered?: IStyle;
+
+  /**
+   * Style for the menu chevron when pressed.
+   */
+  menuIconPressed?: IStyle;
+
+  /**
+   * Style for the menu chevron when expanded.
+   */
+  menuIconExpanded?: IStyle;
+
+  /**
+ * Style for the menu chevron when expanded and hovered.
+ */
+  menuIconExpandedHovered?: IStyle;
+
+  /**
    * Style override for the menu chevron when the button is disabled.
    */
   menuIconDisabled?: IStyle;


### PR DESCRIPTION
…red, pressed, expanded and expandedHovered.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Button control with menu chevron doesn't support same set of states for chevron as it does for icon or body.  This change is to apply styles from root to the chevron for hovered, pressed, expanded and expandedHovered states.  

This support is needed for OWA Calendar, where design is asking to change button color/background in various states.

#### Focus areas to test

(optional)
