### PR TITLE
mergeStyleSets selectors now support $token for referencing other areas in the set.

### DIFF
--- a/common/changes/@uifabric/merge-styles/mergestylesets_2017-10-04-23-23.json
+++ b/common/changes/@uifabric/merge-styles/mergestylesets_2017-10-04-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Adding selector support to target child class names that were generated in the same mergeStyleSets set.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -4,7 +4,25 @@ The `merge-styles` library provides utilities for loading styles through javascr
 
 The library was built for speed and size; the entire package is 2.62k gzipped. It has no dependencies other than `tslib`.
 
-The basic idea is to provide a method which can take in one or more style objects css styling javascript objects representing the styles for a given element, and return a single class name. If the same set of styling is passed in, the same name returns and nothing is re-registered.
+Simple usage:
+```
+import { mergeStyles, mergeStyleSet } from '@uifabric/merge-styles';
+
+// Produces 'css-0' class name which can be used anywhere
+mergeStyles({ background: 'red' });
+
+// Produces a class map for a bunch of rules all at once
+mergeStyleSet({
+  root: { background: 'red' },
+  child: { background: 'green' }
+});
+
+// Returns { root: 'root-0', child: 'child-1' }
+```
+
+Both utilities behave similar to a deep Object.assign; you can collapse may objects down into one class name or class map.
+
+The basic idea is to provide tools which can take in one or more css styling objects representing the styles for a given element, and return a single class name. If the same set of styling is passed in, the same name returns and nothing is re-registered.
 
 ## Motivation
 
@@ -145,7 +163,7 @@ Custom selectors can be defined within `IStyle` definitions under the `selectors
 }
 ```
 
-By default, the rule will be appended to the current selector scope. That is, in the above scenario, there will be 2 rules inserted when using `mergeRules`:
+By default, the rule will be appended to the current selector scope. That is, in the above scenario, there will be 2 rules inserted when using `mergeStyles`:
 
 ```css
 .css-0 { background: red; }
@@ -188,7 +206,14 @@ mergeStyleSets({
 });
 ```
 
