### PR TITLE
Dropdown: Fix selection logic

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-dropdown-selection_2017-10-24-17-37.json
+++ b/common/changes/office-ui-fabric-react/fix-dropdown-selection_2017-10-24-17-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Dropdown's falsey check in selection to strict check for undefined in case key is 0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "a.erich@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -4,6 +4,7 @@ import * as ReactDOM from 'react-dom';
 /* tslint:enable:no-unused-variable */
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
+import { mount, shallow } from 'enzyme';
 
 import {
   KeyCodes,
@@ -255,6 +256,27 @@ describe('Dropdown', () => {
       }
     });
 
+    it('sets the selected item even when key is number 0', () => {
+      const options = [{ key: 0, text: 'item1' }, { key: 1, text: 'item2' }];
+      const selectedKey = 0;
+
+      const wrapper = shallow(
+        <Dropdown
+          options={ options }
+        />
+      );
+
+      // Use .dive() because Dropdown is a decorated component
+      let state = wrapper.dive().state('selectedIndices');
+      expect(state).toEqual([]);
+
+      const newProps = { options, selectedKey };
+      wrapper.setProps(newProps);
+      wrapper.update();
+      state = wrapper.dive().state('selectedIndices');
+      expect(state).toEqual([selectedKey]);
+    });
+
     it('issues the onChanged callback when the selected item is different', () => {
       let container = document.createElement('div');
       let dropdownRoot: HTMLElement | undefined;
@@ -399,6 +421,28 @@ describe('Dropdown', () => {
       let titleElement = dropdownRoot.querySelector('.ms-Dropdown-title') as HTMLElement;
 
       expect(titleElement.textContent).toEqual('1');
+    });
+
+    it('sets the selected items even when key is number 0', () => {
+      const options = [{ key: 0, text: 'item1' }, { key: 1, text: 'item2' }];
+      const selectedKeys = [0, 1];
+
+      const wrapper = shallow(
+        <Dropdown
+          multiSelect
+          options={ options }
+        />
+      );
+
+      // Use .dive() because Dropdown is a decorated component
+      let state = wrapper.dive().state('selectedIndices');
+      expect(state).toEqual([]);
+
+      const newProps = { options, selectedKeys };
+      wrapper.setProps(newProps);
+      wrapper.update();
+      state = wrapper.dive().state('selectedIndices');
+      expect(state).toEqual(selectedKeys);
     });
 
     it('Renders multiple selected items if multiple options specify selected', () => {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -531,7 +531,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
 
   // Get all selected indexes for multi-select mode
   private _getSelectedIndexes(options: IDropdownOption[], selectedKey: string | number | string[] | number[] | undefined): number[] {
-    if (!selectedKey) {
+    if (selectedKey === undefined) {
       if (this.props.multiSelect) {
         return this._getAllSelectedIndices(options);
       }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
 >
   <div
     aria-activedescendant={null}
-    aria-describedby="Dropdown92-option"
+    aria-describedby="Dropdown94-option"
     aria-disabled={undefined}
     aria-expanded="false"
     aria-label={undefined}
@@ -14,7 +14,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
     aria-owns={null}
     className="ms-Dropdown"
     data-is-focusable={true}
-    id="Dropdown92"
+    id="Dropdown94"
     onBlur={[Function]}
     onClick={[Function]}
     onKeyDown={[Function]}
@@ -26,7 +26,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
       aria-atomic={true}
       aria-readonly="true"
       className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder"
-      id="Dropdown92-option"
+      id="Dropdown94-option"
       role="textbox"
     />
     <span


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Changed the falsey check for `!selectedKey` to a strict check for `undefined` in case the Dropdown option keys are numbers. If the selectedKey is 0, `!selectedKey` would previously return true.