### PR TITLE
ComboBox: Check offsetParent exists before calling scrollIntoView

### DIFF
--- a/common/changes/office-ui-fabric-react/comboBoxOffsetParent_2017-10-22-22-02.json
+++ b/common/changes/office-ui-fabric-react/comboBoxOffsetParent_2017-10-22-22-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed an issue where ComboBox would throw an exception under shallow rendering tests",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "alexbettadapur@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -918,11 +918,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     if (onScrollToItem) {
       // Use the custom scroll handler
       onScrollToItem((currentPendingValueValidIndex >= 0 || currentPendingValue !== '') ? currentPendingValueValidIndex : selectedIndex);
-    } else {
+    } else if (this._selectedElement && this._selectedElement.offsetParent) {
       // We are using refs, scroll the ref into view
-      if (this._selectedElement && this._selectedElement.offsetParent && scrollSelectedToTop) {
+      if (scrollSelectedToTop) {
         this._selectedElement.offsetParent.scrollIntoView(true);
-      } else if (this._selectedElement) {
+      } else {
         let alignToTop = true;
 
         if (this._comboBoxMenu.offsetParent) {
@@ -934,9 +934,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           }
         }
 
-        if (this._selectedElement.offsetParent) {
-          this._selectedElement.offsetParent.scrollIntoView(alignToTop);
-        }
+        this._selectedElement.offsetParent.scrollIntoView(alignToTop);
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -920,7 +920,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       onScrollToItem((currentPendingValueValidIndex >= 0 || currentPendingValue !== '') ? currentPendingValueValidIndex : selectedIndex);
     } else {
       // We are using refs, scroll the ref into view
-      if (this._selectedElement && scrollSelectedToTop) {
+      if (this._selectedElement && this._selectedElement.offsetParent && scrollSelectedToTop) {
         this._selectedElement.offsetParent.scrollIntoView(true);
       } else if (this._selectedElement) {
         let alignToTop = true;
@@ -934,7 +934,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           }
         }
 
-        this._selectedElement.offsetParent.scrollIntoView(alignToTop);
+        if (this._selectedElement.offsetParent) {
+          this._selectedElement.offsetParent.scrollIntoView(alignToTop);
+        }
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/VirtualizedComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/VirtualizedComboBox.tsx
@@ -37,6 +37,7 @@ export class VirtualizedComboBox extends BaseComponent<IComboBoxProps, {}> {
     );
   }
 
+  @autobind
   protected _onScrollToItem(itemIndex: number): void {
     // We are using the List component, call scrollToIndex
     this._list.scrollToIndex(itemIndex);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3188
- [x] Include a change request file using `$ npm run change`

#### Description of changes
ComboBox used to call this._selectedElement.offsetParent.scrollIntoView without checking that offsetParent was defined. OffsetParent could be undefined in cases where the element was not yet rendered on the page, such as rendering via React shallow rendering.

Added null checks.
