### PR TITLE
[BaseAutoFill] Adds onInputChange prop

### DIFF
--- a/common/changes/@uifabric/example-app-base/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/@uifabric/example-app-base/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "joem@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/@uifabric/experiments/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "joem@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/@uifabric/fabric-website/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "joem@microsoft.com"
+}

--- a/common/changes/@uifabric/icons/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/@uifabric/icons/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "joem@microsoft.com"
+}

--- a/common/changes/@uifabric/jest-serializer-merge-styles/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/@uifabric/jest-serializer-merge-styles/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/jest-serializer-merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/jest-serializer-merge-styles",
+  "email": "joem@microsoft.com"
+}

--- a/common/changes/@uifabric/merge-styles/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/@uifabric/merge-styles/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "joem@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/@uifabric/styling/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "joem@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/@uifabric/utilities/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "joem@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
+++ b/common/changes/office-ui-fabric-react/joem-peoplePicker-sanitize-input_2017-10-19-17-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds \"onInputChanged\" prop to BasePicker",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joem@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/AutoFill/BaseAutoFill.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/AutoFill/BaseAutoFill.Props.ts
@@ -51,6 +51,7 @@ export interface IBaseAutoFillProps extends
    * The suggested autofill value that will display.
    */
   suggestedDisplayValue?: string;
+
   /**
    * A callback for when the current input value changes.
    */
@@ -88,4 +89,8 @@ export interface IBaseAutoFillProps extends
    */
   shouldSelectFullInputValueInComponentDidUpdate?: () => boolean;
 
+  /**
+   * A callback used to modify the input string.
+   */
+  onInputChange?: (value: string) => string;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/AutoFill/BaseAutoFill.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/AutoFill/BaseAutoFill.tsx
@@ -192,8 +192,9 @@ export class BaseAutoFill extends BaseComponent<IBaseAutoFillProps, IBaseAutoFil
     }
   }
 
+  @autobind
   private _updateValue(newValue: string) {
-    this._value = newValue;
+    this._value = this.props.onInputChange ? this.props.onInputChange(newValue) : newValue;
     let displayValue = newValue;
     if (this.props.suggestedDisplayValue &&
       this._doesTextStartWith(this.props.suggestedDisplayValue, displayValue)
@@ -202,7 +203,7 @@ export class BaseAutoFill extends BaseComponent<IBaseAutoFillProps, IBaseAutoFil
     }
     this.setState({
       displayValue: newValue
-    }, () => this._notifyInputChange(newValue));
+    }, () => this._notifyInputChange(this._value));
   }
 
   private _doesTextStartWith(text: string, startWith: string) {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts
@@ -116,6 +116,10 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    * The items that the base picker should currently display as selected. If this is provided then the picker will act as a controlled component.
    */
   selectedItems?: T[];
+  /**
+   * A callback used to sanitize the input string.
+   */
+  onInputChanged?: (input: string) => string;
 }
 
 export interface IBasePickerSuggestionsProps {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.Props.ts
@@ -117,9 +117,9 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    */
   selectedItems?: T[];
   /**
-   * A callback used to sanitize the input string.
+   * A callback used to modify the input string.
    */
-  onInputChanged?: (input: string) => string;
+  onInputChange?: (input: string) => string;
 }
 
 export interface IBasePickerSuggestionsProps {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -361,7 +361,9 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
 
   @autobind
   protected onInputChange(value: string) {
-    this.updateValue(value);
+    const newInput = this.props.onInputChanged ? this.props.onInputChanged(value) : value;
+
+    this.updateValue(newInput);
     this.setState({
       moreSuggestionsAvailable: true,
       isMostRecentlyUsedVisible: false

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -180,6 +180,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
                 role='combobox'
                 disabled={ disabled }
                 aria-controls='selected-suggestion-alert'
+                onInputChange={ this.props.onInputChange }
               />) }
             </div>
           </SelectionZone>
@@ -361,9 +362,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
 
   @autobind
   protected onInputChange(value: string) {
-    const newInput = this.props.onInputChanged ? this.props.onInputChanged(value) : value;
-
-    this.updateValue(newInput);
+    this.updateValue(value);
     this.setState({
       moreSuggestionsAvailable: true,
       isMostRecentlyUsedVisible: false

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -173,6 +173,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
           'aria-label': 'People Picker'
         } }
         componentRef={ this._resolveRef('_picker') }
+        onInputChanged={ this._onInputChanged }
       />
     );
   }
@@ -433,4 +434,21 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
     }
   }
 
+  /**
+   * Takes in the picker input and modifies it in whichever way
+   * the caller wants, i.e. parsing entries copied from Outlook (sample
+   * input: "Aaron Reid <aaron>").
+   *
+   * @param input The text entered into the picker.
+   */
+  private _onInputChanged(input: string): string {
+    const outlookRegEx = /<.*>/g;
+    const emailAddress = outlookRegEx.exec(input);
+
+    if (emailAddress && emailAddress[0]) {
+      return emailAddress[0].substring(1, emailAddress[0].length - 1);
+    }
+
+    return input;
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -173,7 +173,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
           'aria-label': 'People Picker'
         } }
         componentRef={ this._resolveRef('_picker') }
-        onInputChanged={ this._onInputChanged }
+        onInputChange={ this._onInputChange }
       />
     );
   }
@@ -441,7 +441,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
    *
    * @param input The text entered into the picker.
    */
-  private _onInputChanged(input: string): string {
+  private _onInputChange(input: string): string {
     const outlookRegEx = /<.*>/g;
     const emailAddress = outlookRegEx.exec(input);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Adds `onInputChange` prop to BaseAutoFill so consumers of pickers can modify the input string if necessary
- Adds `onInputChange` prop to BasePicker to pass through to BaseAutoFill
- Example use case: Users want to copy contacts from Outlook (i.e. "Joe Martella" <joem@microsoft.com>), but picker only accepts email addresses. Using this prop, the consumer of the picker can take in that string, strip out the email address, and use that as the input to use.
