### PR TITLE
Reserve red as a color in the personacoin color palette

### DIFF
--- a/common/changes/office-ui-fabric-react/mtennoe-reserve_red_in_personacoin_2017-10-26-14-19.json
+++ b/common/changes/office-ui-fabric-react/mtennoe-reserve_red_in_personacoin_2017-10-26-14-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": " Make red a reserved color for the PersonaCoin, so it can only be used if you override the personacoint color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mariust@outlook.com"
+}

--- a/common/changes/office-ui-fabric-react/mtennoe-reserve_red_in_personacoin_2017-10-26-14-19.json
+++ b/common/changes/office-ui-fabric-react/mtennoe-reserve_red_in_personacoin_2017-10-26-14-19.json
@@ -1,11 +1,9 @@
 {
-  "changes": [
-    {
-      "packageName": "office-ui-fabric-react",
-      "comment": " Make red a reserved color for the PersonaCoin, so it can only be used if you override the personacoint color",
-      "type": "patch"
-    }
-  ],
+  "changes": [{
+    "packageName": "office-ui-fabric-react",
+    "comment": "Make red a reserved color for the PersonaCoin so it can only be used if you override the personacoin color",
+    "type": "minor"
+  }],
   "packageName": "office-ui-fabric-react",
   "email": "mariust@outlook.com"
 }

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`Facepile Render personas and buttons renders Facepile correctly 1`] = `
             >
               <div
                 aria-hidden="true"
-                className="ms-Persona-initials ms-Persona-initials--black undefined"
+                className="ms-Persona-initials ms-Persona-initials--darkGreen undefined"
                 style={undefined}
               >
                 <span>

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
@@ -166,6 +166,9 @@ export enum PersonaInitialsColor {
   purple = 10,
   black = 11,
   orange = 12,
+  /**
+   * Red is a color that often has a special meaning, so it is considered a reserved color and can only be set with overrides
+   */
   red = 13,
   darkRed = 14
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
@@ -8,7 +8,7 @@ import { mount, ReactWrapper } from 'enzyme';
 
 const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 const STYLES = {
-  darkRed: '.ms-Persona-initials--darkRed',
+  green: '.ms-Persona-initials--green',
   initials: '.ms-Persona-initials',
   black: '.ms-Persona-initials--black',
   red: '.ms-Persona-initials--red',
@@ -39,7 +39,7 @@ describe('Persona', () => {
       expect(result).toHaveLength(1);
 
       const wrapper2 = mount(<Persona primaryText='Annie Lindqvist' />);
-      result = wrapper2.find(STYLES.darkRed);
+      result = wrapper2.find(STYLES.green);
       expect(result).toHaveLength(1);
     });
 

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
@@ -10,7 +10,7 @@ const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYA
 const STYLES = {
   darkRed: '.ms-Persona-initials--darkRed',
   initials: '.ms-Persona-initials',
-  lightBlue: '.ms-Persona-initials--lightBlue',
+  black: '.ms-Persona-initials--black',
   red: '.ms-Persona-initials--red',
 
 };
@@ -35,7 +35,7 @@ describe('Persona', () => {
   describe('initials and colors', () => {
     it('renders with expected initialsColor if none was provided', () => {
       const wrapper = mount(<Persona primaryText='Kat Larrson' />);
-      let result = wrapper.find(STYLES.red);
+      let result = wrapper.find(STYLES.black);
       expect(result).toHaveLength(1);
 
       const wrapper2 = mount(<Persona primaryText='Annie Lindqvist' />);
@@ -44,8 +44,8 @@ describe('Persona', () => {
     });
 
     it('uses provided initialsColor if one was specified', () => {
-      const wrapper = mount(<Persona primaryText='Kat Larrson' initialsColor={ PersonaInitialsColor.lightBlue } />);
-      let result = wrapper.find(STYLES.lightBlue);
+      const wrapper = mount(<Persona primaryText='Kat Larrson' initialsColor={ PersonaInitialsColor.red } />);
+      let result = wrapper.find(STYLES.red);
       expect(result).toHaveLength(1);
     });
 

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -33,6 +33,9 @@ const SIZE_TO_PIXELS = {
   [PersonaSize.extraLarge]: 100
 };
 
+/**
+ * Red is a color that often has a special meaning, so it is considered a reserved color and can only be set with overrides
+ */
 const COLOR_SWATCHES_LOOKUP: PersonaInitialsColor[] = [
   PersonaInitialsColor.lightGreen,
   PersonaInitialsColor.lightBlue,
@@ -47,8 +50,7 @@ const COLOR_SWATCHES_LOOKUP: PersonaInitialsColor[] = [
   PersonaInitialsColor.blue,
   PersonaInitialsColor.darkBlue,
   PersonaInitialsColor.orange,
-  PersonaInitialsColor.darkRed,
-  PersonaInitialsColor.red
+  PersonaInitialsColor.darkRed
 ];
 
 const COLOR_SWATCHES_NUM_ENTRIES = COLOR_SWATCHES_LOOKUP.length;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
     >
       <div
         aria-hidden="true"
-        className="ms-Persona-initials ms-Persona-initials--red undefined"
+        className="ms-Persona-initials ms-Persona-initials--black undefined"
         style={undefined}
       >
         <span>


### PR DESCRIPTION
#### Pull request checklist

- [  ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

For several applications the color red is a reserved color, and is often used as a warning color. This change allows the consumer of PersonaCoin to still set Red as an override, but red will not be used in the default palette.

#### Focus areas to test
Nothing special. Non-risky change
