### PR TITLE
Website: Added /removed Best Practices links on component pages

### DIFF
--- a/apps/fabric-website/src/pages/Components/CheckboxComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/CheckboxComponentPage.tsx
@@ -17,6 +17,10 @@ export class CheckboxComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/ChoiceGroupComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ChoiceGroupComponentPage.tsx
@@ -17,6 +17,10 @@ export class ChoiceGroupComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/ColorPickerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ColorPickerComponentPage.tsx
@@ -17,10 +17,6 @@ export class ColorPickerComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
-                  'text': 'Best Practices',
-                  'location': 'Best Practices'
-                },
-                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/CommandBarComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/CommandBarComponentPage.tsx
@@ -17,6 +17,10 @@ export class CommandBarComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/ContextualMenuComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ContextualMenuComponentPage.tsx
@@ -17,6 +17,10 @@ export class ContextualMenuComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/DatePickerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DatePickerComponentPage.tsx
@@ -17,6 +17,10 @@ export class DatePickerComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/DetailsListComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DetailsListComponentPage.tsx
@@ -17,6 +17,10 @@ export class DetailsListComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/DialogComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DialogComponentPage.tsx
@@ -17,6 +17,10 @@ export class DialogComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/DocumentCardComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DocumentCardComponentPage.tsx
@@ -17,6 +17,10 @@ export class DocumentCardComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/DropdownComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DropdownComponentPage.tsx
@@ -17,6 +17,10 @@ export class DropdownComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/FacepileComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/FacepileComponentPage.tsx
@@ -17,6 +17,10 @@ export class FacepileComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/GroupedListComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/GroupedListComponentPage.tsx
@@ -17,10 +17,6 @@ export class GroupedListComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
-                  'text': 'Best Practices',
-                  'location': 'Best Practices'
-                },
-                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/LabelComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/LabelComponentPage.tsx
@@ -17,6 +17,10 @@ export class LabelComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/LinkComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/LinkComponentPage.tsx
@@ -17,6 +17,10 @@ export class LinkComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/MessageBarComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/MessageBarComponentPage.tsx
@@ -17,6 +17,10 @@ export class MessageBarComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/ModalComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ModalComponentPage.tsx
@@ -17,6 +17,10 @@ export class ModalComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/OverlayComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/OverlayComponentPage.tsx
@@ -17,6 +17,10 @@ export class OverlayComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/PanelComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PanelComponentPage.tsx
@@ -17,6 +17,10 @@ export class PanelComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/PeoplePickerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PeoplePickerComponentPage.tsx
@@ -17,6 +17,10 @@ export class PeoplePickerComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/PersonaComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PersonaComponentPage.tsx
@@ -17,6 +17,10 @@ export class PersonaComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/PivotComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PivotComponentPage.tsx
@@ -17,6 +17,10 @@ export class PivotComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/ProgressIndicatorComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ProgressIndicatorComponentPage.tsx
@@ -17,6 +17,10 @@ export class ProgressIndicatorComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/ResizeGroupComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ResizeGroupComponentPage.tsx
@@ -14,7 +14,11 @@ export class ResizeGroupComponentPage extends React.Component<any, any> {
               [
                 {
                   'text': 'Overview',
-                  'location': 'Overview'
+                  'location': 'Overview',
+                },
+                {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
                 },
                 {
                   'text': 'Variants',

--- a/apps/fabric-website/src/pages/Components/ResizeGroupComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ResizeGroupComponentPage.tsx
@@ -14,7 +14,7 @@ export class ResizeGroupComponentPage extends React.Component<any, any> {
               [
                 {
                   'text': 'Overview',
-                  'location': 'Overview',
+                  'location': 'Overview'
                 },
                 {
                   'text': 'Best Practices',

--- a/apps/fabric-website/src/pages/Components/SearchBoxComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SearchBoxComponentPage.tsx
@@ -17,6 +17,10 @@ export class SearchBoxComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/SpinnerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SpinnerComponentPage.tsx
@@ -17,6 +17,10 @@ export class SpinnerComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/SwatchColorPickerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SwatchColorPickerComponentPage.tsx
@@ -17,6 +17,10 @@ export class SwatchColorPickerComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/TextFieldComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/TextFieldComponentPage.tsx
@@ -17,6 +17,10 @@ export class TextFieldComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/apps/fabric-website/src/pages/Components/ToggleComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ToggleComponentPage.tsx
@@ -17,6 +17,10 @@ export class ToggleComponentPage extends React.Component<any, any> {
                   'location': 'Overview'
                 },
                 {
+                  'text': 'Best Practices',
+                  'location': 'Best Practices'
+                },
+                {
                   'text': 'Variants',
                   'location': 'Variants'
                 },

--- a/common/changes/@uifabric/fabric-website/best-practices-links_2017-10-06-16-59.json
+++ b/common/changes/@uifabric/fabric-website/best-practices-links_2017-10-06-16-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Added/removed Best Practices links for component pages that had/didn't have a Best Practices section.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -160,7 +160,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
     if (this.props.bestPractices) {
       dosAndDonts.push(
         <div className='ComponentPage-usage' id='Best Practices' key='best-practices'>
-          <h2 className='ComponentPage-subHeading'>Best practices</h2>
+          <h2 className='ComponentPage-subHeading'>Best Practices</h2>
           { this.props.bestPractices }
         </div>
       );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Some component pages were missing a link to Best Practices, and some component pages didn't have a BP section but still had the link.

This PR is a short term fix for that. Long term, it would be great to use logic like in the ComponentPage component to make it so we don't have to use hardcoded link values depending on the sections we include on each page.

#### Focus areas to test

(optional)
