### PR TITLE
Theme Generator: improve perf

### DIFF
--- a/common/changes/@uifabric/example-app-base/phkuo-tgPerf_2017-10-26-03-29.json
+++ b/common/changes/@uifabric/example-app-base/phkuo-tgPerf_2017-10-26-03-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/phkuo-tgPerf_2017-10-26-03-29.json
+++ b/common/changes/@uifabric/experiments/phkuo-tgPerf_2017-10-26-03-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/phkuo-tgPerf_2017-10-26-03-29.json
+++ b/common/changes/@uifabric/fabric-website/phkuo-tgPerf_2017-10-26-03-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/icons/phkuo-tgPerf_2017-10-26-03-29.json
+++ b/common/changes/@uifabric/icons/phkuo-tgPerf_2017-10-26-03-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/jest-serializer-merge-styles/phkuo-tgPerf_2017-10-26-03-29.json
+++ b/common/changes/@uifabric/jest-serializer-merge-styles/phkuo-tgPerf_2017-10-26-03-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/jest-serializer-merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/jest-serializer-merge-styles",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/merge-styles/phkuo-tgPerf_2017-10-26-03-29.json
+++ b/common/changes/@uifabric/merge-styles/phkuo-tgPerf_2017-10-26-03-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/phkuo-tgPerf_2017-10-26-03-29.json
+++ b/common/changes/@uifabric/styling/phkuo-tgPerf_2017-10-26-03-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/phkuo-tgPerf_2017-10-26-03-29.json
+++ b/common/changes/office-ui-fabric-react/phkuo-tgPerf_2017-10-26-03-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Theme Generator: improve perf",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/IThemeSlotRule.ts
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/IThemeSlotRule.ts
@@ -16,4 +16,6 @@ export interface IThemeSlotRule {
   isBackgroundShade?: boolean;
   /* Whether this slot has been manually overridden (else, it was automatically generated based on inheritance). */
   isCustomized?: boolean;
+  /* A collection of rules that inherit from this one. It is the responsibility of the inheriting rule to add itself to its parent's dependentRules collection. */
+  dependentRules: IThemeSlotRule[];
 }

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.ts
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.ts
@@ -23,7 +23,6 @@ export class ThemeGenerator {
   public static setSlot(
     rule: IThemeSlotRule,
     color: string | IColor,
-    slotRules: IThemeRules,
     isInverted = false,
     isCustomization = false,
     overwriteCustomColor = true
@@ -43,9 +42,9 @@ export class ThemeGenerator {
       } else {
         colorAsIColor = color;
       }
-      ThemeGenerator._setSlot(rule, colorAsIColor, slotRules, isInverted, isCustomization, overwriteCustomColor);
+      ThemeGenerator._setSlot(rule, colorAsIColor, isInverted, isCustomization, overwriteCustomColor);
     } else if (rule.color) {
-      ThemeGenerator._setSlot(rule, rule.color, slotRules, isInverted, isCustomization, overwriteCustomColor);
+      ThemeGenerator._setSlot(rule, rule.color, isInverted, isCustomization, overwriteCustomColor);
     }
   }
 
@@ -63,7 +62,7 @@ export class ThemeGenerator {
           if (!rule.color) {
             throw 'A color slot rule that does not inherit must provide its own color.';
           }
-          ThemeGenerator._setSlot(rule, rule.color, slotRules, isInverted, false, false);
+          ThemeGenerator._setSlot(rule, rule.color, isInverted, false, false);
         }
       }
     }
