### PR TITLE
 Restore 'forceAnchor' prop for INavLink elements

### DIFF
--- a/common/changes/office-ui-fabric-react/cicciodm-navlink-force-anchor_2017-10-24-15-21.json
+++ b/common/changes/office-ui-fabric-react/cicciodm-navlink-force-anchor_2017-10-24-15-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Restore forceAnchor prop for INavLink elements",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "frdim@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -164,11 +164,11 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
         className={ mergeStyles(
           'ms-Nav-link' + link.onClick && 'ms-Nav-linkButton',
           styles.link,
-          link.onClick && styles.buttonEntry,
+          link.onClick && !link.forceAnchor && styles.buttonEntry,
           this._hasExpandButton && 'isOnExpanded') as string
         }
         styles={ buttonStyles }
-        href={ link.url }
+        href={ link.url || (link.forceAnchor ? 'javascript:' : undefined) }
         iconProps={ { iconName: link.icon || '' } }
         description={ link.title || link.name }
         onClick={ link.onClick ? this._onNavButtonLinkClicked.bind(this, link) : this._onNavAnchorLinkClicked.bind(this, link) }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes [#3210](https://github.com/OfficeDev/office-ui-fabric-react/issues/3210)
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Restore the `forceAnchor` prop for `INavLinks`.
 - The `buttonEntry` style will now be applied only if `link.onClick` is **defined**  and `link.forceAnchor` is **false**.
 - The `href` prop will now be `javascript:` if **no** `url` is provided and `forceAnchor` is set to **true**: this will force the `ActionButton` to render as an `a` element.

#### Focus areas to test

In the Nav example, add `forceAnchor` as a prop to an entry with a click callback
 - Verify that the text is not blue, and the the element is rendered as an `a`
Then make the `url` prop an empty string
 - Verify that styling and HTML element are unchanged
