### PR TITLE
vr-tests: Update Storybook config to prevent log spam in Travis

### DIFF
--- a/apps/vr-tests/.storybook/webpack.config.js
+++ b/apps/vr-tests/.storybook/webpack.config.js
@@ -41,15 +41,8 @@ module.exports = (storybookBaseConfig, configType) => {
   rules.forEach(rule => storybookBaseConfig.module.rules.push(rule));
   extensions.forEach(ext => storybookBaseConfig.resolve.extensions.push(ext));
 
-  /**
-   * This removes ProgressPlugin in Storybook's webpack config found here:
-   * ~\vr-tests\node_modules\@storybook\react\dist\server\config\webpack.config.js
-   * This plugin is what causes the logging spam in Travis.
-   * Note this workaround may not be safe if Storybook changes their config in the future.
-   * https://github.com/storybooks/storybook/issues/2029
-   */
-  storybookBaseConfig.plugins.pop();
-  console.warn('Warning: Storybook webpack config plugins are being manually changed. If there are any issues with Storybook\'s build, \'~/vr-tests/.storybook/webpack.config.js\' may need to be updated.');
+  // Remove this plugin because it spams Travis log
+  storybookBaseConfig.plugins = storybookBaseConfig.plugins.filter(plugin => plugin.constructor.name !== 'ProgressPlugin');
 
   // Return the altered config
   return storybookBaseConfig;

--- a/apps/vr-tests/.storybook/webpack.config.js
+++ b/apps/vr-tests/.storybook/webpack.config.js
@@ -38,6 +38,8 @@ module.exports = {
     ],
   },
   stats: {
-    maxModules: 3
+    chunks: false,
+    chunkModules: false,
+    maxModules: 0
   }
 };

--- a/apps/vr-tests/.storybook/webpack.config.js
+++ b/apps/vr-tests/.storybook/webpack.config.js
@@ -1,45 +1,56 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /.css$/,
-        loaders: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.tsx?$/,
-        exclude: /node_modules/,
-        loaders: ['babel-loader', 'awesome-typescript-loader'],
-      },
-      {
-        test: /\.(gif|jpg|jpeg|png|svg)$/,
-        loader: 'file-loader?name=[name].[ext]',
-      },
-      {
-        test: /\.(woff|woff2|ttf)$/,
-        loader: 'file-loader?name=[name].[ext]',
-      },
-      {
-        test: /\.md$/,
-        loader: 'raw-loader',
-      },
-    ],
-  },
-  resolve: {
-    // This replaces Storybook's resolve.extensions so we need to provide all of these
-    extensions: [
-      '.js',
-      '.json',
-      '.jsx',
-      '.ts',
-      '.tsx',
-      '.md',
-    ],
-  },
-  stats: {
-    chunks: false,
-    chunkModules: false,
-    maxModules: 0
-  }
+const path = require('path');
+
+module.exports = (storybookBaseConfig, configType) => {
+
+  const rules = [
+    {
+      test: /.css$/,
+      loaders: ['style-loader', 'css-loader'],
+    },
+    {
+      test: /\.tsx?$/,
+      exclude: /node_modules/,
+      loaders: ['babel-loader', 'awesome-typescript-loader'],
+    },
+    {
+      test: /\.(gif|jpg|jpeg|png|svg)$/,
+      loader: 'file-loader?name=[name].[ext]',
+    },
+    {
+      test: /\.(woff|woff2|ttf)$/,
+      loader: 'file-loader?name=[name].[ext]',
+    },
+    {
+      test: /\.md$/,
+      loader: 'raw-loader',
+    },
+  ];
+
+  // This replaces Storybook's resolve.extensions so we need to provide all of these
+  const extensions = [
+    '.js',
+    '.json',
+    '.jsx',
+    '.ts',
+    '.tsx',
+    '.md',
+  ];
+
+  rules.forEach(rule => storybookBaseConfig.module.rules.push(rule));
+  extensions.forEach(ext => storybookBaseConfig.resolve.extensions.push(ext));
+
+  /**
+   * This removes ProgressPlugin in Storybook's webpack config found here:
+   * ~\vr-tests\node_modules\@storybook\react\dist\server\config\webpack.config.js
+   * This plugin is what causes the logging spam in Travis.
+   * Note this workaround may not be safe if Storybook changes their config in the future.
+   * https://github.com/storybooks/storybook/issues/2029
+   */
+  storybookBaseConfig.plugins.pop();
+  console.warn('Warning: Storybook webpack config plugins are being manually changed. If there are any issues with Storybook\'s build, \'~/vr-tests/.storybook/webpack.config.js\' may need to be updated.');
+
+  // Return the altered config
+  return storybookBaseConfig;
 };

--- a/apps/vr-tests/.storybook/webpack.config.js
+++ b/apps/vr-tests/.storybook/webpack.config.js
@@ -37,5 +37,7 @@ module.exports = {
       '.md',
     ],
   },
-  stats: 'none'
+  stats: {
+    maxModules: 3
+  }
 };

--- a/apps/vr-tests/.storybook/webpack.config.js
+++ b/apps/vr-tests/.storybook/webpack.config.js
@@ -37,4 +37,5 @@ module.exports = {
       '.md',
     ],
   },
+  stats: 'none'
 };

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "",
     "clean": "",
-    "screener": "screener-storybook --conf screener.config.js --debug",
+    "screener": "screener-storybook --conf screener.config.js",
     "screener:local": "screener-storybook --conf screener.local.config.js --debug",
     "start": "start-storybook --port 5555"
   },


### PR DESCRIPTION
#### Description of changes

Updated webpack.config.js for Storybook to stop it from adding thousands of lines to the Travis log by removing the ProgressPlugin, and removed -debug arg from Screener command.


**19,000+ lines (only 10,000 displayed) to < 2,000!**

![log1](https://user-images.githubusercontent.com/15041132/31696478-830d0468-b366-11e7-8394-1d03c28233b9.PNG)


**Back to sanity:**
![log2](https://user-images.githubusercontent.com/15041132/31696479-83265882-b366-11e7-96b9-d71eb846b2cb.PNG)
