### PR TITLE
Add ariaHidden prop to buttons

### DIFF
--- a/common/changes/office-ui-fabric-react/bekaise-ariaHidden_2017-10-26-19-49.json
+++ b/common/changes/office-ui-fabric-react/bekaise-ariaHidden_2017-10-26-19-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add ariaHidden prop to buttons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "bekaise@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -74,6 +74,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     const {
       ariaDescription,
       ariaLabel,
+      ariaHidden,
       className,
       description,
       disabled,
@@ -157,6 +158,10 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         'aria-pressed': checked
       }
     );
+
+    if (ariaHidden) {
+      buttonProps['aria-hidden'] = true;
+    }
 
     if (this._isSplitButton) {
       return (

--- a/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.Props.ts
@@ -85,6 +85,11 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
   ariaDescription?: string;
 
   /**
+   * If provided and is true it adds an 'aria-hidden' attribute instructing screen readers to ignore the element.
+   */
+  ariaHidden?: boolean;
+
+  /**
   * Text to render button label. If text is supplied, it will override any string in button children. Other children components will be passed through after the text.
   */
   text?: string;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3238
- [x] Include a change request file using `$ npm run change`

#### Description of changes

To improve accessibility support, the button component should support
the ariaHidden attribute allowing it to be hidden from screen readers.

#### Focus areas to test

Buttons with ariaHidden prop passed.
