### PR TITLE
OverflowSet: Add focusZoneProps and the ability to set role for OverflowSet

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-AddFocusZonePropsToOverflowSet_2017-10-11-02-01.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-AddFocusZonePropsToOverflowSet_2017-10-11-02-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "OverflowSet: Add FocusZoneProps and the ability to set the role",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.Props.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { OverflowSet } from './OverflowSet';
 import { IRenderFunction } from '../../Utilities';
+import { IFocusZoneProps } from '../../FocusZone';
 
 export interface IOverflowSet {
   /**
@@ -40,6 +41,17 @@ export interface IOverflowSetProps extends React.Props<OverflowSet> {
    * the overflowItems passed in as props to this function.
   */
   onRenderOverflowButton: IRenderFunction<any[]>;
+
+  /**
+   * Custom properties for OverflowSet's FocusZone.
+   */
+  focusZoneProps?: IFocusZoneProps;
+
+  /**
+   * The role for the OverflowSet.
+   * @default 'menubar'
+   */
+  role?: string;
 }
 
 export interface IOverflowSetItemProps {

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -19,15 +19,18 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
       items,
       overflowItems,
       onRenderOverflowButton,
-      className
+      className,
+      focusZoneProps,
+      role = 'menubar'
     } = this.props;
 
     return (
       <FocusZone
+        { ...focusZoneProps }
         componentRef={ this._resolveRef('_focusZone') }
         className={ css('ms-OverflowSet', styles.root, className) }
         direction={ FocusZoneDirection.horizontal }
-        role='menubar'
+        role={ role }
       >
         { items && this._onRenderItems(items) }
         { overflowItems && overflowItems.length > 0 && onRenderOverflowButton(overflowItems) }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Currently there's no way to provide props specifically for the FocusZone that's contained within the OverflowSet, this change fixes that.

Also users of OverflowSet may have it in a context where menubar does not make sense (when it is represented as a tablist, for example). I'm adding the ability to specify a different role, if needed
