### PR TITLE
Dialog: Don't add empty spans to footer for falsy children of DialogF…

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2017-10-20-20-08.json
+++ b/common/changes/office-ui-fabric-react/master_2017-10-20-20-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dialog: Don't add empty spans to footer for falsy children of DialogFooter",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.tsx
@@ -16,7 +16,7 @@ export class DialogFooter extends BaseComponent<any, any> {
 
   private _renderChildrenAsActions() {
     return React.Children.map(this.props.children, child =>
-      <span className={ css('ms-Dialog-action', styles.action) }>{ child }</span>
+      child && <span className={ css('ms-Dialog-action', styles.action) }>{ child }</span>
     );
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3175 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

If a DialogFooter child is falsy, don't wrap a `<span>` around it.

#### Focus areas to test

(optional)
