### PR TITLE
Fix exception being thrown in Dropdown example

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Dropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { autobind } from '../../../Utilities';
 import './Dropdown.Basic.Example.scss';
 
 export class DropdownBasicExample extends React.Component<any, any> {
@@ -164,6 +165,7 @@ export class DropdownBasicExample extends React.Component<any, any> {
     return list;
   }
 
+  @autobind
   public changeState(item: IDropdownOption) {
     console.log('here is the things updating...' + item.key + ' ' + item.text + ' ' + item.selected);
     this.setState({ selectedItem: item });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3011

#### Description of changes

Clicking on an item in the controlled `Dropdown` example on the example page didn't work, as there was a TypeError thrown trying to dereference an undefined `this`. Fix was to apply `@autobind` to the offending method in the example code.

#### Focus areas to test

(optional)
