### PR TITLE
MessageBar: Replaced DefaultButton with MessageBarButton

### DIFF
--- a/apps/vr-tests/src/stories/MessageBar.stories.tsx
+++ b/apps/vr-tests/src/stories/MessageBar.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { DefaultButton, Link, MessageBar, IMessageBarProps, MessageBarType } from 'office-ui-fabric-react';
+import { MessageBarButton, Link, MessageBar, IMessageBarProps, MessageBarType } from 'office-ui-fabric-react';
 
 let noop = (): void => { /**/ };
 // tslint:disable-next-line:max-line-length
@@ -29,8 +29,8 @@ storiesOf('MessageBar', module)
     <MessageBar
       actions={
         <div>
-          <DefaultButton>Yes</DefaultButton>
-          <DefaultButton>No</DefaultButton>
+          <MessageBarButton>Yes</MessageBarButton>
+          <MessageBarButton>No</MessageBarButton>
         </div>
       }
     >Info/default message bar. { link }

--- a/common/changes/office-ui-fabric-react/messageBarExamples-button_2017-10-10-18-39.json
+++ b/common/changes/office-ui-fabric-react/messageBarExamples-button_2017-10-10-18-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: replaced DefaultButton with MessageBarButton.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/index.ts
@@ -7,5 +7,6 @@ export * from './CommandButton/CommandButton';
 export * from './CompoundButton/CompoundButton';
 export * from './DefaultButton/DefaultButton';
 export * from './CommandButton/CommandButton';
+export * from './MessageBarButton/MessageBarButton';
 export * from './PrimaryButton/PrimaryButton';
 export * from './IconButton/IconButton';

--- a/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
@@ -1,7 +1,7 @@
 /* tslint:disable:no-unused-variable */
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { MessageBarButton } from 'office-ui-fabric-react/lib/Button';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
@@ -38,8 +38,8 @@ export const MessageBarBasicExample = () => (
       messageBarType={ MessageBarType.severeWarning }
       actions={
         <div>
-          <DefaultButton>Yes</DefaultButton>
-          <DefaultButton>No</DefaultButton>
+          <MessageBarButton>Yes</MessageBarButton>
+          <MessageBarButton>No</MessageBarButton>
         </div>
       }
     >
@@ -51,8 +51,8 @@ export const MessageBarBasicExample = () => (
     <MessageBar
       actions={
         <div>
-          <DefaultButton>Yes</DefaultButton>
-          <DefaultButton>No</DefaultButton>
+          <MessageBarButton>Yes</MessageBarButton>
+          <MessageBarButton>No</MessageBarButton>
         </div>
       }
       messageBarType={ MessageBarType.success }
@@ -68,8 +68,8 @@ export const MessageBarBasicExample = () => (
       ariaLabel='Aria help text here'
       actions={
         <div>
-          <DefaultButton>Yes</DefaultButton>
-          <DefaultButton>No</DefaultButton>
+          <MessageBarButton>Yes</MessageBarButton>
+          <MessageBarButton>No</MessageBarButton>
         </div>
       }
     >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

In a recent [PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/2985), I added a new button type specifically for the different MessageBarButton styling. 

Added that button to the MessageBar in this PR.
Screenshot of update:
![image](https://user-images.githubusercontent.com/16619843/31403954-9133149a-adaf-11e7-9f2b-940946bebafd.png)

#### Focus areas to test

(optional)
