### PR TITLE
ContextualMenu: Make it possible for menu items using onRender to dismiss the menu

### DIFF
--- a/common/changes/office-ui-fabric-react/onDismissRenderParam_2017-10-12-23-26.json
+++ b/common/changes/office-ui-fabric-react/onDismissRenderParam_2017-10-12-23-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Pass in a menu dismiss function into onRender to allow custom rendered menu items to dismiss the menu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/experiments/src/components/CommandBar/CommandBar.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.tsx
@@ -183,7 +183,11 @@ export class CommandBar extends BaseComponent<ICommandBarProps, {}> implements I
   private _onRenderItems(item: ICommandBarItemProps): JSX.Element | React.ReactNode {
     let { buttonStyles } = this.props;
 
-    if (item.onRender) { return item.onRender(item); }
+    if (item.onRender) {
+      // These are the top level items, there is no relevant menu dismissing function to
+      // provide for the IContextualMenuItem onRender function. Pass in a no op function instead.
+      return item.onRender(item, () => undefined);
+    }
     const commandButtonProps: ICommandBarItemProps = {
       ...item,
       styles: { root: { height: COMMANDBAR_HEIGHT }, ...item.styles, ...buttonStyles },

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -166,7 +166,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     if (item.onRender) {
       return (
         <div className={ css('ms-CommandBarItem', styles.item, item.className) } key={ item.key } ref={ item.key }>
-          { item.onRender(item) }
+          { item.onRender(item, this._onContextMenuDismiss) }
         </div>
       );
     }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -354,9 +354,12 @@ export interface IContextualMenuItem {
    * Method to custom render this menu item.
    * For keyboard accessibility, the top-level rendered item should be a focusable element
    * (like an anchor or a button) or have the `data-is-focusable` property set to true.
+   *
+   * The function receives a function that can be called to dismiss the menu as a second argument.
+   *  This can be used to make sure that a custom menu item click dismisses the menu.
    * @defaultvalue undefined
    */
-  onRender?: (item: any) => React.ReactNode;
+  onRender?: (item: any, onDismiss: (ev?: any, dismissAll?: boolean) => void) => React.ReactNode;
 
   /**
    * A function to be executed onMouseDown. This is executed before an onClick event and can

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -359,7 +359,7 @@ export interface IContextualMenuItem {
    *  This can be used to make sure that a custom menu item click dismisses the menu.
    * @defaultvalue undefined
    */
-  onRender?: (item: any, onDismiss: (ev?: any, dismissAll?: boolean) => void) => React.ReactNode;
+  onRender?: (item: any, dismissMenu: (ev?: any, dismissAll?: boolean) => void) => React.ReactNode;
 
   /**
    * A function to be executed onMouseDown. This is executed before an onClick event and can

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -411,7 +411,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderNormalItem(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {
     if (item.onRender) {
-      return [item.onRender(item)];
+      return [item.onRender(item, this.dismiss)];
     }
     if (item.href) {
       return this._renderAnchorMenuItem(item, classNames, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
@@ -6,13 +6,9 @@ import { autobind } from 'office-ui-fabric-react/lib/Utilities';
 import './ContextualMenuExample.scss';
 
 export class ContextualMenuCustomizationExample extends React.Component<{}, {}> {
-  private _button: IButton | undefined;
-
   public render() {
     return (
       <DefaultButton
-        // tslint:disable-next-line:jsx-no-lambda
-        componentRef={ (button) => this._button = button }
         className='ContextualMenuButton3'
         text='Click for ContextualMenu'
         menuProps={
@@ -192,20 +188,13 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
   }
 
   @autobind
-  private _dismissMenu() {
-    if (this._button) {
-      this._button.dismissMenu();
-    }
-  }
-
-  @autobind
-  private _renderCharmMenuItem(item: any) {
+  private _renderCharmMenuItem(item: any, onDismiss: () => void) {
     return (
       <IconButton
         iconProps={ { iconName: item.name } }
         className='ms-ContextualMenu-customizationExample-icon ms-ContextualMenu-link'
         data-is-focusable={ true }
-        onClick={ this._dismissMenu }
+        onClick={ onDismiss }
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
@@ -188,13 +188,13 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
   }
 
   @autobind
-  private _renderCharmMenuItem(item: any, onDismiss: () => void) {
+  private _renderCharmMenuItem(item: any, dismissMenu: () => void) {
     return (
       <IconButton
         iconProps={ { iconName: item.name } }
         className='ms-ContextualMenu-customizationExample-icon ms-ContextualMenu-link'
         data-is-focusable={ true }
-        onClick={ onDismiss }
+        onClick={ dismissMenu }
       />
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x ] Include a change request file using `$ npm run change`

#### Description of changes
The primary customization hook for menu item customization is the "onRender" property on IContextualMenuItem. This is often used for rendering custom control types within the menu. Often times, developers want their custom menu items to dismiss the menu when they are clicked. This PR provides a mechanism to do this by adding a new parameter to be passed to consumers of onRender. This parameter is a function that can be bound to a click handler to dismiss the menu. 

