### PR TITLE
Dropdown: add onDismiss callback

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-ondismiss_2017-10-11-07-42.json
+++ b/common/changes/office-ui-fabric-react/dropdown-ondismiss_2017-10-11-07-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: add onDismiss callback. Example multi select dropdown with filters, we want to apply filters after user has dismissed the dropdown. ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jchiarino@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.Props.ts
@@ -21,6 +21,11 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<HTMLDivEle
   onChanged?: (option: IDropdownOption, index?: number) => void;
 
   /**
+   * Callback issues when the options callout is dismissed
+   */
+  onDismiss?: () => void;
+
+  /**
    * Optional custom renderer for placeholder text
    */
   onRenderPlaceHolder?: IRenderFunction<IDropdownProps>;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -219,6 +219,35 @@ describe('Dropdown', () => {
       }
     });
 
+    it('issues the onDismiss callback when dismissing options callout', () => {
+      let container = document.createElement('div');
+      let dropdownRoot: HTMLElement | undefined;
+
+      document.body.appendChild(container);
+
+      let onDismissSpy = jasmine.createSpy('onDismiss');
+
+      try {
+        ReactDOM.render(
+          <Dropdown
+            label='testgroup'
+            defaultSelectedKey='1'
+            onDismiss={ onDismissSpy }
+            options={ DEFAULT_OPTIONS }
+          />,
+          container);
+        dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+        ReactTestUtils.Simulate.click(dropdownRoot);
+
+        let secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="2"]') as HTMLElement;
+        ReactTestUtils.Simulate.click(secondItemElement);
+      }
+      finally {
+        expect(onDismissSpy).toHaveBeenCalledTimes(1);
+      }
+    });
+
     it('issues the onChanged callback when the selected item is different', () => {
       let container = document.createElement('div');
       let dropdownRoot: HTMLElement | undefined;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -198,7 +198,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           </span>
         </div>
         { isOpen && (
-          onRenderContainer(this.props, this._onRenderContainer, this._onRenderList)
+          onRenderContainer(this.props, this._onRenderContainer)
         ) }
         {
           errorMessage &&
@@ -349,7 +349,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             onDismissed={ this._onDismiss }
             hasCloseButton={ false }
           >
-            { onRenderList(props, this._onRenderList, this._onRenderItem) }
+            { onRenderList(props, this._onRenderList) }
           </Panel>
         )
         :
@@ -367,7 +367,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             onPositioned={ this._onPositioned }
             calloutWidth={ dropdownWidth || this._dropDown.clientWidth }
           >
-            { onRenderList(props, this._onRenderList, this._onRenderItem) }
+            { onRenderList(props, this._onRenderList) }
           </Callout>
         )
     );

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -109,6 +109,10 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   public componentDidUpdate(prevProps: IDropdownProps, prevState: IDropdownState) {
     if (prevState.isOpen === true && this.state.isOpen === false) {
       this._dropDown.focus();
+
+      if (this.props.onDismiss) {
+        this.props.onDismiss();
+      }
     }
   }
 
@@ -194,7 +198,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
           </span>
         </div>
         { isOpen && (
-          onRenderContainer(this.props, this._onRenderContainer)
+          onRenderContainer(this.props, this._onRenderContainer, this._onRenderList)
         ) }
         {
           errorMessage &&
@@ -345,7 +349,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             onDismissed={ this._onDismiss }
             hasCloseButton={ false }
           >
-            { onRenderList(props, this._onRenderList) }
+            { onRenderList(props, this._onRenderList, this._onRenderItem) }
           </Panel>
         )
         :
@@ -363,7 +367,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             onPositioned={ this._onPositioned }
             calloutWidth={ dropdownWidth || this._dropDown.clientWidth }
           >
-            { onRenderList(props, this._onRenderList) }
+            { onRenderList(props, this._onRenderList, this._onRenderItem) }
           </Callout>
         )
     );


### PR DESCRIPTION
#### Description of changes

Dropdown: add onDismiss callback. Example usage: multi select dropdown with filters, we want to apply filters after user has dismissed the dropdown.
