### PR TITLE
Website: Fix in page navigation for Chrome and Firefox

### DIFF
--- a/apps/fabric-website/src/components/PageHeaderLink/PageHeaderLink.tsx
+++ b/apps/fabric-website/src/components/PageHeaderLink/PageHeaderLink.tsx
@@ -44,26 +44,27 @@ export class PageHeaderLink extends React.Component<IPageHeaderLink, {}> {
   private _eventListener(event) {
     event.preventDefault();
     history.pushState({}, '', this._els.link.getAttribute('href'));
+    let navigatorUserAgent = navigator.userAgent.toLowerCase();
     let hash = this._extractAnchorLink(window.location.hash);
-    if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+    if (navigatorUserAgent.indexOf('firefox') > -1) {
       hash = decodeURI(hash);
     }
     let el = document.getElementById(hash);
     let elRect = el.getBoundingClientRect();
     let bodySTop = document.body.scrollTop;
-    let currentScrollPosition;
+    let currentScrollPosition = bodySTop + elRect.top;
+    let scrollTarget: HTMLBodyElement | HTMLHtmlElement = document.querySelector('body');
 
-    currentScrollPosition = bodySTop + elRect.top;
+    if (navigatorUserAgent.indexOf('firefox') > -1 || navigatorUserAgent.indexOf('chrome') > -1 && navigatorUserAgent.indexOf('edge') < 0) {
+      currentScrollPosition += window.scrollY;
+      scrollTarget = document.querySelector('html');
+    }
 
     if (currentScrollPosition < 0) {
       currentScrollPosition = 0;
     }
 
-    let scrollTarget = (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) ?
-      document.querySelector('html') :
-      document.querySelector('body');
-
-    Animate.scrollTo(scrollTarget as HTMLElement, {
+    Animate.scrollTo(scrollTarget, {
       duration: 0.3,
       top: currentScrollPosition - this.scrollDistance
     });

--- a/common/changes/@uifabric/fabric-website/in-page-nav_2017-10-17-18-48.json
+++ b/common/changes/@uifabric/fabric-website/in-page-nav_2017-10-17-18-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fixed in page navigation for Chrome and Firefox.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

In Firefox, the issue has been that the PageHeaderLinks will initially scroll to the correct target, then bounce around after subsequent clicks. In Chrome, the links haven't been working at all. The element rectangle's top value was bouncing around. Adding window.scrollY into the equation fixed the issue. 

**Chrome before:**
![chrome-scroll-before](https://user-images.githubusercontent.com/16619843/31683993-5ac1e272-b333-11e7-941a-c6ee56618e0f.gif)

**Chrome after:**
![chrome-scroll-after](https://user-images.githubusercontent.com/16619843/31683998-5e27beb4-b333-11e7-90fa-93d141dee3f0.gif)

**Firefox before:**
![firefox-scroll-before](https://user-images.githubusercontent.com/16619843/31684002-6161629c-b333-11e7-9be9-2c66de4f53f1.gif)

**Firefox after:**
![firefox-scroll-after](https://user-images.githubusercontent.com/16619843/31684007-63a895ac-b333-11e7-85b3-3dfbcfb6a204.gif)


#### Focus areas to test

(optional)
