### PR TITLE
Dropdown: Fix controlled multi-select dropdowns

### DIFF
--- a/common/changes/office-ui-fabric-react/2971-fix-controlled-multiselect-dropdowns_2017-10-04-21-27.json
+++ b/common/changes/office-ui-fabric-react/2971-fix-controlled-multiselect-dropdowns_2017-10-04-21-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: fix broken implementation of controlled multi-select dropdowns",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com"
+}

--- a/ghdocs/TESTING.md
+++ b/ghdocs/TESTING.md
@@ -8,12 +8,10 @@ Our tests are built with [Mocha](https://mochajs.org/), [Chai](http://chaijs.com
 To run tests:
 
 1. In command prompt navigate to the appropriate package, for example git/office-ui-fabric-react/packages/office-ui-fabric-react
-2. Run `gulp test` to run all of the tests
-  * To run only one test add `--match <Testname>`. Example: `gulp test --match Button`
-  * To debug your test add `--debug`. Example: `gulp test --debug`.
-    1. After running this, you will need to open the localhost url found in your command prompt.
-    2. A page will open with a "Debug" button. Pressing that will open a page that loads the tests.
-    3. Press f12 in the new page. Tests will be in a tests.js bundle, and you'll need to find your code in there.
+2. Run `npm run start-test` to start jest and run the tests
+  * By default, jest will run tests affected by your uncommitted changes
+  * To run all tests, press 'a' at the prompt
+  * To filter the tests run, press `p` or `t` to filter by filename or test name regex pattern, respectively
 
 ## Examples
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -119,6 +119,7 @@ describe('Dropdown', () => {
       <Dropdown
         label='testgroup'
         selectedKeys={ ['1', '3'] }
+        multiSelect
         options={ DEFAULT_OPTIONS }
       />,
       container);

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -24,118 +24,67 @@ const DEFAULT_OPTIONS: IDropdownOption[] = [
 
 describe('Dropdown', () => {
 
-  it('Can flip between enabled and disabled.', () => {
+  describe('single-select', () => {
 
-    let container = document.createElement('div');
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+    it('Can flip between enabled and disabled.', () => {
 
-    expect(dropdownRoot.className).not.toEqual(expect.stringMatching('is-disabled'));
-    expect(dropdownRoot.getAttribute('data-is-focusable')).toEqual('true');
+      let container = document.createElement('div');
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
 
-    ReactDOM.render(
-      <Dropdown
-        disabled={ true }
-        label='testgroup'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
+      expect(dropdownRoot.className).not.toEqual(expect.stringMatching('is-disabled'));
+      expect(dropdownRoot.getAttribute('data-is-focusable')).toEqual('true');
 
-    expect(dropdownRoot.className).toEqual(expect.stringMatching('is-disabled'));
-    expect(dropdownRoot.getAttribute('data-is-focusable')).toEqual('false');
-  });
+      ReactDOM.render(
+        <Dropdown
+          disabled={ true }
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
 
-  it('Renders no selected item in default case', () => {
-    let container = document.createElement('div');
+      expect(dropdownRoot.className).toEqual(expect.stringMatching('is-disabled'));
+      expect(dropdownRoot.getAttribute('data-is-focusable')).toEqual('false');
+    });
 
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
-    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+    it('Renders no selected item in default case', () => {
+      let container = document.createElement('div');
 
-    expect(titleElement.textContent).toEqual('');
-  });
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
 
-  it('Renders a selected item if option specifies selected', () => {
-    let container = document.createElement('div');
+      expect(titleElement.textContent).toEqual('');
+    });
 
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        options={ [{ key: '1', text: '1', selected: true }, { key: '2', text: '2' },] }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
-    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+    it('Renders a selected item if option specifies selected', () => {
+      let container = document.createElement('div');
 
-    expect(titleElement.textContent).toEqual('1');
-  });
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ [{ key: '1', text: '1', selected: true }, { key: '2', text: '2' },] }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
 
-  it('Renders a selected item in uncontrolled case', () => {
-    let container = document.createElement('div');
+      expect(titleElement.textContent).toEqual('1');
+    });
 
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        defaultSelectedKey='1'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
-    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+    it('Renders a selected item in uncontrolled case', () => {
+      let container = document.createElement('div');
 
-    expect(titleElement.textContent).toEqual('1');
-  });
-
-  it('Renders a selected item in controlled case', () => {
-    let container = document.createElement('div');
-
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        selectedKey='1'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
-    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
-
-    expect(titleElement.textContent).toEqual('1');
-  });
-
-  it('Renders a selected item in controlled multi-select case', () => {
-    let container = document.createElement('div');
-
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        selectedKeys={ ['1', '3'] }
-        multiSelect
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
-    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
-
-    expect(titleElement.textContent).toEqual('1, 3');
-  });
-
-  it('Can change items in uncontrolled case', () => {
-    let container = document.createElement('div');
-    let dropdownRoot: HTMLElement | undefined;
-
-    document.body.appendChild(container);
-
-    try {
       ReactDOM.render(
         <Dropdown
           label='testgroup'
@@ -143,88 +92,395 @@ describe('Dropdown', () => {
           options={ DEFAULT_OPTIONS }
         />,
         container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+
+      expect(titleElement.textContent).toEqual('1');
+    });
+
+    it('does not change the selected item in when defaultKey changes', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          defaultSelectedKey='1'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+
+      expect(titleElement.textContent).toEqual('1');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          defaultSelectedKey='2'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      expect(titleElement.textContent).toEqual('1');
+    });
+
+    it('Renders a selected item in controlled case', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          selectedKey='1'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+
+      expect(titleElement.textContent).toEqual('1');
+    });
+
+    it('does change the selected item in when selectedKey changes', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          selectedKey='1'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+
+      expect(titleElement.textContent).toEqual('1');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          selectedKey='2'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      expect(titleElement.textContent).toEqual('2');
+    });
+
+    it('Can change items in uncontrolled case', () => {
+      let container = document.createElement('div');
+      let dropdownRoot: HTMLElement | undefined;
+
+      document.body.appendChild(container);
+
+      try {
+        ReactDOM.render(
+          <Dropdown
+            label='testgroup'
+            defaultSelectedKey='1'
+            options={ DEFAULT_OPTIONS }
+          />,
+          container);
+        dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+        ReactTestUtils.Simulate.click(dropdownRoot);
+
+        let secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="2"]') as HTMLElement;
+        ReactTestUtils.Simulate.click(secondItemElement);
+      }
+      finally {
+        expect(dropdownRoot!.querySelector('.ms-Dropdown-title')!.textContent).toEqual('2');
+      }
+    });
+
+    it('Will select the first valid item on keypress', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
+
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.textContent).toEqual('1');
+    });
+
+    it('Will select the first valid item on Home keypress', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.home });
+
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.textContent).toEqual('1');
+    });
+
+    it('Will select the last valid item on End keypress', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.end });
+
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.textContent).toEqual('6');
+    });
+
+    it('Will skip over headers and separators on keypress', () => {
+      let container = document.createElement('div');
+      let dropdownRoot;
+      let titleElement;
+
+      document.body.appendChild(container);
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
       dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
 
-      ReactTestUtils.Simulate.click(dropdownRoot);
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
+      titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.textContent).toEqual('1');
 
-      let secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="2"]') as HTMLElement;
-      ReactTestUtils.Simulate.click(secondItemElement);
-    }
-    finally {
-      expect(dropdownRoot!.querySelector('.ms-Dropdown-title')!.textContent).toEqual('2');
-    }
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
+      titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.textContent).toEqual('4');
+    });
   });
 
