### PR TITLE
Slider: Add aria-valuetext property

### DIFF
--- a/common/changes/office-ui-fabric-react/slider-ariavaluetext_2017-10-27-23-04.json
+++ b/common/changes/office-ui-fabric-react/slider-ariavaluetext_2017-10-27-23-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add 'aria-valuetext' property to Slider",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "a.erich@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/slider-ariavaluetext_2017-10-27-23-04.json
+++ b/common/changes/office-ui-fabric-react/slider-ariavaluetext_2017-10-27-23-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Add `ariaValueText` property to Slider",
+      "comment": "Slider: added `ariaValueText` property for better screen-reader support.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/slider-ariavaluetext_2017-10-27-23-04.json
+++ b/common/changes/office-ui-fabric-react/slider-ariavaluetext_2017-10-27-23-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Add 'aria-valuetext' property to Slider",
+      "comment": "Add `ariaValueText` property to Slider",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.Props.ts
@@ -65,6 +65,10 @@ export interface ISliderProps {
   ariaLabel?: string;
 
   /**
+   * A text description of the Slider number value for the benefit of screen readers. This should be used when the Slider number value is not accurately represented by a number.
+   */
+  ariaValueText?: (value: number) => string;
+  /**
    * Optional flag to render the slider vertically. Defaults to rendering horizontal.
    */
   vertical?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
@@ -94,4 +94,31 @@ describe('Slider', () => {
     );
     expect(slider!.value).toEqual(12);
   });
+
+  it('renders correct aria-valuetext', () => {
+    let component = ReactTestUtils.renderIntoDocument(
+      <Slider />
+    );
+    let renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+    let button = renderedDOM.querySelector('.ms-Slider-slideBox') as HTMLElement;
+    let ariaValueText = button.getAttribute('aria-valuetext');
+
+    expect(ariaValueText).toBeNull();
+
+    const values = ['small', 'medium', 'large'];
+    const selected = 1;
+    const getTextValue = (value: number) => values[value];
+
+    component = ReactTestUtils.renderIntoDocument(
+      <Slider
+        value={ selected }
+        ariaValueText={ getTextValue }
+      />
+    );
+    renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
+    button = renderedDOM.querySelector('.ms-Slider-slideBox') as HTMLElement;
+    ariaValueText = button.getAttribute('aria-valuetext');
+
+    expect(ariaValueText).toEqual(values[selected]);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
@@ -114,6 +114,7 @@ export class Slider extends BaseComponent<ISliderProps, ISliderState> implements
             aria-valuenow={ value }
             aria-valuemin={ min }
             aria-valuemax={ max }
+            aria-valuetext={ this._getAriaValueText(value) }
             aria-label={ ariaLabel || label }
             { ...onMouseDownProp }
             { ...onTouchStartProp }
@@ -163,6 +164,13 @@ export class Slider extends BaseComponent<ISliderProps, ISliderState> implements
 
   public get value(): number | undefined {
     return this.state.value;
+  }
+
+  @autobind
+  private _getAriaValueText(value: number | undefined): string | void {
+    if (this.props.ariaValueText && value !== undefined) {
+      return this.props.ariaValueText(value);
+    }
   }
 
   private _getThumbStyle(vertical: boolean | undefined, thumbOffsetPercent: number): any {

--- a/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Slider renders Slider correctly 1`] = `
       aria-valuemax={10}
       aria-valuemin={0}
       aria-valuenow={0}
+      aria-valuetext={undefined}
       className="ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions undefined"
       disabled={false}
       id="Slider0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3256
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added `aria-valuetext` property to Slider so aria text can be set when the Slider value isn't accurately represented by a number, e.g. small, medium, large. [Reference](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuetext_attribute)