### PR TITLE
Adding merge-styles attribute

### DIFF
--- a/common/changes/@uifabric/merge-styles/adding-merge-styles-attr_2017-10-12-23-36.json
+++ b/common/changes/@uifabric/merge-styles/adding-merge-styles-attr_2017-10-12-23-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Adding data-merge-styles attribute to the style element so that it can be uniquely identified.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -197,6 +197,7 @@ export class Stylesheet {
   private _getElement(): HTMLStyleElement | undefined {
     if (!this._styleElement && typeof document !== 'undefined') {
       this._styleElement = document.createElement('style');
+      this._styleElement.setAttribute('data-merge-styles', 'true');
       document.head.appendChild(this._styleElement);
     }
 


### PR DESCRIPTION
In some cases we want to identify the style element being created by merge-styles. Adding `data-merge-styles=true` attribute.