### PR TITLE
Adding IconNames const enum to @uifabric/icons.

### DIFF
--- a/common/changes/@uifabric/icons/iconnames_2017-10-05-05-46.json
+++ b/common/changes/@uifabric/icons/iconnames_2017-10-05-05-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/icons",
+      "comment": "Exporting `IconNames` const enum.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/icons/src/IconNames.ts
+++ b/packages/icons/src/IconNames.ts
@@ -1,4 +1,4 @@
-export const enum IconName {
+export const enum IconNames {
   DecreaseIndentLegacy = 'DecreaseIndentLegacy',
   IncreaseIndentLegacy = 'IncreaseIndentLegacy',
   GlobalNavButton = 'GlobalNavButton',

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -20,3 +20,5 @@ export function initializeIcons(baseUrl: string = DEFAULT_BASE_URL): void {
     (initialize: (url: string) => void) => initialize(baseUrl)
   );
 }
+
+export { IconNames } from './IconNames';


### PR DESCRIPTION
Lets people import the icon names in the package and get intellisense without any bundle impact.