### PR TITLE
Fix selection UX states in DetailsList

### DIFF
--- a/common/changes/office-ui-fabric-react/select-all_2017-10-20-23-01.json
+++ b/common/changes/office-ui-fabric-react/select-all_2017-10-20-23-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Ensure that Select All checkbox can still be focused",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -177,6 +177,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                       id={ `${this._id}-check` }
                       aria-label={ ariaLabelForSelectionColumn }
                       aria-describedby={ `${this._id}-checkTooltip` }
+                      data-is-focusable={ true }
                       selected={ isAllSelected }
                       anySelected={ false }
                       canSelect={ true }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -17,10 +17,11 @@ import { GroupSpacer } from '../GroupedList/GroupSpacer';
 import { CollapseAllVisibility } from '../../GroupedList';
 import { DetailsRowCheck } from './DetailsRowCheck';
 import { ITooltipHostProps } from '../../Tooltip';
-import * as checkStyles from './DetailsRowCheck.scss';
+import * as checkStylesModule from './DetailsRowCheck.scss';
 import { ISelection, SelectionMode, SELECTION_CHANGE } from '../../utilities/selection/interfaces';
 import * as stylesImport from './DetailsHeader.scss';
 const styles: any = stylesImport;
+const checkStyles: any = checkStylesModule;
 
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 const MOUSEMOVE_PRIMARY_BUTTON = 1; // for mouse move event we are using ev.buttons property, 1 means left button
@@ -159,6 +160,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                 styles.cell,
                 styles.cellIsCheck,
                 checkStyles.owner,
+                checkStyles.header,
                 isAllSelected && checkStyles.isSelected
               ) }
               aria-labelledby={ `${this._id}-check` }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -160,7 +160,6 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                 styles.cell,
                 styles.cellIsCheck,
                 checkStyles.owner,
-                checkStyles.header,
                 isAllSelected && checkStyles.isSelected
               ) }
               aria-labelledby={ `${this._id}-check` }
@@ -180,6 +179,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                       aria-label={ ariaLabelForSelectionColumn }
                       aria-describedby={ `${this._id}-checkTooltip` }
                       data-is-focusable={ true }
+                      isHeader={ true }
                       selected={ isAllSelected }
                       anySelected={ false }
                       canSelect={ true }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
@@ -22,6 +22,14 @@
   @include focus(true) {
     opacity: 1;
   }
+
+  :global(.ms-DetailsList--Compact) & {
+    height: 32px;
+  }
+
+  .header & {
+    height: 32px;
+  }
 }
 
 .owner {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
@@ -27,7 +27,7 @@
     height: 32px;
   }
 
-  .header & {
+  &.isHeader {
     height: 32px;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -11,6 +11,7 @@ const CheckStyles: any = CheckStylesModule;
 // tslint:enable:no-any
 
 export interface IDetailsRowCheckProps extends React.HTMLAttributes<HTMLElement> {
+  isHeader?: boolean;
   selected?: boolean;
   /**
    * Deprecated at v.65.1 and will be removed by v 1.0. Use 'selected' instead.
@@ -27,6 +28,8 @@ export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
     isSelected = false,
     anySelected = false,
     selected = false,
+    isHeader = false,
+    className,
     ...buttonProps
   } = props;
 
@@ -37,8 +40,9 @@ export const DetailsRowCheck = (props: IDetailsRowCheckProps) => {
       { ...buttonProps }
       role='checkbox'
       className={
-        css('ms-DetailsRow-check', DetailsRowCheckStyles.check, CheckStyles.checkHost, {
-          [`ms-DetailsRow-check--isDisabled ${DetailsRowCheckStyles.isDisabled}`]: !props.canSelect
+        css(className, 'ms-DetailsRow-check', DetailsRowCheckStyles.check, CheckStyles.checkHost, {
+          [`ms-DetailsRow-check--isDisabled ${DetailsRowCheckStyles.isDisabled}`]: !props.canSelect,
+          [`ms-DetailsRow-check--isHeader ${DetailsRowCheckStyles.isHeader}`]: props.isHeader
         })
       }
       aria-checked={ isPressed }


### PR DESCRIPTION
### Overview

This change fixes a minor bug in which the `DetailsRowCheck` in `DetailsHeader` was no longer keyboard-focusable, due to `DetailsRowCheck` being changed to use `div` and not be focusable by default.
This change also fixes the height of `DetailsRowCheck` in header cells and compact lists.