### PR TITLE
Website: Updated initializeIcons call to fix the IE/Edge icon bug

### DIFF
--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -14,7 +14,7 @@ import './styles/styles.scss';
 
 import { initializeIcons } from '@uifabric/icons/lib/index';
 
-initializeIcons('./dist/');
+initializeIcons();
 
 let isProduction = process.argv.indexOf('--production') > -1;
 

--- a/common/changes/@uifabric/fabric-website/initializeicons-fix_2017-10-26-18-53.json
+++ b/common/changes/@uifabric/fabric-website/initializeicons-fix_2017-10-26-18-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fixed initializeIcons call to pull from cdn instead of dist.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Icons on the website were not being pulled correctly from the cdn. I had them pointing to the dist folder, which doesn't work with the intended initialize icons functionality.

**Before:**
_Note that in this image, in the 'Styles' tab, that the .ms-Icon class references the FabricMDL2Icons font-family from Fabric Core, but this is being overridden by the class .css-45, which is supposed to be pulling the  FabricMDL2Icons-3 font-family from the fabric-cdn but is not._
![image](https://user-images.githubusercontent.com/16619843/32071720-f660fb06-ba44-11e7-96ef-d2931633b030.png)

**After:**
_FabricMDL2Icons-3 font-family is now being pulled correctly from the cdn!_
![image](https://user-images.githubusercontent.com/16619843/32071691-df53b6e2-ba44-11e7-8b50-ce0d6e4ddcc8.png)

#### Focus areas to test

(optional)
