### PR TITLE
Website: Support for IconGrid to handle wide icons

### DIFF
--- a/apps/fabric-website/src/components/IconGrid/IconGrid.module.scss
+++ b/apps/fabric-website/src/components/IconGrid/IconGrid.module.scss
@@ -15,6 +15,7 @@
     justify-content: space-around;
     padding: 8px;
     width: 80px;
+    overflow: hidden;
 
     span {
       color: $ms-color-neutralPrimary;
@@ -24,8 +25,21 @@
     }
 
     &:hover {
+      overflow: visible;
+
       span {
         opacity: 1;
+      }
+    }
+  }
+
+  i {
+    &:hover {
+      z-index: 1;
+
+      &:global(.hoverIcon) {
+        background-color: $ms-color-neutralLight;
+        padding: 0 8px;
       }
     }
   }

--- a/apps/fabric-website/src/components/IconGrid/IconGrid.tsx
+++ b/apps/fabric-website/src/components/IconGrid/IconGrid.tsx
@@ -41,7 +41,7 @@ export class IconGrid extends React.Component<IIconGridProps, IIconGridState> {
               let iconRefElement = this.refs[icon.name] as HTMLElement;
 
               if (iconRefElement && iconRefElement.offsetWidth > 80) {
-                iconJsxElement = <i className={ `ms-Icon ms-Icon--${icon.name} hoverIcon` } title={ `${icon.name}` } aria-hidden='true' />;
+                iconJsxElement = <i ref={ (`${icon.name}`) } className={ `ms-Icon ms-Icon--${icon.name} hoverIcon` } title={ `${icon.name}` } aria-hidden='true' />;
               }
 
               return (

--- a/apps/fabric-website/src/components/IconGrid/IconGrid.tsx
+++ b/apps/fabric-website/src/components/IconGrid/IconGrid.tsx
@@ -36,12 +36,21 @@ export class IconGrid extends React.Component<IIconGridProps, IIconGridState> {
         <ul className={ styles.grid }>
           { icons
             .filter(icon => icon.name.toLowerCase().indexOf(searchQuery.toLowerCase()) !== -1)
-            .map((icon, iconIndex) => (
-              <li key={ iconIndex } aria-label={ icon.name + ' icon' }>
-                <i className={ `ms-Icon ms-Icon--${icon.name}` } title={ `${icon.name}` } aria-hidden='true' />
-                <span>{ icon.name }</span>
-              </li>
-            ))
+            .map((icon, iconIndex) => {
+              let iconJsxElement = <i ref={ (`${icon.name}`) } className={ `ms-Icon ms-Icon--${icon.name}` } title={ `${icon.name}` } aria-hidden='true' />;
+              let iconRefElement = this.refs[icon.name] as HTMLElement;
+
+              if (iconRefElement && iconRefElement.offsetWidth > 80) {
+                iconJsxElement = <i className={ `ms-Icon ms-Icon--${icon.name} hoverIcon` } title={ `${icon.name}` } aria-hidden='true' />;
+              }
+
+              return (
+                < li key={ iconIndex } aria-label={ icon.name + ' icon' } >
+                  { iconJsxElement }
+                  <span>{ icon.name }</span>
+                </li>
+              );
+            })
           }
         </ul>
       </div>

--- a/common/changes/@uifabric/fabric-website/icon-grid_2017-10-23-22-00.json
+++ b/common/changes/@uifabric/fabric-website/icon-grid_2017-10-23-22-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Added support to IconGrid for icons wider than the grid.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3148 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

I implemented as Mike suggested in the issue above but only targeted icons that were wider than we have the grid set to.

**Before:**
![image](https://user-images.githubusercontent.com/16619843/31915422-3ed7aefa-b803-11e7-891d-091eebe3ca0d.png)

**After:**
![icongrid-after](https://user-images.githubusercontent.com/16619843/31915645-153ef020-b804-11e7-94f2-999f5d6c2fb5.gif)


#### Focus areas to test

(optional)
