### PR TITLE
Tooltip: pass calloutProps.className to Callout

### DIFF
--- a/common/changes/office-ui-fabric-react/patch_2017-10-12-13-32.json
+++ b/common/changes/office-ui-fabric-react/patch_2017-10-12-13-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltip: pass calloutProps.className to Callout",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "ambar.lee@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
@@ -55,6 +55,7 @@ export class Tooltip extends BaseComponent<ITooltipProps, any> {
           styles.root,
           (delay === TooltipDelay.medium) && styles.hasMediumDelay,
           (maxWidth !== null) && { maxWidth: maxWidth },
+          calloutProps ? calloutProps.className : undefined,
           this.props.className
         ) }
       >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Pass `calloutProps.className` to Callout

#### Focus areas to test

```css
<TooltipHost
  calloutProps={{className: styles.callout}} 
...

```