### PR TITLE
Textfield: required with icon, no label bug fix

### DIFF
--- a/common/changes/office-ui-fabric-react/textfield-icon-required_2017-10-24-16-24.json
+++ b/common/changes/office-ui-fabric-react/textfield-icon-required_2017-10-24-16-24.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "New styling for required textfield with an icon but no label.",
+      "comment": "TextField/DatePicker: The required astrisk is now more correctly positioned.",
       "packageName": "office-ui-fabric-react",
       "type": "patch"
     }

--- a/common/changes/office-ui-fabric-react/textfield-icon-required_2017-10-24-16-24.json
+++ b/common/changes/office-ui-fabric-react/textfield-icon-required_2017-10-24-16-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "New styling for required textfield with an icon but no label.",
+      "packageName": "office-ui-fabric-react",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -4,7 +4,6 @@ import {
   DayOfWeek,
   IDatePickerStrings
 } from 'office-ui-fabric-react/lib/DatePicker';
-import './DatePicker.Example.scss';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: [
@@ -85,10 +84,9 @@ export class DatePickerRequiredExample extends React.Component<any, IDatePickerR
     let { firstDayOfWeek } = this.state;
 
     return (
-      <div className='ms-DatePickerExample'>
+      <div>
         <p>Validation will happen when Date Picker loses focus.</p>
         <DatePicker label='Date required' isRequired={ true } firstDayOfWeek={ firstDayOfWeek } strings={ DayPickerStrings } placeholder='Select a date...' />
-        <DatePicker isRequired={ true } firstDayOfWeek={ firstDayOfWeek } strings={ DayPickerStrings } placeholder='Select a date (no label)...' />
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -4,6 +4,7 @@ import {
   DayOfWeek,
   IDatePickerStrings
 } from 'office-ui-fabric-react/lib/DatePicker';
+import './DatePicker.Example.scss';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: [
@@ -84,9 +85,10 @@ export class DatePickerRequiredExample extends React.Component<any, IDatePickerR
     let { firstDayOfWeek } = this.state;
 
     return (
-      <div>
+      <div className='ms-DatePickerExample'>
         <p>Validation will happen when Date Picker loses focus.</p>
         <DatePicker label='Date required' isRequired={ true } firstDayOfWeek={ firstDayOfWeek } strings={ DayPickerStrings } placeholder='Select a date...' />
+        <DatePicker isRequired={ true } firstDayOfWeek={ firstDayOfWeek } strings={ DayPickerStrings } placeholder='Select a date (no label)...' />
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Label/LabelMixins.scss
+++ b/packages/office-ui-fabric-react/src/components/Label/LabelMixins.scss
@@ -8,22 +8,3 @@
     color: $ms-color-error;
   }
 }
-
-@mixin ms-TextField-fieldGroup-is-required {
-  &::after {
-    content: ' *';
-    color: $ms-color-error;
-    @include ms-padding-right(12px);
-  }
-}
-
-@mixin ms-Icon-is-required {
-  &::before {
-    content: ' *';
-    color: $ms-color-error;
-    position: absolute;
-    top: -4px;
-    @include ms-right(8px);
-    @include ms-padding-right(12px);
-  }
-}

--- a/packages/office-ui-fabric-react/src/components/Label/LabelMixins.scss
+++ b/packages/office-ui-fabric-react/src/components/Label/LabelMixins.scss
@@ -22,7 +22,7 @@
     content: ' *';
     color: $ms-color-error;
     position: absolute;
-    top: -7px;
+    top: -4px;
     @include ms-right(8px);
     @include ms-padding-right(12px);
   }

--- a/packages/office-ui-fabric-react/src/components/Label/LabelMixins.scss
+++ b/packages/office-ui-fabric-react/src/components/Label/LabelMixins.scss
@@ -23,7 +23,7 @@
     color: $ms-color-error;
     position: absolute;
     top: -7px;
-    @include ms-right(12px);
+    @include ms-right(8px);
     @include ms-padding-right(12px);
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Label/LabelMixins.scss
+++ b/packages/office-ui-fabric-react/src/components/Label/LabelMixins.scss
@@ -16,3 +16,14 @@
     @include ms-padding-right(12px);
   }
 }
+
+@mixin ms-Icon-is-required {
+  &::before {
+    content: ' *';
+    color: $ms-color-error;
+    position: absolute;
+    top: -7px;
+    @include ms-right(12px);
+    @include ms-padding-right(12px);
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -137,13 +137,24 @@ $field-error-color: $errorTextColor;
 
 .root.rootIsRequiredPlaceholderOnly {
   :global(.ms-TextField-fieldGroup) {
-    @include ms-TextField-fieldGroup-is-required;
+    &::after {
+      content: ' *';
+      color: $ms-color-error;
+      @include ms-padding-right(12px);
+    }
   }
 }
 
 .root.rootIsRequiredPlaceholderIcon {
   :global(.ms-Icon) {
-    @include ms-Icon-is-required;
+    &::before {
+      content: ' *';
+      color: $ms-color-error;
+      position: absolute;
+      top: -4px;
+      @include ms-right(8px);
+      @include ms-padding-right(12px);
+    }
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -155,9 +155,11 @@ $field-error-color: $errorTextColor;
 .icon {
   pointer-events: none;
   position: absolute;
-  bottom: 8px;
+  bottom: 5px;
   @include right(8px);
   top: auto;
+  font-size: 16px;
+  line-height: 18px;
 }
 
 .description {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -141,6 +141,12 @@ $field-error-color: $errorTextColor;
   }
 }
 
+.root.rootIsRequiredPlaceholderIcon {
+  :global(.ms-Icon) {
+    @include ms-Icon-is-required;
+  }
+}
+
 //= State: An active textfield
 .root.rootIsActive {
   border-color: $field-border-focus-color;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -146,7 +146,8 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
 
     const textFieldClassName = css('ms-TextField', styles.root, className, {
       ['is-required ' + styles.rootIsRequiredLabel]: this.props.label && required,
-      ['is-required ' + styles.rootIsRequiredPlaceholderOnly]: !this.props.label && required,
+      ['is-required ' + styles.rootIsRequiredPlaceholderOnly]: !this.props.label && required && !iconProps,
+      ['is-required ' + styles.rootIsRequiredPlaceholderIcon]: !this.props.label && required && iconProps,
       ['is-disabled ' + styles.rootIsDisabled]: disabled,
       ['is-active ' + styles.rootIsActive]: isFocused,
       ['ms-TextField--multiline ' + styles.rootIsMultiline]: multiline,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3209 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Recently made change to handle the asterisk for TextField without a label. This functionality didn't work with icons.
- Added new class + mixin to handle the same condition with icons.

**Before:**
![image](https://user-images.githubusercontent.com/16619843/31955655-e086e7c6-b89d-11e7-9096-8d5735b728f2.png)

**After:**
- In TextField:
![image](https://user-images.githubusercontent.com/16619843/31955707-0ab07ee0-b89e-11e7-972f-8e8f37766612.png)

- In DatePicker:
![image](https://user-images.githubusercontent.com/16619843/31955688-fe55e572-b89d-11e7-815f-3f211fcc96fd.png)

#### Focus areas to test

(optional)
