### PR TITLE
Adding stroke css property to typings

### DIFF
--- a/common/changes/@uifabric/merge-styles/stroke_2017-10-23-23-19.json
+++ b/common/changes/@uifabric/merge-styles/stroke_2017-10-23-23-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Adding `stroke` css property to typings.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -1366,6 +1366,12 @@ export interface IRawStyleBase extends IRawFontStyle {
   speakAs?: ICSSRule | string;
 
   /**
+   * The stroke property in CSS is for adding a border to SVG shapes.
+   * See SVG 1.1 https://www.w3.org/TR/SVG/painting.html#Stroke
+   */
+  stroke?: ICSSRule | string;
+
+  /**
    * SVG: Specifies the opacity of the outline on the current object.
    * See SVG 1.1 https://www.w3.org/TR/SVG/painting.html#StrokeOpacityProperty
    */


### PR DESCRIPTION
Looks like stroke was missing.