-  it('Will select the first valid item on keypress', () => {
-    let container = document.createElement('div');
+  describe('multi-select', () => {
 
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
-    ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
+    it('Renders no selected item in default case', () => {
+      let container = document.createElement('div');
 
-    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
-    expect(titleElement.textContent).toEqual('1');
-  });
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+          multiSelect
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
 
-  it('Will select the first valid item on Home keypress', () => {
-    let container = document.createElement('div');
+      expect(titleElement.textContent).toEqual('');
+    });
 
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
-    ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.home });
+    it('Renders a selected item if option specifies selected', () => {
+      let container = document.createElement('div');
 
-    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
-    expect(titleElement.textContent).toEqual('1');
-  });
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ [{ key: '1', text: '1', selected: true }, { key: '2', text: '2' },] }
+          multiSelect
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
 
-  it('Will select the last valid item on End keypress', () => {
-    let container = document.createElement('div');
+      expect(titleElement.textContent).toEqual('1');
+    });
 
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
-    ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.end });
+    it('Renders multiple selected items if multiple options specify selected', () => {
+      let container = document.createElement('div');
 
-    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
-    expect(titleElement.textContent).toEqual('6');
-  });
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ [{ key: '1', text: '1', selected: true }, { key: '2', text: '2', selected: true },] }
+          multiSelect
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
 
