### PR TITLE
Fix: office-ui-fabric-react so that it preserves enum consts

### DIFF
--- a/apps/fabric-website/tsconfig.json
+++ b/apps/fabric-website/tsconfig.json
@@ -11,6 +11,7 @@
     "importHelpers": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "types": [
       "chai",
       "mocha",

--- a/apps/test-bundle-button/tsconfig.json
+++ b/apps/test-bundle-button/tsconfig.json
@@ -11,6 +11,7 @@
     "importHelpers": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "types": [
       "webpack-env"
     ],

--- a/apps/todo-app/tsconfig.json
+++ b/apps/todo-app/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "types": [
       "chai",
       "mocha",

--- a/apps/vr-tests/tsconfig.json
+++ b/apps/vr-tests/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "types": [
       "webpack-env"
     ]

--- a/common/changes/@uifabric/example-app-base/positioning-refactor_2017-09-28-20-50.json
+++ b/common/changes/@uifabric/example-app-base/positioning-refactor_2017-09-28-20-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/example-app-base/preserveenumconsts_2017-10-05-21-04.json
+++ b/common/changes/@uifabric/example-app-base/preserveenumconsts_2017-10-05-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "TSConfig: update to use preserveConstEnums so that certain builds s ystems don't break when importing const enums",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/positioning-refactor_2017-09-28-20-50.json
+++ b/common/changes/@uifabric/experiments/positioning-refactor_2017-09-28-20-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/preserveenumconsts_2017-10-05-21-04.json
+++ b/common/changes/@uifabric/experiments/preserveenumconsts_2017-10-05-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "TSConfig: update to use preserveConstEnums so that certain builds s ystems don't break when importing const enums",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/positioning-refactor_2017-09-28-20-50.json
+++ b/common/changes/@uifabric/fabric-website/positioning-refactor_2017-09-28-20-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/preserveenumconsts_2017-10-05-21-04.json
+++ b/common/changes/@uifabric/fabric-website/preserveenumconsts_2017-10-05-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "TSConfig: update to use preserveConstEnums so that certain builds s ystems don't break when importing const enums",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/icons/preserveenumconsts_2017-10-05-21-04.json
+++ b/common/changes/@uifabric/icons/preserveenumconsts_2017-10-05-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/icons",
+      "comment": "TSConfig: update to use preserveConstEnums so that certain builds s ystems don't break when importing const enums",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/merge-styles/preserveenumconsts_2017-10-05-21-04.json
+++ b/common/changes/@uifabric/merge-styles/preserveenumconsts_2017-10-05-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "TSConfig: update to use preserveConstEnums so that certain builds s ystems don't break when importing const enums",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/positioning-refactor_2017-09-28-20-50.json
+++ b/common/changes/@uifabric/styling/positioning-refactor_2017-09-28-20-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/preserveenumconsts_2017-10-05-21-04.json
+++ b/common/changes/@uifabric/styling/preserveenumconsts_2017-10-05-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "TSConfig: update to use preserveConstEnums so that certain builds s ystems don't break when importing const enums",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/preserveenumconsts_2017-10-05-21-04.json
+++ b/common/changes/@uifabric/utilities/preserveenumconsts_2017-10-05-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "TSConfig: update to use preserveConstEnums so that certain builds s ystems don't break when importing const enums",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/preserveenumconsts_2017-10-05-21-04.json
+++ b/common/changes/office-ui-fabric-react/preserveenumconsts_2017-10-05-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TSConfig: update to use preserveConstEnums so that certain builds systems don't break when importing const enums",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/example-app-base/tsconfig.json
+++ b/packages/example-app-base/tsconfig.json
@@ -11,6 +11,7 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "outDir": "lib",
     "lib": [
       "es2017",

--- a/packages/experiments/tsconfig.json
+++ b/packages/experiments/tsconfig.json
@@ -14,6 +14,7 @@
     "strictNullChecks": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "lib": [
       "es2017",
       "dom"

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -14,6 +14,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "types": []
   },
   "include": [

--- a/packages/merge-styles/tsconfig.json
+++ b/packages/merge-styles/tsconfig.json
@@ -15,6 +15,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "types": [
       "jest"
     ]

--- a/packages/office-ui-fabric-react/tsconfig.json
+++ b/packages/office-ui-fabric-react/tsconfig.json
@@ -13,6 +13,7 @@
     "strictNullChecks": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "lib": [
       "es2017",
       "dom"

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -13,6 +13,7 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": [
       "es2017",
       "dom"

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -16,6 +16,7 @@
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "preserveConstEnums": true,
     "types": [
       "jest"
     ]


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

TSConfig: update to use preserveConstEnums so that certain builds s ystems don't break when importing const enums

#### Focus areas to test

(optional)
