### PR TITLE
Switch to .svg files for FolderCover images

### DIFF
--- a/common/changes/@uifabric/experiments/folder-covers_2017-10-23-16-25.json
+++ b/common/changes/@uifabric/experiments/folder-covers_2017-10-23-16-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Switch to .svg files for FolderCover images",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -20,7 +20,7 @@
   }
 }
 
-.shadow {
+.front {
   display: block;
   position: absolute;
   left: -3px;
@@ -28,20 +28,12 @@
   bottom: -4px;
 }
 
-.front {
-  display: block;
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-}
-
 .back {
   display: block;
   position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  left: -3px;
+  right: -3px;
+  bottom: -4px;
 }
 
 .content {

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -40,7 +40,6 @@ const SIZES: {
 const ASSETS: {
   [P in FolderCoverSize]: {
     [T in FolderCoverType]: {
-      shadow: string;
       back: string;
       front: string;
     };
@@ -48,26 +47,22 @@ const ASSETS: {
 } = {
     small: {
       default: {
-        shadow: `${ASSET_CDN_BASE_URL}/foldericons/72x52_shadow_empty.png`,
-        back: `${ASSET_CDN_BASE_URL}/foldericons/s-ldefaultback.png`,
-        front: `${ASSET_CDN_BASE_URL}/foldericons/s-ldefaultfront.png`
+        back: `${ASSET_CDN_BASE_URL}/foldericons/folder-small_backplate.svg`,
+        front: `${ASSET_CDN_BASE_URL}/foldericons/folder-small_frontplate_thumbnail.svg` // Yes, it's mis-named.
       },
       media: {
-        shadow: `${ASSET_CDN_BASE_URL}/foldericons/72x52_shadow_empty.png`,
-        back: `${ASSET_CDN_BASE_URL}/foldericons/s-lphotoback.png`,
-        front: `${ASSET_CDN_BASE_URL}/foldericons/s-lphotosfront.png`
+        back: `${ASSET_CDN_BASE_URL}/foldericons/folder-small_backplate.svg`,
+        front: `${ASSET_CDN_BASE_URL}/foldericons//folder-small_frontplate_nopreview.svg` // Yes, it's mis-named
       }
     },
     large: {
       default: {
-        shadow: `${ASSET_CDN_BASE_URL}/foldericons/112x80_shadow_empty.png`,
-        back: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xldefaultback.png`,
-        front: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xldefaultfront.png`
+        back: `${ASSET_CDN_BASE_URL}/foldericons/folder-large_backplate.svg`,
+        front: `${ASSET_CDN_BASE_URL}/foldericons/folder-large_frontplate_nopreview.svg`
       },
       media: {
-        shadow: `${ASSET_CDN_BASE_URL}/foldericons/112x80_shadow_empty.png`,
-        back: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xlphotoback.png`,
-        front: `${ASSET_CDN_BASE_URL}/foldericons/xxxxl-xlphotofront.png`
+        back: `${ASSET_CDN_BASE_URL}/foldericons/folder-large_backplate.svg`,
+        front: `${ASSET_CDN_BASE_URL}/foldericons//folder-large_frontplate_thumbnail.svg`
       }
     }
   };
@@ -95,11 +90,6 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
           [`ms-FolderCover--hideContent ${FolderCoverStyles.hideContent}`]: hideContent
         }) }
       >
-        <img
-          aria-hidden={ true }
-          className={ css('ms-FolderCover-shadow', FolderCoverStyles.shadow) }
-          src={ assets.shadow }
-        />
         <img
           aria-hidden={ true }
           className={ css('ms-FolderCover-back', FolderCoverStyles.back) }


### PR DESCRIPTION
### Overview

This change switches to the .svg images for `FolderCover`, to ensure that the covers do not appear blurry on retina displays.