### PR TITLE
date picker: 3161: do not parse formatted dates

### DIFF
--- a/common/changes/office-ui-fabric-react/fpintos-datePicker_3161_do_not_parse_formatted_dates_2017-10-19-21-44.json
+++ b/common/changes/office-ui-fabric-react/fpintos-datePicker_3161_do_not_parse_formatted_dates_2017-10-19-21-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker will not try to parse a string if the formatted string of the selected date is the same as the string to be parsed.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "fpintos@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -415,12 +415,9 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
         // Don't parse if the selected date has the same formatted string as what we're about to parse.
         // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
         // not be able to come up with the exact same date.
-        if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) == inputValue)
-        {
+        if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
           date = this.state.selectedDate;
-        }
-        else
-        {
+        } else {
           date = parseDateFromString!(inputValue);
           if (!date) {
             this.setState({

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -391,7 +391,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
 
   @autobind
   private _validateTextInput() {
-    let { isRequired, allowTextInput, strings, parseDateFromString, onSelectDate } = this.props;
+    let { isRequired, allowTextInput, strings, parseDateFromString, onSelectDate, formatDate } = this.props;
     const inputValue = this.state.formattedDate;
 
     // Do validation only if DatePicker's popup is dismissed
@@ -412,16 +412,26 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     if (allowTextInput) {
       let date = null;
       if (inputValue) {
-        date = parseDateFromString!(inputValue);
-        if (!date) {
-          this.setState({
-            errorMessage: strings!.invalidInputErrorMessage || '*'
-          });
-        } else {
-          this.setState({
-            selectedDate: date,
-            errorMessage: ''
-          });
+        // Don't parse if the selected date has the same formatted string as what we're about to parse.
+        // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
+        // not be able to come up with the exact same date.
+        if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) == inputValue)
+        {
+          date = this.state.selectedDate;
+        }
+        else
+        {
+          date = parseDateFromString!(inputValue);
+          if (!date) {
+            this.setState({
+              errorMessage: strings!.invalidInputErrorMessage || '*'
+            });
+          } else {
+            this.setState({
+              selectedDate: date,
+              errorMessage: ''
+            });
+          }
         }
       } else {
         // No input date string shouldn't be an error if field is not required

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePickerPage.tsx
@@ -9,6 +9,7 @@ import { DatePickerBasicExample } from './examples/DatePicker.Basic.Example';
 import { DatePickerWeekNumbersExample } from './examples/DatePicker.WeekNumbers.Example';
 import { DatePickerRequiredExample } from './examples/DatePicker.Required.Example';
 import { DatePickerInputExample } from './examples/DatePicker.Input.Example';
+import { DatePickerFormatExample } from './examples/DatePicker.Format.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { DatePickerStatus } from './DatePicker.checklist';
 
@@ -16,6 +17,8 @@ const DatePickerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/s
 const DatePickerWeekNumbersExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx') as string;
 const DatePickerRequiredExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx') as string;
 const DatePickerInputExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx') as string;
+const DatePickerFormatExampleCode = require
+('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx') as string;
 
 export class DatePickerPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -36,6 +39,9 @@ export class DatePickerPage extends React.Component<IComponentDemoPageProps, {}>
             </ExampleCard>
             <ExampleCard title='DatePicker allows input date string' code={ DatePickerInputExampleCode }>
               <DatePickerInputExample />
+            </ExampleCard>
+            <ExampleCard title='DatePicker allows dates to be formatted' code={ DatePickerFormatExampleCode }>
+              <DatePickerFormatExample />
             </ExampleCard>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
@@ -1,0 +1,145 @@
+import * as React from "react";
+import { DefaultButton } from "office-ui-fabric-react/lib/Button";
+import {
+  DatePicker,
+  DayOfWeek,
+  IDatePickerStrings
+} from "office-ui-fabric-react/lib/DatePicker";
+import { autobind } from "office-ui-fabric-react/lib/Utilities";
+
+const DayPickerStrings: IDatePickerStrings = {
+  months: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+  ],
+
+  shortMonths: [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec"
+  ],
+
+  days: [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"
+  ],
+
+  shortDays: ["S", "M", "T", "W", "T", "F", "S"],
+
+  goToToday: "Go to today",
+  prevMonthAriaLabel: "Go to previous month",
+  nextMonthAriaLabel: "Go to next month",
+  prevYearAriaLabel: "Go to previous year",
+  nextYearAriaLabel: "Go to next year",
+
+  isRequiredErrorMessage: "Start date is required.",
+
+  invalidInputErrorMessage: "Invalid date format."
+};
+
+export interface IDatePickerFormatExampleState {
+  firstDayOfWeek?: DayOfWeek;
+  value?: Date | null;
+}
+
+export class DatePickerFormatExample extends React.Component<
+  any,
+  IDatePickerFormatExampleState
+> {
+  public constructor() {
+    super();
+
+    this.state = {
+      firstDayOfWeek: DayOfWeek.Sunday,
+      value: null
+    };
+  }
+
+  public render() {
+    let { firstDayOfWeek, value } = this.state;
+    const desc =
+      "This field is required. One of the support input formats is year dash month dash day.";
+    return (
+      <div>
+        <p>
+          Applications can customize how dates are formatted and parsed. Formatted dates
+          can be ambiguous, so the control will avoid parsing the formatted
+          strings of dates selected using the UI when text input is allowed. In
+          this example, we are formatting and parsing dates as dd/MM/yy.
+        </p>
+        <DatePicker
+          label="Start date"
+          isRequired={false}
+          allowTextInput={true}
+          ariaLabel={desc}
+          firstDayOfWeek={firstDayOfWeek}
+          strings={DayPickerStrings}
+          value={value!}
+          onSelectDate={this._onSelectDate}
+          formatDate={this._onFormatDate}
+          parseDateFromString={this._onParseDateFromString}
+        />
+        <DefaultButton onClick={this._onClick} text="Clear" />
+        <div>{(this.state.value || "").toString()}</div>
+      </div>
+    );
+  }
+
+  @autobind
+  private _onSelectDate(date: Date | null | undefined): void {
+    this.setState({ value: date });
+  }
+
+  @autobind
+  private _onClick(): void {
+    this.setState({ value: null });
+  }
+
+  @autobind
+  private _onFormatDate(date: Date): string {
+    return (
+      date.getDate() +
+      "/" +
+      (date.getMonth() + 1) +
+      "/" +
+      date.getFullYear() % 100
+    );
+  }
+
+  @autobind
+  private _onParseDateFromString(value:string): Date {
+    let date = this.state.value || new Date();
+    let values = (value || '').trim().split('/');
+    let day = values.length > 0 ? Math.max(1, Math.min(31, parseInt(values[0]))) : date.getDate();
+    let month = values.length > 1 ? Math.max(1, Math.min(12, parseInt(values[1]))) - 1 : date.getMonth();
+    let year = values.length > 2 ? parseInt(values[2]) : date.getFullYear();
+    if (year < 100) {
+      year += date.getFullYear() - (date.getFullYear() % 100);
+    }
+    return new Date(year, month, day);
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
@@ -1,64 +1,64 @@
-import * as React from "react";
-import { DefaultButton } from "office-ui-fabric-react/lib/Button";
+import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import {
   DatePicker,
   DayOfWeek,
   IDatePickerStrings
-} from "office-ui-fabric-react/lib/DatePicker";
-import { autobind } from "office-ui-fabric-react/lib/Utilities";
+} from 'office-ui-fabric-react/lib/DatePicker';
+import { autobind } from 'office-ui-fabric-react/lib/Utilities';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December"
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December'
   ],
 
   shortMonths: [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec"
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec'
   ],
 
   days: [
-    "Sunday",
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday"
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday'
   ],
 
-  shortDays: ["S", "M", "T", "W", "T", "F", "S"],
+  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
 
-  goToToday: "Go to today",
-  prevMonthAriaLabel: "Go to previous month",
-  nextMonthAriaLabel: "Go to next month",
-  prevYearAriaLabel: "Go to previous year",
-  nextYearAriaLabel: "Go to next year",
+  goToToday: 'Go to today',
+  prevMonthAriaLabel: 'Go to previous month',
+  nextMonthAriaLabel: 'Go to next month',
+  prevYearAriaLabel: 'Go to previous year',
+  nextYearAriaLabel: 'Go to next year',
 
-  isRequiredErrorMessage: "Start date is required.",
+  isRequiredErrorMessage: 'Start date is required.',
 
-  invalidInputErrorMessage: "Invalid date format."
+  invalidInputErrorMessage: 'Invalid date format.'
 };
 
 export interface IDatePickerFormatExampleState {
@@ -82,17 +82,18 @@ export class DatePickerFormatExample extends React.Component<
   public render() {
     let { firstDayOfWeek, value } = this.state;
     const desc =
-      "This field is required. One of the support input formats is year dash month dash day.";
+      'This field is required. One of the support input formats is year dash month dash day.';
     return (
       <div>
         <p>
-          Applications can customize how dates are formatted and parsed. Formatted dates
-          can be ambiguous, so the control will avoid parsing the formatted
-          strings of dates selected using the UI when text input is allowed. In
-          this example, we are formatting and parsing dates as dd/MM/yy.
+          Applications can customize how dates are formatted and parsed.
+          Formatted dates can be ambiguous, so the control will avoid parsing
+          the formatted strings of dates selected using the UI when text input
+          is allowed. In this example, we are formatting and parsing dates as
+          dd/MM/yy.
         </p>
         <DatePicker
-          label="Start date"
+          label='Start date'
           isRequired={false}
           allowTextInput={true}
           ariaLabel={desc}
@@ -103,8 +104,8 @@ export class DatePickerFormatExample extends React.Component<
           formatDate={this._onFormatDate}
           parseDateFromString={this._onParseDateFromString}
         />
-        <DefaultButton onClick={this._onClick} text="Clear" />
-        <div>{(this.state.value || "").toString()}</div>
+        <DefaultButton onClick={this._onClick} text='Clear' />
+        <div>{(this.state.value || '').toString()}</div>
       </div>
     );
   }
@@ -123,22 +124,28 @@ export class DatePickerFormatExample extends React.Component<
   private _onFormatDate(date: Date): string {
     return (
       date.getDate() +
-      "/" +
+      '/' +
       (date.getMonth() + 1) +
-      "/" +
+      '/' +
       date.getFullYear() % 100
     );
   }
 
   @autobind
-  private _onParseDateFromString(value:string): Date {
+  private _onParseDateFromString(value: string): Date {
     let date = this.state.value || new Date();
     let values = (value || '').trim().split('/');
-    let day = values.length > 0 ? Math.max(1, Math.min(31, parseInt(values[0]))) : date.getDate();
-    let month = values.length > 1 ? Math.max(1, Math.min(12, parseInt(values[1]))) - 1 : date.getMonth();
-    let year = values.length > 2 ? parseInt(values[2]) : date.getFullYear();
+    let day =
+      values.length > 0
+        ? Math.max(1, Math.min(31, parseInt(values[0], 10)))
+        : date.getDate();
+    let month =
+      values.length > 1
+        ? Math.max(1, Math.min(12, parseInt(values[1], 10))) - 1
+        : date.getMonth();
+    let year = values.length > 2 ? parseInt(values[2], 10) : date.getFullYear();
     if (year < 100) {
-      year += date.getFullYear() - (date.getFullYear() % 100);
+      year += date.getFullYear() - date.getFullYear() % 100;
     }
     return new Date(year, month, day);
   }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3161 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Updated DatePicker so that it will not parse the text input if the inputValue is the same as the formatted string of the selected date. In cases where the formatted string might be ambiguous, the parser might not be able to come up with the exact same date.

An example of the issue can be seen in this CodePen: https://codepen.io/fpintos/pen/oGyrzR, where entering and exiting the control by tabbing has the side-effect of changing the selected date.

With the fix, simply tabbing thru the control will not result in a date change.

#### Focus areas to test

A new example is added to the sample pages, showing DatePicker with custom formatting and parsing. This is basically a copy of DatePickerInputExample with callbacks for formatDate and parseDateFromString.

Tabbing thru the control should will not invoke the parser.
If the user enters the control and edits the text, but reverts it back to the same string produced by the selected date, the parser is not invoked and the selected date remains the same.


