### PR TITLE
PersonaCoin: Display initials only if no imageUrl or error loading image

### DIFF
--- a/common/changes/office-ui-fabric-react/personacoin-fix-flicker_2017-10-17-18-02.json
+++ b/common/changes/office-ui-fabric-react/personacoin-fix-flicker_2017-10-17-18-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "PersonaCoin - display initials only if no imageUrl is provided or if error loading image",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "a.erich@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -35,15 +35,6 @@ exports[`Facepile Render personas and buttons renders Facepile correctly 1`] = `
             style={undefined}
           >
             <div
-              aria-hidden="true"
-              className="ms-Persona-initials ms-Persona-initials--darkRed undefined"
-              style={undefined}
-            >
-              <span>
-                AL
-              </span>
-            </div>
-            <div
               className="ms-Image ms-Persona-image"
               style={
                 Object {
@@ -81,15 +72,6 @@ exports[`Facepile Render personas and buttons renders Facepile correctly 1`] = `
             className="ms-Persona-imageArea"
             style={undefined}
           >
-            <div
-              aria-hidden="true"
-              className="ms-Persona-initials ms-Persona-initials--lightPink undefined"
-              style={undefined}
-            >
-              <span>
-                AR
-              </span>
-            </div>
             <div
               className="ms-Image ms-Persona-image"
               style={

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -55,6 +55,7 @@ const COLOR_SWATCHES_NUM_ENTRIES = COLOR_SWATCHES_LOOKUP.length;
 
 export interface IPersonaState {
   isImageLoaded?: boolean;
+  isImageError?: boolean;
 }
 
 export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
@@ -70,6 +71,7 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
 
     this.state = {
       isImageLoaded: false,
+      isImageError: false
     };
   }
 
@@ -105,6 +107,7 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
           >
             {
               !this.state.isImageLoaded &&
+              (!imageUrl || this.state.isImageError) &&
               (
                 <div
                   className={ css(
@@ -176,7 +179,8 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
   @autobind
   private _onPhotoLoadingStateChange(loadState: ImageLoadState) {
     this.setState({
-      isImageLoaded: loadState === ImageLoadState.loaded
+      isImageLoaded: loadState === ImageLoadState.loaded,
+      isImageError: loadState === ImageLoadState.error
     });
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1934
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Display initials only if no `imageUrl` is provided, or if there is an error loading the image. This will prevent the quick flicker of displaying the initials then displaying the image.

#### Focus areas to test

If this change is approved, perhaps we can get rid of the `isImageLoaded` state property? I don't think there would be any breaking changes -- as far as I can tell, this property is only used to determine if the initials should be displayed. 
