### PR TITLE
ComboBox: Add styling property for the label in the disabled state

### DIFF
--- a/common/changes/office-ui-fabric-react/combo-box-label-disabled_2017-10-23-20-57.json
+++ b/common/changes/office-ui-fabric-react/combo-box-label-disabled_2017-10-23-20-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Add support for custom styling of the label in the disabled state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "<christianjordangonzalez@gmail.com>"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.Props.ts
@@ -126,6 +126,11 @@ export interface IComboBoxStyles {
   label: IStyle;
 
   /**
+   * Style for the label element of the ComboBox in the disabled state.
+   */
+  labelDisabled: IStyle;
+
+  /**
    * Base styles for the root element of all ComboBoxes.
    */
   root: IStyle;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.classNames.ts
@@ -38,7 +38,8 @@ export const getClassNames = memoizeFunction((
       styles.container,
     ),
     label: mergeStyles(
-      styles.label
+      styles.label,
+      disabled && styles.labelDisabled
     ),
     root: mergeStyles(
       'ms-ComboBox',

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -201,6 +201,7 @@ export const getStyles = memoizeFunction((
   const styles: IComboBoxStyles = {
     container: {},
     label: {},
+    labelDisabled: {},
     root: [
       fonts.medium,
       {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x ] Include a change request file using `$ npm run change`

#### Description of changes
Some consumers of combo box may want to customize the label appearance in the disabled state (such as changing the text color). This change adds a new labelDisabled property to enable this functionality. 