### PR TITLE
Callout/ContextualMenu: Fix (and deprecate) broken `targetPoint` prop

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-broken-target-point-prop_2017-10-20-20-02.json
+++ b/common/changes/office-ui-fabric-react/fix-broken-target-point-prop_2017-10-20-20-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu/Callout: Fix (and deprecate) broken 'targetPoint' API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.Props.ts
@@ -23,7 +23,7 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
    * It can be either an HTMLElement a querySelector string of a valid HTMLElement
    * or a MouseEvent. If MouseEvent is given then the origin point of the event will be used.
    */
-  target?: HTMLElement | string | MouseEvent | null;
+  target?: HTMLElement | string | MouseEvent | IPoint | null;
 
   /**
    * How the element should be positioned
@@ -75,11 +75,13 @@ export interface ICalloutProps extends React.Props<Callout | CalloutContent> {
   /**
    * If true use a point rather than rectangle to position the Callout.
    * For example it can be used to position based on a click.
+   * @deprecated Use 'target' instead
    */
   useTargetPoint?: boolean;
 
   /**
    * Point used to position the Callout
+   * @deprecated Use 'target' instead
    */
   targetPoint?: IPoint;
 

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.tsx
@@ -11,6 +11,11 @@ export class Callout extends BaseComponent<ICalloutProps, ICalloutState> {
 
   constructor(props: ICalloutProps) {
     super(props);
+
+    this._warnDeprecations({
+      'targetPoint': 'target',
+      'useTargetPoint': 'target',
+    });
   }
 
   public render() {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.Props.ts
@@ -38,7 +38,7 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * It can be either an HTMLElement a querySelector string of a valid HTMLElement
    * or a MouseEvent. If MouseEvent is given then the origin point of the event will be used.
    */
-  target?: HTMLElement | string | MouseEvent | null;
+  target?: HTMLElement | string | MouseEvent | IPoint | null;
 
   /**
    * How the element should be positioned
@@ -78,11 +78,13 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
   /**
    * If true use a point rather than rectangle to position the ContextualMenu.
    * For example it can be used to position based on a click.
+   * @deprecated Use 'target' instead
    */
   useTargetPoint?: boolean;
 
   /**
    * Point used to position the ContextualMenu
+   * @deprecated Use 'target' instead
    */
   targetPoint?: IPoint;
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -129,7 +129,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       'useTargetPoint': 'target',
     });
 
-
     this._isFocusingPreviousElement = false;
     this._enterTimerId = 0;
   }
@@ -255,9 +254,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       return (
         <Callout
           {...calloutProps}
-          target={ target }
-          targetPoint={ targetPoint }
-          useTargetPoint={ useTargetPoint }
+          target={ useTargetPoint ? targetPoint : target }
           isBeakVisible={ isBeakVisible }
           beakWidth={ beakWidth }
           directionalHint={ directionalHint }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -14,6 +14,7 @@ import {
 } from './ContextualMenu.classNames';
 import {
   BaseComponent,
+  IPoint,
   anchorProperties,
   buttonProperties,
   getNativeProps,
@@ -112,7 +113,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   private _isFocusingPreviousElement: boolean;
   private _enterTimerId: number;
   private _targetWindow: Window;
-  private _target: HTMLElement | MouseEvent | null;
+  private _target: HTMLElement | MouseEvent | IPoint | null;
   private _classNames: IContextualMenuClassNames;
 
   constructor(props: IContextualMenuProps) {
@@ -122,6 +123,12 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       contextualMenuItems: undefined,
       subMenuId: getId('ContextualMenu')
     };
+
+    this._warnDeprecations({
+      'targetPoint': 'target',
+      'useTargetPoint': 'target',
+    });
+
 
     this._isFocusingPreviousElement = false;
     this._enterTimerId = 0;
@@ -763,19 +770,22 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     }
   }
 
