### PR TITLE
Fix merge-styles: class names in selector values expanded into parent…

### DIFF
--- a/common/changes/@uifabric/merge-styles/style-to-classname_2017-10-31-23-57.json
+++ b/common/changes/@uifabric/merge-styles/style-to-classname_2017-10-31-23-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/merge-styles",
-      "comment": "Fix mergeStyles generates wrong CSS rules for registered classnames as selector values",
+      "comment": "When selectors use previously registered class names as values, they are now correctly auto expanded.",
       "type": "patch"
     }
   ],

--- a/common/changes/@uifabric/merge-styles/style-to-classname_2017-10-31-23-57.json
+++ b/common/changes/@uifabric/merge-styles/style-to-classname_2017-10-31-23-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Fix mergeStyles generates wrong CSS rules for registered classnames as selector values",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "stzh@microsoft.com"
+}

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -129,6 +129,18 @@ describe('styleToClassName', () => {
     expect(_stylesheet.getRules()).toEqual('.css-0{background:red;}.css-1{background:red;color:white;}');
   });
 
+  it('can expand previously defined rules in selectors', () => {
+    const className = styleToClassName({ background: 'red' });
+    const newClassName = styleToClassName({
+      selectors: {
+        '& > *': className
+      },
+    });
+
+    expect(newClassName).toEqual('css-1');
+    expect(_stylesheet.getRules()).toEqual('.css-0{background:red;}.css-1 > *{background:red;}');
+  });
+
   it('can expand an array of rules', () => {
     styleToClassName([
       { background: 'red' },

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -42,7 +42,7 @@ function extractRules(
       const expandedRules = stylesheet.argsFromClassName(arg);
 
       if (expandedRules) {
-        extractRules(expandedRules, rules);
+        extractRules(expandedRules, rules, currentSelector);
       }
       // Else if the arg is an array, we need to recurse in.
     } else if (Array.isArray(arg)) {


### PR DESCRIPTION
… scope instead within the selector

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3278
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix: registered class in selectors are expanded into the parent class instead of in selector

#### Focus areas to test

(optional)
