### PR TITLE
Add modal selection support on touch to Selection Zone and List controls

### DIFF
--- a/common/changes/@uifabric/experiments/tile-selection_2017-10-18-22-10.json
+++ b/common/changes/@uifabric/experiments/tile-selection_2017-10-18-22-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add modal selection behavior to TilesList",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/tile-selection_2017-10-18-22-10.json
+++ b/common/changes/office-ui-fabric-react/tile-selection_2017-10-18-22-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add opt-in modal selection behavior on touch",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Tile/Tile.Props.ts
+++ b/packages/experiments/src/components/Tile/Tile.Props.ts
@@ -39,6 +39,21 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    */
   selection?: ISelection;
   /**
+   * Whether or not the item should be invoked if clicked.
+   *
+   * @type {boolean}
+   * @memberof ITileProps
+   */
+  invokeSelection?: boolean;
+  /**
+   * Whether or not once any item is selected, invocation of the tile should be blocked
+   * and only selection should be allowed.
+   *
+   * @type {boolean}
+   * @memberof ITileProps
+   */
+  disableInvokeIfAnySelected?: boolean;
+  /**
    * Name to use on the nameplate for the tile.
    *
    * @type {(React.ReactNode | React.ReactNode[])}

--- a/packages/experiments/src/components/Tile/Tile.Props.ts
+++ b/packages/experiments/src/components/Tile/Tile.Props.ts
@@ -46,14 +46,6 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    */
   invokeSelection?: boolean;
   /**
-   * Whether or not once any item is selected, invocation of the tile should be blocked
-   * and only selection should be allowed.
-   *
-   * @type {boolean}
-   * @memberof ITileProps
-   */
-  disableInvokeIfAnySelected?: boolean;
-  /**
    * Name to use on the nameplate for the tile.
    *
    * @type {(React.ReactNode | React.ReactNode[])}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -15,7 +15,9 @@
   transition: transform 0.1s linear;
   color: $ms-color-neutralPrimary;
 
-  &:hover {
+  user-select: none;
+
+  &.selectable:hover {
     background-color: $ms-color-neutralLighter;
 
     &.selected {
@@ -46,7 +48,7 @@
   &.hasBackgroundFrame {
     box-shadow: 0 1px 3px 1px rgba(1, 1, 0, 0.05);
 
-    &:hover {
+    &.selectable:hover {
       outline: 1px solid $ms-color-neutralTertiaryAlt;
     }
 
@@ -71,7 +73,7 @@
     }
   }
 
-  &:active {
+  &.invokable:active {
     transform: scale(0.95);
   }
 }
@@ -100,6 +102,8 @@
   align-items: stretch;
   align-content: stretch;
   text-decoration: none;
+
+  pointer-events: none;
 }
 
 .foreground {
@@ -113,6 +117,11 @@
   justify-content: center;
   opacity: 1;
   transition: opacity 0.2s linear;
+
+  .tile.invokable & {
+    pointer-events: auto;
+    cursor: pointer;
+  }
 
   &.foregroundHide {
     opacity: 0;
@@ -141,18 +150,29 @@
 .check {
   @include focus-border($position: absolute);
   display: none;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
   top: 0;
   @include right(0);
   border: none;
   background: none;
   opacity: 0;
+  box-sizing: border-box;
+  padding: 6px;
+
+  .tile.uninvokable & {
+    width: 100%;
+    height: 100%;
+  }
 
   .tile.selectable & {
-    display: block;
+    display: flex;
   }
 
   .tile.selected &,
-  .tile:hover & {
+  .tile:hover &,
+  .tile.showCheck & {
     opacity: 1;
   }
 
@@ -169,10 +189,6 @@
   }
 }
 
-button.check {
-  padding: 6px;
-}
-
 .background {
   position: absolute;
   top: 0;
@@ -184,6 +200,11 @@ button.check {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
+  .tile.invokable & {
+    cursor: pointer;
+    pointer-events: auto;
+  }
 
   opacity: 1;
 
@@ -217,7 +238,10 @@ button.check {
 }
 
 .nameplate {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
   position: relative;
   margin: auto 0 0 0;
   padding: 12px 8px;
@@ -225,7 +249,16 @@ button.check {
   z-index: 0;
 
   .name {
+    .tile.invokable & {
+      pointer-events: auto;
+      cursor: pointer;
+    }
+
     transition: color 0.2s linear;
+
+    .link:hover & {
+      text-decoration: underline;
+    }
   }
 
   .activity {
@@ -233,6 +266,7 @@ button.check {
   }
 
   .tile.hasBackgroundFrame & {
+    align-items: flex-start;
     padding: 12px 10px;
   }
 }
@@ -263,6 +297,7 @@ button.check {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 100%;
 
   @include margin-left(-8px);
   @include padding-left(8px);
@@ -302,6 +337,7 @@ button.check {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 100%;
 
   // Simulate a 20px line-height by using negative margins.
   // This allows extenders and descenders to fit while still enforcing bounds

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -26,7 +26,7 @@ const enum TileLayoutValues {
 
 export interface ITileState {
   isSelected?: boolean;
-  anySelected?: boolean;
+  isModal?: boolean;
 }
 
 const SIZES: {
@@ -82,11 +82,11 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     } = props;
 
     const isSelected = !!selection && selectionIndex > -1 && selection.isIndexSelected(selectionIndex);
-    const anySelected = !!selection && selection.getSelectedCount() > 0;
+    const isModal = !!selection && !!selection.isModal && selection.isModal();
 
     this.state = {
       isSelected: isSelected,
-      anySelected: anySelected
+      isModal: isModal
     };
   }
 
@@ -103,11 +103,11 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
 
     if (selection !== nextSelection || selectionIndex !== nextSelectionIndex) {
       const isSelected = !!nextSelection && nextSelectionIndex > -1 && nextSelection.isIndexSelected(nextSelectionIndex);
-      const anySelected = !!nextSelection && nextSelection.getSelectedCount() > 0;
+      const isModal = !!nextSelection && nextSelection.isModal && nextSelection.isModal();
 
       this.setState({
         isSelected: isSelected,
-        anySelected: anySelected
+        isModal: isModal
       });
     }
   }
@@ -162,7 +162,6 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
       contentSize,
       ariaLabel,
       descriptionAriaLabel,
-      disableInvokeIfAnySelected = false,
       href,
       onClick,
       ...divProps
@@ -170,11 +169,11 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
 
     const {
       isSelected = false,
-      anySelected = false
+      isModal = false
     } = this.state;
 
     const isSelectable = !!selection && selectionIndex > -1;
-    const isInvokable = (!!href || !!onClick || !!invokeSelection) && (!disableInvokeIfAnySelected || !anySelected);
+    const isInvokable = (!!href || !!onClick || !!invokeSelection) && !isModal;
 
     return (
       <div
@@ -195,7 +194,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
           [`ms-Tile--invokable ${TileStyles.invokable}`]: isInvokable,
           [`ms-Tile--uninvokable ${TileStyles.uninvokable}`]: !isInvokable,
           [`ms-Tile--isDisabled ${TileStyles.disabled}`]: !isSelectable && !isInvokable,
-          [`ms-Tile--showCheck ${TileStyles.showCheck}`]: anySelected && disableInvokeIfAnySelected
+          [`ms-Tile--showCheck ${TileStyles.showCheck}`]: isModal
         }) }
         data-is-focusable={ true }
         data-is-sub-focuszone={ true }
@@ -348,7 +347,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         role='checkbox'
         aria-label={ this.props.toggleSelectionAriaLabel }
         className={ css('ms-Tile-check', TileStyles.check, CheckStyles.checkHost, {
-          [CheckStyles.hostShowCheck]: this.state.anySelected
+          [CheckStyles.hostShowCheck]: this.state.isModal
         }) }
         data-selection-toggle={ true }
         aria-checked={ isSelected }
@@ -368,11 +367,11 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     } = this.props;
 
     const isSelected = selectionIndex > -1 && !!selection && selection.isIndexSelected(selectionIndex);
-    const anySelected = !!selection && selection.getSelectedCount() > 0;
+    const isModal = !!selection && !!selection.isModal && selection.isModal();
 
     this.setState({
       isSelected: isSelected,
-      anySelected: anySelected
+      isModal: isModal
     });
   }
 }

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
@@ -2,9 +2,12 @@
 import * as React from 'react';
 import {
   TilesList,
-  ITileSize
+  ITileSize,
+  ITilesGridItem,
+  ITilesGridSegment
 } from '../../TilesList';
 import { Tile, getTileLayout, renderTileWithLayout } from '../../../Tile';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { Selection, SelectionZone } from 'office-ui-fabric-react/lib/Selection';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { autobind } from 'office-ui-fabric-react/lib/Utilities';
@@ -39,7 +42,12 @@ declare class TilesListClass extends TilesList<IExampleItem> { }
 
 const TilesListType: typeof TilesListClass = TilesList;
 
-export class TilesListMediaExample extends React.Component<{}, {}> {
+export interface ITilesListMediaExampleState {
+  isModalSelection: boolean;
+  cells: (ITilesGridItem<IExampleItem> | ITilesGridSegment<IExampleItem>)[];
+}
+
+export class TilesListMediaExample extends React.Component<{}, ITilesListMediaExampleState> {
   private _selection: Selection;
 
   constructor() {
@@ -47,32 +55,57 @@ export class TilesListMediaExample extends React.Component<{}, {}> {
 
     this._selection = new Selection({
       getKey: (item: IExampleItem) => item.key,
+      onSelectionChanged: this._onSelectionChange
     });
 
     this._selection.setItems(ITEMS);
-  }
-  public render(): JSX.Element {
-    const items = getTileCells(GROUPS, {
-      onRenderCell: this._onRenderMediaCell,
-      onRenderHeader: this._onRenderHeader
-    });
 
+    this.state = {
+      isModalSelection: this._selection.isModal(),
+      cells: getTileCells(GROUPS, {
+        onRenderCell: this._onRenderMediaCell,
+        onRenderHeader: this._onRenderHeader
+      })
+    };
+  }
+
+  public render(): JSX.Element {
     return (
       // tslint:disable-next-line:jsx-ban-props
       <div style={ { padding: '4px' } }>
+        <Toggle
+          label='Enable Modal Selection'
+          checked={ this.state.isModalSelection }
+          onChanged={ this._onToggleIsModalSelection }
+          onText='Modal'
+          offText='Normal'
+        />
         <MarqueeSelection selection={ this._selection }>
           <SelectionZone
             selection={ this._selection }
             onItemInvoked={ this._onItemInvoked }
+            enterModalOnTouch={ true }
           >
             <TilesListType
               role='list'
-              items={ items }
+              items={ this.state.cells }
             />
           </SelectionZone>
         </MarqueeSelection>
       </div>
     );
+  }
+
+  @autobind
+  private _onToggleIsModalSelection(checked: boolean): void {
+    this._selection.setModal(checked);
+  }
+
+  @autobind
+  private _onSelectionChange(): void {
+    this.setState({
+      isModalSelection: this._selection.isModal()
+    });
   }
 
   @autobind
@@ -94,6 +127,7 @@ export class TilesListMediaExample extends React.Component<{}, {}> {
         className={ AnimationClassNames.fadeIn400 }
         selection={ this._selection }
         selectionIndex={ item.index }
+        invokeSelection={ true }
         background={
           <span /> // Placeholder
         }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.Props.ts
@@ -205,6 +205,11 @@ export interface IDetailsListProps extends React.Props<DetailsList>, IWithViewpo
    * Optional class name to add to the cell of a checkbox
    */
   checkboxCellClassName?: string;