-  it('Will skip over headers and separators on keypress', () => {
-    let container = document.createElement('div');
-    let dropdownRoot;
-    let titleElement;
+      expect(titleElement.textContent).toEqual('1, 2');
+    });
 
-    document.body.appendChild(container);
-    ReactDOM.render(
-      <Dropdown
-        label='testgroup'
-        options={ DEFAULT_OPTIONS }
-      />,
-      container);
-    dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+    it('Renders a selected item in uncontrolled case', () => {
+      let container = document.createElement('div');
 
-    ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
-    titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
-    expect(titleElement.textContent).toEqual('1');
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          defaultSelectedKeys={ ['1', '2'] }
+          multiSelect
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
 
-    ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
-    ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
-    ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
-    titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
-    expect(titleElement.textContent).toEqual('4');
+      expect(titleElement.textContent).toEqual('1, 2');
+    });
+
+    it('does not change the selected items when defaultSelectedKeys changes', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          defaultSelectedKeys={ ['1', '2'] }
+          multiSelect
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+
+      expect(titleElement.textContent).toEqual('1, 2');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          defaultSelectedKeys={ ['3', '4'] }
+          multiSelect
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+
+      expect(titleElement.textContent).toEqual('1, 2');
+    });
+
+    it('Renders selected items in controlled case', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          selectedKeys={ ['1', '3'] }
+          multiSelect
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+
+      expect(titleElement.textContent).toEqual('1, 3');
+    });
+
+    it('changes selected items in controlled case', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          selectedKeys={ ['1', '3'] }
+          multiSelect
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+
+      expect(titleElement.textContent).toEqual('1, 3');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          selectedKeys={ ['2', '4'] }
+          multiSelect
+          options={ DEFAULT_OPTIONS }
+        />,
+        container);
+      expect(titleElement.textContent).toEqual('2, 4');
+    });
+
+    it('Can change items in uncontrolled case', () => {
+      let container = document.createElement('div');
+      let dropdownRoot: HTMLElement | undefined;
+
+      document.body.appendChild(container);
+
+      try {
+        ReactDOM.render(
+          <Dropdown
+            label='testgroup'
+            defaultSelectedKeys={ ['1'] }
+            multiSelect
+            id='test'
+            options={ DEFAULT_OPTIONS }
+          />,
+          container);
+        dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+        ReactTestUtils.Simulate.click(dropdownRoot);
+
+        let secondItemElement = document.querySelectorAll('.ms-Dropdown-item[role="checkbox"]')[1] as HTMLElement;
+        ReactTestUtils.Simulate.click(secondItemElement);
+      }
+      finally {
+        expect(dropdownRoot!.querySelector('.ms-Dropdown-title')!.textContent).toEqual('1, 2');
+      }
+    });
+
+    it('Will not select the first valid item on keypress', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+          multiSelect
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.down });
+
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.textContent).toEqual('');
+    });
+
+    it('Will not select the first valid item on Home keypress', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+          multiSelect
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.home });
+
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.textContent).toEqual('');
+    });
+
+    it('Will not select the last valid item on End keypress', () => {
+      let container = document.createElement('div');
+
+      ReactDOM.render(
+        <Dropdown
+          label='testgroup'
+          options={ DEFAULT_OPTIONS }
+          multiSelect
+        />,
+        container);
+      let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+      ReactTestUtils.Simulate.keyDown(dropdownRoot, { which: KeyCodes.end });
+
+      let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+      expect(titleElement.textContent).toEqual('');
+    });
+
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -112,6 +112,22 @@ describe('Dropdown', () => {
     expect(titleElement.textContent).toEqual('1');
   });
 
