### PR TITLE
FocusZone: add includeElementsIn(Child)FocusZones prop to be passed to getNext/PreviousElement

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-Add_IncludeElementsInFocusZonesProp_2017-10-09-22-07.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-Add_IncludeElementsInFocusZonesProp_2017-10-09-22-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add includeElementInFocusZones prop to FocusZone",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
@@ -102,6 +102,12 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
 
   /** Allow focus to move to root */
   allowFocusRoot?: boolean;
+
+  /**
+   * Should this FocusZone include elements that are inside of child FocusZones?
+   * @default false
+   */
+  includeElementsInFocusZones?: boolean;
 }
 
 export enum FocusZoneDirection {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.Props.ts
@@ -107,7 +107,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
    * Should this FocusZone include elements that are inside of child FocusZones?
    * @default false
    */
-  includeElementsInFocusZones?: boolean;
+  includeElementsInChildFocusZones?: boolean;
 }
 
 export enum FocusZoneDirection {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -44,7 +44,8 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
   public static defaultProps: IFocusZoneProps = {
     isCircularNavigation: false,
-    direction: FocusZoneDirection.bidirectional
+    direction: FocusZoneDirection.bidirectional,
+    includeElementsInFocusZones: false
   };
 
   private _root: HTMLElement;
@@ -155,7 +156,16 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
       } else {
         const firstChild = this._root.firstChild as HTMLElement;
 
-        return this.focusElement(getNextElement(this._root, firstChild, true) as HTMLElement);
+        return this.focusElement(
+          getNextElement(
+            this._root,
+            firstChild,
+            true /* checkNode */,
+            undefined /* suppressParentTraversal */,
+            undefined /* suppressChildTraversal */,
+            this.props.includeElementsInFocusZones
+          ) as HTMLElement
+        );
       }
     }
     return false;
