### PR TITLE
SearchBox onKeyDown: prevent default events only when specified by the user

### DIFF
--- a/common/changes/office-ui-fabric-react/cicciodm-onkeydown-search-fix_2017-10-23-08-32.json
+++ b/common/changes/office-ui-fabric-react/cicciodm-onkeydown-search-fix_2017-10-23-08-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SearchBox onKeyDown: prevent default events only when specified by the user",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "frdim@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -145,14 +145,14 @@ export class SearchBox extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
         break;
 
       default:
-        if (this.props.onKeyDown) {
-          this.props.onKeyDown(ev);
-        } else {
+        this.props.onKeyDown && this.props.onKeyDown(ev);
+        if (!ev.defaultPrevented) {
           return;
         }
     }
 
-    // We only get here if the keypress has been handled.
+    // We only get here if the keypress has been handled,
+    // or preventDefault was called in case of default keyDown handler
     ev.preventDefault();
     ev.stopPropagation();
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Discovered a bug while using the `onKeyDown` handler with `SearchBox`: the presence of the handler automatically prevented default events to occur, and the `onChange` handler, for example, was not called.

This fix aims at improving and fine-tuning what I believe are the expectations of a `SearchBox` user, which I mentioned in my previous PR [#3128](https://github.com/OfficeDev/office-ui-fabric-react/pull/3128), but were not actually met.

Now, these are the interactions the user can expect:

- Press Enter: only the `onSearch` callback is called
- Press Escape: only the `onEscape` callback is called.
   - If `e.preventDefault` is called, the text is not cleared.
- Press a text key: the `onKeyDown` handler is called if present, followed by the `onChange` handler
   - if `e.preventDefault` is called, the `onChange` handler is not invoked

This means that if the user wants to listen to `enter`, `escape` and `change` events, they would provide appropriate handlers, while the `onKeyDown` would be there for all other interactions/keyPresses.

Another alternative, as previously suggested by @micahgodbolt, would be to simply put the `onKeyDown` handler at the top of the function, and override all other handlers if necessary. This might be preferable, as currently, calling `preventDefault` on a `keyDown` event would not override `onSearch` and `onEscape`. Overriding every interaction would be more consistent.

@dzearing for more comments on this.

#### Focus areas to test

In any `SearchBox` example, add an `onKeyDown` handler. Verify that `onKeyDown` is called, the text in the searchBox changes accordingly, and onChange is also invoked.

Add a `e.preventDefault()` call in the `onKeyDown` handler. Verify that the text in the box does not update, and `onChange` is not called.