### PR TITLE
Add a mechanism for providing a Fabric-wide icon renderer function

### DIFF
--- a/common/changes/office-ui-fabric-react/jessecar-SvgSupport_2017-10-17-16-15.json
+++ b/common/changes/office-ui-fabric-react/jessecar-SvgSupport_2017-10-17-16-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add a mechanism to provide a Fabric-wide icon renderer function (as opposed to the control-specific onRenderIcon fn",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jessecar@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jessecar-SvgSupport_2017-10-17-16-15.json
+++ b/common/changes/office-ui-fabric-react/jessecar-SvgSupport_2017-10-17-16-15.json
@@ -1,11 +1,9 @@
 {
-  "changes": [
-    {
-      "packageName": "office-ui-fabric-react",
-      "comment": "Add a mechanism to provide a Fabric-wide icon renderer function (as opposed to the control-specific onRenderIcon fn",
-      "type": "minor"
-    }
-  ],
+  "changes": [{
+    "packageName": "office-ui-fabric-react",
+    "comment": "Icon: Add a mechanism to provide a Fabric-wide icon renderer function (as opposed to the control-specific onRenderIcon)",
+    "type": "minor"
+  }],
   "packageName": "office-ui-fabric-react",
   "email": "jessecar@microsoft.com"
 }

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -48,7 +48,7 @@ export const Icon = (props: IIconProps): JSX.Element => {
     let iconFromCustomRendererFn: JSX.Element | undefined;
     for (let i = 0; i < _iconRendererFns.length; i++) {
       let icon = _iconRendererFns[i](props);
-      if (icon !== null) {
+      if (icon) {
         iconFromCustomRendererFn = icon;
         break;
       }

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -9,7 +9,21 @@ import {
   htmlElementProperties
 } from '../../Utilities';
 import { getIcon, IIconRecord } from '../../Styling';
+import { IRenderFunction } from '../../Utilities';
 import { getClassNames } from './Icon.classNames';
+
+let _iconRendererFns: IRenderFunction<IIconProps>[] = [];
+export function registerIconRenderer(renderFunction: IRenderFunction<IIconProps>): () => void {
+  _iconRendererFns.push(renderFunction);
+
+  // return an unsubscribe fn
+  return () => {
+    const index = _iconRendererFns.indexOf(renderFunction);
+    if (index > -1) {
+      _iconRendererFns.splice(index, 1);
+    }
+  };
+}
 
 export const Icon = (props: IIconProps): JSX.Element => {
   let {
@@ -31,6 +45,15 @@ export const Icon = (props: IIconProps): JSX.Element => {
       className
     );
 
+    let iconFromCustomRendererFn: JSX.Element | undefined;
+    for (let i = 0; i < _iconRendererFns.length; i++) {
+      let icon = _iconRendererFns[i](props);
+      if (icon !== null) {
+        iconFromCustomRendererFn = icon;
+        break;
+      }
+    }
+
     return (
       <div
         className={
@@ -39,7 +62,7 @@ export const Icon = (props: IIconProps): JSX.Element => {
             classNames.root
           ) }
       >
-        <Image { ...props.imageProps as any } />
+        { iconFromCustomRendererFn ? iconFromCustomRendererFn : <Image { ...props.imageProps as any } /> }
       </div>
     );
   } else if (typeof iconName === 'string' && iconName.length === 0) {

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -9,21 +9,8 @@ import {
   htmlElementProperties
 } from '../../Utilities';
 import { getIcon, IIconRecord } from '../../Styling';
-import { IRenderFunction } from '../../Utilities';
 import { getClassNames } from './Icon.classNames';
-
-let _iconRendererFns: IRenderFunction<IIconProps>[] = [];
-export function registerIconRenderer(renderFunction: IRenderFunction<IIconProps>): () => void {
-  _iconRendererFns.push(renderFunction);
-
-  // return an unsubscribe fn
-  return () => {
-    const index = _iconRendererFns.indexOf(renderFunction);
-    if (index > -1) {
-      _iconRendererFns.splice(index, 1);
-    }
-  };
-}
+import { getIconFromRendererFunctions } from './registerIconRenderer';
 
 export const Icon = (props: IIconProps): JSX.Element => {
   let {
@@ -45,14 +32,7 @@ export const Icon = (props: IIconProps): JSX.Element => {
       className
     );
 
-    let iconFromCustomRendererFn: JSX.Element | undefined;
-    for (let i = 0; i < _iconRendererFns.length; i++) {
-      let icon = _iconRendererFns[i](props);
-      if (icon) {
-        iconFromCustomRendererFn = icon;
-        break;
-      }
-    }
+    let iconFromRendererFns = getIconFromRendererFunctions(props);
 
     return (
       <div
@@ -62,7 +42,7 @@ export const Icon = (props: IIconProps): JSX.Element => {
             classNames.root
           ) }
       >
-        { iconFromCustomRendererFn ? iconFromCustomRendererFn : <Image { ...props.imageProps as any } /> }
+        { iconFromRendererFns ? iconFromRendererFns : <Image { ...props.imageProps as any } /> }
       </div>
     );
   } else if (typeof iconName === 'string' && iconName.length === 0) {

--- a/packages/office-ui-fabric-react/src/components/Icon/IconPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/IconPage.tsx
@@ -8,12 +8,14 @@ import {
 import { IconBasicExample } from './examples/Icon.Basic.Example';
 import { IconColorExample } from './examples/Icon.Color.Example';
 import { IconImageSheetExample } from './examples/Icon.ImageSheet.Example';
+import { IconRegisterIconRendererExample } from './examples/Icon.RegisterIconRenderer.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { IconStatus } from './Icon.checklist';
 
 const IconBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Icon/examples/Icon.Basic.Example.tsx') as string;
 const IconColorExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Icon/examples/Icon.Color.Example.tsx') as string;
 const IconImageSheetExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Icon/examples/Icon.ImageSheet.Example.tsx') as string;
+const IconRegisterIconRendererExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Icon/examples/Icon.RegisterIconRenderer.Example.tsx') as string;
 
 export class IconPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -31,6 +33,9 @@ export class IconPage extends React.Component<IComponentDemoPageProps, {}> {
             </ExampleCard>
             <ExampleCard title='Icon using image sheet' code={ IconImageSheetExampleCode }>
               <IconImageSheetExample />
+            </ExampleCard>
+            <ExampleCard title='Icon using RegisterIconRenderer function' code={ IconRegisterIconRendererExampleCode }>
+              <IconRegisterIconRendererExample />
             </ExampleCard>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/Icon/examples/Icon.RegisterIconRenderer.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/examples/Icon.RegisterIconRenderer.Example.tsx
@@ -10,15 +10,19 @@ export class IconRegisterIconRendererExample extends React.Component<any, any> {
   public componentWillMount() {
     this._unsubscribeRendererFn = registerIconRenderer((iconProps: IIconProps) => {
       // This function can return any valid JSX.Element icon (e.g. an svg, an svg use reference, an img that points to a png/bmp, a sprite w/ appropriate css styling applied, etc.)
-      if (iconProps.iconName === 'Dot') {
-        return (
-          <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
-            <circle cx='50' cy='50' r='40' fill='orange' />
-          </svg>);
+      switch (iconProps.iconName) {
+        case 'Dot':
+          return (
+            <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
+              <circle cx='50' cy='50' r='40' fill='orange' />
+            </svg>);
+        case 'OneDrive':
+          return oneDriveIcon();
+        case 'Yammer':
+          return yammerIcon();
       }
-      return iconProps.iconName === 'OneDrive' ? oneDriveIcon() :
-        iconProps.iconName === 'Yammer' ? yammerIcon() :
-          null;
+
+      return null;
     });
   }
 

--- a/packages/office-ui-fabric-react/src/components/Icon/examples/Icon.RegisterIconRenderer.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/examples/Icon.RegisterIconRenderer.Example.tsx
@@ -1,0 +1,70 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+import { Icon, IconType, IIconProps, registerIconRenderer } from 'office-ui-fabric-react/lib/Icon';
+import './IconExample.scss';
+
+export class IconRegisterIconRendererExample extends React.Component<any, any> {
+  private _unsubscribeRendererFn: () => void;
+
+  public componentWillMount() {
+    this._unsubscribeRendererFn = registerIconRenderer((iconProps: IIconProps) => {
+      // This function can return any valid JSX.Element icon (e.g. an svg, an svg use reference, an img that points to a png/bmp, a sprite w/ appropriate css styling applied, etc.)
+      if (iconProps.iconName === 'Dot') {
+        return (
+          <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
+            <circle cx='50' cy='50' r='40' fill='orange' />
+          </svg>);
+      }
+      return iconProps.iconName === 'OneDrive' ? oneDriveIcon() :
+        iconProps.iconName === 'Yammer' ? yammerIcon() :
+          null;
+    });
+  }
+
+  public componentWillUnmount() {
+    this._unsubscribeRendererFn && this._unsubscribeRendererFn();
+  }
+
+  public render() {
+    return (
+      <div>
+        <Icon
+          iconName={ 'Dot' }
+          iconType={ IconType.image }
+          className={ 'ms-IconRegisterIconRendererExample-dot' }
+        />
+        <Icon
+          iconName={ 'OneDrive' }
+          iconType={ IconType.image }
+          className={ 'ms-IconRegisterIconRendererExample-icon' }
+        />
+        <Icon
+          iconName={ 'Yammer' }
+          iconType={ IconType.image }
+          className={ 'ms-IconRegisterIconRendererExample-icon' }
+        />
+      </div>
+    );
+  }
+}
+
+function oneDriveIcon(): JSX.Element {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0,0,2048,2048'>
+      <g fill='#1B559B'>
+        <path d='M 1860 1196 q 53 10 94 37 q 18 12 35 29 q 16 16 30 40 q 13 23 21 53 q 8 30 8 68 q 0 37 -10 75 q -11 38 -34 69 q -23 31 -58 51 q -36 20 -86 20 h -1079 q -78 0 -131 -24 q -54 -25 -87 -65 q -34 -40 -49 -91 q -15 -52 -15 -107 q 0 -46 12 -81 q 11 -35 31 -61 q 19 -27 43 -45 q 24 -19 50 -31 q 60 -29 136 -35 q 0 -1 4 -26 q 3 -25 16 -61 q 12 -37 36 -80 q 24 -43 64 -79 q 39 -37 98 -61 q 59 -25 141 -25 q 57 0 103 15 q 45 15 81 38 q 35 23 62 52 q 26 28 44 55 q 18 -10 42 -18 q 20 -7 48 -12 q 27 -6 60 -6 q 40 0 91 15 q 50 14 94 48 q 44 33 75 88 q 30 55 30 136 m -1463 174 q 0 53 10 99 q 10 46 29 86 h -170 q -52 0 -100 -23 q -48 -23 -85 -61 q -37 -38 -59 -87 q -22 -50 -22 -104 q 0 -49 11 -87 q 10 -38 27 -66 q 17 -29 39 -49 q 21 -21 44 -35 q 53 -33 121 -41 q -1 -9 -1 -18 q -1 -9 -1 -17 q 0 -72 27 -134 q 27 -63 73 -110 q 45 -47 106 -74 q 60 -27 127 -27 q 36 0 66 7 q 29 6 51 14 q 25 10 45 21 q 27 -48 65 -89 q 37 -41 84 -71 q 46 -30 101 -47 q 55 -17 115 -17 q 39 0 80 8 q 41 7 83 24 q 72 28 121 71 q 49 42 81 90 q 32 47 49 94 q 16 46 22 82 q -23 2 -43 5 q -21 3 -40 8 q -66 -69 -148 -104 q -82 -36 -177 -36 q -76 0 -136 17 q -60 17 -106 45 q -47 28 -81 64 q -34 36 -58 75 q -24 38 -39 76 q -15 37 -23 67 q -51 12 -102 38 q -52 26 -93 68 q -42 42 -67 101 q -26 59 -26 137' />
+      </g>
+    </svg>
+  );
+}
+
+function yammerIcon(): JSX.Element {
+  return (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0,0,2048,2048'>
+      <g fill='rgb(0,92,185)'>
+        <path d='M 1887 888 q 33 8 54 34 q 21 26 21 61 q 0 35 -22 62 q -23 26 -57 31 q -57 0 -121 -2 q -64 -3 -128 -7 q -64 -5 -122 -11 q -59 -7 -104 -16 q -45 -9 -72 -20 q -27 -12 -27 -26 q 0 -13 37 -26 q 37 -13 94 -24 q 57 -12 126 -22 q 68 -11 131 -18 q 63 -8 112 -12 q 48 -4 66 -4 m -163 549 q 17 14 26 34 q 9 20 9 41 q 0 21 -8 39 q -8 17 -21 30 q -14 13 -31 20 q -17 7 -36 7 q -10 0 -18 -2 q -8 -2 -19 -8 q -15 -8 -54 -34 q -39 -26 -88 -61 q -50 -35 -104 -76 q -54 -41 -98 -78 q -45 -37 -74 -67 q -29 -30 -29 -44 q 0 -8 9 -10 q 8 -3 19 -3 q 22 0 57 9 q 34 9 77 25 q 42 15 91 36 q 48 20 98 44 q 50 23 100 49 q 49 25 94 49 m 0 -901 q -67 37 -144 75 q -77 38 -149 69 q -73 30 -132 50 q -60 19 -93 19 q -11 0 -19 -2 q -8 -3 -8 -10 q 0 -14 29 -44 q 29 -30 74 -67 q 44 -38 98 -78 q 54 -41 104 -76 q 49 -36 88 -62 q 39 -26 54 -34 q 11 -6 20 -8 q 8 -2 18 -2 q 18 0 36 8 q 17 7 30 20 q 13 12 21 30 q 8 17 8 38 q 0 21 -9 41 q -9 19 -26 33 m -1191 823 l -430 -1051 q -6 -16 -6 -33 q 0 -20 8 -38 q 7 -19 21 -33 q 13 -15 33 -24 q 19 -9 42 -9 q 30 0 56 16 q 26 16 40 44 l 343 866 h 4 l 326 -860 q 11 -29 37 -46 q 25 -18 56 -18 q 22 0 40 9 q 18 8 31 22 q 13 13 21 31 q 7 17 7 36 q 0 14 -5 31 l -462 1154 q -30 74 -62 136 q -32 62 -76 107 q -44 44 -105 69 q -62 24 -151 24 q -28 0 -57 -2 q -30 -3 -54 -12 q -24 -10 -39 -28 q -16 -19 -16 -52 q 0 -21 8 -38 q 8 -17 21 -29 q 13 -12 30 -18 q 17 -6 35 -6 q 1 0 9 1 q 7 0 17 1 q 10 0 19 1 q 9 0 14 0 q 48 0 84 -15 q 36 -15 65 -46 q 28 -31 51 -78 q 22 -48 45 -112' />
+      </g>
+    </svg>
+  );
+}

--- a/packages/office-ui-fabric-react/src/components/Icon/examples/IconExample.scss
+++ b/packages/office-ui-fabric-react/src/components/Icon/examples/IconExample.scss
@@ -1,60 +1,59 @@
 :global {
-
   .ms-IconExample {
     font-size: 50px;
     margin-left: 25px;
     margin-right: 25px;
   }
-
   .ms-IconColorExample-deepSkyBlue {
     color: deepskyblue;
   }
-
   .ms-IconColorExample-greenYellow {
     color: #adff2f;
   }
-
   .ms-IconColorExample-salmon {
     color: salmon;
   }
-
   .ms-IconImageSheetExample-one {
     width: 48px;
     height: 44px;
     margin-left: 27px;
   }
-
   .ms-IconImageSheetExample-one-image {
     display: inline-block;
     position: relative;
     left: -6px;
     top: -4px;
   }
-
   .ms-IconImageSheetExample-check {
     width: 35px;
     height: 43px;
     margin-left: 55px;
   }
-
   .ms-IconImageSheetExample-check-image {
     display: inline-block;
     position: relative;
     left: -60px;
     top: -5px;
   }
-
   .ms-IconImageSheetExample-lock {
     width: 35px;
     height: 42px;
     margin-left: 65px;
   }
-
   .ms-IconImageSheetExample-lock-image {
     display: inline-block;
     position: relative;
     left: -109px;
     top: -5px;
   }
-
+  .ms-IconRegisterIconRendererExample-dot {
+    width: 48px;
+    height: 44px;
+    margin-left: 27px;
+  }
+  .ms-IconRegisterIconRendererExample-icon {
+    width: 48px;
+    height: 44px;
+    margin-left: 55px;
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/Icon/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/index.ts
@@ -1,2 +1,3 @@
 export * from './Icon';
 export * from './Icon.Props';
+export { registerIconRenderer } from './registerIconRenderer';

--- a/packages/office-ui-fabric-react/src/components/Icon/registerIconRenderer.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/registerIconRenderer.test.tsx
@@ -1,0 +1,63 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+
+import { Icon } from './Icon';
+import { IconType, IIconProps } from './Icon.Props';
+import { registerIconRenderer, getIconFromRendererFunctions } from './registerIconRenderer';
+import { TestImages } from '../../common/TestImages';
+import { shallow } from 'enzyme';
+
+describe('Test registerIconRenderer', () => {
+  it('registered renderer function gets invoked on Icon render', () => {
+    const mockIconRenderer = jest.fn();
+    registerIconRenderer(mockIconRenderer);
+    shallow(<Icon iconType={ IconType.image } imageProps={ { src: TestImages.iconOne } } />);
+    expect(mockIconRenderer.mock.calls.length).toBe(1);
+  });
+
+  it('unsubscribe detaches renderer function', () => {
+    const mockIconRenderer = jest.fn();
+    let unsubscribeCustomRenderer = registerIconRenderer(mockIconRenderer);
+    shallow(<Icon iconType={ IconType.image } imageProps={ { src: TestImages.iconOne } } />);
+    unsubscribeCustomRenderer();
+    shallow(<Icon iconType={ IconType.image } imageProps={ { src: TestImages.iconOne } } />);
+    expect(mockIconRenderer.mock.calls.length).toBe(1);
+  });
+
+  it('uses multiple renderer functions when appropriate', () => {
+    const mockIconRendererOne = jest.fn();
+    registerIconRenderer(mockIconRendererOne);
+    shallow(<Icon iconType={ IconType.image } imageProps={ { src: TestImages.iconOne } } />);
+    const mockIconRendererTwo = jest.fn();
+    registerIconRenderer(mockIconRendererTwo);
+
+    // Note that neither renderer ever returns a JSX.Element so Icon render should try both fns
+    shallow(<Icon iconType={ IconType.image } imageProps={ { src: TestImages.iconOne } } />);
+    expect(mockIconRendererOne.mock.calls.length).toBe(2);
+    expect(mockIconRendererTwo.mock.calls.length).toBe(1);
+  });
+
+  it('renderer function overrides Icon render behavior', () => {
+    // Rendering the OneNote icon does not result in svg elements
+    const oneNoteIcon = <Icon iconName='One' iconType={ IconType.image } imageProps={ { src: TestImages.iconOne } } />
+    let wrapper = shallow(oneNoteIcon);
+    expect(wrapper.find('svg').length).toEqual(0);
+
+    // Unless we add an iconRenderer fn that causes the icon to render as an SVG circle
+    registerIconRenderer((iconProps: IIconProps) => {
+      return (iconProps.iconName === 'One') ? <svg xmlns='http://www.w3.org/2000/svg'><circle cx='5' cy='5' r='5' /></svg> : null;
+    });
+    wrapper = shallow(oneNoteIcon);
+    expect(wrapper.find('svg').length).toEqual(1);
+  });
+
+  it('renderer function only affects intentional icons', () => {
+    const wrapper1 = shallow(<Icon iconName='PPT' iconType={ IconType.image } imageProps={ { src: TestImages.iconPpt } } />);
+    registerIconRenderer((iconProps: IIconProps) => {
+      return (iconProps.iconName === 'One') ? <svg xmlns='http://www.w3.org/2000/svg'><circle cx='5' cy='5' r='5' /></svg> : null;
+    });
+    const wrapper2 = shallow(<Icon iconName='PPT' iconType={ IconType.image } imageProps={ { src: TestImages.iconPpt } } />);
+    expect(wrapper1 === wrapper2);
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/Icon/registerIconRenderer.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/registerIconRenderer.test.tsx
@@ -40,7 +40,7 @@ describe('Test registerIconRenderer', () => {
 
   it('renderer function overrides Icon render behavior', () => {
     // Rendering the OneNote icon does not result in svg elements
-    const oneNoteIcon = <Icon iconName='One' iconType={ IconType.image } imageProps={ { src: TestImages.iconOne } } />
+    const oneNoteIcon = <Icon iconName='One' iconType={ IconType.image } imageProps={ { src: TestImages.iconOne } } />;
     let wrapper = shallow(oneNoteIcon);
     expect(wrapper.find('svg').length).toEqual(0);
 

--- a/packages/office-ui-fabric-react/src/components/Icon/registerIconRenderer.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/registerIconRenderer.ts
@@ -1,0 +1,39 @@
+import { IIconProps, IconType } from './Icon.Props';
+import { IRenderFunction } from '../../Utilities';
+
+let _iconRendererFns: IRenderFunction<IIconProps>[] = [];
+
+/**
+ * Registers a function that will be called whenever an Icon gets rendered
+ * The function can return a JSX.Element for the icon depending on iconProps, which could be an SVG, a dyamically-generated icon, etc.
+ * The function should return null for icons that are not specifically handled; in such cases, the Icon will fallback to default rendering
+ * @param renderFunction The callback function that will be invoked whenever an Icon gets rendered
+ * @returns an unsubscribe function that can be used to detach the callback from Icon rendering
+ */
+export function registerIconRenderer(renderFunction: IRenderFunction<IIconProps>): () => void {
+  _iconRendererFns.push(renderFunction);
+
+  // return an unsubscribe fn
+  return () => {
+    const index = _iconRendererFns.indexOf(renderFunction);
+    if (index > -1) {
+      _iconRendererFns.splice(index, 1);
+    }
+  };
+}
+
+/**
+ * Iterates through the custom IconRenderFunctions and returns the first JSX.Element returned by a callback or null if a callback isn't registered/if none of the callbacks returns an Icon
+ * Note that this function is internal and only intended to be called by the Icon component
+ */
+export function getIconFromRendererFunctions(props: IIconProps): JSX.Element | undefined {
+  let iconFromRenderers: JSX.Element | undefined;
+  for (let renderer of _iconRendererFns) {
+    let icon = renderer(props);
+    if (icon) {
+      iconFromRenderers = icon;
+      break;
+    }
+  }
+  return iconFromRenderers;
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add a mechanism to provide a Fabric-wide icon renderer function (as opposed to the control-specific onRenderIcon fn).  This allows consumers to return any valid JSX.Element icon (e.g. an svg, an svg use reference, an img that points to a png/bmp, a sprite w/ appropriate css styling applied, etc.)
