### PR TITLE
CommandBar: iconOnly prop (target 5.0)

### DIFF
--- a/common/changes/office-ui-fabric-react/commandBar-iconOnly5.0_2017-10-31-14-20.json
+++ b/common/changes/office-ui-fabric-react/commandBar-iconOnly5.0_2017-10-31-14-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: iconOnly items prop",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-panu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.Props.ts
@@ -52,3 +52,11 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   className?: string;
 }
+
+export interface ICommandBarItemProps extends IContextualMenuItem {
+  /**
+   * Remove text when button is not in the overflow
+   * @defaultvalue false
+   */
+  iconOnly?: boolean;
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -18,6 +18,7 @@ import {
   IIconProps
 } from '../../Icon';
 import { FontClassNames } from '../../Styling';
+import { TooltipHost } from '../../Tooltip';
 import * as stylesImport from './CommandBar.scss';
 const styles: any = stylesImport;
 
@@ -182,75 +183,90 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     const isNameVisible = !!item.name && !item.iconOnly;
     const ariaLabel = item.ariaLabel || (item.iconOnly ? item.name : '');
 
+    let command: React.ReactNode;
+    if (isLink) {
+      command = (
+        <button
+          { ...getNativeProps(item, buttonProperties) }
+          id={ this._id + item.key }
+          className={ className }
+          onClick={ this._onItemClick(item) }
+          data-command-key={ itemKey }
+          aria-haspopup={ hasSubmenuItems(item) }
+          aria-expanded={ hasSubmenuItems(item) ? expandedMenuItemKey === item.key : undefined }
+          role='menuitem'
+          aria-label={ ariaLabel }
+        >
+          { (hasIcon) ? this._renderIcon(item) : (null) }
+          { isNameVisible && (
+            <span
+              className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
+            >
+              { item.name }
+            </span>
+          ) }
+          { hasSubmenuItems(item) ? (
+            <Icon className={ css('ms-CommandBarItem-chevronDown', styles.itemChevronDown) } iconName='ChevronDown' />
+          ) : (null) }
+        </button>
+      );
+    } else if (item.href) {
+      command = (
+        <a
+          { ...getNativeProps(item, anchorProperties) }
+          id={ this._id + item.key }
+          className={ className }
+          href={ item.href }
+          data-command-key={ itemKey }
+          aria-haspopup={ hasSubmenuItems(item) }
+          role='menuitem'
+          aria-label={ ariaLabel }
+        >
+          { (hasIcon) ? this._renderIcon(item) : (null) }
+          { isNameVisible && (
+            <span
+              className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
+            >
+              { item.name }
+            </span>
+          ) }
+        </a>
+      );
+    } else {
+      command = (
+        <div
+          { ...getNativeProps(item, divProperties) }
+          id={ this._id + item.key }
+          className={ className }
+          data-command-key={ itemKey }
+          aria-haspopup={ hasSubmenuItems(item) }
+          aria-label={ ariaLabel }
+        >
+          { (hasIcon) ? this._renderIcon(item) : (null) }
+          { (isNameVisible) && (
+            <span
+              className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
+              aria-hidden='true'
+              role='presentation'
+            >
+              { item.name }
+            </span>
+          ) }
+        </div>
+      );
+    }
+
+    if (item.iconOnly && item.name) {
+      command = (
+        <TooltipHost content={ item.name }>
+          { command }
+        </TooltipHost>
+      );
+    }
+
     return (
       <div className={ css('ms-CommandBarItem', styles.item, item.className) } key={ itemKey } ref={ itemKey }>
-        { (() => {
-          if (isLink) {
-            return <button
-              { ...getNativeProps(item, buttonProperties) }
-              id={ this._id + item.key }
-              className={ className }
-              onClick={ this._onItemClick(item) }
-              data-command-key={ itemKey }
-              aria-haspopup={ hasSubmenuItems(item) }
-              aria-expanded={ hasSubmenuItems(item) ? expandedMenuItemKey === item.key : undefined }
-              role='menuitem'
-              aria-label={ ariaLabel }
-            >
-              { (hasIcon) ? this._renderIcon(item) : (null) }
-              { isNameVisible && (
-                <span
-                  className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
-                >
-                  { item.name }
-                </span>
-              ) }
-              { hasSubmenuItems(item) ? (
-                <Icon className={ css('ms-CommandBarItem-chevronDown', styles.itemChevronDown) } iconName='ChevronDown' />
-              ) : (null) }
-            </button>;
-          } else if (item.href) {
-            return <a
-              { ...getNativeProps(item, anchorProperties) }
-              id={ this._id + item.key }
-              className={ className }
-              href={ item.href }
-              data-command-key={ itemKey }
-              aria-haspopup={ hasSubmenuItems(item) }
-              role='menuitem'
-              aria-label={ ariaLabel }
-            >
-              { (hasIcon) ? this._renderIcon(item) : (null) }
-              { isNameVisible && (
-                <span
-                  className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
-                >
-                  { item.name }
-                </span>
-              ) }
-            </a>;
-          } else {
-            return <div
-              { ...getNativeProps(item, divProperties) }
-              id={ this._id + item.key }
-              className={ className }
-              data-command-key={ itemKey }
-              aria-haspopup={ hasSubmenuItems(item) }
-              aria-label={ ariaLabel }
-            >
-              { (hasIcon) ? this._renderIcon(item) : (null) }
-              { (isNameVisible) && (
-                <span
-                  className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
-                  aria-hidden='true'
-                  role='presentation'
-                >
-                  { item.name }
-                </span>
-              ) }
-            </div>;
-          }
-        })() }
+        { command }
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -181,7 +181,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     );
     let hasIcon = !!item.icon || !!item.iconProps;
     const isNameVisible = !!item.name && !item.iconOnly;
-    const ariaLabel = item.ariaLabel || (item.iconOnly ? item.name : '');
+    const ariaLabel = item.ariaLabel || (item.iconOnly ? item.name : undefined);
 
     let command: React.ReactNode;
     if (isLink) {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -9,7 +9,7 @@ import {
   getId,
   getNativeProps
 } from '../../Utilities';
-import { ICommandBar, ICommandBarProps } from './CommandBar.Props';
+import { ICommandBar, ICommandBarProps, ICommandBarItemProps } from './CommandBar.Props';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { ContextualMenu, IContextualMenuProps, IContextualMenuItem, hasSubmenuItems } from '../../ContextualMenu';
 import { DirectionalHint } from '../../common/DirectionalHint';
@@ -162,7 +162,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     this.refs.focusZone.focus();
   }
 
-  private _renderItemInCommandBar(item: IContextualMenuItem, index: number, expandedMenuItemKey: string, isFarItem?: boolean) {
+  private _renderItemInCommandBar(item: ICommandBarItemProps, index: number, expandedMenuItemKey: string, isFarItem?: boolean) {
     if (item.onRender) {
       return (
         <div className={ css('ms-CommandBarItem', styles.item, item.className) } key={ item.key } ref={ item.key }>
@@ -179,6 +179,8 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
       (expandedMenuItemKey === item.key) && ('is-expanded ' + styles.itemLinkIsExpanded)
     );
     let hasIcon = !!item.icon || !!item.iconProps;
+    const isNameVisible = !!item.name && !item.iconOnly;
+    const ariaLabel = item.ariaLabel || (item.iconOnly ? item.name : '');
 
     return (
       <div className={ css('ms-CommandBarItem', styles.item, item.className) } key={ itemKey } ref={ itemKey }>
@@ -193,10 +195,10 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
               aria-haspopup={ hasSubmenuItems(item) }
               aria-expanded={ hasSubmenuItems(item) ? expandedMenuItemKey === item.key : undefined }
               role='menuitem'
-              aria-label={ item.ariaLabel }
+              aria-label={ ariaLabel }
             >
               { (hasIcon) ? this._renderIcon(item) : (null) }
-              { (!!item.name) && (
+              { isNameVisible && (
                 <span
                   className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
                 >
@@ -216,10 +218,10 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
               data-command-key={ itemKey }
               aria-haspopup={ hasSubmenuItems(item) }
               role='menuitem'
-              aria-label={ item.ariaLabel }
+              aria-label={ ariaLabel }
             >
               { (hasIcon) ? this._renderIcon(item) : (null) }
-              { (!!item.name) && (
+              { isNameVisible && (
                 <span
                   className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
                 >
@@ -234,9 +236,10 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
               className={ className }
               data-command-key={ itemKey }
               aria-haspopup={ hasSubmenuItems(item) }
+              aria-label={ ariaLabel }
             >
               { (hasIcon) ? this._renderIcon(item) : (null) }
-              { (!!item.name) && (
+              { (isNameVisible) && (
                 <span
                   className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
                   aria-hidden='true'

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
@@ -19,17 +19,17 @@ export class CommandBarBasicExample extends React.Component<any, any> {
     let { isSearchBoxVisible: searchBoxVisible, areIconsVisible: iconsVisible, areNamesVisible: namesVisible } = this.state;
 
     let filteredItems = items.map((item: any) => assign({}, item, {
-      name: namesVisible ? item.name : '',
+      iconOnly: !namesVisible,
       icon: iconsVisible ? item.icon : ''
     }));
 
     let filteredOverflowItems = overflowItems.map((item: any) => assign({}, item, {
-      name: namesVisible ? item.name : '',
+      iconOnly: !namesVisible,
       icon: iconsVisible ? item.icon : ''
     }));
 
     let filteredFarItems = farItems.map((item: any) => assign({}, item, {
-      name: namesVisible ? item.name : '',
+      iconOnly: !namesVisible,
       icon: iconsVisible ? item.icon : ''
     }));
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1840 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

`iconOnly` has been implemented in new CommandBar (available in experiments, and also merged to future 6.0 branch). This work makes this work available in 5.0 branch with minimum changes.

- `ICommandBarItemProps` has been added to declare `iconOnly`, but it's not widely used yet, only declared in the method where it was necessary.
- `TooltipHost` is used to display `name` in `iconOnly` items.
- `aria-label` is used to describe `name` in `iconOnly` items, so screen readers can name it.

#### Focus areas to test

- `CommandBar`. Basic example has been changed to use iconOnly instead of clearing `name` property of items when the Toggle is used.