### PR TITLE
Contextual Menu: Fix typings for getMenuClassNames

### DIFF
--- a/common/changes/office-ui-fabric-react/className-typing_2017-10-11-01-05.json
+++ b/common/changes/office-ui-fabric-react/className-typing_2017-10-11-01-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Update the typing for getMenuClassNames",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -201,7 +201,7 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * defined in ContextualMenu.classnames.
    * @default getContextualMenuClassNames
    */
-  getMenuClassNames?: (theme: ITheme, className: string) => IContextualMenuClassNames;
+  getMenuClassNames?: (theme: ITheme, className?: string) => IContextualMenuClassNames;
 
   /**
   * Method to provide the classnames to style the individual items inside a menu. Default value is the getItemClassnames func

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -22,7 +22,7 @@ export interface IMenuItemClassNames {
 
 export const getContextualMenuClassNames = memoizeFunction((
   theme: ITheme,
-  className: string
+  className?: string
 ): IContextualMenuClassNames => {
 
   const styles = getContextualMenuStyles(theme);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -202,7 +202,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     } = this.props;
 
     let menuClassNames = this.props.getMenuClassNames ? this.props.getMenuClassNames : getContextualMenuClassNames;
-    this._classNames = menuClassNames(theme!, className!);
+    this._classNames = menuClassNames(theme!, className);
 
     let hasIcons = itemsHaveIcons(items);
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
ClassNames is an optional prop, the typings should reflect that instead of assuming that it is always defined. 