### PR TITLE
Merge styles: fixed RTL registration case.

### DIFF
--- a/common/changes/@uifabric/merge-styles/merge-styles-fix_2017-10-17-16-40.json
+++ b/common/changes/@uifabric/merge-styles/merge-styles-fix_2017-10-17-16-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "mergeStyles: in RTL we were seeing exceptions with registering opacity: 0 in keyframes. This has been addressed and a test has been added to cover the case.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/keyframes.test.ts
+++ b/packages/merge-styles/src/keyframes.test.ts
@@ -3,6 +3,7 @@ import {
   Stylesheet,
   InjectionMode
 } from './Stylesheet';
+import { setRTL } from './transforms/rtlifyRules';
 
 const _stylesheet: Stylesheet = Stylesheet.getInstance();
 
@@ -13,7 +14,27 @@ describe('keyframes', () => {
     _stylesheet.reset();
   });
 
+  afterEach(() => {
+    setRTL(false);
+  });
+
   it('can register from/to keyframes', () => {
+    keyframes({
+      from: {
+        opacity: 0,
+      },
+      to: {
+        opacity: 1
+      }
+    });
+
+    expect(_stylesheet.getRules()).toEqual(
+      '@keyframes css-0{from{opacity:0;}to{opacity:1;}}'
+    );
+  });
+
+  it('can register from/to keyframes in rtl', () => {
+    setRTL(true);
     keyframes({
       from: {
         opacity: 0,

--- a/packages/merge-styles/src/mergeStyles.test.ts
+++ b/packages/merge-styles/src/mergeStyles.test.ts
@@ -3,6 +3,7 @@ import {
   Stylesheet,
   InjectionMode
 } from './Stylesheet';
+import { setRTL } from './transforms/rtlifyRules';
 
 const _stylesheet: Stylesheet = Stylesheet.getInstance();
 
@@ -11,6 +12,21 @@ _stylesheet.setConfig({ injectionMode: InjectionMode.none });
 describe('mergeStyles', () => {
   beforeEach(() => {
     _stylesheet.reset();
+  });
+
+  afterEach(() => {
+    setRTL(false);
+  });
+
+  it('can register left', () => {
+    mergeStyles({ left: 10 });
+    expect(_stylesheet.getRules()).toEqual('.css-0{left:10px;}');
+  });
+
+  it('can register left in rtl', () => {
+    setRTL(true);
+    mergeStyles({ left: 10 });
+    expect(_stylesheet.getRules()).toEqual('.css-0{right:10px;}');
   });
 
   it('can join strings', () => {

--- a/packages/merge-styles/src/transforms/provideUnits.test.ts
+++ b/packages/merge-styles/src/transforms/provideUnits.test.ts
@@ -55,7 +55,7 @@ describe('provideUnits', () => {
 
     provideUnits(testSet, 0);
 
-    expect(testSet).toEqual(['opacity', 0]);
+    expect(testSet).toEqual(['opacity', '0']);
   });
 
 });

--- a/packages/merge-styles/src/transforms/provideUnits.ts
+++ b/packages/merge-styles/src/transforms/provideUnits.ts
@@ -18,10 +18,9 @@ export function provideUnits(
   const name = rulePairs[index];
   const value = rulePairs[index + 1];
 
-  if (
-    typeof value === 'number' &&
-    NON_PIXEL_NUMBER_PROPS.indexOf(name as string) === -1
-  ) {
-    rulePairs[index + 1] = `${value}px`;
+  if (typeof value === 'number') {
+    const unit = (NON_PIXEL_NUMBER_PROPS.indexOf(name as string) === -1) ? 'px' : '';
+
+    rulePairs[index + 1] = `${value}${unit}`;
   }
 }


### PR DESCRIPTION
In the RTL case, we were seeing a bug showing up in `rtlifyRules` where it assumed the input would be a string. However in trying to register a number value (opacity: 0), it would error when calling `indexOf` on the value.

Addressed this by adjusting the `provideUnits` transform to always convert number values to strings, so that we can not deal with variable types downstream.
