### PR TITLE
Layer: Allow default host to be configurable

### DIFF
--- a/common/changes/office-ui-fabric-react/layer-defaulthost_2017-10-24-00-43.json
+++ b/common/changes/office-ui-fabric-react/layer-defaulthost_2017-10-24-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Layer: exposing `setDefaultTarget(selector)` static method to set a default target element where layered content should render by default.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
@@ -10,6 +10,7 @@ import * as stylesImport from './Layer.scss';
 const styles: any = stylesImport;
 
 let _layersByHostId: { [hostId: string]: Layer[] } = {};
+let _defaultHostSelector: string | undefined;
 
 export class Layer extends BaseComponent<ILayerProps, {}> {
 
@@ -30,6 +31,10 @@ export class Layer extends BaseComponent<ILayerProps, {}> {
     if (_layersByHostId[id]) {
       _layersByHostId[id].forEach(layer => layer.forceUpdate());
     }
+  }
+
+  public static setDefaultTarget(selector: string) {
+    _defaultHostSelector = selector;
   }
 
   constructor(props: ILayerProps) {
@@ -139,7 +144,7 @@ export class Layer extends BaseComponent<ILayerProps, {}> {
     if (hostId) {
       return doc.getElementById(hostId) as Node;
     } else {
-      return doc.body;
+      return _defaultHostSelector ? doc.querySelector(_defaultHostSelector) as Node : doc.body;
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
@@ -33,7 +33,15 @@ export class Layer extends BaseComponent<ILayerProps, {}> {
     }
   }
 
-  public static setDefaultTarget(selector: string) {
+  /**
+   * Sets the default target selector to use when determining the host in which
+   * Layered content will be injected into. If not provided, an element will be
+   * created at the end of the document body.
+   *
+   * Passing in a falsey value will clear the default target and reset back to
+   * using a created element at the end of document body.
+   */
+  public static setDefaultTarget(selector?: string) {
     _defaultHostSelector = selector;
   }
 


### PR DESCRIPTION
When writing automation, sometimes we need the layered content to render within a test div.

Adding the ability to target a specific element as the default layer host:

```tsx
Layer.setDefaultTarget('[data-default-layer]=true]');

...
<div data-default-layer='true' />
```
