### PR TITLE
Website: Updated themeLight color - fixed typo

### DIFF
--- a/apps/fabric-website/src/data/colors-theme.json
+++ b/apps/fabric-website/src/data/colors-theme.json
@@ -31,7 +31,7 @@
   },
   {
     "name": "themeLight",
-    "value": "#c730f4",
+    "value": "#c7e0f4",
     "labelColorClass": "ms-fontColor-black"
   },
   {

--- a/common/changes/@uifabric/fabric-website/update-themeLIght_2017-10-06-23-27.json
+++ b/common/changes/@uifabric/fabric-website/update-themeLIght_2017-10-06-23-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Updated themeLight color - typo",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3052 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

When fixing this color earlier, I read E as 3. fixed!

Toolkit:
![image](https://user-images.githubusercontent.com/16619843/31302054-a192aa84-aab3-11e7-9df4-c36109a8ff24.png)


#### Focus areas to test

(optional)
