### PR TITLE
Add a way to force a layout update for ScrollablePane

### DIFF
--- a/common/changes/office-ui-fabric-react/brwatt-scrollable-ref_2017-10-18-22-20.json
+++ b/common/changes/office-ui-fabric-react/brwatt-scrollable-ref_2017-10-18-22-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add a way to force a layout update for ScrollablePane",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "brwatt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.Props.ts
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import { ScrollablePane } from './ScrollablePane';
 
+export interface IScrollablePane {
+  /** Triggers a layout update for the pane. */
+  forceLayoutUpdate(): void;
+}
+
 export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement | ScrollablePane> {
   /**
-   * Gets ref to component interface.
+   * Optional callback to access the IScrollablePane interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
    */
-  componentRef?: (component: IScrollablePaneProps) => void;
+  componentRef?: (component: IScrollablePane) => void;
 
   /**
    * Class name to apply to the root in addition to ms-ScrollablePane.

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.tsx
@@ -8,7 +8,7 @@ import {
   BaseComponent,
   css
 } from '../../Utilities';
-import { IScrollablePaneProps } from './ScrollablePane.Props';
+import { IScrollablePane, IScrollablePaneProps } from './ScrollablePane.Props';
 import { Sticky } from '../../Sticky';
 import * as stylesImport from './ScrollablePane.scss';
 const styles: any = stylesImport;
@@ -17,7 +17,7 @@ export interface IScrollablePaneContext {
   scrollablePane: PropTypes.Requireable<object>;
 }
 
-export class ScrollablePane extends BaseComponent<IScrollablePaneProps, {}> {
+export class ScrollablePane extends BaseComponent<IScrollablePaneProps, {}> implements IScrollablePane {
   public static childContextTypes: IScrollablePaneContext = {
     scrollablePane: PropTypes.object
   };
@@ -94,6 +94,10 @@ export class ScrollablePane extends BaseComponent<IScrollablePaneProps, {}> {
         { this.props.children }
       </div>
     );
+  }
+
+  public forceLayoutUpdate() {
+    this._onWindowResize();
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The pane currently watches for window resizes to update itself. I need a way to tell the pane that its container changed sizes when it is not a direct result of a window resize.
