### PR TITLE
Callout: Fix calculation of max height

### DIFF
--- a/common/changes/office-ui-fabric-react/callout-fix-height_2017-10-24-22-49.json
+++ b/common/changes/office-ui-fabric-react/callout-fix-height_2017-10-24-22-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CalloutContent: Fix calculation of max size if calloutMaxHeight is not provided",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "a.erich@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -144,7 +144,7 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
       : '';
 
     let getContentMaxHeight: number = this._getMaxHeight() + this.state.heightOffset!;
-    let contentMaxHeight: number = calloutMaxHeight! && (calloutMaxHeight! > getContentMaxHeight) ? getContentMaxHeight : calloutMaxHeight!;
+    let contentMaxHeight: number = calloutMaxHeight! && (calloutMaxHeight! < getContentMaxHeight) ? calloutMaxHeight! : getContentMaxHeight!;
 
     let beakVisible = isBeakVisible && (!!target);
 

--- a/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Callout renders Callout correctly 1`] = `
       style={
         Object {
           "backgroundColor": undefined,
-          "maxHeight": undefined,
+          "maxHeight": 750,
         }
       }
     >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3214 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Rearranged the conditional logic that calculates the Callout's max height because if `calloutMaxHeight` was not passed in as a prop, `contentMaxHeight` would be undefined. This resulted in Callouts that could render beyond the viewport without a scrollbar, e.g. a ComboBox with a long list of options.

This fix will set the max height to `getContentMaxHeight` if `calloutMaxHeight` is not provided, or if `calloutMaxHeight` is larger than `getContentMaxHeight`.