### PR TITLE
Website: Updates to links for license and branding guidance + link styling fixes

### DIFF
--- a/apps/fabric-website/README.md
+++ b/apps/fabric-website/README.md
@@ -19,7 +19,7 @@ Before you get started, make sure you have [node.js](https://nodejs.org/), [gulp
 
 All files on the Office UI Fabric React GitHub repository are subject to the MIT license. Please read the License file at the root of the project.
 
-Usage of the fonts referenced in Office UI Fabric files is subject to the [license](https://spoprod-a.akamaihd.net/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf).
+Usage of the fonts referenced in Office UI Fabric files is subject to the [license](https://spoprod-a.akamaihd.net/files/fabric/assets/microsoft_fabric_assets_license_agreement_v2_09262017.pdf).
 
 - - -
 

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -206,7 +206,7 @@ initializeIcons('https://my.cdn.com/path/to/icons/');`
           <h3>Need an icon or feature Fabric Core doesn&rsquo;t have?</h3>
           <p>First, check the <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>Fabric React issue queue</a> or <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/projects'>projects</a> to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the component you're looking for, please <a className={ styles.getStartedLink } href='https://github.com/OfficeDev/office-ui-fabric-react/issues'>file an issue in the repo</a>, and we'll respond if it's being built or on our radar.</p>
 
-          <p className={ styles.trademark }>Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.getStartedLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement</a>.</p>
+          <p className={ styles.trademark }>Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.getStartedLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_v2_09262017.pdf'>assets license agreement</a>.</p>
         </div>
 
       </div>

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -81,7 +81,7 @@ export class HomePage extends React.Component<any, any> {
               </a>
             </li>
           </ul>
-          <span className={ styles.trademark }>All trademarks are the property of their respective owners. Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.homePageLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement</a>.</span>
+          <span className={ styles.trademark }>All trademarks are the property of their respective owners. Usage of Fabric assets, such as fonts and icons, is subject to the <a className={ styles.homePageLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_v2_09262017.pdf'>assets license agreement</a>.</span>
           <span className={ styles.featuredTitle }>Design Toolkit</span>
           <span className={ styles.featuredDescription } id={ styles.toolkitDescription }>The Fabric design toolkit is built with Adobe XD and provides controls and layout templates that enable you to create seamless, beautiful Office experiences. <a className={ styles.homePageLink } href='#/resources'>Learn more</a></span>
         </div>

--- a/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.module.scss
+++ b/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.module.scss
@@ -52,6 +52,10 @@
   }
 }
 
+.brandIconsPage .brandIconsPageLink {
+  color: $ms-color-themePrimary;
+}
+
 @media screen and (min-width: $uhf-screen-min-mobile) {
   .iconList {
     li {

--- a/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { CodeBlock } from '../../../components/CodeBlock/CodeBlock';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 import { Table } from '../../../components/Table/Table';
 import { IconGrid } from '../../../components/IconGrid/IconGrid';
@@ -19,7 +20,7 @@ export class BrandIconsPage extends React.Component<any, any> {
     let documentIcons = documentIconsData;
 
     return (
-      <div className={ pageStyles.basePage }>
+      <div className={ css(pageStyles.basePage, styles.brandIconsPage) }>
         <PageHeader
           pageTitle='Office brand icons'
           links={
@@ -52,7 +53,7 @@ export class BrandIconsPage extends React.Component<any, any> {
         <div className={ pageStyles.u_maxTextWidth }>
           <h2 id='overview'>Overview</h2>
           <p>Fabric includes product and document icons that you can use to connect your experience with other Office and Office 365 endpoints. The icons come in three formats &mdash; SVG and PNG for multicolor and the icon font for monochrome &mdash; in a variety of sizes and resolutions.</p>
-          <p>Usage of these icons is subject to the <a href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement (PDF)</a> and our <a href={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/files/office_marketing_guidelines.pdf' }>brand guidelines (PDF)</a>. Please read this document and the resolution/size guidance carefully to ensure that you use our branded icons correctly to create the best experience.</p>
+          <p>Usage of these icons is subject to the <a className={ styles.brandIconsPageLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement (PDF)</a>. Please read this document and the resolution/size guidance carefully to ensure that you use our branded icons correctly to create the best experience.</p>
         </div>
         <h3>Product icons</h3>
         <div className='ms-Grid ms-Grid--wide'>
@@ -105,7 +106,7 @@ export class BrandIconsPage extends React.Component<any, any> {
               <p className={ styles.paragraphInGrid }>Multicolor product and document icons look best at 16x16, 48x48, and 96x96 px sizes in the UI of Microsoft products. Fabric provides these icons in both SVG and PNG formats. SVGs are more versatile but are not supported by all browsers. PNGs are supported by most browsers, but require many sizes to remain visually crisp.</p>
               <p className={ styles.paragraphInGrid }>PNGs come in 16x16, 32x32, 48x48, and 96x96 pixel sizes. Where possible, use the default sizes to prevent artifacts and split pixels. Otherwise, use a size that is close to one of the default sizes.</p>
               <p className={ styles.paragraphInGrid }>Because SVGs are vectors, you can resize them more easily. They come in two sizes: 16x16 and 48x48 px. Use the size that most closely maps to what you need for your experience for the best quality.</p>
-              <p className={ styles.paragraphInGrid }>Monochrome product icons that are included in the icon font are subject to the branding guidelines, but you can reference them just like other icons noted in the <a href='#/styles/icons'>icons section</a>.</p>
+              <p className={ styles.paragraphInGrid }>Monochrome product icons that are included in the icon font are subject to the branding guidelines, but you can reference them just like other icons noted in the <a className={ styles.brandIconsPageLink } href='#/styles/icons'>icons section</a>.</p>
             </div>
             <div className='ms-Grid-col ms-sm12 ms-lg6'>
               <ul className={ styles.exampleIcons }>
@@ -242,7 +243,7 @@ https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/pn
         </ul>
 
         <h3>Single-color icons</h3>
-        <p>Fabric&rsquo;s <a href='#/styles/icons'>icon set</a> also contains single-color product and document icons. You use these single-color icons like all other icons in Fabric. For more information, see the <a href='#/styles/icons'>icons page</a> or the following example:</p>
+        <p>Fabric&rsquo;s <a className={ styles.brandIconsPageLink } href='#/styles/icons'>icon set</a> also contains single-color product and document icons. You use these single-color icons like all other icons in Fabric. For more information, see the <a className={ styles.brandIconsPageLink } href='#/styles/icons'>icons page</a> or the following example:</p>
         <CodeBlock language='html' isLightTheme={ true }>
           {
             `<i class="ms-Icon ms-Icon--AccessLogo" aria-hidden="true"></i>`

--- a/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/BrandIconsPage/BrandIconsPage.tsx
@@ -53,7 +53,7 @@ export class BrandIconsPage extends React.Component<any, any> {
         <div className={ pageStyles.u_maxTextWidth }>
           <h2 id='overview'>Overview</h2>
           <p>Fabric includes product and document icons that you can use to connect your experience with other Office and Office 365 endpoints. The icons come in three formats &mdash; SVG and PNG for multicolor and the icon font for monochrome &mdash; in a variety of sizes and resolutions.</p>
-          <p>Usage of these icons is subject to the <a className={ styles.brandIconsPageLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_sept092017.pdf'>assets license agreement (PDF)</a>. Please read this document and the resolution/size guidance carefully to ensure that you use our branded icons correctly to create the best experience.</p>
+          <p>Usage of these icons is subject to the <a className={ styles.brandIconsPageLink } href='https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_v2_09262017.pdf'>assets license agreement (PDF)</a>. Please read this document and the resolution/size guidance carefully to ensure that you use our branded icons correctly to create the best experience.</p>
         </div>
         <h3>Product icons</h3>
         <div className='ms-Grid ms-Grid--wide'>

--- a/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.module.scss
+++ b/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.module.scss
@@ -4,6 +4,10 @@
   @include ms-padding-left($contentInGrid);
 }
 
+.overview .colorsPageLink {
+  color: $ms-color-themePrimary;
+}
+
 // XL and up
 @media screen and (min-width: $ms-screen-min-xl) {
   .accentGroup {

--- a/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/ColorsPage/ColorsPage.tsx
@@ -36,9 +36,9 @@ export class ColorsPage extends React.Component<any, any> {
           }
           backgroundColor='#006f94'
         />
-        <div className={ pageStyles.u_maxTextWidth }>
+        <div className={ css(pageStyles.u_maxTextWidth, styles.overview) }>
           <h2 id='Overview'>Overview</h2>
-          <p>Fabric includes 9 theme colors and 11 neutral colors. Each has helper classes for text, background, border, and hover states. When selecting colors, refer to the <a href={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf' }>color accessibility guidance (PDF)</a> to ensure that your text can be ready by everyone.</p>
+          <p>Fabric includes 9 theme colors and 11 neutral colors. Each has helper classes for text, background, border, and hover states. When selecting colors, refer to the <a className={ styles.colorsPageLink } href={ 'https://static2.sharepointonline.com/files/fabric/fabric-website/files/coloraccessibility_29sep2016.pdf' }>color accessibility guidance (PDF)</a> to ensure that your text can be ready by everyone.</p>
         </div>
         <h2 id='implementation'>Implementation</h2>
         <p>Colors can be applied to text, backgrounds, or borders using the following class name conventions:</p>

--- a/apps/fabric-website/src/pages/Styles/IconsPage/IconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/IconsPage/IconsPage.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { CodeBlock } from '../../../components/CodeBlock/CodeBlock';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { IconGrid } from '../../../components/IconGrid/IconGrid';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
+import * as stylesImport from './IconsPage.module.scss';
+const styles: any = stylesImport;
 const pageStyles: any = require('../../PageStyles.module.scss');
 
 const iconData = require('../../../../node_modules/office-ui-fabric-core/src/data/icons.json');
@@ -9,7 +12,7 @@ const iconData = require('../../../../node_modules/office-ui-fabric-core/src/dat
 export class IconsPage extends React.Component<any, any> {
   public render() {
     return (
-      <div className={ pageStyles.basePage }>
+      <div className={ css(pageStyles.basePage, styles.iconsPage) }>
         <PageHeader
           pageTitle='Icons'
           links={
@@ -37,10 +40,10 @@ export class IconsPage extends React.Component<any, any> {
           }
         </CodeBlock>
         <div className={ pageStyles.u_maxTextWidth }>
-          <p>Note the <code>aria-hidden</code> attribute, which prevents screen readers from reading the icon. In cases where meaning is conveyed only through the icon, such as an icon-only navigation bar, use the <a href='https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute'><code>aria-label</code> attribute</a> on the button for accessibility.</p>
+          <p>Note the <code>aria-hidden</code> attribute, which prevents screen readers from reading the icon. In cases where meaning is conveyed only through the icon, such as an icon-only navigation bar, use the <a className={ styles.iconsPageLink } href='https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute'><code>aria-label</code> attribute</a> on the button for accessibility.</p>
         </div>
 
-        <strong>See the <a href='#/styles/brand-icons'>brand icons page</a> for multi-color product and document icons.</strong>
+        <strong>See the <a className={ styles.iconsPageLink } href='#/styles/brand-icons'>brand icons page</a> for multi-color product and document icons.</strong>
 
         <h2 id='icons'>Icons</h2>
 

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/TypographyPage.module.scss
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/TypographyPage.module.scss
@@ -1,5 +1,5 @@
 @import '../../../styles/variables';
 
-.iconsPage .iconsPageLink {
+.typographyPage .typographyPageLink {
   color: $ms-color-themePrimary;
 }

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/TypographyPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/TypographyPage.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { PageHeader } from '../../../components/PageHeader/PageHeader';
 import { Table } from '../../../components/Table/Table';
+import * as stylesImport from './TypographyPage.module.scss';
+const styles: any = stylesImport;
 const pageStyles: any = require('../../PageStyles.module.scss');
 
 const typeRampData = require('../../../data/type-ramp.json');
@@ -10,7 +13,7 @@ const typeWeightData = require('../../../data/type-weights.json');
 export class TypographyPage extends React.Component<any, any> {
   public render() {
     return (
-      <div className={ pageStyles.basePage }>
+      <div className={ css(pageStyles.basePage, styles.typographyPage) }>
         <PageHeader
           pageTitle='Typography'
           links={
@@ -39,7 +42,7 @@ export class TypographyPage extends React.Component<any, any> {
         <Table responsive={ true } content={ typeRampData } />
 
         <div className={ pageStyles.u_maxTextWidth }>
-          <p>To provide flexibility, text color is not included in these base classes. We recommend using 'neutral primary' for most text on white backgrounds. See the <a href='#/styles/colors'>color documentation</a> for guidance.</p>
+          <p>To provide flexibility, text color is not included in these base classes. We recommend using 'neutral primary' for most text on white backgrounds. See the <a className={ styles.typographyPageLink } href='#/styles/colors'>color documentation</a> for guidance.</p>
         </div>
         <h2 id='size'>Size classes</h2>
         <p>To set the text size independent of the weight, use a size class.</p>

--- a/common/changes/@uifabric/fabric-website/cela-branding_2017-10-16-21-07.json
+++ b/common/changes/@uifabric/fabric-website/cela-branding_2017-10-16-21-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Removed branding guidance pdf and fixed link colors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}

--- a/common/changes/@uifabric/fabric-website/cela-branding_2017-10-16-21-07.json
+++ b/common/changes/@uifabric/fabric-website/cela-branding_2017-10-16-21-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/fabric-website",
-      "comment": "Removed branding guidance pdf and fixed link colors",
+      "comment": "Removed branding guidance pdf, updated fabric asset license pdf, and fixed link colors",
       "type": "patch"
     }
   ],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Removed branding guidance pdf
- Updated asset license pdf
- Fixed link styles that were being overwritten by UHF in Brand Icons and other pages in the same navigation level
- Removed a bunch of css from the IconsPage that was not being used anywhere

#### Focus areas to test

(optional)