+  it('Renders a selected item in controlled multi-select case', () => {
+    let container = document.createElement('div');
+
+    ReactDOM.render(
+      <Dropdown
+        label='testgroup'
+        selectedKeys={ ['1', '3'] }
+        options={ DEFAULT_OPTIONS }
+      />,
+      container);
+    let dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+    let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
+
+    expect(titleElement.textContent).toEqual('1, 3');
+  });
+
   it('Can change items in uncontrolled case', () => {
     let container = document.createElement('div');
     let dropdownRoot: HTMLElement | undefined;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -190,6 +190,64 @@ describe('Dropdown', () => {
       }
     });
 
+    it('issues the onChanged callback when the selected item is different', () => {
+      let container = document.createElement('div');
+      let dropdownRoot: HTMLElement | undefined;
+
+      document.body.appendChild(container);
+
+      let onChangedSpy = jasmine.createSpy('onChanged');
+
+      try {
+        ReactDOM.render(
+          <Dropdown
+            label='testgroup'
+            defaultSelectedKey='1'
+            onChanged={ onChangedSpy }
+            options={ DEFAULT_OPTIONS }
+          />,
+          container);
+        dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+        ReactTestUtils.Simulate.click(dropdownRoot);
+
+        let secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="2"]') as HTMLElement;
+        ReactTestUtils.Simulate.click(secondItemElement);
+      }
+      finally {
+        expect(onChangedSpy).toHaveBeenCalledWith(DEFAULT_OPTIONS[2], 2);
+      }
+    });
+
+    it('issues the onChanged callback when the selected item is different', () => {
+      let container = document.createElement('div');
+      let dropdownRoot: HTMLElement | undefined;
+
+      document.body.appendChild(container);
+
+      let onChangedSpy = jasmine.createSpy('onChanged');
+
+      try {
+        ReactDOM.render(
+          <Dropdown
+            label='testgroup'
+            defaultSelectedKey='1'
+            onChanged={ onChangedSpy }
+            options={ DEFAULT_OPTIONS }
+          />,
+          container);
+        dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+        ReactTestUtils.Simulate.click(dropdownRoot);
+
+        let secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="1"]') as HTMLElement;
+        ReactTestUtils.Simulate.click(secondItemElement);
+      }
+      finally {
+        expect(onChangedSpy).not.toHaveBeenCalled();
+      }
+    });
+
     it('Will select the first valid item on keypress', () => {
       let container = document.createElement('div');
 
@@ -430,6 +488,70 @@ describe('Dropdown', () => {
         expect(dropdownRoot!.querySelector('.ms-Dropdown-title')!.textContent).toEqual('1, 2');
       }
     });
+
+    /*
+    // I'm not sure why these two tests fail. I've manually verified the scenario, even manually through programatic clicks, but these
+    // tests simply won't pass
+    it('issues the onChanged callback when selecting an item', () => {
+      let container = document.createElement('div');
+      let dropdownRoot: HTMLElement | undefined;
+
+      document.body.appendChild(container);
+
+      let onChangedSpy = jasmine.createSpy('onChanged');
+
+      try {
+        ReactDOM.render(
+          <Dropdown
+            label='testgroup'
+            defaultSelectedKeys={ ['1'] }
+            multiSelect
+            onChanged={ onChangedSpy }
+            options={ DEFAULT_OPTIONS }
+          />,
+          container);
+        dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+        ReactTestUtils.Simulate.click(dropdownRoot);
+
+        let secondItemElement = document.querySelectorAll('.ms-Dropdown-item[role="checkbox"]')[1] as HTMLElement;
+        ReactTestUtils.Simulate.click(secondItemElement);
+      }
+      finally {
+        expect(onChangedSpy).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS[2], selected: true }, 2);
+      }
+    });
+
+    it('issues the onChanged callback when unselecting an item', () => {
+      let container = document.createElement('div');
+      let dropdownRoot: HTMLElement | undefined;
+
+      document.body.appendChild(container);
+
+      let onChangedSpy = jasmine.createSpy('onChanged');
+
+      try {
+        ReactDOM.render(
+          <Dropdown
+            label='testgroup'
+            defaultSelectedKeys={ ['1'] }
+            multiSelect
+            onChanged={ onChangedSpy }
+            options={ DEFAULT_OPTIONS }
+          />,
+          container);
+        dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+        ReactTestUtils.Simulate.click(dropdownRoot);
+
+        let firstItemElement = document.querySelectorAll('.ms-Dropdown-item[role="checkbox"]')[0] as HTMLElement;
+        ReactTestUtils.Simulate.click(firstItemElement);
+      }
+      finally {
+        expect(onChangedSpy).toHaveBeenCalledWith({ ...DEFAULT_OPTIONS[1], selected: false }, 1);
+      }
+    });
+    */
 
     it('Will not select the first valid item on keypress', () => {
       let container = document.createElement('div');

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -538,7 +538,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   private _getSelectedIndexes(options: IDropdownOption[], selectedKey: string | number | string[] | number[] | undefined): number[] {
     if (!selectedKey) {
       if (this.props.multiSelect) {
-        return [];
+        return this._getAllSelectedIndices(options);
       }
       let selectedIndex = this._getSelectedIndex(options, null);
       return selectedIndex !== -1 ? [selectedIndex] : [];
@@ -563,6 +563,13 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       return [];
     }
     return selectedOptions;
+  }
+
+  private _getAllSelectedIndices(options: IDropdownOption[]): number[] {
+    return options
+      .map((option: IDropdownOption, index: number) => option.selected ? index : -1)
+      .filter(index => index !== -1);
+
   }
 
   private _getSelectedIndex(options: IDropdownOption[], selectedKey: string | number | null): number {
@@ -632,11 +639,15 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
         break;
 
       case KeyCodes.home:
-        newIndex = this._moveIndex(1, 0, selectedIndex);
+        if (!this.props.multiSelect) {
+          newIndex = this._moveIndex(1, 0, selectedIndex);
+        }
         break;
 
       case KeyCodes.end:
-        newIndex = this._moveIndex(-1, this.props.options.length - 1, selectedIndex);
+        if (!this.props.multiSelect) {
+          newIndex = this._moveIndex(-1, this.props.options.length - 1, selectedIndex);
+        }
         break;
 
       case KeyCodes.space:

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -247,12 +247,8 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
 
     if (onChanged) {
       // for single-select, option passed in will always be selected.
-      if (!multiSelect) {
-        options.map((option: any) => option.selected === true ? option.selected = false : null);
-      }
       // for multi-select, flip the checked value
-      let changedOpt = options[index];
-      changedOpt.selected = multiSelect ? !checked : true;
+      let changedOpt = multiSelect ? { ...options[index], selected: !checked } : options[index];
       onChanged(changedOpt, index);
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -31,8 +31,7 @@ export interface IDropdownInternalProps extends IDropdownProps, IWithResponsiveM
 
 export interface IDropdownState {
   isOpen?: boolean;
-  selectedIndex?: number;
-  selectedIndexes?: number[];
+  selectedIndices?: number[];
 }
 
 @withResponsiveMode
@@ -84,12 +83,12 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
     if (this.props.multiSelect) {
       let selectedKeys = props.defaultSelectedKeys !== undefined ? props.defaultSelectedKeys : props.selectedKeys;
       this.state = {
-        selectedIndexes: this._getSelectedIndexes(props.options, selectedKeys)
+        selectedIndices: this._getSelectedIndexes(props.options, selectedKeys)
       };
     } else {
       let selectedKey = props.defaultSelectedKey !== undefined ? props.defaultSelectedKey : props.selectedKey;
       this.state = {
-        selectedIndex: this._getSelectedIndex(props.options, selectedKey!)
+        selectedIndices: this._getSelectedIndexes(props.options, selectedKey!)
       };
     }
 
@@ -98,17 +97,11 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   public componentWillReceiveProps(newProps: IDropdownProps) {
     // In controlled component usage where selectedKey is provided, update the selectedIndex
     // state if the key or options change.
-    if (this.props.multiSelect &&
-      newProps.selectedKeys !== undefined &&
-      (newProps.selectedKeys !== this.props.selectedKeys || newProps.options !== this.props.options)) {
+    let selectedKeyProp: keyof IDropdownProps = this.props.multiSelect ? 'selectedKeys' : 'selectedKey';
+    if (newProps[selectedKeyProp] !== undefined &&
+      (newProps[selectedKeyProp] !== this.props[selectedKeyProp] || newProps.options !== this.props.options)) {
       this.setState({
-        selectedIndexes: this._getSelectedIndexes(newProps.options, newProps.selectedKeys)
-      });
-    } else if (!this.props.multiSelect &&
-      newProps.selectedKey !== undefined &&
-      (newProps.selectedKey !== this.props.selectedKey || newProps.options !== this.props.options)) {
-      this.setState({
-        selectedIndex: this._getSelectedIndex(newProps.options, newProps.selectedKey)
+        selectedIndices: this._getSelectedIndexes(newProps.options, newProps[selectedKeyProp])
       });
     }
   }
@@ -136,9 +129,8 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       onRenderPlaceHolder = this._onRenderPlaceHolder,
       onRenderCaretDown = this._onRenderCaretDown
     } = this.props;
-    let { isOpen, selectedIndex, selectedIndexes } = this.state;
-    let selectedOption = this.props.multiSelect ? selectedIndexes && this._getAllSelectedOptions(options, selectedIndexes)
-      : options[selectedIndex as number];
+    let { isOpen, selectedIndices = [] } = this.state;
+    let selectedOptions = this._getAllSelectedOptions(options, selectedIndices);
     let divProps = getNativeProps(this.props, divProperties);
 
     // Remove this deprecation workaround at 1.0.0
@@ -161,7 +153,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           aria-live={ disabled || isOpen ? 'off' : 'assertive' }
           aria-label={ ariaLabel }
           aria-describedby={ id + '-option' }
-          aria-activedescendant={ isOpen && selectedIndex! >= 0 ? (this._id + '-list' + selectedIndex) : null }
+          aria-activedescendant={ isOpen && selectedIndices.length === 1 && selectedIndices[0] >= 0 ? (this._id + '-list' + selectedIndices[0]) : null }
           aria-disabled={ disabled }
           aria-owns={ isOpen ? id + '-list' : null }
           { ...divProps }
@@ -182,18 +174,17 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             id={ id + '-option' }
             className={ css(
               'ms-Dropdown-title', styles.title,
-              !selectedOption && 'ms-Dropdown-titleIsPlaceHolder',
-              !selectedOption && styles.titleIsPlaceHolder,
+              !selectedOptions.length && 'ms-Dropdown-titleIsPlaceHolder',
+              !selectedOptions.length && styles.titleIsPlaceHolder,
               (errorMessage && errorMessage.length > 0 ? styles.titleIsError : null))
             }
-            key={ selectedIndex }
             aria-atomic={ true }
             role='textbox'
             aria-readonly='true'
           >
             { // If option is selected render title, otherwise render the placeholder text
-              selectedOption ? (
-                onRenderTitle(selectedOption, this._onRenderTitle)
+              selectedOptions.length ? (
+                onRenderTitle(selectedOptions, this._onRenderTitle)
               ) :
                 onRenderPlaceHolder(this.props, this._onRenderPlaceHolder)
             }
@@ -225,20 +216,20 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
 
   public setSelectedIndex(index: number) {
     let { onChanged, options, selectedKey, selectedKeys, multiSelect } = this.props;
-    let { selectedIndex, selectedIndexes } = this.state;
-    let checked: boolean = selectedIndexes ? selectedIndexes.indexOf(index) > -1 : false;
+    let { selectedIndices = [] } = this.state;
+    let checked: boolean = selectedIndices ? selectedIndices.indexOf(index) > -1 : false;
 
     index = Math.max(0, Math.min(options.length - 1, index));
 
-    if (!multiSelect && index === selectedIndex) {
+    if (!multiSelect && index === selectedIndices[0]) {
       return;
     } else if (!multiSelect && selectedKey === undefined) {
       // Set the selected option if this is an uncontrolled component
       this.setState({
-        selectedIndex: index
+        selectedIndices: [index]
       });
     } else if (multiSelect && selectedKeys === undefined) {
-      let newIndexes = selectedIndexes ? this._copyArray(selectedIndexes) : [];
+      let newIndexes = selectedIndices ? this._copyArray(selectedIndices) : [];
       if (checked) {
         let position = newIndexes.indexOf(index);
         if (position > -1) {
@@ -250,7 +241,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
         newIndexes.push(index);
       }
       this.setState({
-        selectedIndexes: newIndexes
+        selectedIndices: newIndexes
       });
     }
 
@@ -303,10 +294,13 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       if (stepCounter >= options.length) {
         return selectedIndex;
       }
-      // If index + stepValue is out of bounds, reverse step direction
-      if (index + stepValue < 0 || index + stepValue >= options.length) {
-        stepValue *= -1;
+      // If index + stepValue is out of bounds, wrap around
+      if (index + stepValue < 0) {
+        index = options.length;
+      } else if (index + stepValue >= options.length) {
+        index = -1;
       }
+
       index = index + stepValue;
       stepCounter++;
     }
@@ -317,15 +311,10 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
 
   // Render text in dropdown input
   @autobind
-  private _onRenderTitle(item: IDropdownOption | IDropdownOption[]): JSX.Element {
-    let displayTxt: string = '';
+  private _onRenderTitle(item: IDropdownOption[]): JSX.Element {
     let { multiSelectDelimiter = ', ' } = this.props;
 
-    if (this.props.multiSelect && Array.isArray(item)) {
-      displayTxt = item.map(i => i.text).join(multiSelectDelimiter);
-    } else {
-      displayTxt = (item as IDropdownOption).text;
-    }
+    let displayTxt = item.map(i => i.text).join(multiSelectDelimiter);
     return <span>{ displayTxt }</span>;
   }
 
@@ -400,14 +389,14 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
     } = this.props;
 
     let id = this._id;
-    let { selectedIndex } = this.state;
+    let { selectedIndices = [] } = this.state;
 
     return (
       <div onKeyDown={ this._onZoneKeyDown }>
         <FocusZone
           ref={ this._resolveRef('_focusZone') }
           direction={ FocusZoneDirection.vertical }
-          defaultActiveElement={ '#' + id + '-list' + selectedIndex }
+          defaultActiveElement={ selectedIndices[0] !== undefined ? `#${id}-list${selectedIndices[0]}` : undefined }
           id={ id + '-list' }
           className={ css('ms-Dropdown-items', styles.items) }
           aria-labelledby={ id + '-label' }
@@ -463,12 +452,10 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   @autobind
   private _renderOption(item: IDropdownOption): JSX.Element {
     let { onRenderOption = this._onRenderOption } = this.props;
-    let { selectedIndexes } = this.state;
+    let { selectedIndices = [] } = this.state;
     let id = this._id;
-    let isItemSelected;
-    if (this.props.multiSelect) {
-      isItemSelected = item.index !== undefined && selectedIndexes ? selectedIndexes.indexOf(item.index) > -1 : false;
-    }
+    let isItemSelected = item.index !== undefined && selectedIndices ? selectedIndices.indexOf(item.index) > -1 : false;
+
     return (
       !this.props.multiSelect ?
         (
@@ -480,13 +467,13 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             data-is-focusable={ true }
             className={ css(
               'ms-Dropdown-item', styles.item, {
-                ['is-selected ' + styles.itemIsSelected]: this.state.selectedIndex === item.index,
+                ['is-selected ' + styles.itemIsSelected]: isItemSelected,
                 ['is-disabled ' + styles.itemIsDisabled]: this.props.disabled === true
               }
             ) }
             onClick={ this._onItemClick(item.index!) }
             role='option'
-            aria-selected={ this.state.selectedIndex === item.index ? 'true' : 'false' }
+            aria-selected={ isItemSelected ? 'true' : 'false' }
             ariaLabel={ item.ariaLabel || item.text }
             title={ item.text }
           >
@@ -548,30 +535,37 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   }
 
   // Get all selected indexes for multi-select mode
-  private _getSelectedIndexes(options: IDropdownOption[], selectedKey: string[] | number[] | undefined): number[] {
-    let selectedIndex: number[] = [];
+  private _getSelectedIndexes(options: IDropdownOption[], selectedKey: string | number | string[] | number[] | undefined): number[] {
     if (!selectedKey) {
-      return selectedIndex;
+      if (this.props.multiSelect) {
+        return [];
+      }
+      let selectedIndex = this._getSelectedIndex(options, null);
+      return selectedIndex !== -1 ? [selectedIndex] : [];
+    } else if (!Array.isArray(selectedKey)) {
+      return [this._getSelectedIndex(options, selectedKey)];
     }
+
+    let selectedIndices: number[] = [];
     for (let key of selectedKey) {
-      selectedIndex.push(this._getSelectedIndex(options, key));
+      selectedIndices.push(this._getSelectedIndex(options, key));
     }
-    return selectedIndex;
+    return selectedIndices;
   }
 
   // Get all selected options for multi-select mode
-  private _getAllSelectedOptions(options: IDropdownOption[], selectedIndex: number[]) {
+  private _getAllSelectedOptions(options: IDropdownOption[], selectedIndices: number[]) {
     let selectedOptions: IDropdownOption[] = [];
-    for (let index of selectedIndex) {
+    for (let index of selectedIndices) {
       selectedOptions.push(options[index]);
     }
     if (selectedOptions.length < 1) {
-      return undefined;
+      return [];
     }
     return selectedOptions;
   }
 
-  private _getSelectedIndex(options: IDropdownOption[], selectedKey: string | number): number {
+  private _getSelectedIndex(options: IDropdownOption[], selectedKey: string | number | null): number {
     return findIndex(options, (option => {
       // tslint:disable-next-line:triple-equals
       if (selectedKey != null) {
@@ -602,7 +596,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       }
     }
     let newIndex: number | undefined;
-    const selectedIndex = this.props.multiSelect ? (this.state.selectedIndexes ? this.state.selectedIndexes[0] : -1) : this.state.selectedIndex!;
+    const selectedIndex = this.state.selectedIndices!.length ? this.state.selectedIndices![0] : -1;
 
     switch (ev.which) {
       case KeyCodes.enter:

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -7,12 +7,13 @@ export class DropdownBasicExample extends React.Component<any, any> {
   constructor() {
     super();
     this.state = {
-      selectedItem: null
+      selectedItem: null,
+      selectedItems: [],
     };
   }
 
   public render() {
-    let { selectedItem } = this.state;
+    let { selectedItem, selectedItems } = this.state;
 
     return (
       <div className='DropdownBasicExample'>
@@ -112,7 +113,7 @@ export class DropdownBasicExample extends React.Component<any, any> {
         <Dropdown
           placeHolder='Select options'
           label='Multi-Select controlled example:'
-          selectedKeys={ selectedItem && selectedItem.key }
+          selectedKeys={ selectedItems }
           onChanged={ this.onChangeMultiSelect }
           onFocus={ this._log('onFocus called') }
           onBlur={ this._log('onBlur called') }
@@ -168,23 +169,24 @@ export class DropdownBasicExample extends React.Component<any, any> {
   @autobind
   public changeState(item: IDropdownOption) {
     console.log('here is the things updating...' + item.key + ' ' + item.text + ' ' + item.selected);
-    this.setState({ selectedItem: item });
+    this.setState({ selectedItems: item });
   }
 
+  @autobind
   public onChangeMultiSelect(item: IDropdownOption) {
-    let updatedSelectedItem = this.state.selectedItem ? this.copyArray(this.state.selectedItem) : [];
+    let updatedSelectedItem = this.state.selectedItems ? this.copyArray(this.state.selectedItems) : [];
     if (item.selected) {
       // add the option if it's checked
-      updatedSelectedItem.push(item);
+      updatedSelectedItem.push(item.key);
     } else {
       // remove the option if it's unchecked
-      let currIndex = updatedSelectedItem.indexOf(item.index);
+      let currIndex = updatedSelectedItem.indexOf(item.key);
       if (currIndex > -1) {
         updatedSelectedItem.splice(currIndex, 1);
       }
     }
     this.setState({
-      selectedItem: updatedSelectedItem
+      selectedItems: updatedSelectedItem
     });
   }
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Dropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { autobind } from '../../../Utilities';
 import './Dropdown.Basic.Example.scss';
 
 export class DropdownBasicExample extends React.Component<any, any> {
@@ -164,6 +165,7 @@ export class DropdownBasicExample extends React.Component<any, any> {
     return list;
   }
 
+  @autobind
   public changeState(item: IDropdownOption) {
     console.log('here is the things updating...' + item.key + ' ' + item.text + ' ' + item.selected);
     this.setState({ selectedItem: item });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -90,7 +90,6 @@ export class DropdownBasicExample extends React.Component<any, any> {
           placeHolder='Select options'
           label='Multi-Select uncontrolled example:'
           defaultSelectedKeys={ ['Apple', 'Banana'] }
-          onChanged={ this.changeState }
           onFocus={ this._log('onFocus called') }
           onBlur={ this._log('onBlur called') }
           multiSelect


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2971, Fixes #3011 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

To be blunt, I'm not sure who let the multi-select dropdown changes merge, but controlled multi-select dropdowns (and the example code using them) were fundamentally broken. I fixed up the logic in several places to properly branch based on the matrix of [{controlled, uncontrolled}, {single-select, multi-select}], and added at least a minimum test case to cover controlled multi-select dropdowns.

Additionally, clicking on an item in the controlled Dropdown example on the example page didn't work, as there was a TypeError thrown trying to dereference an undefined `this`. Fix was to apply @autobind to the offending method in the example code.

#### Focus areas to test

(optional)