-In some cases, you may need to alter one child area by interacting with the parent. For example, when the parent focus is set, change the child background. You can reference the areas defined in the style set using $ tokens:
+Produces:
+
+```css
+.root-0 { background: red; }
+.thumb-1 { background: green; }
+```
+
+In some cases, you may need to alter a child area by interacting with the parent. For example, when the parent is hovered, change the child background. You can reference the areas defined in the style set using $ tokens:
 
 ```tsx
 mergeStyleSets({
@@ -205,11 +230,23 @@ The `$thumb` reference in the selector on root will be replaced with the class n
 
 ## Custom class names
 
-By default when using `mergeStyles`, class names that are generated will use the prefix `css-` followed by a number, creating unique rules where needed.
+By default when using `mergeStyles`, class names that are generated will use the prefix `css-` followed by a number, creating unique rules where needed. For example, the first class name produced will be 'css-0'.
 
 When using `mergeStyleSets`, class names automatically use the area name as the prefix.
 
-If you'd like to override the default prefx in either case, you can pass in a `displayName` to resolve this:
+Merging rules like:
+
+```ts
+mergeStyleSets({ a: { ... }, b: { ... } })
+```
+
+Will produce the class name map:
+
+```ts
+{ a: 'a-0', b: 'b-1' }
+```
+
+If you'd like to override the default prefix in either case, you can pass in a `displayName` to resolve this:
 
 ```tsx
 {

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -130,6 +130,8 @@ export const MyComponent = () => {
 
 ## Selectors
 
+### Basic pseudo-selectors (:hover, :active, etc)
+
 Custom selectors can be defined within `IStyle` definitions under the `selectors` section:
 
 ```tsx
@@ -149,6 +151,8 @@ By default, the rule will be appended to the current selector scope. That is, in
 .css-0 { background: red; }
 .css-0:hover { background: green; }
 ```
+
+### Parent/child selectors
 
 In some cases, you may need to use parent or child selectors. To do so, you can define a selector from scratch and use the `&` character to represent the generated class name. When using the `&`, the current scope is ignored. Example:
 
@@ -173,12 +177,39 @@ This would register the rules:
 .ms-Fabric.is-focusVisible .css-0 { background: red; }
 .css-0 .child { background: green; }
 ```
+### Referencing child elements within the mergeStyleSets scope
+
+One important concept about `mergeStyleSets` is that it produces a map of class names for the given elements:
+
+```tsx
+mergeStyleSets({
+  root: { background: 'red' }
+  thumb: { background: 'green' }
+});
+```
+
+In some cases, you may need to alter one child area by interacting with the parent. For example, when the parent focus is set, change the child background. You can reference the areas defined in the style set using $ tokens:
+
+```tsx
+mergeStyleSets({
+  root: {
+    selectors: {
+      ':hover $thumb': { background: 'lightgreen' }
+    }
+   }
+  thumb: { background: 'green' }
+});
+```
+
+The `$thumb` reference in the selector on root will be replaced with the class name generated for thumb.
 
 ## Custom class names
 
-By default class names that are generated will use the prefix `css-` followed by a number, creating unique rules where needed.
+By default when using `mergeStyles`, class names that are generated will use the prefix `css-` followed by a number, creating unique rules where needed.
 
-While this prefix is fine, sometimes a more readable prefix is desired. You can pass in a `displayName` to resolve this:
+When using `mergeStyleSets`, class names automatically use the area name as the prefix.
+
+If you'd like to override the default prefx in either case, you can pass in a `displayName` to resolve this:
 
 ```tsx
 {

--- a/packages/merge-styles/src/extractStyleParts.ts
+++ b/packages/merge-styles/src/extractStyleParts.ts
@@ -1,0 +1,40 @@
+import { IStyle } from './IStyle';
+import { Stylesheet } from './Stylesheet';
+
+/**
+ * Separates the classes and style objects. Any classes that are pre-registered
+ * args are auto expanded into objects.
+ */
+export function extractStyleParts(
+  ...args: (IStyle | IStyle[] | false | null | undefined)[]
+): { classes: string[], objects: IStyle[] } {
+  const classes: string[] = [];
+  const objects: {}[] = [];
+  const stylesheet = Stylesheet.getInstance();
+
+  function _processArgs(argsList: (IStyle | IStyle[])[]): void {
+    for (const arg of argsList) {
+      if (arg) {
+        if (typeof arg === 'string') {
+          const translatedArgs = stylesheet.argsFromClassName(arg);
+          if (translatedArgs) {
+            objects.push(translatedArgs);
+          } else {
+            classes.push(arg);
+          }
+        } else if (Array.isArray(arg)) {
+          _processArgs(arg);
+        } else if (typeof arg === 'object') {
+          objects.push(arg);
+        }
+      }
+    }
+  }
+
+  _processArgs(args);
+
+  return {
+    classes,
+    objects
+  };
+}

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -54,33 +54,30 @@ describe('mergeStyleSets', () => {
             ':hover $b': {
               background: 'green'
             },
-            ':focus $c': {
+            ':focus $c-foo': {
               background: 'red'
             },
-            ':focus .d': {
+            ':active .d': {
               background: 'pink'
             }
           }
         },
         b: {
-          displayName: 'b',
           background: 'blue'
         },
-        c: {
-          displayName: 'c'
-        }
+        'c-foo': {}
       });
 
     expect(result).toEqual({
       a: 'a-0',
       b: 'b-1',
-      c: 'c-2'
+      'c-foo': 'c-foo-2'
     });
 
     expect(_stylesheet.getRules()).toEqual(
       '.a-0:hover .b-1{background:green;}' +
-      '.a-0:focus .c-2{background:red;}' +
-      '.a-0:focus .d{background:pink;}' +
+      '.a-0:focus .c-foo-2{background:red;}' +
+      '.a-0:active .d{background:pink;}' +
       '.b-1{background:blue;}'
     );
   });

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -34,15 +34,55 @@ describe('mergeStyleSets', () => {
     );
 
     expect(result).toEqual({
-      root: 'css-0',
-      a: 'css-1',
-      b: 'css-2'
+      root: 'root-0',
+      a: 'a-1',
+      b: 'b-2'
     });
 
     expect(_stylesheet.getRules()).toEqual(
-      '.css-0{background:red;}.css-0:hover{background:yellow;}' +
-      '.css-1{background:white;}' +
-      '.css-2{background:blue;}'
+      '.root-0{background:red;}.root-0:hover{background:yellow;}' +
+      '.a-1{background:white;}' +
+      '.b-2{background:blue;}'
     );
   });
