### PR TITLE
Callout: Update typings on target prop to make it compatible with react refs

### DIFF
--- a/common/changes/office-ui-fabric-react/callout-target-type_2017-10-12-20-11.json
+++ b/common/changes/office-ui-fabric-react/callout-target-type_2017-10-12-20-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout: Update the typings on the target prop to make it compatible with React refs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -23,7 +23,7 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
    * It can be either an HTMLElement a querySelector string of a valid HTMLElement
    * or a MouseEvent. If MouseEvent is given then the origin point of the event will be used.
    */
-  target?: HTMLElement | string | MouseEvent;
+  target?: HTMLElement | string | MouseEvent | null;
 
   /**
    * How the element should be positioned

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Basic.Example.tsx
@@ -9,7 +9,7 @@ export interface ICalloutBaiscExampleState {
 }
 
 export class CalloutBasicExample extends React.Component<any, ICalloutBaiscExampleState> {
-  private _menuButtonElement: HTMLElement;
+  private _menuButtonElement: HTMLElement | null;
 
   public constructor() {
     super();
@@ -27,7 +27,7 @@ export class CalloutBasicExample extends React.Component<any, ICalloutBaiscExamp
 
     return (
       <div className='ms-CalloutExample'>
-        <div className='ms-CalloutBasicExample-buttonArea' ref={ (menuButton) => this._menuButtonElement = menuButton! }>
+        <div className='ms-CalloutBasicExample-buttonArea' ref={ (menuButton) => this._menuButtonElement = menuButton }>
           <DefaultButton
             onClick={ this._onShowMenuClicked }
             text={ isCalloutVisible ? 'Hide callout' : 'Show callout' }

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Cover.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Cover.Example.tsx
@@ -27,7 +27,7 @@ const DIRECTION_OPTIONS = [
 ];
 
 export class CalloutCoverExample extends React.Component<any, ICalloutCoverExampleState> {
-  private _menuButtonElement: HTMLElement;
+  private _menuButtonElement: HTMLElement | null;
 
   public constructor() {
     super();
@@ -55,7 +55,7 @@ export class CalloutCoverExample extends React.Component<any, ICalloutCoverExamp
             onChanged={ this._onDirectionalChanged }
           />
         </div>
-        <div className='ms-CalloutCoverExample-buttonArea' ref={ (menuButton) => this._menuButtonElement = menuButton! }>
+        <div className='ms-CalloutCoverExample-buttonArea' ref={ (menuButton) => this._menuButtonElement = menuButton }>
           <DefaultButton
             text={ isCalloutVisible ? 'Hide callout' : 'Show callout' }
             onClick={ this._onShowMenuClicked }

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Directional.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Directional.Example.tsx
@@ -36,7 +36,7 @@ const DIRECTION_OPTIONS = [
 ];
 
 export class CalloutDirectionalExample extends React.Component<any, ICalloutDirectionalExampleState> {
-  private _menuButtonElement: HTMLElement;
+  private _menuButtonElement: HTMLElement | null;
   public constructor() {
     super();
 
@@ -81,7 +81,7 @@ export class CalloutDirectionalExample extends React.Component<any, ICalloutDire
             onChanged={ this._onDirectionalChanged }
           />
         </div>
-        <div className='ms-CalloutExample-buttonArea' ref={ (menuButton) => this._menuButtonElement = menuButton! }>
+        <div className='ms-CalloutExample-buttonArea' ref={ (menuButton) => this._menuButtonElement = menuButton }>
           <DefaultButton
             className={ 'calloutExampleButton' }
             onClick={ this._onShowMenuClicked }

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Nested.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Nested.Example.tsx
@@ -9,7 +9,7 @@ export interface ICalloutBaiscExampleState {
 }
 
 export class CalloutNestedExample extends React.Component<any, ICalloutBaiscExampleState> {
-  private _menuButtonElement: HTMLElement;
+  private _menuButtonElement: HTMLElement | null;
 
   public constructor() {
     super();
@@ -26,7 +26,7 @@ export class CalloutNestedExample extends React.Component<any, ICalloutBaiscExam
 
     return (
       <div className='ms-CalloutExample'>
-        <div className='ms-CalloutBasicExample-buttonArea' ref={ (menuButton) => this._menuButtonElement = menuButton! }>
+        <div className='ms-CalloutBasicExample-buttonArea' ref={ (menuButton) => this._menuButtonElement = menuButton }>
           <DefaultButton
             onClick={ this._onDismiss }
             text={ isCalloutVisible ? 'Hide callout' : 'Show callout' }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -38,7 +38,7 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * It can be either an HTMLElement a querySelector string of a valid HTMLElement
    * or a MouseEvent. If MouseEvent is given then the origin point of the event will be used.
    */
-  target?: HTMLElement | string | MouseEvent;
+  target?: HTMLElement | string | MouseEvent | null;
 
   /**
    * How the element should be positioned


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Often times, the target passed to a callout or contextual menu is obtained using a React ref. The typings on a ref are typically HTMLElement | null. Currently, null cannot be passed to target, which has resulted in some usages of the ! operator to get around strict null checks in the callout demo page. 