@@ -274,7 +284,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
    */
   @autobind
   private _onKeyDown(ev: React.KeyboardEvent<HTMLElement>) {
-    const { direction, disabled, isInnerZoneKeystroke } = this.props;
+    const { direction, disabled, isInnerZoneKeystroke, includeElementsInFocusZones } = this.props;
 
     if (disabled) {
       return;
@@ -307,7 +317,16 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           return;
         }
       } else if (isElementFocusSubZone(ev.target as HTMLElement)) {
-        if (!this.focusElement(getNextElement(ev.target as HTMLElement, (ev.target as HTMLElement).firstChild as HTMLElement, true) as HTMLElement)) {
+        if (!this.focusElement(
+          getNextElement(
+            ev.target as HTMLElement,
+            (ev.target as HTMLElement).firstChild as HTMLElement,
+            true /* checkNode */,
+            undefined /* suppressParentTraversal */,
+            undefined /* suppressChildTraversal */,
+            includeElementsInFocusZones
+          ) as HTMLElement
+        )) {
           return;
         }
       } else {
@@ -354,7 +373,16 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
             return false;
           }
           const firstChild = this._root.firstChild as HTMLElement;
-          if (this.focusElement(getNextElement(this._root, firstChild, true) as HTMLElement)) {
+          if (this.focusElement(
+            getNextElement(
+              this._root,
+              firstChild,
+              true /* checkNode */,
+              undefined /* suppressParentTraversal */,
+              undefined /* suppressChildTraversal */,
+              includeElementsInFocusZones
+            ) as HTMLElement
+          )) {
             break;
           }
           return;
@@ -453,6 +481,9 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
     let candidateElement: HTMLElement | undefined = undefined;
     let changedFocus = false;
     let isBidirectional = this.props.direction === FocusZoneDirection.bidirectional;
+    let {
+      includeElementsInFocusZones
+    } = this.props;
 
     if (!element) {
       return false;
@@ -468,8 +499,23 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
     do {
       element = (isForward ?
-        getNextElement(this._root, element) :
-        getPreviousElement(this._root, element)) as HTMLElement;
+        getNextElement(
+          this._root,
+          element,
+          undefined /* checkNode */,
+          undefined /* suppressParentTraversal */,
+          undefined /* suppressChildTraversal */,
+          includeElementsInFocusZones
+        ) :
+        getPreviousElement(
+          this._root,
+          element,
+          undefined /* checkNode */,
+          undefined /* suppressParentTraversal */,
+          undefined /* suppressChildTraversal */,
+          includeElementsInFocusZones
+        )
+      ) as HTMLElement;
 
       if (isBidirectional) {
         if (element) {
@@ -503,7 +549,16 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
       this.focusElement(candidateElement);
     } else if (this.props.isCircularNavigation) {
       if (isForward) {
-        return this.focusElement(getNextElement(this._root, this._root.firstElementChild as HTMLElement, true) as HTMLElement);
+        return this.focusElement(
+          getNextElement(
+            this._root,
+            this._root.firstElementChild as HTMLElement,
+            true /* checkNode */,
+            undefined /* suppressParentTraversal */,
+            undefined /* suppressChildTraversal */,
+            includeElementsInFocusZones
+          ) as HTMLElement
+        );
       } else {
         return this.focusElement(getPreviousElement(this._root, this._root.lastElementChild as HTMLElement, true, true, true) as HTMLElement);
       }

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -45,7 +45,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   public static defaultProps: IFocusZoneProps = {
     isCircularNavigation: false,
     direction: FocusZoneDirection.bidirectional,
-    includeElementsInFocusZones: false
+    includeElementsInChildFocusZones: false
   };
 
   private _root: HTMLElement;
@@ -163,7 +163,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
             true /* checkNode */,
             undefined /* suppressParentTraversal */,
             undefined /* suppressChildTraversal */,
-            this.props.includeElementsInFocusZones
+            this.props.includeElementsInChildFocusZones
           ) as HTMLElement
         );
       }
@@ -284,7 +284,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
    */
   @autobind
   private _onKeyDown(ev: React.KeyboardEvent<HTMLElement>) {
-    const { direction, disabled, isInnerZoneKeystroke, includeElementsInFocusZones } = this.props;
+    const { direction, disabled, isInnerZoneKeystroke, includeElementsInChildFocusZones } = this.props;
 
     if (disabled) {
       return;
@@ -324,7 +324,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
             true /* checkNode */,
             undefined /* suppressParentTraversal */,
             undefined /* suppressChildTraversal */,
-            includeElementsInFocusZones
+            includeElementsInChildFocusZones
           ) as HTMLElement
         )) {
           return;
@@ -380,7 +380,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
               true /* checkNode */,
               undefined /* suppressParentTraversal */,
               undefined /* suppressChildTraversal */,
-              includeElementsInFocusZones
+              includeElementsInChildFocusZones
             ) as HTMLElement
           )) {
             break;
@@ -482,7 +482,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
     let changedFocus = false;
     let isBidirectional = this.props.direction === FocusZoneDirection.bidirectional;
     let {
-      includeElementsInFocusZones
+      includeElementsInChildFocusZones
     } = this.props;
 
     if (!element) {
@@ -505,7 +505,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           undefined /* checkNode */,
           undefined /* suppressParentTraversal */,
           undefined /* suppressChildTraversal */,
-          includeElementsInFocusZones
+          includeElementsInChildFocusZones
         ) :
         getPreviousElement(
           this._root,
@@ -513,7 +513,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           undefined /* checkNode */,
           undefined /* suppressParentTraversal */,
           undefined /* suppressChildTraversal */,
-          includeElementsInFocusZones
+          includeElementsInChildFocusZones
         )
       ) as HTMLElement;
 
@@ -556,7 +556,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
             true /* checkNode */,
             undefined /* suppressParentTraversal */,
             undefined /* suppressChildTraversal */,
-            includeElementsInFocusZones
+            includeElementsInChildFocusZones
           ) as HTMLElement
         );
       } else {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There is no way of telling a FocusZone to include element in child FocusZones. This adds that functionality. By default nothing all calls are treated the same

#### Focus areas to test

Verified that I can get focus inside of a child FocusZone as expected