@@ -147,7 +146,6 @@ export class ThemeGenerator {
   private static _setSlot(
     rule: IThemeSlotRule,
     color: IColor,
-    slotRules: IThemeRules,
     isInverted: boolean,
     isCustomization: boolean,
     overwriteCustomColor = true
@@ -171,14 +169,9 @@ export class ThemeGenerator {
         rule.isCustomized = true;
       }
 
-      // then run through the rest of the rules and update dependent colors
-      for (let ruleName in slotRules) {
-        if (slotRules.hasOwnProperty(ruleName)) {
-          let ruleToUpdate: IThemeSlotRule = slotRules[ruleName];
-          if (ruleToUpdate.inherits === rule) {
-            ThemeGenerator._setSlot(ruleToUpdate, rule.color, slotRules, isInverted, false, overwriteCustomColor);
-          }
-        }
+      // then update dependent colors
+      for (let ruleToUpdate of rule.dependentRules) {
+        ThemeGenerator._setSlot(ruleToUpdate, rule.color, isInverted, false, overwriteCustomColor);
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
@@ -40,7 +40,7 @@ const BackgroundImageUriKey = 'backgroundImageUri';
 const BackgroundOverlayKey = 'backgroundOverlay';
 
 export class ThemeGeneratorPage extends React.Component<any, IThemeGeneratorPageState> {
-
+  private _semanticSlotColorChangeTimeout: number;
   private _imgUrl: string;
 
   constructor() {
@@ -301,32 +301,31 @@ export class ThemeGeneratorPage extends React.Component<any, IThemeGeneratorPage
       ThemeGenerator.setSlot(
         themeRules[BaseSlots[BaseSlots.backgroundColor]],
         bgColor,
-        themeRules,
         bgColorIsDark,
         true,
         true);
       ThemeGenerator.setSlot(
         themeRules[BaseSlots[BaseSlots.primaryColor]],
         '#' + response.color.accentColor,
-        themeRules,
         bgColorIsDark,
         true,
         true);
       ThemeGenerator.setSlot(
         themeRules[BaseSlots[BaseSlots.foregroundColor]],
         getHexFromColor(response.color.dominantColorForeground, false),
-        themeRules,
         bgColorIsDark,
         true,
         true);
 
       themeRules[BackgroundImageUriKey] = {
         name: BackgroundImageUriKey,
-        value: 'url(\'' + this._imgUrl + '\')'
+        value: 'url(\'' + this._imgUrl + '\')',
+        dependentRules: []
       };
       themeRules[BackgroundOverlayKey] = {
         name: BackgroundOverlayKey,
-        color: updateA((themeRules[BaseSlots[BaseSlots.backgroundColor]]).color!, 50)
+        color: updateA((themeRules[BaseSlots[BaseSlots.backgroundColor]]).color!, 50),
+        dependentRules: []
       };
 
       this.setState({ themeRules: themeRules }, this._makeNewTheme);
@@ -343,10 +342,17 @@ export class ThemeGeneratorPage extends React.Component<any, IThemeGeneratorPage
 
   @autobind
   private _semanticSlotRuleChanged(slotRule: IThemeSlotRule, color: string) {
-    let { themeRules } = this.state;
+    if (this._semanticSlotColorChangeTimeout) {
+      clearTimeout(this._semanticSlotColorChangeTimeout);
+    }
+    this._semanticSlotColorChangeTimeout = setTimeout(() => {
+      let { themeRules } = this.state;
 
-    ThemeGenerator.setSlot(slotRule, color, themeRules, isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!), true, true);
-    this.setState({ themeRules: themeRules }, this._makeNewTheme);
+      ThemeGenerator.setSlot(slotRule, color, isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!), true, true);
+      this.setState({ themeRules: themeRules }, this._makeNewTheme);
+    }, 20);
+    // 20ms is low enough that you can slowly drag to change color and see that theme,
+    // but high enough that quick changes don't get bogged down by a million changes inbetween
   }
 
   @autobind
@@ -477,21 +483,29 @@ export class ThemeGeneratorPage extends React.Component<any, IThemeGeneratorPage
 
   @autobind
   private _baseColorSlotPicker(baseSlot: BaseSlots, title: string) {
+    let colorChangeTimeout: number;
+
     function _onColorChanged(newColor: string) {
-      let themeRules = this.state.themeRules;
-      const currentIsDark = isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!);
-      ThemeGenerator.setSlot(
-        themeRules[BaseSlots[baseSlot]],
-        newColor,
-        themeRules,
-        currentIsDark,
-        true,
-        true);
-      if (currentIsDark !== isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!)) {
-        // isInverted got swapped, so need to refresh slots with new shading rules
-        ThemeGenerator.insureSlots(themeRules, !currentIsDark);
+      if (colorChangeTimeout) {
+        clearTimeout(colorChangeTimeout);
       }
-      this.setState({ themeRules: themeRules }, this._makeNewTheme);
+      colorChangeTimeout = setTimeout(() => {
+        let themeRules = this.state.themeRules;
+        const currentIsDark = isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!);
+        ThemeGenerator.setSlot(
+          themeRules[BaseSlots[baseSlot]],
+          newColor,
+          currentIsDark,
+          true,
+          true);
+        if (currentIsDark !== isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!)) {
+          // isInverted got swapped, so need to refresh slots with new shading rules
+          ThemeGenerator.insureSlots(themeRules, !currentIsDark);
+        }
+        this.setState({ themeRules: themeRules }, this._makeNewTheme);
+      }, 20);
+      // 20ms is low enough that you can slowly drag to change color and see that theme,
+      // but high enough that quick changes don't get bogged down by a million changes inbetween
     }
 
     return (

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import './ThemeGeneratorPage.scss';
-import { autobind } from 'office-ui-fabric-react/lib/Utilities';
+import {
+  BaseComponent,
+  autobind
+} from 'office-ui-fabric-react/lib/Utilities';
 
 import { loadTheme } from 'office-ui-fabric-react/lib/Styling';
 import {
@@ -39,7 +42,7 @@ export interface IThemeGeneratorPageState {
 const BackgroundImageUriKey = 'backgroundImageUri';
 const BackgroundOverlayKey = 'backgroundOverlay';
 
-export class ThemeGeneratorPage extends React.Component<any, IThemeGeneratorPageState> {
+export class ThemeGeneratorPage extends BaseComponent<any, IThemeGeneratorPageState> {
   private _semanticSlotColorChangeTimeout: number;
   private _imgUrl: string;
 
@@ -345,7 +348,7 @@ export class ThemeGeneratorPage extends React.Component<any, IThemeGeneratorPage
     if (this._semanticSlotColorChangeTimeout) {
       clearTimeout(this._semanticSlotColorChangeTimeout);
     }
-    this._semanticSlotColorChangeTimeout = setTimeout(() => {
+    this._semanticSlotColorChangeTimeout = this._async.setTimeout(() => {
       let { themeRules } = this.state;
 
       ThemeGenerator.setSlot(slotRule, color, isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!), true, true);
@@ -489,7 +492,7 @@ export class ThemeGeneratorPage extends React.Component<any, IThemeGeneratorPage
       if (colorChangeTimeout) {
         clearTimeout(colorChangeTimeout);
       }
-      colorChangeTimeout = setTimeout(() => {
+      colorChangeTimeout = this._async.setTimeout(() => {
         let themeRules = this.state.themeRules;
         const currentIsDark = isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!);
         ThemeGenerator.setSlot(

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeRulesStandard.ts
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeRulesStandard.ts
@@ -67,7 +67,8 @@ export function themeRulesStandardCreator() {
     // first make the SlotRule for the unshaded base Color
     slotRules[baseSlot] = {
       name: baseSlot,
-      isCustomized: true
+      isCustomized: true,
+      dependentRules: []
     };
 
     // then make a rule for each shade of this base color, but skip unshaded
@@ -75,13 +76,18 @@ export function themeRulesStandardCreator() {
       if (shadeName === Shade[Shade.Unshaded]) {
         return;
       }
-      slotRules[baseSlot + shadeName] = {
+      let inherits = slotRules[baseSlot];
+      let thisSlotRule = {
         name: baseSlot + shadeName,
         inherits: slotRules[baseSlot],
         asShade: shadeValue,
         isCustomized: false,
-        isBackgroundShade: baseSlot === BaseSlots[BaseSlots.backgroundColor] ? true : false
+        isBackgroundShade: baseSlot === BaseSlots[BaseSlots.backgroundColor] ? true : false,
+        dependentRules: []
       };
+      slotRules[baseSlot + shadeName] = thisSlotRule;
+      inherits.dependentRules.push(thisSlotRule);
+
       return void 0;
     });
 
@@ -114,13 +120,17 @@ export function themeRulesStandardCreator() {
   slotRules[BaseSlots[BaseSlots.foregroundColor] + Shade[Shade.Shade8]].color = getColorFromString('#000000');
 
   function _makeFabricSlotRule(slotName: string, inheritedBase: BaseSlots, inheritedShade: Shade, isBackgroundShade = false) {
-    slotRules[slotName] = {
+    let inherits = slotRules[BaseSlots[inheritedBase]];
+    let thisSlotRule = {
       name: slotName,
-      inherits: slotRules[BaseSlots[inheritedBase]],
+      inherits: inherits,
       asShade: inheritedShade,
       isCustomized: false,
-      isBackgroundShade: isBackgroundShade
+      isBackgroundShade: isBackgroundShade,
+      dependentRules: []
     };
+    slotRules[slotName] = thisSlotRule;
+    inherits.dependentRules.push(thisSlotRule);
   }
   _makeFabricSlotRule(FabricSlots[FabricSlots.themePrimary], BaseSlots.primaryColor, Shade.Unshaded);
   _makeFabricSlotRule(FabricSlots[FabricSlots.themeLighterAlt], BaseSlots.primaryColor, Shade.Shade1);
@@ -170,23 +180,32 @@ export function themeRulesStandardCreator() {
   slotRules[primaryBackground] = {
     name: primaryBackground,
     inherits: slotRules[FabricSlots[FabricSlots.white]],
-    isCustomized: false
+    isCustomized: false,
+    dependentRules: []
   };
+  slotRules[FabricSlots[FabricSlots.white]].dependentRules.push(slotRules[primaryBackground]);
+
   let primaryText = 'primaryText';
   slotRules[primaryText] = {
     name: primaryText,
     inherits: slotRules[FabricSlots[FabricSlots.neutralPrimary]],
-    isCustomized: false
+    isCustomized: false,
+    dependentRules: []
   };
+  slotRules[FabricSlots[FabricSlots.neutralPrimary]].dependentRules.push(slotRules[primaryText]);
 
   /*** SEMANTIC SLOTS */
   // create the SlotRule for a semantic slot
   function _makeSemanticSlotRule(semanticSlot: SemanticColorSlots, inheritedFabricSlot: FabricSlots) {
-    slotRules[SemanticColorSlots[semanticSlot]] = {
+    let inherits = slotRules[FabricSlots[inheritedFabricSlot]];
+    let thisSlotRule = {
       name: SemanticColorSlots[semanticSlot],
       inherits: slotRules[FabricSlots[inheritedFabricSlot]],
-      isCustomized: false
+      isCustomized: false,
+      dependentRules: []
     };
+    slotRules[SemanticColorSlots[semanticSlot]] = thisSlotRule;
+    inherits.dependentRules.push(thisSlotRule);
   }
 
   // Basics simple content slots


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Improve overall Theme Generator perf.
1) Prevent O(n^2) behavior. Not a big deal now, but will become worse as more [semantic] slots are added.
2) Add a slight delay on the color picker callback. This vastly smooths the responsiveness.

#### Focus areas to test

(optional)
