### PR TITLE
Expose data-is-focusable property in breadcrumb items.

### DIFF
--- a/common/changes/office-ui-fabric-react/isdatafocusable_2017-10-25-06-33.json
+++ b/common/changes/office-ui-fabric-react/isdatafocusable_2017-10-25-06-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Expose data-is-focusable property in breadcrumb items.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "toreriks@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.Props.ts
@@ -72,4 +72,9 @@ export interface IBreadcrumbItem {
    * If this breadcrumb item is the item the user is currently on, if set to true, aria-current="page" will be applied to this breadcrumb link
    */
   isCurrentItem?: boolean;
+
+  /**
+   * Switch to toggle whether or not breadcrumb item should be focusable. Default is true.
+   */
+  dataIsFocusable?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -84,4 +84,48 @@ describe('Breadcrumb', () => {
     expect(itemLink[0].textContent).toEqual('TestText3');
   });
 
+  it('sets the correct value of data-is-focusable', () => {
+
+    const items: IBreadcrumbItem[] = [
+      { text: 'TestText1', key: 'TestKey1', onClick: (e) => void 0 },
+      { text: 'TestText2', key: 'TestKey2', onClick: (e) => void 0 },
+      { text: 'TestText3', key: 'TestKey3', onClick: (e) => void 0 },
+      { text: 'TestText4', key: 'TestKey4', onClick: (e) => void 0 }
+    ];
+
+    let component = ReactTestUtils.renderIntoDocument<Breadcrumb>(
+      <Breadcrumb
+        items={ items }
+        maxDisplayedItems={ 2 }
+      />
+    );
+
+    let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+    let overFlowButton = renderedDOM.querySelectorAll('.ms-Breadcrumb-overflowButton');
+    let linkButton = renderedDOM.querySelectorAll('.ms-Breadcrumb-itemLink');
+
+    let focusable = (element: Element): string => {
+      return element && element.getAttribute('data-is-focusable') || '';
+    };
+
+    expect(focusable(overFlowButton[0])).toEqual('true');
+    expect(focusable(linkButton[0])).toEqual('true');
+
+    items.forEach(item => item.dataIsFocusable = false);
+
+    component = ReactTestUtils.renderIntoDocument<Breadcrumb>(
+      <Breadcrumb
+        items={ items }
+        maxDisplayedItems={ 2 }
+      />
+
+    );
+
+    renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+    overFlowButton = renderedDOM.querySelectorAll('.ms-Breadcrumb-overflowButton');
+    linkButton = renderedDOM.querySelectorAll('.ms-Breadcrumb-itemLink');
+
+    expect(focusable(overFlowButton[0])).toEqual('false');
+    expect(focusable(linkButton[0])).toEqual('false');
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -97,6 +97,7 @@ export class Breadcrumb extends BaseComponent<IBreadcrumbProps, any> {
                   role='button'
                   aria-haspopup='true'
                   onRenderMenuIcon={ nullFunction }
+                  data-is-focusable={ this._isDataFocusable(renderedOverflowItems[0]) }
                   menuProps={ {
                     items: contextualItems,
                     directionalHint: DirectionalHint.bottomLeftEdge
@@ -132,6 +133,7 @@ export class Breadcrumb extends BaseComponent<IBreadcrumbProps, any> {
           className={ css('ms-Breadcrumb-itemLink', styles.itemLink) }
           href={ item.href }
           aria-current={ item.isCurrentItem ? 'page' : null }
+          data-is-focusable={ this._isDataFocusable(item) }
           onClick={ this._onBreadcrumbClicked.bind(this, item) }
         >
           <TooltipHost
@@ -161,5 +163,10 @@ export class Breadcrumb extends BaseComponent<IBreadcrumbProps, any> {
     if (item.onClick) {
       item.onClick(ev, item);
     }
+  }
+
+  @autobind
+  private _isDataFocusable(item: IBreadcrumbItem): boolean {
+    return item.dataIsFocusable === void 0 && true || item.dataIsFocusable;
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds possibility for breadcrumb items to not be focusable by setting property 'dataIsFocusable'. Default value is true.

#### Focus areas to test

(optional)
