### PR TITLE
ComboBox: Fix custom styling issues

### DIFF
--- a/common/changes/office-ui-fabric-react/combo-box-classnames_2017-10-18-23-28.json
+++ b/common/changes/office-ui-fabric-react/combo-box-classnames_2017-10-18-23-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Fix custom styling on menu options",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.classNames.ts
@@ -89,9 +89,7 @@ export const getClassNames = memoizeFunction((
 });
 
 export const getComboBoxOptionClassNames = memoizeFunction((
-  styles: IComboBoxOptionStyles,
-  optionIsSelected: boolean,
-  disabled: boolean,
+  styles: Partial<IComboBoxOptionStyles>,
 ): IComboBoxOptionClassNames => {
   return {
     optionText: mergeStyles(

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -26,7 +26,8 @@ import {
 } from './ComboBox.styles';
 import {
   IComboBoxClassNames,
-  getClassNames
+  getClassNames,
+  getComboBoxOptionClassNames
 } from './ComboBox.classNames';
 
 export interface IComboBoxState {
@@ -936,8 +937,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   // Render content of item
   @autobind
   private _onRenderOption(item: IComboBoxOption): JSX.Element {
-    const optionStyles = this._getCurrentOptionStyles(item);
-    return <span className={ optionStyles.optionText as string }>{ item.text }</span>;
+    const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
+    return <span className={ optionClassNames.optionText }>{ item.text }</span>;
   }
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
ComboBox option stylings are broken because we are assigning an object to the classNames field:
![image](https://user-images.githubusercontent.com/1581488/31747438-b8e45b84-b421-11e7-91f5-d7628a7192c8.png)

After fix: 
![image](https://user-images.githubusercontent.com/1581488/31747432-abcae67a-b421-11e7-8523-cd98bdf1c83c.png)