+
+  /**
+   * Whether or not the selection zone should enter modal state on touch.
+   */
+  enterModalSelectionOnTouch?: boolean;
 }
 
 export interface IColumn {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -322,6 +322,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
                 selectionMode={ selectionMode }
                 onItemInvoked={ onItemInvoked }
                 onItemContextMenu={ onItemContextMenu }
+                enterModalOnTouch={ this.props.enterModalSelectionOnTouch }
               >
                 { groups ? (
                   <GroupedList

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
@@ -190,6 +190,11 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
 
   &.checkCell {
     padding: 0;
+    // Ensure that the check cell covers the top border of the cell.
+    // This ensures the click target does not leave a spot which would
+    // cause other items to be deselected.
+    padding-top: 1px;
+    margin-top: -1px;
   }
 
   & > button {
@@ -212,8 +217,7 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
   @include ms-padding-right($isPaddedMargin + $rowHorizontalPadding);
 
   &.checkCell {
-    padding: 0;
-    margin: 0;
+    @include ms-padding-right(0);
   }
 }
 
@@ -231,4 +235,17 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
 .cellMeasurer .cell {
   overflow: visible;
   white-space: nowrap;
+}
+
+.checkCover {
+  position: absolute;
+  top: -1px;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  display: none;
+
+  .anySelected & {
+    display: block;
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -23,10 +23,11 @@ import {
   IDragDropOptions,
 } from './../../utilities/dragdrop/interfaces';
 import { IViewport } from '../../utilities/decorators/withViewport';
+import { AnimationClassNames } from '../../Styling';
 import * as stylesImport from './DetailsRow.scss';
 const styles: any = stylesImport;
-import { AnimationClassNames } from '../../Styling';
-import * as checkStyles from './DetailsRowCheck.scss';
+import * as checkStylesImport from './DetailsRowCheck.scss';
+const checkStyles: any = checkStylesImport;
 
 export interface IDetailsRowProps extends React.Props<DetailsRow> {
   componentRef?: () => void;
@@ -54,7 +55,7 @@ export interface IDetailsRowProps extends React.Props<DetailsRow> {
 
 export interface IDetailsRowSelectionState {
   isSelected: boolean;
-  anySelected: boolean;
+  isSelectionModal: boolean;
 }
 
 export interface IDetailsRowState {
@@ -186,10 +187,10 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
       getRowAriaLabel,
       checkButtonAriaLabel,
       checkboxCellClassName,
-      selection
+      selection,
     } = this.props;
     const { columnMeasureInfo, isDropping, groupNestingDepth } = this.state;
-    const { isSelected, anySelected } = this.state.selectionState as IDetailsRowSelectionState;
+    const { isSelected = false, isSelectionModal = false } = this.state.selectionState as IDetailsRowSelectionState;
     const isDraggable = Boolean(dragDropEvents && dragDropEvents.canDrag && dragDropEvents.canDrag(item));
     const droppingClassName = isDropping ? (this._droppingClassNames ? this._droppingClassNames : DEFAULT_DROPPING_CSS_CLASS) : '';
     const ariaLabel = getRowAriaLabel ? getRowAriaLabel(item) : null;
@@ -214,6 +215,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
           {
             [`is-contentUnselectable ${styles.rootIsContentUnselectable}`]: isContentUnselectable,
             [`is-selected ${checkStyles.isSelected} ${styles.rootIsSelected}`]: isSelected,
+            [`${styles.anySelected} ${checkStyles.anySelected}`]: isSelectionModal,
             [`is-check-visible ${checkStyles.isVisible}`]: checkboxVisibility === CheckboxVisibility.always
           }) }
         data-is-focusable={ true }
@@ -235,10 +237,10 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
             className={ css('ms-DetailsRow-cell', 'ms-DetailsRow-cellCheck', checkStyles.owner, styles.cell, styles.checkCell, checkboxCellClassName) }
           >
             { onRenderCheck({
-              isSelected,
-              anySelected,
+              selected: isSelected,
+              anySelected: isSelectionModal,
               title: checkButtonAriaLabel,
-              canSelect
+              canSelect: canSelect
             }) }
           </div>
         ) }
@@ -270,6 +272,13 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
             />
           </span>
         ) }
+
+        <span
+          role='checkbox'
+          className={ css(styles.checkCover) }
+          aria-checked={ isSelected }
+          data-selection-toggle={ true }
+        />
       </FocusZone>
     );
   }
