### PR TITLE
 Adding hex/red/green/blue/alpha label props so applications can provide localized strings.

### DIFF
--- a/common/changes/office-ui-fabric-react/color-picker-custom-labels_2017-10-19-05-42.json
+++ b/common/changes/office-ui-fabric-react/color-picker-custom-labels_2017-10-19-05-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Adding hex/red/green/blue/alpha label props so applications can provide localized strings. Also turns off spell check for corresponding text fields.",
+      "comment": "ColorPicker: Adding hex/red/green/blue/alpha label props so applications can provide localized strings. Also turns off spell check for corresponding text fields.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/color-picker-custom-labels_2017-10-19-05-42.json
+++ b/common/changes/office-ui-fabric-react/color-picker-custom-labels_2017-10-19-05-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding hex/red/green/blue/alpha label props so applications can provide localized strings. Also turns off spell check for corresponding text fields.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "sllynn8907@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.Props.ts
@@ -18,4 +18,34 @@ export interface IColorPickerProps {
    * The setting of whether to hide the alpha control slider.
    */
   alphaSliderHidden?: boolean;
+
+  /**
+   * Label for the hex textfield.
+   * @default Hex
+   */
+  hexLabel?: string;
+
+  /**
+   * Label for the red textfield
+   * @default Red
+   */
+  redLabel?: string;
+
+  /**
+   * Label for the green textfield
+   * @default Green
+   */
+  greenLabel?: string;
+
+  /**
+   * Label for the blue textfield
+   * @default Blue
+   */
+  blueLabel?: string;
+
+  /**
+   * Label for the alpha textfield
+   * @default Alpha
+   */
+  alphaLabel?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -68,6 +68,30 @@ describe('ColorPicker', () => {
     expect(alphaTableInput).toBeNull();
   });
 
+  it('Renders default RGBA/Hex strings', () => {
+    const component = ReactTestUtils.renderIntoDocument(
+      <ColorPicker color='#FFFFFF' />
+    ) as ColorPicker;
+
+    const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+    const tableHeaders = renderedDOM.querySelectorAll('.ms-ColorPicker-table > thead > tr > td') as NodeListOf<HTMLTableDataCellElement>;
+
+    const hexTableHeader = tableHeaders[0];
+    expect(hexTableHeader.textContent).toEqual(ColorPicker.defaultProps.hexLabel);
+
+    const redTableHeader = tableHeaders[1];
+    expect(redTableHeader.textContent).toEqual(ColorPicker.defaultProps.redLabel);
+
+    const greenTableHeader = tableHeaders[2];
+    expect(greenTableHeader.textContent).toEqual(ColorPicker.defaultProps.greenLabel);
+
+    const blueTableHeader = tableHeaders[3];
+    expect(blueTableHeader.textContent).toEqual(ColorPicker.defaultProps.blueLabel);
+
+    const alphaTableHeader = tableHeaders[4];
+    expect(alphaTableHeader.textContent).toEqual(ColorPicker.defaultProps.alphaLabel);
+  });
+
   it('Renders custom RGBA/Hex strings', () => {
     const customHexLabel = 'Custom Hex';
     const customRedLabel = 'Custom Red';

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -17,7 +17,7 @@ describe('ColorPicker', () => {
   });
 
   it('Props are correctly parsed', () => {
-    let component = ReactTestUtils.renderIntoDocument(
+    const component = ReactTestUtils.renderIntoDocument(
       <ColorPicker color='#FFFFFF' />
     ) as ColorPicker;
 
@@ -25,7 +25,7 @@ describe('ColorPicker', () => {
   });
 
   it('Reacts to props changes', () => {
-    let component = ReactTestUtils.renderIntoDocument(
+    const component = ReactTestUtils.renderIntoDocument(
       <ColorPicker color='#FFFFFF' />
     ) as ColorPicker;
 
@@ -39,7 +39,7 @@ describe('ColorPicker', () => {
       color = str;
     };
 
-    let component = ReactTestUtils.renderIntoDocument(
+    const component = ReactTestUtils.renderIntoDocument(
       <ColorPicker
         color={ color }
         onColorChanged={ onColorChanged }
@@ -54,17 +54,54 @@ describe('ColorPicker', () => {
   });
 
   it('Hides alpha control slider', () => {
-    let component = ReactTestUtils.renderIntoDocument(
+    const component = ReactTestUtils.renderIntoDocument(
       <ColorPicker color='#FFFFFF' alphaSliderHidden={ true } />
     ) as ColorPicker;
 
-    let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
-    let alphaSlider = renderedDOM.querySelector('.is-alpha');
-    let alphaTableHeader = renderedDOM.querySelector('.ms-ColorPicker-table > thead > tr > td:nth-child(5)');
-    let alphaTableInput = renderedDOM.querySelector('.ms-ColorPicker-table > tbody> tr > td:nth-child(5)');
+    const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+    const alphaSlider = renderedDOM.querySelector('.is-alpha');
+    const alphaTableHeader = renderedDOM.querySelector('.ms-ColorPicker-table > thead > tr > td:nth-child(5)');
+    const alphaTableInput = renderedDOM.querySelector('.ms-ColorPicker-table > tbody> tr > td:nth-child(5)');
 
     expect(alphaSlider).toBeNull();
     expect(alphaTableHeader).toBeNull();
     expect(alphaTableInput).toBeNull();
+  });
+
+  it('Renders custom RGBA/Hex strings', () => {
+    const customHexLabel = 'Custom Hex';
+    const customRedLabel = 'Custom Red';
+    const customGreenLabel = 'Custom Green';
+    const customBlueLabel = 'Custom Blue';
+    const customAlphaLabel = 'Custom Alpha';
+
+    const component = ReactTestUtils.renderIntoDocument(
+      <ColorPicker
+        color='#FFFFFF'
+        hexLabel={ customHexLabel }
+        redLabel={ customRedLabel }
+        greenLabel={ customGreenLabel }
+        blueLabel={ customBlueLabel }
+        alphaLabel={ customAlphaLabel }
+      />
+    ) as ColorPicker;
+
+    const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+    const tableHeaders = renderedDOM.querySelectorAll('.ms-ColorPicker-table > thead > tr > td') as NodeListOf<HTMLTableDataCellElement>;
+
+    const hexTableHeader = tableHeaders[0];
+    expect(hexTableHeader.textContent).toEqual(customHexLabel);
+
+    const redTableHeader = tableHeaders[1];
+    expect(redTableHeader.textContent).toEqual(customRedLabel);
+
+    const greenTableHeader = tableHeaders[2];
+    expect(greenTableHeader.textContent).toEqual(customGreenLabel);
+
+    const blueTableHeader = tableHeaders[3];
+    expect(blueTableHeader.textContent).toEqual(customBlueLabel);
+
+    const alphaTableHeader = tableHeaders[4];
+    expect(alphaTableHeader.textContent).toEqual(customAlphaLabel);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -27,6 +27,14 @@ export interface IColorPickerState {
 }
 
 export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerState> {
+  public static defaultProps = {
+    hexLabel: 'Hex',
+    redLabel: 'Red',
+    greenLabel: 'Green',
+    blueLabel: 'Blue',
+    alphaLabel: 'Alpha'
+  };
+
   private hexText: TextField;
   private rText: TextField;
   private gText: TextField;
@@ -73,12 +81,12 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
           <table className={ css('ms-ColorPicker-table', styles.table) } cellPadding='0' cellSpacing='0'>
             <thead>
               <tr className={ FontClassNames.small }>
-                <td className={ styles.tableHexCell }>{ this.props.hexLabel || 'Hex' }</td>
-                <td>{ this.props.redLabel || 'Red' }</td>
-                <td>{ this.props.greenLabel || 'Green' }</td>
-                <td>{ this.props.blueLabel || 'Blue' }</td>
+                <td className={ styles.tableHexCell }>{ this.props.hexLabel }</td>
+                <td>{ this.props.redLabel }</td>
+                <td>{ this.props.greenLabel }</td>
+                <td>{ this.props.blueLabel }</td>
                 { !this.props.alphaSliderHidden && (
-                  <td>{ this.props.alphaLabel || 'Alpha' }</td>) }
+                  <td>{ this.props.alphaLabel }</td>) }
               </tr>
             </thead>
             <tbody>

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -73,12 +73,12 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
           <table className={ css('ms-ColorPicker-table', styles.table) } cellPadding='0' cellSpacing='0'>
             <thead>
               <tr className={ FontClassNames.small }>
-                <td className={ styles.tableHexCell }>Hex</td>
-                <td>Red</td>
-                <td>Green</td>
-                <td>Blue</td>
+                <td className={ styles.tableHexCell }>{ this.props.hexLabel || 'Hex' }</td>
+                <td>{ this.props.redLabel || 'Red' }</td>
+                <td>{ this.props.greenLabel || 'Green' }</td>
+                <td>{ this.props.blueLabel || 'Blue' }</td>
                 { !this.props.alphaSliderHidden && (
-                  <td>Alpha</td>) }
+                  <td>{ this.props.alphaLabel || 'Alpha' }</td>) }
               </tr>
             </thead>
             <tbody>
@@ -89,6 +89,7 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
                     value={ color.hex }
                     ref={ (ref) => this.hexText = ref! }
                     onBlur={ this._onHexChanged }
+                    spellCheck={ false }
                   />
                 </td>
                 <td style={ { width: '18%' } }>
@@ -97,6 +98,7 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
                     onBlur={ this._onRGBAChanged }
                     value={ String(color.r) }
                     ref={ (ref) => this.rText = ref! }
+                    spellCheck={ false }
                   />
                 </td>
                 <td style={ { width: '18%' } }>
@@ -105,6 +107,7 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
                     onBlur={ this._onRGBAChanged }
                     value={ String(color.g) }
                     ref={ (ref) => this.gText = ref! }
+                    spellCheck={ false }
                   />
                 </td>
                 <td style={ { width: '18%' } }>
@@ -113,6 +116,7 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
                     onBlur={ this._onRGBAChanged }
                     value={ String(color.b) }
                     ref={ (ref) => this.bText = ref! }
+                    spellCheck={ false }
                   />
                 </td>
                 { !this.props.alphaSliderHidden && (
@@ -122,6 +126,7 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
                       onBlur={ this._onRGBAChanged }
                       value={ String(color.a) }
                       ref={ (ref) => this.aText = ref! }
+                      spellCheck={ false }
                     />
                   </td>
                 ) }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -131,6 +131,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onChange={[Function]}
                     onFocus={[Function]}
                     onInput={[Function]}
+                    spellCheck={false}
                     type="text"
                     value="ffffff"
                   />
@@ -164,6 +165,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onChange={[Function]}
                     onFocus={[Function]}
                     onInput={[Function]}
+                    spellCheck={false}
                     type="text"
                     value="255"
                   />
@@ -197,6 +199,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onChange={[Function]}
                     onFocus={[Function]}
                     onInput={[Function]}
+                    spellCheck={false}
                     type="text"
                     value="255"
                   />
@@ -230,6 +233,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onChange={[Function]}
                     onFocus={[Function]}
                     onInput={[Function]}
+                    spellCheck={false}
                     type="text"
                     value="255"
                   />
@@ -263,6 +267,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onChange={[Function]}
                     onFocus={[Function]}
                     onInput={[Function]}
+                    spellCheck={false}
                     type="text"
                     value="100"
                   />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3142
- [x] Include a change request file using `$ npm run change`

#### Description of changes

 Adding hex/red/green/blue/alpha label props so applications can provide localized strings. Also turns off spell check for corresponding text fields.
