### PR TITLE
Dropdown: now with less crash

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-dropdown_2017-10-16-17-38.json
+++ b/common/changes/office-ui-fabric-react/fix-dropdown_2017-10-16-17-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Fixing nullref when nothing is selected in multi select rendering.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -559,8 +559,8 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
     for (let index of selectedIndices) {
       const option = options[index];
 
-      if (options) {
-        selectedOptions.push(options[index]);
+      if (option) {
+        selectedOptions.push(option);
       }
     }
     if (selectedOptions.length < 1) {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -557,7 +557,11 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   private _getAllSelectedOptions(options: IDropdownOption[], selectedIndices: number[]) {
     let selectedOptions: IDropdownOption[] = [];
     for (let index of selectedIndices) {
-      selectedOptions.push(options[index]);
+      const option = options[index];
+
+      if (options) {
+        selectedOptions.push(options[index]);
+      }
     }
     if (selectedOptions.length < 1) {
       return [];

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -563,9 +563,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
         selectedOptions.push(option);
       }
     }
-    if (selectedOptions.length < 1) {
-      return [];
-    }
+
     return selectedOptions;
   }
 


### PR DESCRIPTION
It seems that there is a nullref occurring in `_onRenderTitle` when no items are selected. Addressing this.