### PR TITLE
getColorFromString: insure callers handle undefined case

### DIFF
--- a/common/changes/office-ui-fabric-react/phkuo-colorPicker_2017-10-13-00-56.json
+++ b/common/changes/office-ui-fabric-react/phkuo-colorPicker_2017-10-13-00-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Colors Utility: add error checking if an invalid string is given",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -163,7 +163,11 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
     }));
   }
 
-  private _updateColor(newColor: IColor) {
+  private _updateColor(newColor?: IColor) {
+    if (!newColor) {
+      return;
+    }
+
     let { onColorChanged } = this.props;
 
     if (newColor.str !== this.state.color.str) {

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -178,7 +178,7 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
   private _onRenderColorOption(colorOption: IColorCellProps): JSX.Element {
     // Build an SVG for the cell with the given shape and color properties
     return (
-      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '') } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string).str } >
+      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '') } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
         {
           this.props.cellShape === 'circle' ?
             <circle cx='50%' cy='50%' r='50%' /> :

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.ts
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.ts
@@ -36,7 +36,10 @@ export class ThemeGenerator {
     if (overwriteCustomColor) {
       let colorAsIColor: IColor;
       if (typeof color === 'string') {
-        colorAsIColor = getColorFromString(color);
+        colorAsIColor = getColorFromString(color)!; // the ! is a lie here but we'll verify it in the next line
+        if (!colorAsIColor) {
+          throw 'color is invalid in setSlot(): ' + color;
+        }
       } else {
         colorAsIColor = color;
       }

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
@@ -297,7 +297,7 @@ export class ThemeGeneratorPage extends React.Component<any, IThemeGeneratorPage
 
       let { themeRules } = this.state;
       const bgColor = getHexFromColor(response.color.dominantColorBackground, true);
-      const bgColorIsDark = isDark(getColorFromString(bgColor));
+      const bgColorIsDark = isDark(getColorFromString(bgColor)!);
       ThemeGenerator.setSlot(
         themeRules[BaseSlots[BaseSlots.backgroundColor]],
         bgColor,

--- a/packages/office-ui-fabric-react/src/utilities/color/colors.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/colors.ts
@@ -24,7 +24,7 @@ export interface IColor extends IRGB, IHSV {
   str: string;
 }
 
-export function cssColor(color: string): IRGB {
+export function cssColor(color: string): IRGB | undefined {
   return (_named(color)
     || _hex3(color)
     || _hex6(color)
@@ -155,8 +155,14 @@ export function hsv2rgb(h: number, s: number, v: number): IRGB {
   };
 }
 
-export function getColorFromString(color: string): IColor {
-  let { a, b, g, r } = cssColor(color);
+export function getColorFromString(inputColor: string): IColor | undefined {
+  let color = cssColor(inputColor);
+
+  if (!color) {
+    return;
+  }
+
+  let { a, b, g, r } = color;
   let { h, s, v } = rgb2hsv(r, g, b);
 
   return {
@@ -167,7 +173,7 @@ export function getColorFromString(color: string): IColor {
     hex: rgb2hex(r, g, b),
     r: r,
     s: s,
-    str: color,
+    str: inputColor,
     v: v
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3079 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

getColorFromString() can return nothing, make sure the places calling this are aware of that and handle that case.

#### Focus areas to test

(optional)
