### PR TITLE
Vertically center checkbox in details header

### DIFF
--- a/common/changes/office-ui-fabric-react/maxlus-headerPolish_2017-10-04-22-18.json
+++ b/common/changes/office-ui-fabric-react/maxlus-headerPolish_2017-10-04-22-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Vertically center checkbox in DetailsList header",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "maxlus@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -55,6 +55,9 @@ $isPaddedMargin: 24px;
     position: relative;
     padding: 0;
     margin: 0;
+    display: inline-flex;
+    justify-content: center;
+    flex-direction: column;
   }
 
   &.cellIsActionable {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -56,8 +56,7 @@ $isPaddedMargin: 24px;
     padding: 0;
     margin: 0;
     display: inline-flex;
-    justify-content: center;
-    flex-direction: column;
+    align-items: center;
   }
 
   &.cellIsActionable {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Currently the checkbox in the details list header is vertically misaligned. The checkbox is a few pixels below the vertical center of the header. This change vertically centers the checkbox for the header.
