### PR TITLE
SearchBox: Expose onKeyDown Event by invoking an external prop

### DIFF
--- a/common/changes/office-ui-fabric-react/cicciodm-searchBox-onKeyDown_2017-10-16-21-18.json
+++ b/common/changes/office-ui-fabric-react/cicciodm-searchBox-onKeyDown_2017-10-16-21-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SearchBox: expose onKeyDown event by invoking external prop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "f.dimauro92@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -145,7 +145,11 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
         break;
 
       default:
-        return;
+        if (this.props.onKeyDown) {
+          this.props.onKeyDown(ev);
+        } else {
+          return;
+        }
     }
 
     // We only get here if the keypress has been handled.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Fixes issue shown in [this CodePen](https://codepen.io/anon/pen/OxapJV)

If an `onKeyDown` function is passed to the SearchBox, invoke the function if the pressed key is not Enter or Escape.

#### Focus areas to test

In one of the example SearchBoxes, add an `onKeyDown` prop, and verify that it is correctly invoked.
