### PR TITLE
Nav: Add 'onRenderLink' back to rendering

### DIFF
--- a/common/changes/office-ui-fabric-react/nav-fix-onrender_2017-10-23-17-54.json
+++ b/common/changes/office-ui-fabric-react/nav-fix-onrender_2017-10-23-17-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Nav: Add onRenderLink back to JSX to allow custom rendering of links",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "a.erich@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.Props.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IRenderFunction } from '../../Utilities';
 
 export interface INav {
   /**
@@ -31,7 +32,7 @@ export interface INavProps {
    * Used to customize how content inside the link tag is rendered
    * @defaultvalue Default link rendering
    */
-  onRenderLink?: Function;
+  onRenderLink?: IRenderFunction<INavLink>;
 
   /**
    * Function callback invoked when a link in the navigation is clicked

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.scss
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.scss
@@ -96,7 +96,9 @@ $linkRightPadding: 20px;
 }
 
 .linkText {
+  overflow: hidden;
   vertical-align: middle;
+  text-overflow: ellipsis;
 }
 
 .compositeLink {

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.scss
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.scss
@@ -96,6 +96,7 @@ $linkRightPadding: 20px;
 }
 
 .linkText {
+  margin: 0 4px;
   overflow: hidden;
   vertical-align: middle;
   text-overflow: ellipsis;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -131,7 +131,7 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
   }
 
   private _onRenderLink(link: INavLink) {
-    return (<span className={ css('ms-Nav-linkText', styles.linkText) }>{ link.name }</span>);
+    return (<div className={ css('ms-Nav-linkText', styles.linkText) }>{ link.name }</div>);
   }
 
   private _renderNavLink(link: INavLink, linkIndex: number, nestingLevel: number) {

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -46,8 +46,7 @@ export interface INavState {
 export class Nav extends BaseComponent<INavProps, INavState> implements INav {
 
   public static defaultProps: INavProps = {
-    groups: null,
-    onRenderLink: (link: INavLink) => (<span className={ css('ms-Nav-linkText', styles.linkText) }>{ link.name }</span>)
+    groups: null
   };
 
   private _hasExpandButton: boolean;
@@ -131,6 +130,10 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
     return this.state.selectedKey;
   }
 
+  private _onRenderLink(link: INavLink) {
+    return (<span className={ css('ms-Nav-linkText', styles.linkText) }>{ link.name }</span>);
+  }
+
   private _renderNavLink(link: INavLink, linkIndex: number, nestingLevel: number) {
     const isRtl: boolean = getRTL();
     const paddingBefore = _indentationSize * nestingLevel + _baseIndent;
@@ -149,6 +152,9 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
         lineHeight: '36px'
       }
     };
+    let {
+      onRenderLink = this._onRenderLink
+    } = this.props;
 
     // Prevent hijacking of the parent window if link.target is defined
     const rel = link.url && link.target && !isRelativeUrl(link.url) ? 'noopener noreferrer' : undefined;
@@ -171,7 +177,7 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
         rel={ rel }
         aria-label={ link.ariaLabel }
       >
-        { this.props.onRenderLink!(link) }
+        { onRenderLink(link, this._onRenderLink) }
       </ActionButton>);
   }
 

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -171,7 +171,7 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
         rel={ rel }
         aria-label={ link.ariaLabel }
       >
-        { link.name }
+        { this.props.onRenderLink!(link) }
       </ActionButton>);
   }
 

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -144,14 +144,11 @@ exports[`Nav renders Nav correctly 1`] = `
                         }
                     role="presentation"
                   />
-                  <div
-                    className=
-                        ms-Button-textContainer
-                        {
-                          flex-grow: 0;
-                          overflow: hidden;
-                        }
-                  />
+                  <span
+                    className="ms-Nav-linkText"
+                  >
+                    
+                  </span>
                 </div>
               </button>
             </div>

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -144,11 +144,11 @@ exports[`Nav renders Nav correctly 1`] = `
                         }
                     role="presentation"
                   />
-                  <span
+                  <div
                     className="ms-Nav-linkText"
                   >
                     
-                  </span>
+                  </div>
                 </div>
               </button>
             </div>

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.FabricDemoApp.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.FabricDemoApp.Example.tsx
@@ -13,13 +13,15 @@ export class NavFabricDemoAppExample extends React.Component<any, any> {
     );
   }
 
-  private _onRenderLink(link: any): (JSX.Element | null)[] {
-    return ([
-      <span key={ 1 } className='Nav-linkText'>{ link.name }</span>,
-      (link.status !== undefined ?
-        <span key={ 2 } className={ 'Nav-linkFlair ' + 'is-state' + link.status } >{ ExampleStatus[link.status] }</span> :
-        null)
-    ]);
+  private _onRenderLink(link: any): (JSX.Element | null) {
+    return (
+      <span>
+        <span key={ 1 } className='Nav-linkText'>{ link.name }</span>
+        { link.status !== undefined ?
+          <span key={ 2 } className={ 'Nav-linkFlair ' + 'is-state' + link.status } >{ ExampleStatus[link.status] }</span> :
+          null }
+      </span>
+    );
   }
 
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3196
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added `this.props.onRenderLink` back to JSX to allow custom rendering of links. It was removed when Nav was refactored in https://github.com/OfficeDev/office-ui-fabric-react/pull/2728

#### Focus areas to test

Rendering the basic example in the package, I don't see any visual regressions. But I'm attaching the dom inspection for reference because classes are applied a bit differently.

![nav](https://user-images.githubusercontent.com/15041132/31905379-db1ba706-b7e2-11e7-972e-44af67a09a05.png)
