### PR TITLE
Split Button in Menus: Launch Menu with right arrow key

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-splitMenuLaunch_2017-10-19-15-20.json
+++ b/common/changes/office-ui-fabric-react/malozano-splitMenuLaunch_2017-10-19-15-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "\"Menu Split Button: Launch split button menu with right arrow key\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/malozano-splitMenuLaunch_2017-10-19-15-20.json
+++ b/common/changes/office-ui-fabric-react/malozano-splitMenuLaunch_2017-10-19-15-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "\"Menu Split Button: Launch split button menu with right arrow key\"",
+      "comment": "Menu Split Button: Launch split button menu with right arrow key",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -558,7 +558,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       submenuIconProps: item.submenuIconProps
     } as IContextualMenuItem;
     return React.createElement('button',
-      getNativeProps(itemProps, buttonProperties),
+      assign({}, getNativeProps(item, buttonProperties), { onKeyDown: this._onItemKeyDown.bind(this, item) }),
       this._renderMenuItemChildren(itemProps, classNames, index, false, false));
   }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -557,8 +557,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       subMenuProps: item.subMenuProps,
       submenuIconProps: item.submenuIconProps
     } as IContextualMenuItem;
+
     return React.createElement('button',
-      assign({}, getNativeProps(item, buttonProperties), { onKeyDown: this._onItemKeyDown.bind(this, item) }),
+      assign({}, getNativeProps(itemProps, buttonProperties), {
+        onKeyDown: this._onItemKeyDown.bind(this, item)
+      }),
       this._renderMenuItemChildren(itemProps, classNames, index, false, false));
   }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
@@ -30,7 +30,7 @@ export class ContextualMenuCheckmarksExample extends React.Component<any, IConte
         text='Click for ContextualMenu'
         menuProps={
           {
-            shouldFocusOnMount: false,
+            shouldFocusOnMount: true,
             items:
             [
               {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add ability of launching the menu of a split button with the right arrow key. Before this, the menu was launching with the enter key.
