### PR TITLE
Support Calendar date boundaries

### DIFF
--- a/common/changes/office-ui-fabric-react/calendar-minmax_2017-10-27-16-08.json
+++ b/common/changes/office-ui-fabric-react/calendar-minmax_2017-10-27-16-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow optional minimum and maximum date boundaries on Calendar component. ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "evlevy@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.Props.ts
@@ -122,6 +122,16 @@ export interface ICalendarProps extends React.Props<Calendar> {
   * Apply additional formating to dates, for example localized date formatting.
   */
   dateTimeFormatter?: ICalendarFormatDateCallbacks;
+
+  /**
+  * If set the Calendar will not allow navigation to or selection of a date earlier than this value.
+  */
+  minDate?: Date;
+
+  /**
+  * If set the Calendar will not allow navigation to or selection of a date later than this value.
+  */
+  maxDate?: Date;
 }
 
 export interface ICalendarStrings {

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -1,14 +1,11 @@
 @import '../../common/common';
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
-
 //
 // Office UI Fabric
 // --------------------------------------------------
 // Calendar styles
-
 $Calendar-day:40px;
 $Calendar-dayPicker-margin: 10px;
-
 .root {
   @include ms-normalize;
 }
@@ -28,7 +25,6 @@ $Calendar-dayPicker-margin: 10px;
   display: none;
 }
 
-
 // When the picker opens, reveal the content.
 .picker.pickerIsOpened .holder {
   @include ms-borderBox;
@@ -39,7 +35,6 @@ $Calendar-dayPicker-margin: 10px;
 .pickerIsOpened {
   position: relative;
 }
-
 
 // The frame and wrap work together to ensure that
 // clicks within the picker don’t reach the holder.
@@ -54,12 +49,10 @@ $Calendar-dayPicker-margin: 10px;
   display: flex;
 }
 
-
 // Wrapper containing the calendar view to pick a specific date.
 .dayPicker {
   display: block;
 }
-
 
 // The header containing the month and year.
 .header {
@@ -68,7 +61,6 @@ $Calendar-dayPicker-margin: 10px;
   height: $Calendar-day;
   line-height: 44px;
 }
-
 
 // The month and year labels.
 .monthAndYear,
@@ -89,7 +81,6 @@ $Calendar-dayPicker-margin: 10px;
   @include margin-left(5px);
 }
 
