### PR TITLE
Fix visibility of text descenders in Tile component [experiments]

### DIFF
--- a/common/changes/@uifabric/experiments/tile-lines_2017-10-10-22-35.json
+++ b/common/changes/@uifabric/experiments/tile-lines_2017-10-10-22-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fix visibility of Tile descenders",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -253,54 +253,73 @@ button.check {
   }
 }
 
-@mixin preserveExtenders($topMargin: 0px) {
-  padding-top: 8px;
-  margin-top: $topMargin - 8px;
-  @include margin-left(-8px);
-  @include padding-left(8px);
-}
-
 .name {
-  display: block;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
   font-weight: $ms-font-weight-regular;
   color: $ms-color-neutralPrimary;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 
+  @include margin-left(-8px);
+  @include padding-left(8px);
+
   &,
   .isLarge & {
     font-size: $ms-font-size-m;
-    height: 17px;
-    line-height: 17px;
+
+    // Simulate a 15px line-height by using negative margins.
+    // This allows extenders and descenders to fit while still enforcing bounds
+    // for overflow: ellipsis.
+    height: 30px;
+    margin-top: -7px;
+    margin-bottom: -8px;
   }
 
   .isSmall & {
     font-size: $ms-font-size-s;
-    height: 14px;
-    line-height: 14px;
-  }
 
-  @include preserveExtenders();
+    // Simulate a 12px line-height by using negative margins.
+    // This allows extenders and descenders to fit while still enforcing bounds
+    // for overflow: ellipsis.
+    height: 24px;
+    margin-top: -5px;
+    margin-bottom: -7px;
+  }
 }
 
 .activity {
-  margin-top: 4px;
-  display: block;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
   font-weight: $ms-font-weight-regular;
   font-size: $ms-font-size-s;
   color: #767676;
-  height: 14px;
-  line-height: 14px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  @include preserveExtenders(4px);
+
+  // Simulate a 20px line-height by using negative margins.
+  // This allows extenders and descenders to fit while still enforcing bounds
+  // for overflow: ellipsis.
+  height: 24px;
+  margin-bottom: -4px;
+
+  @include margin-left(-8px);
+  @include padding-left(8px);
 }
 
 .hasBackgroundFrame {
-  .nameplate {
-    @include text-align(left);
+  .name {
+    justify-content: flex-start;
+  }
+
+  .activity {
+    justify-content: flex-start;
   }
 }
 

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -16,11 +16,11 @@ const CheckStyles: any = CheckStylesModule;
 
 const enum TileLayoutValues {
   nameplatePadding = 12,
-  largeNameplateNameHeight = 17,
-  smallNameplateNameHeight = 14,
-  nameplateMargin = 4,
-  largeNameplateActivityHeight = 14,
-  smallNameplateActivityHeight = 14,
+  largeNameplateNameHeight = 15,
+  smallNameplateNameHeight = 12,
+  nameplateMargin = 0,
+  largeNameplateActivityHeight = 20,
+  smallNameplateActivityHeight = 20,
   foregroundMargin = 16
 }
 

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -77,6 +77,10 @@
 }
 
 .mention {
+  position: relative;
+
+  top: 0.2em;
+
   color: $ms-color-themePrimary;
 
   .selected & {


### PR DESCRIPTION
### Overview

This change fixes the visibility of text descenders in the nameplate of the `Tile` component.
Descenders such as 'g' were being cut off, which is not ideal.
This change switches the layout within the regions to use flexbox for vertical alignment, and uses negative margins and larger heights to provide clearance for the `New` signal's "glimmer" effect while preserving ellipsis overflow.