### PR TITLE
Fix typo causing an exception in the controlled Dropdown example

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -168,7 +168,7 @@ export class DropdownBasicExample extends React.Component<any, any> {
   @autobind
   public changeState(item: IDropdownOption) {
     console.log('here is the things updating...' + item.key + ' ' + item.text + ' ' + item.selected);
-    this.setState({ selectedItems: item });
+    this.setState({ selectedItem: item });
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3011

#### Description of changes

With the changes I recently made to the Dropdown and its example page, a small typo snuck in and was causing exceptions. This fixes the typo and assigned the controlled Dropdown's key to the correct state value.

#### Focus areas to test

(optional)