+
+  it('can expand child selectors', () => {
+    const result = mergeStyleSets(
+      {
+        a: {
+          selectors: {
+            ':hover $b': {
+              background: 'green'
+            },
+            ':focus $c': {
+              background: 'red'
+            },
+            ':focus .d': {
+              background: 'pink'
+            }
+          }
+        },
+        b: {
+          displayName: 'b',
+          background: 'blue'
+        },
+        c: {
+          displayName: 'c'
+        }
+      });
+
+    expect(result).toEqual({
+      a: 'a-0',
+      b: 'b-1',
+      c: 'c-2'
+    });
+
+    expect(_stylesheet.getRules()).toEqual(
+      '.a-0:hover .b-1{background:green;}' +
+      '.a-0:focus .c-2{background:red;}' +
+      '.a-0:focus .d{background:pink;}' +
+      '.b-1{background:blue;}'
+    );
+  });
+
 });

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -82,4 +82,10 @@ describe('mergeStyleSets', () => {
     );
   });
 
+  it('can merge class names', () => {
+    expect(mergeStyleSets({ root: ['a', 'b', { background: 'red' }] })).toEqual({
+      root: 'a b root-0'
+    });
+  });
+
 });

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -1,6 +1,6 @@
-import { mergeStyles } from './mergeStyles';
 import { concatStyleSets } from './concatStyleSets';
 import { IStyle } from './IStyle';
