### PR TITLE
Contextual Menu: Move getItemClassNames from ContextualMenuProps to IContextualMenuItem

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-ContextualMenu_2017-10-11-05-19.json
+++ b/common/changes/office-ui-fabric-react/malozano-ContextualMenu_2017-10-11-05-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "\"Move getItemClassnNames forontextualMenuProps to IContextualMenuItem\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -203,22 +203,6 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    */
   getMenuClassNames?: (theme: ITheme, className: string) => IContextualMenuClassNames;
 
-  /**
-  * Method to provide the classnames to style the individual items inside a menu. Default value is the getItemClassnames func
-  * defined in ContextualMenu.classnames.
-  * @default getItemClassNames
-  */
-  getItemClassNames?: (theme: ITheme,
-    disabled: boolean,
-    expanded: boolean,
-    checked: boolean,
-    isAnchorLink: boolean,
-    knownIcon: boolean,
-    itemClassname: string,
-    dividerClassName: string,
-    iconClassname: string,
-    subMenuClassname: string) => IMenuItemClassNames;
-
   /** Method to call when trying to render a submenu. */
   onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
 }
@@ -320,6 +304,22 @@ export interface IContextualMenuItem {
    *  can be overridden.
    */
   subMenuProps?: IContextualMenuProps;
+
+  /**
+  * Method to provide the classnames to style the individual items inside a menu. Default value is the getItemClassnames func
+  * defined in ContextualMenu.classnames.
+  * @default getItemClassNames
+  */
+  getItemClassNames?: (theme: ITheme,
+    disabled: boolean,
+    expanded: boolean,
+    checked: boolean,
+    isAnchorLink: boolean,
+    knownIcon: boolean,
+    itemClassname: string,
+    dividerClassName: string,
+    iconClassname: string,
+    subMenuClassname: string) => IMenuItemClassNames;
 
   /**
    *  Properties to apply to render this item as a section.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -316,10 +316,10 @@ export interface IContextualMenuItem {
     checked: boolean,
     isAnchorLink: boolean,
     knownIcon: boolean,
-    itemClassname: string,
+    itemClassName: string,
     dividerClassName: string,
-    iconClassname: string,
-    subMenuClassname: string) => IMenuItemClassNames;
+    iconClassName: string,
+    subMenuClassName: string) => IMenuItemClassNames;
 
   /**
    *  Properties to apply to render this item as a section.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -105,7 +105,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     beakWidth: 16,
     arrowDirection: FocusZoneDirection.vertical,
     getMenuClassNames: getContextualMenuClassNames,
-    getItemClassNames: getItemClassNames,
   };
 
   private _host: HTMLElement;
@@ -309,7 +308,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     // We only send a dividerClassName when the item to be rendered is a divider. For all other cases, the default divider style is used.
     let dividerClassName = item.itemType === ContextualMenuItemType.Divider ? item.className : undefined;
     let subMenuIconClassName = item.submenuIconProps ? item.submenuIconProps.className : '';
-    let getClassNames = this.props.getItemClassNames ? this.props.getItemClassNames : getItemClassNames;
+    let getClassNames = item.getItemClassNames ? item.getItemClassNames : getItemClassNames;
     let itemClassNames = getClassNames(
       this.props.theme!,
       !!item.disabled,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

With the change to javascript styling, getItemClassNames function was added as a prop to ContextualMenuProps to retrieve either default or user provided styles for menu items. By having getItemClassNames live in ContextualMenuProps, the ability to provide different classnames per item in a ContextualMenu is blocked.

By moving getItemClassNames to be inside IContextualMenuItem instead, we are giving developers the ability to provide different classnames per menu item.

