### PR TITLE
Router: regex to be able to render the correct page when we encounter queries

### DIFF
--- a/common/changes/office-ui-fabric-react/router-queries_2017-10-05-21-50.json
+++ b/common/changes/office-ui-fabric-react/router-queries_2017-10-05-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Router: regex to be able to render the correct page when it encounters queries.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/router/Router.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/router/Router.tsx
@@ -26,11 +26,17 @@ export class Router extends BaseComponent<IRouterProps, {}> {
   }
 
   private _getPath() {
-    let path = location.hash;
-    let index = path.lastIndexOf('#');
+    let path = location.hash,
+      hashIndex = path.lastIndexOf('#'),
+      questionMarkIndex = path.indexOf('?');
 
-    if (index > 0) {
-      path = path.substr(0, index);
+    // Look for the start of a query in the currentPath, then strip out the query to find the correct page to render
+    if (questionMarkIndex > -1) {
+      path = path.substr(0, questionMarkIndex);
+    }
+
+    if (hashIndex > 0) {
+      path = path.substr(0, hashIndex);
     }
 
     return path;
@@ -93,15 +99,9 @@ function _match(currentPath: string, child: any): boolean {
     path = path || '';
     currentPath = currentPath || '';
 
-    // Use regex to search for a query in the currentPath, then slice out the query to find the correct page to render
-    let regex = new RegExp(path + '(\\?.*)'),
-      result = regex.exec(currentPath),
-      questionMarkIndex = result ? result[0].indexOf('?') : 0,
-      slicedPath = result ? result[0].slice(0, questionMarkIndex) : '';
-
     return (
       (!path) ||
-      (path.toLowerCase() === currentPath.toLowerCase()) || (path.toLowerCase() === slicedPath.toLowerCase())
+      (path.toLowerCase() === currentPath.toLowerCase())
     );
   }
 

--- a/packages/office-ui-fabric-react/src/utilities/router/Router.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/router/Router.tsx
@@ -93,9 +93,15 @@ function _match(currentPath: string, child: any): boolean {
     path = path || '';
     currentPath = currentPath || '';
 
+    // Use regex to search for a query in the currentPath, then slice out the query to find the correct page to render
+    let regex = new RegExp(path + '(\\?.*)'),
+      result = regex.exec(currentPath),
+      questionMarkIndex = result ? result[0].indexOf('?') : 0,
+      newPath = result ? result[0].slice(0, questionMarkIndex) : '';
+
     return (
       (!path) ||
-      (path.toLowerCase() === currentPath.toLowerCase())
+      (path.toLowerCase() === currentPath.toLowerCase()) || (path.toLowerCase() === newPath.toLowerCase())
     );
   }
 

--- a/packages/office-ui-fabric-react/src/utilities/router/Router.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/router/Router.tsx
@@ -97,11 +97,11 @@ function _match(currentPath: string, child: any): boolean {
     let regex = new RegExp(path + '(\\?.*)'),
       result = regex.exec(currentPath),
       questionMarkIndex = result ? result[0].indexOf('?') : 0,
-      newPath = result ? result[0].slice(0, questionMarkIndex) : '';
+      slicedPath = result ? result[0].slice(0, questionMarkIndex) : '';
 
     return (
       (!path) ||
-      (path.toLowerCase() === currentPath.toLowerCase()) || (path.toLowerCase() === newPath.toLowerCase())
+      (path.toLowerCase() === currentPath.toLowerCase()) || (path.toLowerCase() === slicedPath.toLowerCase())
     );
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adobe sent out an email today with the following link to direct users to download our XD Toolkit from the website's ResourcesPage:
https://aka.ms/fabric-design-downloads?trackingid=MV79S6N7&mv=email 

This link directs to:
https://developer.microsoft.com/en-us/fabric#/resources?trackingid=MV79S6N7&mv=email
which in turn redirects to the homepage instead of to the ResourcesPage.

I put some logic in the Router similar to what I saw being doing in [BlogPost.tsx](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/apps/fabric-website/src/pages/BlogPage/BlogPost.tsx) to catch queries like this and redirect them to the proper page.

#### Focus areas to test

(optional)
