### PR TITLE
SplitButton: now with less rounded corners.

### DIFF
--- a/common/changes/office-ui-fabric-react/button-tweak_2017-10-24-19-17.json
+++ b/common/changes/office-ui-fabric-react/button-tweak_2017-10-24-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Buttons: split button has `borderRadius` set to 0 to override defaults on Mac chrome/safari.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -31,6 +31,7 @@ export const getStyles = memoizeFunction((
         height: 'auto',
         boxSizing: 'border-box',
         border: '1px solid transparent',
+        borderRadius: 0,
         outline: 'transparent',
         userSelect: 'none',
         display: 'inline-block',

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -156,15 +156,6 @@ export class DropdownBasicExample extends React.Component<any, any> {
     );
   }
 
-  public makeList(items: any) {
-    let list = [];
-    for (let i = 0; i < items; i++) {
-      list.push({ key: i, text: 'Option ' + i });
-    }
-
-    return list;
-  }
-
   @autobind
   public changeState(item: IDropdownOption) {
     console.log('here is the things updating...' + item.key + ' ' + item.text + ' ' + item.selected);


### PR DESCRIPTION
On mac chrome/safari, the borderRadius default is now a non-zero number.

We need to force 0 on this or we end up having rounded corners.

Before:
![image](https://user-images.githubusercontent.com/1110944/31963867-ff63ac4c-b8b6-11e7-90c8-29da9cfdd692.png)

After:
![image](https://user-images.githubusercontent.com/1110944/31963902-29dd276e-b8b7-11e7-98df-04729d557c71.png)