-
 // The calendar table of dates.
 .table {
   text-align: center;
@@ -98,11 +89,9 @@ $Calendar-dayPicker-margin: 10px;
   table-layout: fixed;
   font-size: inherit;
   margin-top: 10px;
-
   td {
     margin: 0;
     padding: 0;
-
     &:hover {
       outline: 1px solid transparent;
     }
@@ -110,41 +99,37 @@ $Calendar-dayPicker-margin: 10px;
 }
 
 // The days on the calendar.
-.day, .weekday {
+.day,
+.weekday {
   width: $Calendar-day;
   height: $Calendar-day;
   padding: 0;
   line-height: $Calendar-day;
   @include ms-font-m-plus;
   color: $ms-color-neutralPrimary;
-  box-sizing: border-box;
-  // border-radius: 2px;
+  box-sizing: border-box; // border-radius: 2px;
 }
-
 
 // Today.
 .dayIsToday {
   position: relative;
   background-color: $ms-color-themeLight;
-
   @include high-contrast {
     border: 1px solid WindowText;
   }
 }
-
 
 // Disabled day.
 .dayIsDisabled:before {
   border-top-color: $ms-color-neutralTertiary;
 }
 
-
 // Out of focus days.
-.dayIsUnfocused {
+.dayIsUnfocused,
+.dayIsDisabled {
   color: $ms-color-neutralTertiary;
   font-weight: $ms-font-weight-regular;
 }
-
 
 // Hovered date picker items.
 .dayIsFocused:hover,
@@ -155,7 +140,6 @@ $Calendar-dayPicker-margin: 10px;
 
 .day.dayIsHighlighted.dayIsFocused {
   @include focus-border(1px, $ms-color-white);
-
   @include high-contrast {
     @include focus-border(1px, WindowText);
   }
@@ -165,14 +149,15 @@ $Calendar-dayPicker-margin: 10px;
 .dayIsHighlighted:hover,
 .pickerIsFocused .dayIsHighlighted {
   cursor: pointer;
-
   @include high-contrast {
     border: 2px solid Highlight;
   }
 }
 
-.dayIsUnfocused:active, .dayIsFocused:active, .dayIsHighlighted{
-  &.day{
+.dayIsUnfocused:active,
+.dayIsFocused:active,
+.dayIsHighlighted {
+  &.day {
     color: $ms-color-black;
     background: $ms-color-themeLight;
   }
@@ -185,7 +170,8 @@ $Calendar-dayPicker-margin: 10px;
 }
 
 // Today.
-.dayIsToday, .pickerIsFocused .dayIsToday {
+.dayIsToday,
+.pickerIsFocused .dayIsToday {
   position: relative;
   color: $ms-color-white;
   background-color: $ms-color-themePrimary;
@@ -193,56 +179,59 @@ $Calendar-dayPicker-margin: 10px;
 }
 
 // Highlighted date squares
-.dayBackground, .weekBackground, .monthBackground{
-    background: $ms-color-neutralLight;
+.dayBackground,
+.weekBackground,
+.monthBackground {
+  background: $ms-color-neutralLight;
 }
 
-.dayBackground{
+.dayBackground {
   // border-radius: 2px;
 }
 
-.weekBackground{
-    &:first-child{
-      // border-radius: 2px 0px 0px 2px;
-    }
-
-    &:last-child{
-      // border-radius: 0px 2px 2px 0px;
-    }
+.weekBackground {
+  &:first-child {
+    // border-radius: 2px 0px 0px 2px;
+  }
+  &:last-child {
+    // border-radius: 0px 2px 2px 0px;
+  }
 }
 
-.showWeekNumbers{
-  .weekNumbers{
+.showWeekNumbers {
+  .weekNumbers {
     position: absolute;
     margin-top: $Calendar-day;
     border-right: 1px solid $ms-color-neutralLight;
     box-sizing: border-box;
     width: 30px;
-    .day{
+    .day {
       color: $ms-color-neutralSecondary;
-      &.weekIsHighlighted{
+      &.weekIsHighlighted {
         color: $ms-color-black;
       }
     }
   }
-  .table{
-    &:not(.weekNumbers){
+  .table {
+    &:not(.weekNumbers) {
       margin-left: 30px;
     }
-    .day, .weekday{
+    .day,
+    .weekday {
       width: 30px;
     }
   }
 }
 
 // Month and year previous/next components.
-.monthComponents,.yearComponents,
+.monthComponents,
+.yearComponents,
 .decadeComponents {
   display: inline-flex;
   margin-left: 3px;
 }
 
-.yearComponents{
+.yearComponents {
   margin-left: 3px;
 }
 
@@ -262,12 +251,20 @@ $Calendar-dayPicker-margin: 10px;
   color: $ms-color-neutralDark;
   position: relative;
   top: 2px;
-
   &:hover {
     color: $ms-color-neutralDark;
     cursor: pointer;
     outline: 1px solid transparent;
   }
+}
+
+.prevMonthIsDisabled,
+.nextMonthIsDisabled,
+.prevYearIsDisabled,
+.nextYearIsDisabled,
+.prevDecadeIsDisabled,
+.nextDecadeIsDisabled {
+  visibility: hidden;
 }
 
 // Without modifying the Pickadate JS, this transparent
@@ -310,22 +307,24 @@ $Calendar-dayPicker-margin: 10px;
   @include margin(0, 10px, 10px, 0);
   @include ms-font-s-plus;
   color: $ms-color-neutralPrimary;
-  text-align: center;
-  // border-radius: 2px;
-
+  text-align: center; // border-radius: 2px;
   &:hover {
     color: $ms-color-black;
     background-color: $ms-color-neutralTertiaryAlt;
     outline: 1px solid transparent;
   }
-
   &.isHighlighted {
     background-color: $ms-color-neutralPrimary;
     color: $ms-color-white;
   }
-
 }
 
+.monthOptionIsDisabled,
+.yearOptionIsDisabled {
+  background-color: $ms-color-neutralLighter;
+  color: $ms-color-neutralTertiaryAlt;
+  pointer-events: none;
+}
 
 // Button to navigate to the current date.
 .goToday {
@@ -339,19 +338,17 @@ $Calendar-dayPicker-margin: 10px;
   padding: 0 10px;
   position: absolute !important;
   @include ms-right(13px);
-
   &:hover {
     color: $ms-color-themePrimary;
     outline: 1px solid transparent;
   }
-
   &:active {
     color: $ms-color-themeDark;
   }
 }
 
 // Additional 30px margin needed when "Go to today" button is visible
-.wrap.goTodaySpacing{
+.wrap.goTodaySpacing {
   margin-bottom: 30px;
 }
 
@@ -361,12 +358,10 @@ $Calendar-dayPicker-margin: 10px;
   .dayPicker,
   .monthComponents {
     display: none;
-  }
-  // Hide the month picking components.
+  } // Hide the month picking components.
   .monthPicker {
     display: none;
-  }
-  // Show the year picking components.
+  } // Show the year picking components.
   .yearPicker {
     display: block;
   }
@@ -376,35 +371,26 @@ $Calendar-dayPicker-margin: 10px;
 //
 // On screens that can fit it, we show the month picker next to the day picker if we have it enabled.
 @media (min-device-width: 460px) {
-
   $Calendar-day: 28px;
   $Calendar-month: 40px;
-
   .wrap {
     padding: 9px 8px;
-  }
-  // Update the spacing and text for the day and month pickers
-
-  .dayPicker,.monthPicker {
+  } // Update the spacing and text for the day and month pickers
+  .dayPicker,
+  .monthPicker {
     min-height: 214px;
   }
-
   .header {
     height: $Calendar-day;
     line-height: $Calendar-day;
-  }
-
-  // Calendar day cells are smaller.
+  } // Calendar day cells are smaller.
   .day,
   .weekday {
     width: $Calendar-day;
     height: $Calendar-day;
     line-height: $Calendar-day;
     font-size: $ms-font-size-s;
-  }
-
-
-  // Reduce the size of arrows to change month/year.
+  } // Reduce the size of arrows to change month/year.
   .prevMonth,
   .nextMonth,
   .prevYear,
@@ -416,76 +402,61 @@ $Calendar-dayPicker-margin: 10px;
     height: 24px;
     line-height: 24px;
   }
-
   .holder {
     width: 212px;
     height: auto;
   }
-
   .monthAndYear,
   .year {
     font-size: 17px;
     color: $ms-color-neutralPrimary;
   }
-
-  .yearComponents{
+  .yearComponents {
     margin-left: 1px;
   }
-
   .goToday {
     padding: 0 3px;
   }
-
-  .showWeekNumbers{
-    .weekNumbers{
+  .showWeekNumbers {
+    .weekNumbers {
       margin-top: $Calendar-day;
       width: 26px;
       margin-left: -7px
     }
-    .table{
-      &:not(.weekNumbers){
+    .table {
+      &:not(.weekNumbers) {
         margin-left: 19px;
       }
-      .day, .weekday{
+      .day,
+      .weekday {
         width: 26px;
       }
     }
-  }
-
-  // Show month picker, if enabled
+  } // Show month picker, if enabled
   .monthPickerVisible {
-
     .wrap {
       padding: 10px;
-    }
-
-    // Swap margin for padding so that the border extends the full height.
+    } // Swap margin for padding so that the border extends the full height.
     .dayPicker {
       margin: -$Calendar-dayPicker-margin 0;
       padding: $Calendar-dayPicker-margin 0;
-    }
-
-    // Contains the calendar view for picking a day.
+    } // Contains the calendar view for picking a day.
     .dayPicker {
       @include ms-borderBox;
       @include border-right(1px, solid, $ms-color-neutralLight);
       width: 212px;
       min-height: 214px;
-    }
-    // Show the month picker.
+    } // Show the month picker.
     .monthPicker {
       display: block;
     }
-
     .optionGrid {
       height: 150px;
       width: 212px;
-    }
-    // This component is only used on small displays.
+    } // This component is only used on small displays.
     .toggleMonthView {
       display: none;
-    }
-    // Position the current year and decade labels.
+    } // Position the current year and decade labels.
     .currentYear,
     .currentDecade {
       font-size: 17px;
@@ -493,9 +464,7 @@ $Calendar-dayPicker-margin: 10px;
       height: $Calendar-day;
       line-height: 26px;
       display: inline-block;
-    }
-
-    // Reduce the size of the month buttons.
+    } // Reduce the size of the month buttons.
     .monthOption,
     .yearOption {
       width: $Calendar-month;
@@ -503,16 +472,13 @@ $Calendar-dayPicker-margin: 10px;
       line-height: $Calendar-month;
       font-size: 12px;
       @include margin(0, 11px, 11px, 0);
-
       &:hover {
         outline: 1px solid transparent;
       }
-
-      &:nth-child(4n+4){
+      &:nth-child(4n+4) {
         @include margin(0, 0px, 11px, 0);
       }
-    }
-    // Position the "Go to today" button below the month picker.
+    } // Position the "Go to today" button below the month picker.
     .goToday {
       @include ms-borderBox;
       font-size: 12px;
@@ -522,12 +488,10 @@ $Calendar-dayPicker-margin: 10px;
       @include ms-right(8px);
       @include text-align(right);
       top: 199px;
-    }
-    // When date and month picker are side-by-side and "Go to today" button is visible no additional margin is needed
-    .wrap.goTodaySpacing{
+    } // When date and month picker are side-by-side and "Go to today" button is visible no additional margin is needed
+    .wrap.goTodaySpacing {
       margin-bottom: 0px;
-    }
-    // State: The picker is showing the year components.
+    } // State: The picker is showing the year components.
     // On larger screens the calendar will remain and the years
     // will replace the months.
     .root.isPickingYears {
@@ -536,59 +500,48 @@ $Calendar-dayPicker-margin: 10px;
       .dayPicker,
       .monthComponents {
         display: block;
-      }
-      // Hide the month picking components.
+      } // Hide the month picking components.
       .monthPicker {
         display: none;
-      }
-      // Show the year picking components.
+      } // Show the year picking components.
       .yearPicker {
         display: block;
       }
     }
   }
-
-  .calendarsInline{
+  .calendarsInline {
     .wrap {
       padding: 9px 12px;
     }
-
     .holder {
       width: 440px;
       height: auto;
     }
-
-    .table{
+    .table {
       margin-right: 12px
     }
-
-     .dayPicker {
+    .dayPicker {
       width: auto;
     }
-
-    .monthPicker{
+    .monthPicker {
       margin-left: 13px;
     }
-
     .goToday {
       @include ms-right(13px);
       padding: 0 10px;
     }
-  }
-
-  //when month picker is only visible
-  .monthPickerOnly{
-    .wrap{
+  } //when month picker is only visible
+  .monthPickerOnly {
+    .wrap {
       padding: 10px;
     }
   }
-
-  .monthPickerAsOverlay{
+  .monthPickerAsOverlay {
     .wrap {
       padding-top: 4px;
       padding-bottom: 4px;
     }
-    .holder{
+    .holder {
       height: 240px;
     }
   }
@@ -596,30 +549,23 @@ $Calendar-dayPicker-margin: 10px;
 
 // On smaller screens the month button toggles to the picking months state.
 @media (max-device-width: 459px) {
-
   // Stop elements from going off screen
   .holder {
     width: 300px;
   }
-
-  .calendarsInline{
+  .calendarsInline {
     // Month and year pickers, hidden on small screens by default.
     .monthPicker,
     .yearPicker {
       display: none;
     }
-  }
-
-  // position year components so they do not move when switching between calendars (overlayed calendars)
+  } // position year components so they do not move when switching between calendars (overlayed calendars)
   .yearComponents {
     margin-top: 2px;
   }
 }
 
-
 // Custom CSS for fabric-React
-
-
 .wrap span:focus,
 .wrap div:focus {
   @include focus-border(1px, $ms-color-neutralSecondary);
@@ -634,8 +580,7 @@ $Calendar-dayPicker-margin: 10px;
 .nextYear,
 .prevYear {
   display: inline-block;
-
-  &:hover{
+  &:hover {
     background-color: $ms-color-neutralTertiaryAlt;
   }
 }
@@ -645,10 +590,9 @@ $Calendar-dayPicker-margin: 10px;
   margin-left: 3px;
 }
 
-.monthIsHighlighted{
+.monthIsHighlighted {
   background-color: $ms-color-themeLight;
-
-  &.monthOption:hover{
+  &.monthOption:hover {
     background-color: $ms-color-themeLight;
   }
 }
@@ -657,41 +601,39 @@ $Calendar-dayPicker-margin: 10px;
   font-weight: 600;
   color: $ms-color-white;
   background-color: $ms-color-themePrimary;
-
-  &.monthOption:hover{
+  &.monthOption:hover {
     font-weight: 600;
     color: $ms-color-white;
     background-color: $ms-color-themePrimary;
   }
 }
 
-.monthOption:active{
+.monthOption:active {
   background-color: $ms-color-themeLight;
 }
 
-
 // Highlighted Month date styling.
 // Border-radius to be updated once rolled out across fabric
-.topLeftCornerDate{
+.topLeftCornerDate {
   border-radius: 0;
 }
 
-.topRightCornerDate{
+.topRightCornerDate {
   border-radius: 0;
 }
 
-.bottomLeftCornerDate{
+.bottomLeftCornerDate {
   border-radius: 0;
 }
 
-.bottomRightCornerDate{
+.bottomRightCornerDate {
   border-radius: 0;
 }
 
-.singleTopDate{
+.singleTopDate {
   border-radius: 0;
 }
 
-.singleBottomDate{
+.singleBottomDate {
   border-radius: 0;
 }

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.test.tsx
@@ -247,4 +247,117 @@ describe('Calendar', () => {
       lastSelectedDateRange!.forEach((val, i) => expect(compareDates(val, addDays(firstDate, i))).toEqual(true));
     });
   });
+
+  describe('render with date boundaries', () => {
+    it('out-of-bounds days should be disabled', () => {
+      const defaultDate = new Date('Mar 16 2017');
+      const minDate = new Date('Mar 6 2017');
+      const maxDate = new Date('Mar 24 2017');
+      const renderedComponent = ReactTestUtils.renderIntoDocument(
+        <Calendar
+          strings={ dayPickerStrings }
+          value={ defaultDate }
+          firstDayOfWeek={ DayOfWeek.Sunday }
+          dateRangeType={ DateRangeType.Day }
+          minDate={ minDate }
+          maxDate={ maxDate }
+        />) as Calendar;
+
+      const days = ReactTestUtils.scryRenderedDOMComponentsWithClass(renderedComponent, 'ms-DatePicker-day');
+
+      expect(days.slice(0, 7).every(e => e.classList.contains('ms-DatePicker-day--disabled'))).toBe(true);
+      expect(days.slice(8, 26).every(e => e.classList.contains('ms-DatePicker-day--disabled'))).toBe(false);
+      expect(days.slice(27).every(e => e.classList.contains('ms-DatePicker-day--disabled'))).toBe(true);
+    });
+
+    it('out-of-bounds days should not be part of selected range', () => {
+      let lastSelectedDateRange: Date[] = new Array();
+      const defaultDate = new Date('Mar 16 2017');
+      const minDate = new Date('Mar 6 2017');
+      const maxDate = new Date('Mar 24 2017');
+      const onSelectDate = (): (date: Date, dateRangeArray: Date[]) => void => {
+        return (date: Date, dateRangeArray: Date[]): void => {
+          lastSelectedDateRange = dateRangeArray;
+        };
+      };
+      const renderedComponent = ReactTestUtils.renderIntoDocument(
+        <Calendar
+          strings={ dayPickerStrings }
+          value={ defaultDate }
+          firstDayOfWeek={ DayOfWeek.Sunday }
+          dateRangeType={ DateRangeType.Month }
+          minDate={ minDate }
+          maxDate={ maxDate }
+          onSelectDate={ onSelectDate() }
+        />) as Calendar;
+
+      let days = ReactTestUtils.scryRenderedDOMComponentsWithClass(renderedComponent, 'ms-DatePicker-day');
+      ReactTestUtils.Simulate.click(days[18]);
+      expect(lastSelectedDateRange!.length).toEqual(19);
+      lastSelectedDateRange!.forEach((val, i) => expect(compareDates(val, addDays(minDate, i))).toEqual(true));
+    });
+  });
+
+  it('navigators to out-of-bounds months should be disabled', () => {
+    const defaultDate = new Date('Mar 15 2017');
+    const minDate = new Date('Mar 1 2017');
+    const maxDate = new Date('Mar 31 2017');
+    const renderedComponent = ReactTestUtils.renderIntoDocument(
+      <Calendar
+        strings={ dayPickerStrings }
+        value={ defaultDate }
+        firstDayOfWeek={ DayOfWeek.Sunday }
+        dateRangeType={ DateRangeType.Day }
+        minDate={ minDate }
+        maxDate={ maxDate }
+      />) as Calendar;
+
+    const prevMonth = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-prevMonth');
+    const nextMonth = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-nextMonth');
+
+    expect(prevMonth.classList.contains('ms-DatePicker-prevMonth--disabled')).toBe(true);
+    expect(nextMonth.classList.contains('ms-DatePicker-nextMonth--disabled')).toBe(true);
+  });
+
+  it('out-of-bounds months should be disabled', () => {
+    const defaultDate = new Date('Mar 15 2017');
+    const minDate = new Date('Mar 1 2017');
+    const maxDate = new Date('Oct 1 2017');
+    const renderedComponent = ReactTestUtils.renderIntoDocument(
+      <Calendar
+        strings={ dayPickerStrings }
+        value={ defaultDate }
+        firstDayOfWeek={ DayOfWeek.Sunday }
+        dateRangeType={ DateRangeType.Day }
+        minDate={ minDate }
+        maxDate={ maxDate }
+      />) as Calendar;
+
+    const months = ReactTestUtils.scryRenderedDOMComponentsWithClass(renderedComponent, 'ms-DatePicker-monthOption');
+
+    expect(months.slice(0, 1).every(e => e.classList.contains('ms-DatePicker-monthOption--disabled'))).toBe(true);
+    expect(months.slice(2, 9).some(e => e.classList.contains('ms-DatePicker-monthOption--disabled'))).toBe(false);
+    expect(months.slice(10).every(e => e.classList.contains('ms-DatePicker-monthOption--disabled'))).toBe(true);
+  });
+
+  it('navigators to out-of-bounds years should be disabled', () => {
+    const defaultDate = new Date('Mar 15 2017');
+    const minDate = new Date('Jan 1 2017');
+    const maxDate = new Date('Dec 31 2017');
+    const renderedComponent = ReactTestUtils.renderIntoDocument(
+      <Calendar
+        strings={ dayPickerStrings }
+        value={ defaultDate }
+        firstDayOfWeek={ DayOfWeek.Sunday }
+        dateRangeType={ DateRangeType.Day }
+        minDate={ minDate }
+        maxDate={ maxDate }
+      />) as Calendar;
+
+    const prevMonth = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-prevYear');
+    const nextMonth = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-nextYear');
+
+    expect(prevMonth.classList.contains('ms-DatePicker-prevYear--disabled')).toBe(true);
+    expect(nextMonth.classList.contains('ms-DatePicker-nextYear--disabled')).toBe(true);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -118,7 +118,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
 
   public render() {
     let rootClass = 'ms-DatePicker';
-    let { firstDayOfWeek, dateRangeType, strings, showMonthPickerAsOverlay, autoNavigateOnSelection, showGoToToday, highlightCurrentMonth, navigationIcons } = this.props;
+    let { firstDayOfWeek, dateRangeType, strings, showMonthPickerAsOverlay, autoNavigateOnSelection, showGoToToday, highlightCurrentMonth, navigationIcons, minDate, maxDate } = this.props;
     let { selectedDate, navigatedDate, isMonthPickerVisible, isDayPickerVisible } = this.state;
     let onHeaderSelect = showMonthPickerAsOverlay ? this._onHeaderSelect : undefined;
     let monthPickerOnly = !showMonthPickerAsOverlay && !isDayPickerVisible;
@@ -156,6 +156,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
                   showWeekNumbers={ this.props.showWeekNumbers }
                   firstWeekOfYear={ this.props.firstWeekOfYear! }
                   dateTimeFormatter={ this.props.dateTimeFormatter! }
+                  minDate={ minDate }
+                  maxDate={ maxDate }
                   ref='dayPicker'
                 />
                 }
@@ -169,6 +171,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
                   onHeaderSelect={ onHeaderSelect }
                   navigationIcons={ navigationIcons! }
                   dateTimeFormatter={ this.props.dateTimeFormatter! }
+                  minDate={ minDate }
+                  maxDate={ maxDate }
                   ref='monthPicker'
                 /> }
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../Utilities';
 import { ICalendarStrings, ICalendarIconStrings, ICalendarFormatDateCallbacks } from './Calendar.Props';
 import { FocusZone } from '../../FocusZone';
-import { addYears, setMonth } from '../../utilities/dateMath/DateMath';
+import { addYears, setMonth, getYearStart, getYearEnd, getMonthStart, getMonthEnd, compareDatePart } from '../../utilities/dateMath/DateMath';
 import { Icon } from '../../Icon';
 import * as stylesImport from './Calendar.scss';
 const styles: any = stylesImport;
@@ -23,6 +23,8 @@ export interface ICalendarMonthProps extends React.Props<CalendarMonth> {
   onHeaderSelect?: (focus: boolean) => void;
   navigationIcons: ICalendarIconStrings;
   dateTimeFormatter: ICalendarFormatDateCallbacks;
+  minDate?: Date;
+  maxDate?: Date;
 }
 
 export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
@@ -49,16 +51,22 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
 
   public render() {
 
-    let { navigatedDate, strings, today, highlightCurrentMonth, navigationIcons, dateTimeFormatter } = this.props;
+    let { navigatedDate, strings, today, highlightCurrentMonth, navigationIcons, dateTimeFormatter, minDate, maxDate } = this.props;
     let leftNavigationIcon = navigationIcons.leftNavigation;
     let rightNavigationIcon = navigationIcons.rightNavigation;
+
+    // determine if previous/next years are in bounds
+    const isPrevYearInBounds = minDate ? compareDatePart(minDate, getYearStart(navigatedDate)) < 0 : true;
+    const isNextYearInBounds = maxDate ? compareDatePart(getYearEnd(navigatedDate), maxDate) < 0 : true;
 
     return (
       <div className={ css('ms-DatePicker-monthPicker', styles.monthPicker) }>
         <div className={ css('ms-DatePicker-yearComponents', styles.yearComponents) }>
           <div className={ css('ms-DatePicker-navContainer', styles.navContainer) }>
             <span
-              className={ css('ms-DatePicker-prevYear js-prevYear', styles.prevYear) }
+              className={ css('ms-DatePicker-prevYear js-prevYear', styles.prevYear, {
+                ['ms-DatePicker-prevYear--disabled ' + styles.prevYearIsDisabled]: !isPrevYearInBounds
+              }) }
               onClick={ this._onSelectPrevYear }
               onKeyDown={ this._onSelectPrevYearKeyDown }
               aria-label={ strings.prevYearAriaLabel ? strings.prevYearAriaLabel + ' ' + dateTimeFormatter.formatYear(addYears(navigatedDate, -1)) : undefined }
@@ -68,7 +76,9 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
               <Icon iconName={ getRTL() ? rightNavigationIcon : leftNavigationIcon } />
             </span>
             <span
-              className={ css('ms-DatePicker-nextYear js-nextYear', styles.nextYear) }
+              className={ css('ms-DatePicker-nextYear js-nextYear', styles.nextYear, {
+                ['ms-DatePicker-nextYear--disabled ' + styles.nextYearIsDisabled]: !isNextYearInBounds
+              }) }
               onClick={ this._onSelectNextYear }
               onKeyDown={ this._onSelectNextYearKeyDown }
               aria-label={ strings.nextYearAriaLabel ? strings.nextYearAriaLabel + ' ' + dateTimeFormatter.formatYear(addYears(navigatedDate, 1)) : undefined }
@@ -102,26 +112,34 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
             className={ css('ms-DatePicker-optionGrid', styles.optionGrid) }
             role='grid'
           >
-            { strings.shortMonths.map((month, index) =>
-              <span
-                role='gridcell'
+            { strings.shortMonths.map((month, index) => {
+
+              const indexedMonth = setMonth(navigatedDate, index);
+              const isCurrentMonth = this._isCurrentMonth(index, navigatedDate.getFullYear(), today!);
+              const isNavigatedMonth = navigatedDate.getMonth() === index;
+              const isInBounds = (minDate ? compareDatePart(minDate, getMonthEnd(indexedMonth)) < 1 : true) &&
+                (maxDate ? compareDatePart(getMonthStart(indexedMonth), maxDate) < 1 : true);
+
+              return <span
+                role={ 'gridcell' }
                 className={
-                  css('ms-DatePicker-monthOption',
-                    styles.monthOption,
+                  css('ms-DatePicker-monthOption', styles.monthOption,
                     {
-                      ['ms-DatePicker-day--today ' + styles.monthIsCurrentMonth]: highlightCurrentMonth && this._isCurrentMonth(index, navigatedDate.getFullYear(), today!),
-                      ['ms-DatePicker-day--highlighted ' + styles.monthIsHighlighted]: highlightCurrentMonth && (navigatedDate.getMonth() === index)
+                      ['ms-DatePicker-day--today ' + styles.monthIsCurrentMonth]: highlightCurrentMonth && isCurrentMonth!,
+                      ['ms-DatePicker-day--highlighted ' + styles.monthIsHighlighted]: highlightCurrentMonth && isNavigatedMonth,
+                      ['ms-DatePicker-monthOption--disabled ' + styles.monthOptionIsDisabled]: !isInBounds
                     })
                 }
                 key={ index }
-                onClick={ this._selectMonthCallbacks[index] }
-                aria-label={ dateTimeFormatter.formatMonthYear(setMonth(navigatedDate, index), strings) }
-                aria-selected={ this._isCurrentMonth(index, navigatedDate.getFullYear(), today!) || (navigatedDate.getMonth() === index) }
-                data-is-focusable={ true }
-                ref={ navigatedDate.getMonth() === index ? 'navigatedMonth' : undefined }
+                onClick={ isInBounds ? this._selectMonthCallbacks[index] : undefined }
+                aria-label={ dateTimeFormatter.formatMonthYear(indexedMonth, strings) }
+                aria-selected={ isCurrentMonth || isNavigatedMonth }
+                data-is-focusable={ isInBounds ? true : undefined }
+                ref={ isNavigatedMonth ? 'navigatedMonth' : undefined }
               >
                 { month }
-              </span>
+              </span>;
+            }
             ) }
           </div>
         </FocusZone>

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.test.ts
@@ -411,4 +411,24 @@ describe('DateMath', () => {
     expected = 52;
     expect(result).toEqual(expected);
   });
+
+  it('can get the month start and end', () => {
+    let date = new Date('Dec 15 2017');
+
+    // First day of month
+    expect(DateMath.compareDates(new Date('Dec 1 2017'), DateMath.getMonthStart(date))).toBe(true);
+
+    // Last day of month
+    expect(DateMath.compareDates(new Date('Dec 31 2017'), DateMath.getMonthEnd(date))).toBe(true);
+  });
+
+  it('can get the year start and end', () => {
+    let date = new Date('Dec 15 2017');
+
+    // First day of year
+    expect(DateMath.compareDates(new Date('Jan 1 2017'), DateMath.getYearStart(date))).toBe(true);
+
+    // Last day of year
+    expect(DateMath.compareDates(new Date('Dec 31 2017'), DateMath.getYearEnd(date))).toBe(true);
+  });
 });

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
@@ -68,6 +68,42 @@ export function addYears(date: Date, years: number): Date {
 }
 
 /**
+ * Returns a date that is the first day of the month of the provided date.
+ * @param {Date} date - The origin date
+ * @return {Date} A new Date object with the day set to the first day of the month.
+ */
+export function getMonthStart(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1, 0, 0, 0, 0);
+}
+
+/**
+ * Returns a date that is the last day of the month of the provided date.
+ * @param {Date} date - The origin date
+ * @return {Date} A new Date object with the day set to the last day of the month.
+ */
+export function getMonthEnd(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0, 0, 0, 0, 0);
+}
+
+/**
+ * Returns a date that is the first day of the year of the provided date.
+ * @param {Date} date - The origin date
+ * @return {Date} A new Date object with the day set to the first day of the year.
+ */
+export function getYearStart(date: Date): Date {
+  return new Date(date.getFullYear(), 0, 1, 0, 0, 0, 0);
+}
+
+/**
+ * Returns a date that is the last day of the year of the provided date.
+ * @param {Date} date - The origin date
+ * @return {Date} A new Date object with the day set to the last day of the year.
+ */
+export function getYearEnd(date: Date): Date {
+  return new Date(date.getFullYear() + 1, 0, 0, 0, 0, 0, 0);
+}
+
+/**
  * Returns a date that is a copy of the given date, aside from the month changing to the given month.
  *  The method tries to preserve the day-of-month; however, if the new month does not have enough days
  * to contain the original day-of-month, we'll use the last day of the new month.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

(Note: Feature is required for integrating the fabric DatePicker component into PowerApps control suite. Although this PR is for Calendar only, once merged I will submit the DatePicker change -EL)

Add support to Calendar for optional `minDate` and `maxDate` props. Setting these will affect the following behaviours:

- Day picker days are disabled for out-of-bounds dates.
- Month picker months are disabled for months containing only out-of-bounds dates.
- Previous/next buttons are hidden if they would navigate to a month or year that contains only out-of-bounds dates.
- Auto navigation elements are disabled if they would navigate to a month or year that contains only out-of-bounds dates.
- Keyboard navigation disabled to out-of-bounds dates.
- Selected date ranges are trimmed to exclude out-of-bounds dates.

Default:
![image](https://user-images.githubusercontent.com/33076550/32119842-780dd87e-bb24-11e7-97ad-fdc4c8b3fb41.png)

`minDate={ new Date('Oct 4 2017') }` (note October 1-3 and all moths < Oct are disabled):
![image](https://user-images.githubusercontent.com/33076550/32119954-d62bb084-bb24-11e7-839e-a9b84c193f8a.png)

`minDate={ new Date('Oct 4 2017') }` (note October 1-3 is not part of the selected date range):
`dateRangeType={ DateRangeType.Month }`
![image](https://user-images.githubusercontent.com/33076550/32120644-6fdd08ca-bb27-11e7-905b-5518e201eab3.png)

#### Focus areas to test

- Keyboard day navigation is occasionally wonky, but I believe this behaviour is pre-existing with FocusZone.