### PR TITLE
ComboBox autocomplete property should be a boolean

### DIFF
--- a/common/changes/office-ui-fabric-react/autocompleteBool_2017-10-05-17-09.json
+++ b/common/changes/office-ui-fabric-react/autocompleteBool_2017-10-05-17-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make combo box autocomplete prop a boolean",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "alebet@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
@@ -56,7 +56,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * Whether the ComboBox auto completes. As the user is inputing text, it will be suggested potential matches from the list of options. If
    * the combo box is expanded, this will also scroll to the suggested option, and give it a selected style. Defaults to false.
    */
-  autoComplete?: string;
+  autoComplete?: boolean;
 
   /**
    * Value to show in the input, does not have to map to a combobox option

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -70,7 +70,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   public static defaultProps: IComboBoxProps = {
     options: [],
     allowFreeform: false,
-    autoComplete: 'on',
+    autoComplete: true,
     buttonIconProps: { iconName: 'ChevronDown' }
   };
 
@@ -264,7 +264,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             onClick={ allowFreeform ? this.focus : this._onComboBoxClick }
             onInputValueChange={ this._onInputChange }
             aria-expanded={ isOpen }
-            aria-autocomplete={ (!disabled && autoComplete === 'on') }
+            aria-autocomplete={ (!disabled && autoComplete) }
             role='combobox'
             aria-readonly={ ((allowFreeform || disabled) ? null : 'true') }
             readOnly={ disabled || !allowFreeform }
@@ -386,7 +386,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       // If we are allowing freeform and autocomplete is also true
       // and we've got a pending value that matches an option, remember
       // the matched option's index
-      if (autoComplete === 'on' && currentPendingIndexValid) {
+      if (autoComplete && currentPendingIndexValid) {
         index = currentPendingValueValidIndex;
       }
 
@@ -404,7 +404,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         // If autoComplete is on, return the
         // raw pending value, otherwise remember
         // the matched option's index
-        if (autoComplete === 'on') {
+        if (autoComplete) {
           return currentPendingValue;
         }
 
@@ -470,7 +470,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     let newCurrentPendingValueValidIndex = -1;
 
     // If autoComplete is on, attempt to find a match from the available options
-    if (this.props.autoComplete === 'on') {
+    if (this.props.autoComplete) {
 
       // If autoComplete is on, attempt to find a match where the text of an option starts with the updated value
       let items = currentOptions.map((item, index) => { return { ...item, index }; }).filter((option) => option.itemType !== SelectableOptionMenuItemType.Header && option.itemType !== SelectableOptionMenuItemType.Divider).filter((option) => option.text.toLocaleLowerCase().indexOf(updatedValue) === 0);
@@ -509,7 +509,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       selectedIndex
     } = this.state;
 
-    if (this.props.autoComplete === 'on') {
+    if (this.props.autoComplete) {
 
       // If autoComplete is on while allow freeform is off,
       // we will remember the keypresses and build up a string to attempt to match
@@ -1153,7 +1153,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
       case KeyCodes.space:
         // event handled in _onComboBoxKeyUp
-        if (!allowFreeform && autoComplete === 'off') {
+        if (!allowFreeform && !autoComplete) {
           break;
         }
 
@@ -1173,7 +1173,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         // If we are not allowing freeform and
         // allowing autoComplete, handle the input here
         // since we have marked the input as readonly
-        if (!allowFreeform && autoComplete === 'on') {
+        if (!allowFreeform && autoComplete) {
           this._onInputChange(String.fromCharCode(ev.which));
           break;
         }
@@ -1208,7 +1208,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         // If we are not allowing freeform and are not autoComplete
         // make space expand/collapse the comboBox
         // and allow the event to propagate
-        if (!allowFreeform && autoComplete === 'off') {
+        if (!allowFreeform && !autoComplete) {
           this.setState({
             isOpen: !this.state.isOpen
           });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3041 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Make the ComboBox autocomplete box be a boolean instead of a string 'on' and 'off'