+import { styleToRegistration, applyRegistration } from './styleToClassName';
 
 /**
  * Allows you to pass in 1 or more sets of areas which will return a merged
@@ -11,17 +11,30 @@ import { IStyle } from './IStyle';
 export function mergeStyleSets<T>(
   ...cssSets: ({[P in keyof T]?: IStyle } | null | undefined)[]
 ): T {
-  const classNameSet: Partial<T> = {};
+  // tslint:disable-next-line:no-any
+  const classNameSet: any = {};
   let cssSet = cssSets[0];
 
   if (cssSet) {
     if (cssSets.length > 1) {
       cssSet = concatStyleSets(...cssSets);
     }
+
+    const registrations = [];
+
     for (const prop in cssSet) {
       if (cssSet.hasOwnProperty(prop)) {
-        // tslint:disable-next-line:no-any
-        (classNameSet as any)[prop] = mergeStyles(cssSet[prop] as IStyle);
+        const registration = styleToRegistration({ displayName: prop }, cssSet[prop]);
+        registrations.push(registration);
+        if (registration) {
+          classNameSet[prop] = registration.className;
+        }
+      }
+    }
+
+    for (const registration of registrations) {
+      if (registration) {
+        applyRegistration(registration, classNameSet);
       }
     }
   }

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -1,3 +1,4 @@
+import { extractStyleParts } from './extractStyleParts';
 import { concatStyleSets } from './concatStyleSets';
 import { IStyle } from './IStyle';
 import { styleToRegistration, applyRegistration } from './styleToClassName';
@@ -24,10 +25,16 @@ export function mergeStyleSets<T>(
 
     for (const prop in cssSet) {
       if (cssSet.hasOwnProperty(prop)) {
-        const registration = styleToRegistration({ displayName: prop }, cssSet[prop]);
+        const args: IStyle = cssSet[prop];
+
+        // tslint:disable-next-line:no-any
+        const { classes, objects } = extractStyleParts(args as any);
+        const registration = styleToRegistration({ displayName: prop }, objects);
+
         registrations.push(registration);
+
         if (registration) {
-          classNameSet[prop] = registration.className;
+          classNameSet[prop] = classes.concat([registration.className]).join(' ');
         }
       }
     }

--- a/packages/merge-styles/src/mergeStyles.ts
+++ b/packages/merge-styles/src/mergeStyles.ts
@@ -1,6 +1,6 @@
 import { IStyle } from './IStyle';
 import { styleToClassName } from './styleToClassName';
-import { Stylesheet } from './Stylesheet';
+import { extractStyleParts } from './extractStyleParts';
 
 /**
  * Concatination helper, which can merge class names together. Skips over falsey values.
@@ -10,30 +10,7 @@ import { Stylesheet } from './Stylesheet';
 export function mergeStyles(
   ...args: (IStyle | IStyle[] | false | null | undefined)[]
 ): string {
-  const classes: string[] = [];
-  const objects: {}[] = [];
-  const stylesheet = Stylesheet.getInstance();
-
-  function _processArgs(argsList: (IStyle | IStyle[])[]): void {
-    for (const arg of argsList) {
-      if (arg) {
-        if (typeof arg === 'string') {
-          const translatedArgs = stylesheet.argsFromClassName(arg);
-          if (translatedArgs) {
-            objects.push(translatedArgs);
-          } else {
-            classes.push(arg);
-          }
-        } else if (Array.isArray(arg)) {
-          _processArgs(arg);
-        } else if (typeof arg === 'object') {
-          objects.push(arg);
-        }
-      }
-    }
-  }
-
-  _processArgs(args);
+  const { classes, objects } = extractStyleParts(args);
 
   if (objects.length) {
     classes.push(styleToClassName(objects));

--- a/packages/merge-styles/src/server.test.ts
+++ b/packages/merge-styles/src/server.test.ts
@@ -16,7 +16,7 @@ describe('staticRender', () => {
       return `<div class="${classNames.root}">Hello!</div>`;
     });
 
-    expect(html).toEqual(`<div class="css-0">Hello!</div>`);
-    expect(css).toEqual(`.css-0{background:red;}`);
+    expect(html).toEqual(`<div class="root-0">Hello!</div>`);
+    expect(css).toEqual(`.root-0{background:red;}`);
   });
 });

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -128,14 +128,4 @@ describe('styleToClassName', () => {
     expect(_stylesheet.getRules()).toEqual('.css-0.css-0.css-0{background:red;}');
   });
 
-  it('can avoid registering classnames', () => {
-    expect(styleToClassName({
-      background: 'red',
-      selectors: {
-        '& .ms-Foo': {}
-      }
-    })).toEqual('css-0');
-
-    expect(_stylesheet.getRules()).toEqual('');
-  });
 });

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -75,6 +75,12 @@ describe('styleToClassName', () => {
     expect(styleToClassName()).toEqual('');
   });
 
+  it('returns the same class name for a rule that only has a displayName', () => {
+    expect(styleToClassName({ displayName: 'foo' })).toEqual('foo-0');
+    expect(styleToClassName({ displayName: 'foo' })).toEqual('foo-0');
+    expect(_stylesheet.getRules()).toEqual('');
+  });
+
   it('can preserve displayName in names', () => {
     expect(styleToClassName({ displayName: 'DisplayName', background: 'red' })).toEqual('DisplayName-0');
     expect(_stylesheet.getRules()).toEqual('.DisplayName-0{background:red;}');
@@ -121,4 +127,5 @@ describe('styleToClassName', () => {
 
     expect(_stylesheet.getRules()).toEqual('.css-0.css-0.css-0{background:red;}');
   });
+
 });

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -135,7 +135,6 @@ describe('styleToClassName', () => {
         '& .ms-Foo': {}
       }
     })).toEqual('css-0');
-    debugger;
 
     expect(_stylesheet.getRules()).toEqual('');
   });

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -128,4 +128,15 @@ describe('styleToClassName', () => {
     expect(_stylesheet.getRules()).toEqual('.css-0.css-0.css-0{background:red;}');
   });
 
+  it('can avoid registering classnames', () => {
+    expect(styleToClassName({
+      background: 'red',
+      selectors: {
+        '& .ms-Foo': {}
+      }
+    })).toEqual('css-0');
+    debugger;
+
+    expect(_stylesheet.getRules()).toEqual('');
+  });
 });

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -192,7 +192,7 @@ export function applyRegistration(
         let selector = rulesToInsert[i];
 
         // Fix selector using map.
-        selector = selector.replace(/(&)|\$(\w+)\b/g, (match: string, amp: string, cn: string): string => {
+        selector = selector.replace(/(&)|\$([\w-]+)\b/g, (match: string, amp: string, cn: string): string => {
           if (amp) {
             return '.' + registration.className;
           } else if (cn) {

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -141,33 +141,86 @@ export function serializeRuleEntries(ruleEntries: { [key: string]: string | numb
   return allEntries.join('');
 }
 
-export function styleToClassName(...args: IStyle[]): string {
+export interface IRegistration {
+  className: string;
+  key: string;
+  args: IStyle[];
+  rulesToInsert: string[];
+}
+
+export function styleToRegistration(...args: IStyle[]): IRegistration | undefined {
   const rules: IRuleSet = extractRules(args);
   const key = getKeyForRules(rules);
-  let className = '';
 
   if (key) {
     const stylesheet = Stylesheet.getInstance();
+    const registration: Partial<IRegistration> = {
+      className: stylesheet.classNameFromKey(key),
+      key,
+      args
+    };
 
-    className = stylesheet.classNameFromKey(key)!;
+    if (!registration.className) {
+      registration.className = stylesheet.getClassName(getDisplayName(rules));
+      const rulesToInsert: string[] = [];
 
-    if (!className) {
-      className = stylesheet.getClassName(getDisplayName(rules));
-      const registeredRules: string[] = [];
-
-      for (let selector of rules.__order) {
-        const rulesToInsert: string = serializeRuleEntries(rules[selector]);
-
-        if (rulesToInsert) {
-          registeredRules.push(selector, rulesToInsert);
-          selector = selector.replace(/\&/g, `.${className}`);
-          stylesheet.insertRule(`${selector}{${rulesToInsert}}`);
-        }
+      for (const selector of rules.__order) {
+        rulesToInsert.push(
+          selector,
+          serializeRuleEntries(rules[selector])
+        );
       }
-
-      stylesheet.cacheClassName(className, key, args, registeredRules);
+      registration.rulesToInsert = rulesToInsert;
     }
+
+    return registration as IRegistration;
+  }
+}
+
+export function applyRegistration(
+  registration: IRegistration,
+  classMap?: { [key: string]: string }
+): void {
+  const stylesheet = Stylesheet.getInstance();
+  const { className, key, args, rulesToInsert } = registration;
+
+  if (rulesToInsert) {
+    for (let i = 0; i < rulesToInsert.length; i += 2) {
+      const rules = rulesToInsert[i + 1];
+      if (rules) {
+        let selector = rulesToInsert[i];
+
+        // Fix selector using map.
+        selector = selector.replace(/(&)|\$(\w+)\b/g, (match: string, amp: string, cn: string): string => {
+          if (amp) {
+            return '.' + registration.className;
+          } else if (cn) {
+            return '.' + ((classMap && classMap[cn]) || cn);
+          }
+          return '';
+        });
+
+        // Insert.
+        stylesheet.insertRule(`${selector}{${rules}}`);
+      }
+    }
+    stylesheet.cacheClassName(
+      className!,
+      key!,
+      args!,
+      rulesToInsert
+    );
+
+  }
+}
+
+export function styleToClassName(...args: IStyle[]): string {
+  const registration = styleToRegistration(...args);
+  if (registration) {
+    applyRegistration(registration);
+
+    return registration.className;
   }
 
-  return className;
+  return '';
 }

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -185,6 +185,7 @@ export function applyRegistration(
   const { className, key, args, rulesToInsert } = registration;
 
   if (rulesToInsert) {
+    // rulesToInsert is an ordered array of selector/rule pairs.
     for (let i = 0; i < rulesToInsert.length; i += 2) {
       const rules = rulesToInsert[i + 1];
       if (rules) {

--- a/scripts/tasks/jest-serializer-merge-styles.js
+++ b/scripts/tasks/jest-serializer-merge-styles.js
@@ -40,15 +40,20 @@ function serializeRules(rules, indent) {
   let ruleStrings = [];
 
   for (let i = 0; i < rules.length; i += 2) {
-    ruleStrings.push(indent((i === 0 ? '' : rules[i] + ' ') + `{`));
+    const selector = rules[i];
+    const insertedRules = rules[i + 1];
 
-    rules[i + 1].split(';').sort().forEach(rule => {
-      if (rule) {
-        ruleStrings.push(indent('  ' + rule.replace(':', ': ') + ';'));
-      }
-    });
+    if (insertedRules) {
+      ruleStrings.push(indent((i === 0 ? '' : selector + ' ') + `{`));
 
-    ruleStrings.push(indent('}'));
+      insertedRules.split(';').sort().forEach(rule => {
+        if (rule) {
+          ruleStrings.push(indent('  ' + rule.replace(':', ': ') + ';'));
+        }
+      });
+
+      ruleStrings.push(indent('}'));
+    }
   }
 
   return ruleStrings.join('\n');

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -8,7 +8,7 @@ module.exports = function (options) {
 
   if (fs.existsSync(jestConfigPath)) {
     const jestPath = path.resolve(__dirname, '../node_modules/jest/bin/jest');
-    const customArgs = options.argv.slice(3).join(' ');
+    const customArgs = options && options.argv ? options.argv.slice(3).join(' ') : '';
 
     const args = [
       // Specify the config file.


### PR DESCRIPTION
Scenario:
I want to make a child element within root turn background: red when hovering over the root.

Before:
You would need to append global classname on the child element, and reference it in your root selector:

```tsx
mergeStyleSets({
  root: {
    selectors: {
      ':hover .ms-ComponentName-area': {
        background: 'red'
      }
  },
  child: { background: 'green' }
});
```

Now you can use $tokens to identify the generated class names for areas within the same set. This means no more reliance on global classnames for this scenario:


```tsx
mergeStyleSets({
  root: {
    selectors: {
      ':hover $child': {
        background: 'red'
      }
  },
  child: { background: 'green' }
});
```
