### PR TITLE
SpinButton: fix spinButtonPage code reference for the stateful spinButton example

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-FixSpinButtonPageCodeReference_2017-10-10-19-17.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-FixSpinButtonPageCodeReference_2017-10-10-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SpinButton: Fix the code reference for the stateful spinButton Example (#3023)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButtonPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButtonPage.tsx
@@ -16,6 +16,7 @@ import { SpinButtonStatus } from './SpinButton.checklist';
 
 const SpinButtonBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx') as string;
 const SpinButtonBasicDisabledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicDisabled.Example.tsx') as string;
+const SpinButtonStatefulExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx') as string;
 const SpinButtonBasicWithIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicWithIcon.Example.tsx') as string;
 const SpinButtonBasicWithEndPositionExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicWithEndPosition.Example.tsx') as string;
 const SpinButtonCustomStyledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.CustomStyled.Example.tsx') as string;
@@ -42,7 +43,7 @@ export class SpinButtonPage extends React.Component<IComponentDemoPageProps, {}>
             </ExampleCard>
             <ExampleCard
               title={ 'Stateful SpinButton' }
-              code={ SpinButtonBasicExampleCode }
+              code={ SpinButtonStatefulExampleCode }
             >
               <SpinButtonStatefulExample />
             </ExampleCard>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3023 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

the stateful spinButton example was incorrectly referencing the basic spinButton code. This updates the code reference to correctly point to the stateful spinButton code