-  private _setTargetWindowAndElement(target: HTMLElement | string | MouseEvent): void {
+  private _setTargetWindowAndElement(target: HTMLElement | string | MouseEvent | IPoint): void {
     if (target) {
       if (typeof target === 'string') {
         let currentDoc: Document = getDocument()!;
         this._target = currentDoc ? currentDoc.querySelector(target) as HTMLElement : null;
         this._targetWindow = getWindow()!;
       } else if ((target as MouseEvent).stopPropagation) {
-        this._target = target;
         this._targetWindow = getWindow((target as MouseEvent).toElement as HTMLElement)!;
+        this._target = target;
+      } else if ((target as IPoint).x !== undefined && (target as IPoint).y !== undefined) {
+        this._targetWindow = getWindow()!;
+        this._target = target;
       } else {
         let targetElement: HTMLElement = target as HTMLElement;
-        this._target = target;
         this._targetWindow = getWindow(targetElement)!;
+        this._target = target;
       }
     } else {
       this._targetWindow = getWindow()!;

--- a/packages/office-ui-fabric-react/src/utilities/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning.ts
@@ -32,7 +32,7 @@ export class Rectangle extends FullRectangle {
 }
 
 export interface IPositionProps {
-  target?: HTMLElement | MouseEvent;
+  target?: HTMLElement | MouseEvent | IPoint;
   /** how the element should be positioned */
   directionalHint?: DirectionalHint;
 
@@ -620,12 +620,15 @@ export module positioningFunctions {
     return new Rectangle(rect.left, rect.right, rect.top, rect.bottom);
   }
 
-  export function _getTargetRect(bounds: Rectangle, target: HTMLElement | MouseEvent | undefined) {
+  export function _getTargetRect(bounds: Rectangle, target: HTMLElement | MouseEvent | IPoint | undefined) {
     let targetRectangle: Rectangle;
     if (target) {
       if ((target as MouseEvent).preventDefault) {
         let ev: MouseEvent = target as MouseEvent;
         targetRectangle = new Rectangle(ev.clientX, ev.clientX, ev.clientY, ev.clientY);
+      } else if ((target as IPoint).x !== undefined) {
+        let point: IPoint = target as IPoint;
+        targetRectangle = new Rectangle(point.x, point.x, point.y, point.y);
       } else {
         targetRectangle = _getRectangleFromHTMLElement(target as HTMLElement);
       }
@@ -725,9 +728,10 @@ export function getRelativePositions(props: IPositionProps,
  * of the target given.
  * If no bounds are provided then the window is treated as the bounds.
  */
-export function getMaxHeight(target: HTMLElement | MouseEvent, targetEdge: DirectionalHint, gapSpace: number = 0, bounds?: IRectangle) {
+export function getMaxHeight(target: HTMLElement | MouseEvent | IPoint, targetEdge: DirectionalHint, gapSpace: number = 0, bounds?: IRectangle) {
   let mouseTarget: MouseEvent = target as MouseEvent;
   let elementTarget: HTMLElement = target as HTMLElement;
+  let pointTarget: IPoint = target as IPoint;
   let targetRect: Rectangle;
   let boundingRectangle = bounds ?
     positioningFunctions._getRectangleFromIRect(bounds) :
@@ -735,6 +739,8 @@ export function getMaxHeight(target: HTMLElement | MouseEvent, targetEdge: Direc
 
   if (mouseTarget.stopPropagation) {
     targetRect = new Rectangle(mouseTarget.clientX, mouseTarget.clientX, mouseTarget.clientY, mouseTarget.clientY);
+  } else if (pointTarget.x !== undefined && pointTarget.y !== undefined) {
+    targetRect = new Rectangle(pointTarget.x, pointTarget.x, pointTarget.y, pointTarget.y);
   } else {
     targetRect = positioningFunctions._getRectangleFromHTMLElement(elementTarget);
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

@joschect's refactor around Callout positioning broke the `targetPoint` prop on `Callout` and `ContextualMenu`. This change repairs the break, and adds deprecation warnings to the properties.

#### Focus areas to test

(optional)
