### PR TITLE
Clarify ComboBox autoComplete docs

### DIFF
--- a/common/changes/office-ui-fabric-react/3054-combobox-docs_2017-10-09-16-43.json
+++ b/common/changes/office-ui-fabric-react/3054-combobox-docs_2017-10-09-16-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Update documentation for `autoComplete` prop of `ComboBox` now that it is a string, not a boolean.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "ian.vanschooten@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/3054-combobox-docs_2017-10-09-16-43.json
+++ b/common/changes/office-ui-fabric-react/3054-combobox-docs_2017-10-09-16-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Update documentation for `autoComplete` prop of `ComboBox` now that it is a string, not a boolean.",
+      "comment": "ComboBox: Updated typing and documentation for `autoComplete` to only allow 'on' or 'off' (following html standards) rather than a boolean.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
@@ -54,9 +54,11 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
 
   /**
    * Whether the ComboBox auto completes. As the user is inputing text, it will be suggested potential matches from the list of options. If
-   * the combo box is expanded, this will also scroll to the suggested option, and give it a selected style. Defaults to false.
+   * the combo box is expanded, this will also scroll to the suggested option, and give it a selected style.
+   *
+   * @default "on"
    */
-  autoComplete?: string;
+  autoComplete?: 'on' | 'off';
 
   /**
    * Value to show in the input, does not have to map to a combobox option


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3054 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

This just updates the documentation on the `autoComplete` prop of `ComboBox`, which was changed to a string in https://github.com/OfficeDev/office-ui-fabric-react/pull/2141

#### Focus areas to test

I wasn't sure how to build the website to determine if this is correct, but it seems like a straightforward change.  One thing I wasn't sure of was the proper param name, either `@default` or `@defaultvalue`, as I see both in the code.
