### PR TITLE
Panel: Add optional custom function to handle clicks outside the panel when isLightDismiss=true

### DIFF
--- a/common/changes/office-ui-fabric-react/amkronen-panel_click_outside_2017-10-23-10-38.json
+++ b/common/changes/office-ui-fabric-react/amkronen-panel_click_outside_2017-10-23-10-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Added possibility of using a custom function to handle clicks outside the panel when using isLightDismiss=true",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "amkronen@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.Props.ts
@@ -122,6 +122,11 @@ export interface IPanelProps extends React.Props<Panel> {
   layerProps?: ILayerProps;
 
   /**
+   * Optional custom function to handle clicks outside the panel in lightdismiss mode
+   */
+  onLightDismissClick?: () => void;
+
+  /**
    * Optional custom renderer navigation region. Replaces current close button.
    */
   onRenderNavigation?: IRenderFunction<IPanelProps>;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -80,6 +80,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
       layerProps,
       type,
       customWidth,
+      onLightDismissClick = this._onPanelClick,
       onRenderNavigation = this._onRenderNavigation,
       onRenderHeader = this._onRenderHeader,
       onRenderBody = this._onRenderBody,
@@ -107,7 +108,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
             !isOpen && isAnimating && AnimationClassNames.fadeOut200
           ) }
           isDarkThemed={ false }
-          onClick={ isLightDismiss ? this._onPanelClick : undefined }
+          onClick={ isLightDismiss ? onLightDismissClick : undefined }
         />
       );
     }

--- a/packages/office-ui-fabric-react/src/components/Panel/PanelPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/PanelPage.tsx
@@ -14,6 +14,7 @@ import { PanelLargeFixedExample } from './examples/Panel.LargeFixed.Example';
 import { PanelExtraLargeExample } from './examples/Panel.ExtraLarge.Example';
 import { PanelCustomExample } from './examples/Panel.Custom.Example';
 import { PanelLightDismissExample } from './examples/Panel.LightDismiss.Example';
+import { PanelLightDismissCustomExample } from './examples/Panel.LightDismissCustom.Example';
 import { PanelNonModalExample } from './examples/Panel.NonModal.Example';
 import { PanelFooterExample } from './examples/Panel.Footer.Example';
 import { FontClassNames } from '../../Styling';
@@ -29,6 +30,7 @@ const PanelLargeFixedExampleCode = require('!raw-loader!office-ui-fabric-react/s
 const PanelExtraLargeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.ExtraLarge.Example.tsx') as string;
 const PanelCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Custom.Example.tsx') as string;
 const PanelLightDismissExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismiss.Example.tsx') as string;
+const PanelLightDismissCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx') as string;
 const PanelNonModalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.NonModal.Example.tsx') as string;
 const PanelFooterExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Footer.Example.tsx') as string;
 
@@ -66,6 +68,9 @@ export class PanelPage extends React.Component<IComponentDemoPageProps, {}> {
             </ExampleCard>
             <ExampleCard title='Panel - Light Dismiss' code={ PanelLightDismissExampleCode }>
               <PanelLightDismissExample />
+            </ExampleCard>
+            <ExampleCard title='Panel - Custom Light Dismiss' code={ PanelLightDismissCustomExampleCode }>
+              <PanelLightDismissCustomExample />
             </ExampleCard>
             <ExampleCard title='Panel - Non-Modal' code={ PanelNonModalExampleCode }>
               <PanelNonModalExample />

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { Dialog, DialogType, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { Panel } from 'office-ui-fabric-react/lib/Panel';
+
+export class PanelLightDismissCustomExample extends React.Component<any, any> {
+
+  constructor() {
+    super();
+
+    this.state = { showPanel: false, hideDialog: true };
+  }
+
+  public render() {
+    return (
+      <div>
+        <DefaultButton
+          text='Open panel'
+          onClick={ this._showPanel }
+        />
+        <Panel
+          isOpen={ this.state.showPanel }
+          isLightDismiss={ true }
+          headerText='Light Dismiss Panel'
+          onDismiss={ this._hidePanel }
+          onLightDismissClick={ this._showDialog }
+        >
+          <span>Light Dismiss usage is meant for the Contextual Menu on mobile sized breakpoints.</span>
+        </Panel>
+        <Dialog
+          hidden={ this.state.hideDialog }
+          onDismiss={ this._closeDialog }
+          dialogContentProps={ {
+            type: DialogType.normal,
+            title: 'Are you sure you want to close the panel?'
+          } }
+          modalProps={ {
+            titleAriaId: 'myLabelId',
+            subtitleAriaId: 'mySubTextId',
+            isBlocking: true,
+            containerClassName: 'ms-dialogMainOverride'
+          } }
+        >
+          { null /** You can also include null values as the result of conditionals */ }
+          <DialogFooter>
+            <PrimaryButton onClick={ this._closeDialogAndHidePanel } text='Yes' />
+            <DefaultButton onClick={ this._closeDialog } text='No' />
+          </DialogFooter>
+        </Dialog>
+      </div>
+    );
+  }
+
+  @autobind
+  private _showPanel(): void {
+    this.setState({ showPanel: true });
+  }
+
+  @autobind
+  private _hidePanel(): void {
+    this.setState({ showPanel: false });
+  }
+
+  @autobind
+  private _showDialog() {
+    this.setState({ hideDialog: false });
+  }
+
+  @autobind
+  private _closeDialog() {
+    this.setState({ hideDialog: true });
+  }
+
+  @autobind
+  private _closeDialogAndHidePanel() {
+    this._hidePanel();
+    this._closeDialog();
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ x] Include a change request file using `$ npm run change`

#### Description of changes

Added an optional callback in the props which handles the click. If the custom predicates are met, the Panel can be closed from the outside. If no custom function is set, we default to the current behavior. Also added an example which shows the usage of this: we display a dialog with an "are you sure..." text where the user can confirm that they want to close the panel.

#### Focus areas to test

(optional)