@@ -310,7 +319,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
 
     return {
       isSelected: selection.isIndexSelected(itemIndex),
-      anySelected: selection.getSelectedCount() > 0
+      isSelectionModal: !!selection.isModal && selection.isModal()
     };
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
@@ -4,7 +4,9 @@
 .check {
   @include focus-border();
 
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: default;
   box-sizing: border-box;
   vertical-align: top;
@@ -12,24 +14,20 @@
   border: none;
   opacity: 0;
 
-  &:focus {
-    opacity: 1;
-  }
-}
-
-button.check {
   height: 40px;
   width: 40px;
   padding: 0;
   margin: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+
+  @include focus(true) {
+    opacity: 1;
+  }
 }
 
 .owner {
   &.isSelected,
   &.isVisible,
+  &.anySelected,
   &:hover {
     .check {
       opacity: 1;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -17,32 +17,30 @@ export interface IDetailsRowCheckProps extends React.HTMLAttributes<HTMLElement>
    * @deprecated
    */
   isSelected?: boolean;
-  anySelected: boolean;
+  anySelected?: boolean;
   canSelect: boolean;
 }
 
 export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
   const {
-    canSelect,
-    isSelected,
-    anySelected,
-    selected,
+    canSelect = false,
+    isSelected = false,
+    anySelected = false,
+    selected = false,
     ...buttonProps
   } = props;
 
   let isPressed = props.isSelected || props.selected;
 
   return (
-    <button
+    <div
       { ...buttonProps }
       role='checkbox'
-      className={ css(
-        'ms-DetailsRow-check',
-        DetailsRowCheckStyles.check,
-        CheckStyles.checkHost,
-        !props.canSelect && DetailsRowCheckStyles.isDisabled,
-        !props.canSelect && 'ms-DetailsRow-check--isDisabled'
-      ) }
+      className={
+        css('ms-DetailsRow-check', DetailsRowCheckStyles.check, CheckStyles.checkHost, {
+          [`ms-DetailsRow-check--isDisabled ${DetailsRowCheckStyles.isDisabled}`]: !props.canSelect
+        })
+      }
       aria-checked={ isPressed }
       data-selection-toggle={ true }
       data-automationid='DetailsRowCheck'
@@ -50,6 +48,6 @@ export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
       <Check
         checked={ isPressed }
       />
-    </button>
+    </div>
   );
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -618,7 +618,7 @@ export class DetailsListAdvancedExample extends React.Component<any, IDetailsLis
         column.minWidth = 200;
       } else if (column.key === 'name') {
         column.onRender = (item) => (
-          <Link>{ item.name }</Link>
+          <Link data-selection-invoke={ true }>{ item.name }</Link>
         );
       } else if (column.key === 'key') {
         column.columnActionsMode = ColumnActionsMode.disabled;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -46,6 +46,7 @@ export interface IDetailsListDocumentsExampleState {
   columns: IColumn[];
   items: IDocument[];
   selectionDetails: string;
+  isModalSelection: boolean;
   isCompactMode: boolean;
 }
 
@@ -137,9 +138,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         data: 'number',
         onRender: (item: IDocument) => {
           return (
-            <span
-              data-is-focusable={ true }
-            >
+            <span>
               { item.dateModified }
             </span>
           );
@@ -157,9 +156,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         onColumnClick: this._onColumnClick,
         onRender: (item: IDocument) => {
           return (
-            <span
-              data-is-focusable={ true }
-            >
+            <span>
               { item.modifiedBy }
             </span>
           );
@@ -177,9 +174,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         onColumnClick: this._onColumnClick,
         onRender: (item: IDocument) => {
           return (
-            <span
-              data-is-focusable={ true }
-            >
+            <span>
               { item.fileSize }
             </span>
           );
@@ -188,13 +183,19 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
     ];
 
     this._selection = new Selection({
-      onSelectionChanged: () => this.setState({ selectionDetails: this._getSelectionDetails() })
+      onSelectionChanged: () => {
+        this.setState({
+          selectionDetails: this._getSelectionDetails(),
+          isModalSelection: this._selection.isModal()
+        });
+      }
     });
 
     this.state = {
       items: _items,
       columns: _columns,
       selectionDetails: this._getSelectionDetails(),
+      isModalSelection: this._selection.isModal(),
       isCompactMode: false
     };
   }
@@ -207,8 +208,15 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         <Toggle
           label='Enable Compact Mode'
           checked={ isCompactMode }
-          onChanged={ this._onChangeToggle }
+          onChanged={ this._onChangeCompactMode }
           onText='Compact'
+          offText='Normal'
+        />
+        <Toggle
+          label='Enable Modal Selection'
+          checked={ this.state.isModalSelection }
+          onChanged={ this._onChangeModalSelection }
+          onText='Modal'
           offText='Normal'
         />
         <div>{ selectionDetails }</div>
@@ -227,15 +235,27 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
             selection={ this._selection }
             selectionPreservedOnEmptyClick={ true }
             onItemInvoked={ this._onItemInvoked }
+            enterModalSelectionOnTouch={ true }
           />
         </MarqueeSelection>
       </div>
     );
   }
 
+  public componentDidUpdate(previousProps: any, previousState: IDetailsListDocumentsExampleState) {
+    if (previousState.isModalSelection !== this.state.isModalSelection) {
+      this._selection.setModal(this.state.isModalSelection);
+    }
+  }
+
   @autobind
-  private _onChangeToggle(checked: boolean): void {
+  private _onChangeCompactMode(checked: boolean): void {
     this.setState({ isCompactMode: checked });
+  }
+
+  @autobind
+  private _onChangeModalSelection(checked: boolean): void {
+    this.setState({ isModalSelection: checked });
   }
 
   @autobind

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -48,6 +48,7 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
   private _lastMouseEvent: MouseEvent | undefined;
   private _autoScroll: AutoScroll | undefined;
   private _selectedIndicies: { [key: string]: boolean } | undefined;
+  private _preservedIndicies: number[] | undefined;
   private _itemRectCache: { [key: string]: IRectangle } | undefined;
   private _scrollableParent: HTMLElement;
   private _scrollableSurface: HTMLElement;
@@ -164,9 +165,14 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
       return;
     }
 
+    if (this._isInSelectionToggle(ev)) {
+      return;
+    }
+
     if (!this._isTouch && isEnabled && !this._isDragStartInSelection(ev) && (!onShouldStartSelection || onShouldStartSelection(ev))) {
       if (this._scrollableSurface && ev.button === 0) {
         this._selectedIndicies = {};
+        this._preservedIndicies = undefined;
         this._events.on(window, 'mousemove', this._onAsyncMouseMove);
         this._events.on(this._scrollableParent, 'scroll', this._onAsyncMouseMove);
         this._events.on(window, 'click', this._onMouseUp, true);
@@ -238,6 +244,9 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
       this._onMouseUp(ev);
     } else {
       if (this.state.dragRect || getDistanceBetweenPoints(this._dragOrigin, currentPoint) > MIN_DRAG_DISTANCE) {
+        if (!this.state.dragRect) {
+          this._preservedIndicies = this._getPreservedIndices(this.props);
+        }
         // We need to constrain the current point to the rootRect boundaries.
         let constrainedPoint = this.props.isDraggingConstrainedToRoot ? {
           x: Math.max(0, Math.min(rootRect.width, this._lastMouseEvent!.clientX - rootRect.left)),
@@ -316,6 +325,20 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
     return false;
   }
 
+  private _isInSelectionToggle(ev: MouseEvent): boolean {
+    let element: HTMLElement | null = ev.target as HTMLElement;
+
+    while (element && element !== this.refs.root) {
+      if (element.getAttribute('data-selection-toggle') === 'true') {
+        return true;
+      }
+
+      element = element.parentElement;
+    }
+
+    return false;
+  }
+
   private _evaluateSelection(dragRect: IRectangle, rootRect: IRectangle) {
     // Break early if we don't need to evaluate.
     if (!dragRect) {
@@ -376,6 +399,28 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
       }
     }
 
+    if (this._preservedIndicies) {
+      for (const index of this._preservedIndicies) {
+        selection.setIndexSelected(index, true, false);
+      }
+    }
+
     selection.setChangeEvents(true);
+  }
+
+  private _getPreservedIndices(props: IMarqueeSelectionProps): number[] {
+    const {
+      selection
+    } = props;
+
+    const selectedIndices: number[] = [];
+
+    for (let i = 0, length = selection.getItems().length; i < length; i++) {
+      if (selection.isIndexSelected(i)) {
+        selectedIndices.push(i);
+      }
+    }
+
+    return selectedIndices;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -245,7 +245,11 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
     } else {
       if (this.state.dragRect || getDistanceBetweenPoints(this._dragOrigin, currentPoint) > MIN_DRAG_DISTANCE) {
         if (!this.state.dragRect) {
-          this._preservedIndicies = this._getPreservedIndices(this.props);
+          const {
+            selection
+          } = this.props;
+
+          this._preservedIndicies = selection && selection.getSelectedIndices && selection.getSelectedIndices();
         }
         // We need to constrain the current point to the rootRect boundaries.
         let constrainedPoint = this.props.isDraggingConstrainedToRoot ? {
@@ -406,21 +410,5 @@ export class MarqueeSelection extends BaseComponent<IMarqueeSelectionProps, IMar
     }
 
     selection.setChangeEvents(true);
-  }
-
-  private _getPreservedIndices(props: IMarqueeSelectionProps): number[] {
-    const {
-      selection
-    } = props;
-
-    const selectedIndices: number[] = [];
-
-    for (let i = 0, length = selection.getItems().length; i < length; i++) {
-      if (selection.isIndexSelected(i)) {
-        selectedIndices.push(i);
-      }
-    }
-
-    return selectedIndices;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -33,6 +33,8 @@ exports[`Pickers BasePicker renders BasePicker correctly 1`] = `
       onKeyDownCapture={[Function]}
       onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      onTouchEndCapture={[Function]}
+      onTouchStartCapture={[Function]}
       role="presentation"
     >
       <div
@@ -95,6 +97,8 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
       onKeyDownCapture={[Function]}
       onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
+      onTouchEndCapture={[Function]}
+      onTouchStartCapture={[Function]}
       role="presentation"
     >
       <div

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -19,6 +19,7 @@ export class Selection implements ISelection {
   private _changeEventSuppressionCount: number;
   private _items: IObjectWithKey[];
   private _selectedItems: IObjectWithKey[] | null;
+  private _selectedIndices: number[] | undefined;
   private _isAllSelected: boolean;
   private _exemptedIndices: { [index: string]: boolean };
   private _exemptedCount: number;
@@ -28,6 +29,7 @@ export class Selection implements ISelection {
   private _hasChanged: boolean;
   private _unselectableIndices: { [index: string]: boolean };
   private _unselectableCount: number;
+  private _isModal: boolean;
 
   constructor(options: ISelectionOptions = {}) {
     const {
@@ -48,6 +50,8 @@ export class Selection implements ISelection {
 
     this._onSelectionChanged = onSelectionChanged;
     this._canSelectItem = canSelectItem;
+
+    this._isModal = false;
 
     this.setItems([], true);
   }
@@ -73,6 +77,26 @@ export class Selection implements ISelection {
       if (!suppressChange) {
         this._change();
       }
+    }
+  }
+
+  public isModal(): boolean {
+    return this._isModal;
+  }
+
+  public setModal(isModal: boolean): void {
+    if (this._isModal !== isModal) {
+      this.setChangeEvents(true);
+
+      this._isModal = isModal;
+
+      if (!isModal) {
+        this.setAllSelected(false);
+      }
+
+      this._change();
+
+      this.setChangeEvents(false);
     }
   }
 
@@ -157,9 +181,13 @@ export class Selection implements ISelection {
     if (!this._selectedItems) {
       this._selectedItems = [];
 
-      for (let i = 0; i < this._items.length; i++) {
-        if (this.isIndexSelected(i)) {
-          this._selectedItems.push(this._items[i]);
+      const items = this._items;
+
+      if (items) {
+        for (let i = 0; i < items.length; i++) {
+          if (this.isIndexSelected(i)) {
+            this._selectedItems.push(items[i]);
+          }
         }
       }
     }
@@ -169,6 +197,24 @@ export class Selection implements ISelection {
 
   public getSelectedCount(): number {
     return this._isAllSelected ? (this._items.length - this._exemptedCount - this._unselectableCount) : (this._exemptedCount);
+  }
+
+  public getSelectedIndices(): number[] {
+    if (!this._selectedIndices) {
+      this._selectedIndices = [];
+
+      const items = this._items;
+
+      if (items) {
+        for (let i = 0; i < items.length; i++) {
+          if (this.isIndexSelected(i)) {
+            this._selectedIndices.push(i);
+          }
+        }
+      }
+    }
+
+    return this._selectedIndices;
   }
 
   public isRangeSelected(fromIndex: number, count: number): boolean {
@@ -221,12 +267,21 @@ export class Selection implements ISelection {
 
     let selectableCount = this._items ? (this._items.length - this._unselectableCount) : 0;
 
+    this.setChangeEvents(false);
+
     if (selectableCount > 0 && (this._exemptedCount > 0 || isAllSelected !== this._isAllSelected)) {
       this._exemptedIndices = {};
-      this._exemptedCount = 0;
-      this._isAllSelected = isAllSelected;
+
+      if (isAllSelected !== this._isAllSelected || this._exemptedCount > 0) {
+        this._exemptedCount = 0;
+        this._isAllSelected = isAllSelected;
+        this._change();
+      }
+
       this._updateCount();
     }
+
+    this.setChangeEvents(true);
   }
 
   public setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean): void {
@@ -287,9 +342,7 @@ export class Selection implements ISelection {
       }
     }
 
-    if (hasChanged) {
-      this._updateCount();
-    }
+    this._updateCount();
 
     this.setChangeEvents(true);
   }
@@ -357,13 +410,22 @@ export class Selection implements ISelection {
   }
 
   private _updateCount(): void {
-    this.count = this.getSelectedCount();
-    this._change();
+    const count = this.getSelectedCount();
+
+    if (count !== this.count) {
+      this.count = count;
+      this._change();
+    }
+
+    if (!this.count) {
+      this.setModal(false);
+    }
   }
 
   private _change(): void {
     if (this._changeEventSuppressionCount === 0) {
       this._selectedItems = null;
+      this._selectedIndices = undefined;
 
       EventGroup.raise(this, SELECTION_CHANGE);
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
@@ -99,12 +99,12 @@ describe('SelectionZone', () => {
     expect(_onItemInvokeCalled).toEqual(0);
   });
 
-  it('selects an unselected item on mousedown of invoke without modifiers pressed', () => {
+  it('selects an unselected item on mousedown of surface without modifiers pressed', () => {
     _selection.setAllSelected(true);
     _selection.setIndexSelected(0, false, true);
 
     // Mousedown on the only unselected item's invoke surface should deselect all and select that one.
-    ReactTestUtils.Simulate.mouseDown(_invoke0);
+    ReactTestUtils.Simulate.mouseDown(_surface0);
     expect(_selection.isIndexSelected(0)).toEqual(true);
     expect(_selection.getSelectedCount()).toEqual(1);
   });
@@ -134,9 +134,9 @@ describe('SelectionZone', () => {
     expect(_onItemInvokeCalled).toEqual(0);
   });
 
-  it('does not select an unselected item on mousedown of item surface element', () => {
+  it('selects an unselected item on mousedown of item surface element', () => {
     ReactTestUtils.Simulate.mouseDown(_surface0);
-    expect(_selection.isIndexSelected(0)).toEqual(false);
+    expect(_selection.isIndexSelected(0)).toEqual(true);
   });
 
   it('invokes an item on double clicking the surface element', () => {
@@ -227,6 +227,12 @@ describe('SelectionZone', () => {
     document.documentElement.click();
 
     expect(_selection.getSelectedCount()).toEqual(0);
+  });
+
+  it('does not select an item on mousedown of the surface with no modifiers', () => {
+    ReactTestUtils.Simulate.mouseDown(_invoke0);
+    expect(_selection.isIndexSelected(0)).toEqual(false);
+    expect(_onItemInvokeCalled).toEqual(0);
   });
 });
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -116,6 +116,23 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   private _onMouseDownCapture(ev: any) {
     if (document.activeElement !== ev.target && !elementContains(document.activeElement as HTMLElement, ev.target)) {
       this.ignoreNextFocus();
+      return;
+    }
+
+    if (!elementContains(ev.target, this.refs.root)) {
+      return;
+    }
+
+    let target = ev.target as HTMLElement;
+    let itemRoot = this._findItemRoot(target);
+
+    while (target !== this.refs.root) {
+      if (this._hasAttribute(target, SELECTION_INVOKE_ATTRIBUTE_NAME)) {
+        this.ignoreNextFocus();
+        break;
+      }
+
+      target = getParent(target) as HTMLElement;
     }
   }
 
@@ -167,9 +184,9 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         if (this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME)) {
           break;
         } else if (this._hasAttribute(target, SELECTION_INVOKE_ATTRIBUTE_NAME)) {
-          this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;
-        } else if (target === itemRoot) {
+        } else if (target === itemRoot && !this._isShiftPressed && !this._isCtrlPressed) {
+          this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;
         }
       }

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -45,6 +45,7 @@ export interface ISelectionZoneProps extends React.Props<SelectionZone> {
   layout?: ISelectionLayout;
   selectionMode?: SelectionMode;
   selectionPreservedOnEmptyClick?: boolean;
+  enterModalOnTouch?: boolean;
   isSelectedOnFocus?: boolean;
   onItemInvoked?: (item?: any, index?: number, ev?: Event) => void;
   onItemContextMenu?: (item?: any, index?: number, ev?: Event) => void | boolean;
@@ -68,6 +69,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   private _isMetaPressed: boolean;
   private _shouldHandleFocus: boolean;
   private _shouldHandleFocusTimeoutId: number | undefined;
+  private _isTouch: boolean;
+  private _isTouchTimeoutId: number | undefined;
 
   public componentDidMount() {
     let win = getWindow(this.refs.root);
@@ -86,6 +89,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         onKeyDown={ this._onKeyDown }
         onMouseDown={ this._onMouseDown }
         onKeyDownCapture={ this._onKeyDownCapture }
+        onTouchStartCapture={ this._onTouchStartCapture }
+        onTouchEndCapture={ this._onTouchStartCapture }
         onClick={ this._onClick }
         role='presentation'
 
@@ -124,7 +129,6 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     }
 
     let target = ev.target as HTMLElement;
-    let itemRoot = this._findItemRoot(target);
 
     while (target !== this.refs.root) {
       if (this._hasAttribute(target, SELECTION_INVOKE_ATTRIBUTE_NAME)) {
@@ -159,6 +163,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         if (isToggleModifierPressed) {
           // set anchor only.
           selection.setIndexSelected(index, selection.isIndexSelected(index), true);
+          if (this.props.enterModalOnTouch && this._isTouch && selection.setModal) {
+            selection.setModal(true);
+            this._setIsTouch(false);
+          }
         } else {
           if (this.props.isSelectedOnFocus) {
             this._onItemSurfaceClick(ev, index);
@@ -193,6 +201,11 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
 
       target = getParent(target) as HTMLElement;
     }
+  }
+
+  @autobind
+  private _onTouchStartCapture(ev: React.TouchEvent<HTMLElement>) {
+    this._setIsTouch(true);
   }
 
   @autobind
@@ -398,17 +411,25 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
 
     const selectionMode = this._getSelectionMode();
 
+    selection.setChangeEvents(false);
+
+    if (this.props.enterModalOnTouch && this._isTouch && !selection.isIndexSelected(index) && selection.setModal) {
+      selection.setModal(true);
+      this._setIsTouch(false);
+    }
+
     if (selectionMode === SelectionMode.multiple) {
       selection.toggleIndexSelected(index);
     } else if (selectionMode === SelectionMode.single) {
       let isSelected = selection.isIndexSelected(index);
-      selection.setChangeEvents(false);
       selection.setAllSelected(false);
       selection.setIndexSelected(index, !isSelected, true);
-      selection.setChangeEvents(true);
     } else {
+      selection.setChangeEvents(true);
       return;
     }
+
+    selection.setChangeEvents(true);
 
     ev.stopPropagation();
 
@@ -473,6 +494,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
       selection.setChangeEvents(false);
       selection.setAllSelected(false);
       selection.setIndexSelected(index, true, true);
+      if (this.props.enterModalOnTouch && this._isTouch && selection.setModal) {
+        selection.setModal(true);
+        this._setIsTouch(false);
+      }
       selection.setChangeEvents(true);
     }
   }
@@ -555,6 +580,21 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
       this._async.setTimeout(() => {
         this._shouldHandleFocus = false;
       }, 100);
+    }
+  }
+
+  private _setIsTouch(isTouch: boolean) {
+    if (this._isTouchTimeoutId) {
+      this._async.clearTimeout(this._isTouchTimeoutId);
+      this._isTouchTimeoutId = undefined;
+    }
+
+    this._isTouch = true;
+
+    if (isTouch) {
+      this._async.setTimeout(() => {
+        this._isTouch = false;
+      }, 300);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
@@ -27,6 +27,7 @@ export interface ISelection {
   // Read selection methods.
 
   getSelection(): IObjectWithKey[];
+  getSelectedIndices?(): number[]; // TODO make non-optional on next breaking change
   getSelectedCount(): number;
   isRangeSelected(fromIndex: number, count: number): boolean;
 
@@ -34,11 +35,15 @@ export interface ISelection {
   isKeySelected(key: string): boolean;
   isIndexSelected(index: number): boolean;
 
+  isModal?(): boolean;
+
   // Write selection methods.
 
   setAllSelected(isAllSelected: boolean): void;
   setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean): void;
   setIndexSelected(index: number, isSelected: boolean, shouldAnchor: boolean): void;
+
+  setModal?(isModal: boolean): void; // TODO make non-optional on next breaking change
 
   // Write range selection methods.
 


### PR DESCRIPTION
### Overview

This change adds support for a 'modal' selection state, which can be activated directly on the `Selection` model or via touch events within a `SelectionZone`. Entering the `isModal` state causes `Tile` and `DetailsRow` to make their entire surfaces use the 'toggle' behavior for selection, rather than permitting the items to be activated or exclusively selected.

This change prevents items from being selected at the same time they are activated.

This change ensures that selection marquees cannot originate from an element with the `data-selection-toggle` attribute.

This change allows `MarqueeSelection` to union together multiple drags if the user holds `Ctrl`.