### PR TITLE
Fabric root index no longer calls initializeIcons

### DIFF
--- a/apps/vr-tests/src/utilities/index.ts
+++ b/apps/vr-tests/src/utilities/index.ts
@@ -1,1 +1,5 @@
+import { initializeIcons } from '@uifabric/icons';
+
+initializeIcons();
+
 export * from './FabricDecorator';

--- a/common/changes/@uifabric/styling/register-icons-fix_2017-10-26-00-45.json
+++ b/common/changes/@uifabric/styling/register-icons-fix_2017-10-26-00-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Updating the icon warning to link to documentation for assistance.",
+      "packageName": "@uifabric/styling",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/register-icons-fix_2017-10-26-00-45.json
+++ b/common/changes/office-ui-fabric-react/register-icons-fix_2017-10-26-00-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removing the `initializeIcons` call from the top level import. The bundle in the dist folder used in codepens will still continue to have it, so that codepens don't stop rendering icons.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/index.bundle.ts
+++ b/packages/office-ui-fabric-react/src/index.bundle.ts
@@ -1,0 +1,8 @@
+export * from './index';
+
+// Using the default import, include all icon definitions. Products that care
+// about bundle size should not be using the main entry, until tree shaking
+// is perfected. (Use the top level imports instead.)
+import { initializeIcons } from './Icons';
+
+initializeIcons();

--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -57,10 +57,3 @@ export * from './TextField';
 export * from './Toggle';
 export * from './Tooltip';
 export * from './Utilities';
-
-// Using the default import, include all icon definitions. Products that care
-// about bundle size should not be using the main entry, until tree shaking
-// is perfected. (Use the top level imports instead.)
-import { initializeIcons } from './Icons';
-
-initializeIcons();

--- a/packages/office-ui-fabric-react/webpack.config.js
+++ b/packages/office-ui-fabric-react/webpack.config.js
@@ -5,7 +5,7 @@ const BUNDLE_NAME = 'office-ui-fabric-react';
 const IS_PRODUCTION = process.argv.indexOf('--production') > -1;
 
 let entry = {
-  [BUNDLE_NAME]: './lib/index.js'
+  [BUNDLE_NAME]: './lib/index.bundle.js'
 };
 
 // In production builds, produce the demo-app bundle.

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -31,6 +31,7 @@ export interface IIconRecord {
 }
 
 export interface IIconOptions {
+  disableWarnings: boolean;
   warnOnMissingIcons: boolean;
 }
 
@@ -43,6 +44,7 @@ export interface IIconRecords {
 const ICON_SETTING_NAME = 'icons';
 const _icons = GlobalSettings.getValue<IIconRecords>(ICON_SETTING_NAME, {
   __options: {
+    disableWarnings: false,
     warnOnMissingIcons: true
   },
   __remapped: {}
@@ -66,7 +68,7 @@ export function registerIcons(iconSubset: IIconSubset): void {
       const code = icons[iconName];
       const normalizedIconName = iconName.toLowerCase();
 
-      if (_icons[normalizedIconName]) {
+      if (_icons[normalizedIconName] && !_icons.__options.disableWarnings) {
         warn(`Icon '${iconName} being re-registered`);
       }
 
@@ -120,7 +122,7 @@ export function getIcon(name?: string): IIconRecord | undefined {
         subset.isRegistered = true;
       }
     } else {
-      if (_icons.__options.warnOnMissingIcons) {
+      if (_icons.__options.warnOnMissingIcons && !_icons.__options.disableWarnings) {
         warn(`The icon "${name}" was used but not registered. See http://aka.ms/fabric-icon-usage for more information.`);
       }
     }
@@ -134,7 +136,7 @@ export function getIcon(name?: string): IIconRecord | undefined {
  *
  * @public
  */
-export function setIconOptions(options: IIconOptions): void {
+export function setIconOptions(options: Partial<IIconOptions>): void {
   _icons.__options = {
     ..._icons.__options,
     ...options

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -121,7 +121,7 @@ export function getIcon(name?: string): IIconRecord | undefined {
       }
     } else {
       if (_icons.__options.warnOnMissingIcons) {
-        warn(`The icon "${name}" was referenced but not registered.`);
+        warn(`The icon "${name}" was used but not registered. See http://aka.ms/fabric-icon-usage for more information.`);
       }
     }
   }

--- a/packages/utilities/src/warn.ts
+++ b/packages/utilities/src/warn.ts
@@ -1,4 +1,4 @@
-let _warningCallback: (message: string) => void = warn;
+let _warningCallback: ((message: string) => void) | undefined = undefined;
 
 export type ISettingsMap<T> = {
   [P in keyof T]?: string;
@@ -26,7 +26,7 @@ export function warnDeprecations<P>(
       if (replacementPropName) {
         deprecationMessage += ` Use '${replacementPropName}' instead.`;
       }
-      _warningCallback(deprecationMessage);
+      warn(deprecationMessage);
     }
   }
 }
@@ -48,7 +48,7 @@ export function warnMutuallyExclusive<P>(
     if (props && propName in props) {
       let propInExclusiveMapValue = exclusiveMap[propName];
       if (propInExclusiveMapValue && propInExclusiveMapValue in props) {
-        _warningCallback(
+        warn(
           `${componentName} property '${propName}' is mutually exclusive with '${exclusiveMap[propName]}'. Use one or the other.`
         );
       }
@@ -76,7 +76,7 @@ export function warnConditionallyRequiredProps<P>(
   if (condition === true) {
     for (const requiredPropName of requiredProps) {
       if (!(requiredPropName in props)) {
-        _warningCallback(
+        warn(
           `${componentName} property '${requiredPropName}' is required when '${conditionalPropName}' is used.'`
         );
       }
@@ -91,7 +91,9 @@ export function warnConditionallyRequiredProps<P>(
  * @param message - Warning message.
  */
 export function warn(message: string): void {
-  if (console && console.warn) {
+  if (_warningCallback) {
+    _warningCallback(message);
+  } else if (console && console.warn) {
     console.warn(message);
   }
 }
@@ -104,5 +106,5 @@ export function warn(message: string): void {
  * @param warningCallback - Callback to override the generated warnings.
  */
 export function setWarningCallback(warningCallback?: (message: string) => void): void {
-  _warningCallback = warningCallback === undefined ? warn : warningCallback;
+  _warningCallback = warningCallback;
 }


### PR DESCRIPTION
In some cases, partners are importing directly from `office-ui-fabric-react`, which ends up calling `initializeIcons`. This can be problematic as it can reset the location where the fonts are pulled from, or create race conditions if the definition changes.

Only applications, not libraries, should be calling `initializeIcons` explicitly. We should never do this accidentally.

When icons are referenced (through Icon component) but the user never called `initializeIcons`, I've added a link in the console warning, pointing to icon documentation here: http://aka.ms/fabric-icon-usage

I've also fixed the warn helper to be overridable. The previous design was wonky.