### PR TITLE
vr-test: Fix SpinButton story

### DIFF
--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -10,7 +10,7 @@ let props = {
   defaultValue: '0',
   label: 'Basic SpinButton:',
   min: 0,
-  max: 100,
+  max: 0,
   step: 1
 };
 


### PR DESCRIPTION
Give SpinButton story min and max of 0 to prevent visual regression errors caused by value changes on mousedown