### PR TITLE
Persona: Polish to match toolkit

### DIFF
--- a/apps/vr-tests/src/stories/Persona.stories.tsx
+++ b/apps/vr-tests/src/stories/Persona.stories.tsx
@@ -30,7 +30,7 @@ storiesOf('Persona', module)
   .add('Tiny', () => (
     <Persona
       { ...examplePersona }
-      size={ PersonaSize.size12 }
+      size={ PersonaSize.size10 }
       presence={ PersonaPresence.offline }
     />
   )).add('Extra extra small', () => (

--- a/common/changes/office-ui-fabric-react/persona-polish_2017-11-01-22-23.json
+++ b/common/changes/office-ui-fabric-react/persona-polish_2017-11-01-22-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Persona: Renamed Persona size12 to Persona size10. Polished style to reflect the toolkit.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.Props.ts
@@ -132,7 +132,7 @@ export interface IPersonaProps extends React.HTMLAttributes<Persona> {
 
 export enum PersonaSize {
   /**
-   * tiny size has been deprecated in favor of standardized numeric sizing. Use size12 instead.
+   * tiny size has been deprecated in favor of standardized numeric sizing. Use size10 instead.
    * @deprecated
    */
   tiny = 0,
@@ -169,7 +169,7 @@ export enum PersonaSize {
   extraLarge = 6,
   size28 = 7,
   size16 = 8,
-  size12 = 9,
+  size10 = 9,
   size24 = 10,
   size32 = 11,
   size40 = 12,

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -379,8 +379,8 @@ $ms-Persona-presenceSizeXl: 28px;
 //== Modifier: Size 24 Persona
 //
 .root.rootIsSize24 {
-  height: $ms-Persona-size24;
-  min-width: $ms-Persona-size24;
+  height: $ms-Persona-size32;
+  min-width: $ms-Persona-size32;
 }
 
 .rootIsSize24 {

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -631,12 +631,10 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .secondaryText {
     font-size: $ms-font-size-m;
-    padding-top: 2px;
   }
 
   .tertiaryText {
     display: block;
-    padding-top: 8px;
   }
 }
 
@@ -686,16 +684,11 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .secondaryText {
     font-size: $ms-font-size-m;
-    padding-top: 2px;
   }
 
   .tertiaryText,
   .optionalText {
     display: block; // Show tertiary and optional text
-  }
-
-  .tertiaryText {
-    padding-top: 8px;
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -223,7 +223,7 @@ $ms-Persona-presenceSizeXl: 28px;
 }
 
 .details {
-  @include padding(0, 24px, 0, 12px);
+  @include padding(0, 24px, 0, 16px);
   min-width: 0;
   width: 100%;
   @include text-align(left);
@@ -417,7 +417,7 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 
   .details {
-    padding: 0 8px;
+    padding: 0 12px;
   }
 
   .primaryText {
@@ -484,7 +484,7 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 
   .details {
-    padding: 0 8px;
+    padding: 0 12px;
   }
 
   .primaryText {
@@ -532,10 +532,6 @@ $ms-Persona-presenceSizeXl: 28px;
     font-size: $ms-font-size-m;
     height: $ms-Persona-size32;
     line-height: $ms-Persona-size32;
-  }
-
-  .details {
-    padding: 0 8px;
   }
 
   .primaryText {
@@ -617,7 +613,6 @@ $ms-Persona-presenceSizeXl: 28px;
   .presence {
     height: $ms-Persona-presenceSizeLg;
     width: $ms-Persona-presenceSizeLg;
-    border-width: 3px;
   }
 
   .presenceIcon {
@@ -667,7 +662,6 @@ $ms-Persona-presenceSizeXl: 28px;
   .presence {
     height: $ms-Persona-presenceSizeXl;
     width: $ms-Persona-presenceSizeXl;
-    border-width: 4px;
   }
 
   .presenceIcon {

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -575,7 +575,7 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 
   .primaryText {
-    font-size: $ms-font-size-m;
+    font-size: $ms-font-size-l;
   }
 }
 
@@ -614,6 +614,14 @@ $ms-Persona-presenceSizeXl: 28px;
   .presenceIcon {
     line-height: $ms-Persona-presenceSizeLg;
     font-size: $ms-font-size-m;
+  }
+
+  .primaryText {
+    font-size: $ms-font-size-xl;
+  }
+
+  .secondaryText {
+    font-size: $ms-font-size-m
   }
 
   .tertiaryText {
@@ -663,6 +671,10 @@ $ms-Persona-presenceSizeXl: 28px;
   .primaryText {
     font-size: $ms-font-size-xl;
     font-weight: $ms-font-weight-semilight;
+  }
+
+  .secondaryText {
+    font-size: $ms-font-size-m
   }
 
   .tertiaryText,

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -53,16 +53,12 @@ $ms-Persona-size48:  48px;
 $ms-Persona-size72:  72px;
 $ms-Persona-size100: 100px;
 
-// Details Spacing
-$ms-Persona-imageDetailsSmSpace: 8px;
-$ms-Persona-imageDetailsLgSpace: 12px;
-$ms-Persona-imageDetailsXlSpace: 20px;
-
 // Presence Sizes
-$ms-Persona-presenceSizeXxs: 8px;
-$ms-Persona-presenceSizeMd: 12px;
-$ms-Persona-presenceSizeLg: 20px;
-$ms-Persona-presenceSizeXl: 28px;
+$ms-Persona-presenceSize6: 6px;
+$ms-Persona-presenceSize8: 8px;
+$ms-Persona-presenceSize12: 12px;
+$ms-Persona-presenceSize20: 20px;
+$ms-Persona-presenceSize28: 28px;
 $ms-Persona-presenceBorder: 2px;
 
 .root {
@@ -192,8 +188,8 @@ $ms-Persona-presenceBorder: 2px;
 .presence {
   background-color: $ms-color-presence-available;
   position: absolute;
-  height: $ms-Persona-presenceSizeMd;
-  width: $ms-Persona-presenceSizeMd;
+  height: $ms-Persona-presenceSize12;
+  width: $ms-Persona-presenceSize12;
   border-radius: 50%;
   top: auto;
   @include ms-right(-$ms-Persona-presenceBorder);
@@ -214,7 +210,7 @@ $ms-Persona-presenceBorder: 2px;
   .presenceIcon {
     color: $ms-color-white;
     font-size: 6px;
-    line-height: $ms-Persona-presenceSizeMd;
+    line-height: $ms-Persona-presenceSize12;
     vertical-align: top;
 
     @include high-contrast {
@@ -282,8 +278,8 @@ $ms-Persona-presenceBorder: 2px;
     top: 7px;
     @include ms-left(0);
     border: 0;
-    height: $ms-Persona-presenceSizeXxs;
-    width: $ms-Persona-presenceSizeXxs;
+    height: $ms-Persona-presenceSize8;
+    width: $ms-Persona-presenceSize8;
 
     @include high-contrast {
       top: 9px;
@@ -361,9 +357,9 @@ $ms-Persona-presenceBorder: 2px;
   }
 
   .presence {
-    height: $ms-Persona-presenceSizeXxs - 2px;
-    width: $ms-Persona-presenceSizeXxs - 2px;
-    border-width: 1px;
+    height: $ms-Persona-presenceSize6;
+    width: $ms-Persona-presenceSize6;
+    border-width: 1.5px;
   }
 
   .presenceIcon {
@@ -406,8 +402,8 @@ $ms-Persona-presenceBorder: 2px;
   }
 
   .presence {
-    height: $ms-Persona-presenceSizeXxs;
-    width: $ms-Persona-presenceSizeXxs;
+    height: $ms-Persona-presenceSize8;
+    width: $ms-Persona-presenceSize8;
 
     &:after {
       display: none;
@@ -471,8 +467,8 @@ $ms-Persona-presenceBorder: 2px;
   }
 
   .presence {
-    height: $ms-Persona-presenceSizeXxs;
-    width: $ms-Persona-presenceSizeXxs;
+    height: $ms-Persona-presenceSize8;
+    width: $ms-Persona-presenceSize8;
 
     &:after {
       display: none;
@@ -535,8 +531,8 @@ $ms-Persona-presenceBorder: 2px;
   }
 
   .presence {
-    height: $ms-Persona-presenceSizeXxs;
-    width: $ms-Persona-presenceSizeXxs;
+    height: $ms-Persona-presenceSize8;
+    width: $ms-Persona-presenceSize8;
   }
 
   .presenceIcon {
@@ -620,12 +616,12 @@ $ms-Persona-presenceBorder: 2px;
   }
 
   .presence {
-    height: $ms-Persona-presenceSizeLg;
-    width: $ms-Persona-presenceSizeLg;
+    height: $ms-Persona-presenceSize20;
+    width: $ms-Persona-presenceSize20;
   }
 
   .presenceIcon {
-    line-height: $ms-Persona-presenceSizeLg;
+    line-height: $ms-Persona-presenceSize20;
     font-size: $ms-font-size-s;
   }
 
@@ -669,12 +665,12 @@ $ms-Persona-presenceBorder: 2px;
   }
 
   .presence {
-    height: $ms-Persona-presenceSizeXl;
-    width: $ms-Persona-presenceSizeXl;
+    height: $ms-Persona-presenceSize28;
+    width: $ms-Persona-presenceSize28;
   }
 
   .presenceIcon {
-    line-height: $ms-Persona-presenceSizeXl;
+    line-height: $ms-Persona-presenceSize28;
     font-size: $ms-font-size-m;
   }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -43,7 +43,7 @@ $ms-color-presence-busy-stripe-dark:   #D00E0D;
 $ms-color-presence-busy-average:       #D93B3B;
 
 // Persona Sizes
-$ms-Persona-size10:  30px;
+$ms-Persona-size10:  20px;
 $ms-Persona-size16:  16px;
 $ms-Persona-size24:  24px;
 $ms-Persona-size28:  28px;
@@ -278,9 +278,11 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .presence {
     @include ms-right(auto);
-    top: 10px;
+    top: 7px;
     @include ms-left(0);
     border: 0;
+    height: $ms-Persona-presenceSizeXxs;
+    width: $ms-Persona-presenceSizeXxs;
 
     @include high-contrast {
       top: 9px;
@@ -289,7 +291,7 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 
   .details {
-    @include ms-padding-left(20px);
+    @include ms-padding-left(17px);
   }
 
   .primaryText {
@@ -305,7 +307,7 @@ $ms-Persona-presenceSizeXl: 28px;
 .size10NoPresenceIcon {
   font-size: 10px;
   position: absolute;
-  top: 10px;
+  top: 5px;
   @include ms-right(auto);
   @include ms-left(0);
 }
@@ -628,7 +630,8 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 
   .secondaryText {
-    font-size: $ms-font-size-m
+    font-size: $ms-font-size-m;
+    padding-top: 2px;
   }
 
   .tertiaryText {
@@ -682,7 +685,8 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 
   .secondaryText {
-    font-size: $ms-font-size-m
+    font-size: $ms-font-size-m;
+    padding-top: 2px;
   }
 
   .tertiaryText,

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -288,6 +288,10 @@ $ms-Persona-presenceSizeXl: 28px;
       top: 9px;
       border: 1px solid WindowText;
     }
+
+    .presenceIcon {
+      display: none;
+    }
   }
 
   .details {
@@ -582,6 +586,10 @@ $ms-Persona-presenceSizeXl: 28px;
   .primaryText {
     font-size: $ms-font-size-l;
   }
+
+  .presenceIcon {
+    font-size: 6px;
+  }
 }
 
 
@@ -617,7 +625,7 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .presenceIcon {
     line-height: $ms-Persona-presenceSizeLg;
-    font-size: $ms-font-size-m;
+    font-size: $ms-font-size-s;
   }
 
   .primaryText {
@@ -666,7 +674,7 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .presenceIcon {
     line-height: $ms-Persona-presenceSizeXl;
-    font-size: $ms-font-size-xl;
+    font-size: $ms-font-size-m;
     position: relative;
     top: 1px;
   }

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -43,7 +43,7 @@ $ms-color-presence-busy-stripe-dark:   #D00E0D;
 $ms-color-presence-busy-average:       #D93B3B;
 
 // Persona Sizes
-$ms-Persona-size12:  30px;
+$ms-Persona-size10:  30px;
 $ms-Persona-size16:  16px;
 $ms-Persona-size24:  24px;
 $ms-Persona-size28:  28px;
@@ -261,14 +261,14 @@ $ms-Persona-presenceSizeXl: 28px;
 }
 
 
-//== Modifier: Tiny Persona
+//== Modifier: Size 10 Persona
 //
-.root.rootIsSize12 {
-  height: $ms-Persona-size12;
-  min-width: $ms-Persona-size12;
+.root.rootIsSize10 {
+  height: $ms-Persona-size10;
+  min-width: $ms-Persona-size10;
 }
 
-.rootIsSize12{
+.rootIsSize10{
   .imageArea {
     overflow: visible;
     background: transparent;
@@ -293,8 +293,8 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 
   .primaryText {
-    font-size: $ms-font-size-m;
-    line-height: $ms-Persona-size12;
+    font-size: $ms-font-size-s;
+    line-height: $ms-Persona-size10;
   }
 
   .secondaryText {
@@ -302,12 +302,19 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 }
 
+.size10NoPresenceIcon {
+  font-size: 10px;
+  position: absolute;
+  top: 10px;
+  @include ms-right(auto);
+  @include ms-left(0);
+}
 
-//== Modifier: Tiny Persona with read only state
+//== Modifier: Size 10 Persona with read only state
 //
 // This variant includes a semicolon, and is
 // most often presented within a People Picker.
-.root.rootIsSize12.rootIsReadonly {
+.root.rootIsSize10.rootIsReadonly {
   padding: 0;
   background-color: transparent;
 
@@ -316,7 +323,7 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 }
 
-//== Modifier: 16px Persona
+//== Modifier: Size 16 Persona
 //
 .root.rootIsSize16 {
   height: $ms-Persona-size16;
@@ -367,11 +374,11 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 }
 
-//== Modifier: Extra Small Persona
+//== Modifier: Size 24 Persona
 //
 .root.rootIsSize24 {
-  height: $ms-Persona-size32;
-  min-width: $ms-Persona-size32;
+  height: $ms-Persona-size24;
+  min-width: $ms-Persona-size24;
 }
 
 .rootIsSize24 {
@@ -433,7 +440,7 @@ $ms-Persona-presenceSizeXl: 28px;
 }
 
 
-//== Modifier: 28px Persona
+//== Modifier: Size 28 Persona
 //
 .root.rootIsSize28 {
   height: $ms-Persona-size28;
@@ -500,7 +507,7 @@ $ms-Persona-presenceSizeXl: 28px;
 }
 
 
-//== Modifier: Extra Small Persona
+//== Modifier: Size 32 Persona
 //
 .root.rootIsSize32 {
   height: $ms-Persona-size32;
@@ -549,7 +556,7 @@ $ms-Persona-presenceSizeXl: 28px;
 }
 
 
-//== Modifier: Small Persona
+//== Modifier: Size 40 Persona
 //
 .root.rootIsSize40 {
   height: $ms-Persona-size40;
@@ -580,7 +587,7 @@ $ms-Persona-presenceSizeXl: 28px;
 }
 
 
-//== Modifier: Large Persona
+//== Modifier: Size 72 Persona
 //
 .root.rootIsSize72 {
   height: $ms-Persona-size72;
@@ -626,11 +633,12 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .tertiaryText {
     display: block;
+    padding-top: 8px;
   }
 }
 
 
-//== Modifier: Extra Large Persona
+//== Modifier: Size 100 Persona
 //
 .root.rootIsSize100 {
   height: $ms-Persona-size100;
@@ -680,6 +688,10 @@ $ms-Persona-presenceSizeXl: 28px;
   .tertiaryText,
   .optionalText {
     display: block; // Show tertiary and optional text
+  }
+
+  .tertiaryText {
+    padding-top: 8px;
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -63,6 +63,7 @@ $ms-Persona-presenceSizeXxs: 8px;
 $ms-Persona-presenceSizeMd: 12px;
 $ms-Persona-presenceSizeLg: 20px;
 $ms-Persona-presenceSizeXl: 28px;
+$ms-Persona-presenceBorder: 2px;
 
 .root {
   @include ms-normalize;
@@ -195,9 +196,9 @@ $ms-Persona-presenceSizeXl: 28px;
   width: $ms-Persona-presenceSizeMd;
   border-radius: 50%;
   top: auto;
-  @include ms-right(0px);
-  bottom: -1px;
-  border: 2px solid $ms-color-white;
+  @include ms-right(-$ms-Persona-presenceBorder);
+  bottom: -$ms-Persona-presenceBorder;
+  border: $ms-Persona-presenceBorder solid $ms-color-white;
   text-align: center;
   box-sizing: content-box;
   // Setting -ms-high-contrast-adjust to none Overrides the default behaviors of high contrast more in the Edge browser.
@@ -212,7 +213,7 @@ $ms-Persona-presenceSizeXl: 28px;
 
   .presenceIcon {
     color: $ms-color-white;
-    font-size: 8px;
+    font-size: 6px;
     line-height: $ms-Persona-presenceSizeMd;
     vertical-align: top;
 
@@ -332,8 +333,8 @@ $ms-Persona-presenceSizeXl: 28px;
 //== Modifier: Size 16 Persona
 //
 .root.rootIsSize16 {
-  height: $ms-Persona-size16;
-  min-width: $ms-Persona-size16;
+  height: $ms-Persona-size16 + $ms-Persona-presenceBorder;
+  min-width: $ms-Persona-size16  + $ms-Persona-presenceBorder;
   overflow: hidden;
 }
 
@@ -360,14 +361,13 @@ $ms-Persona-presenceSizeXl: 28px;
   }
 
   .presence {
-    height: $ms-Persona-presenceSizeXxs;
-    width: $ms-Persona-presenceSizeXxs;
-    border: 2px solid $ms-color-white;
+    height: $ms-Persona-presenceSizeXxs - 2px;
+    width: $ms-Persona-presenceSizeXxs - 2px;
+    border-width: 1px;
   }
 
   .presenceIcon {
-    font-size: 6px;
-    line-height: 9px;
+    display: none;
   }
 
   .primaryText {
@@ -383,8 +383,8 @@ $ms-Persona-presenceSizeXl: 28px;
 //== Modifier: Size 24 Persona
 //
 .root.rootIsSize24 {
-  height: $ms-Persona-size32;
-  min-width: $ms-Persona-size32;
+  height: $ms-Persona-size24 + $ms-Persona-presenceBorder;
+  min-width: $ms-Persona-size24 + $ms-Persona-presenceBorder;
 }
 
 .rootIsSize24 {
@@ -408,8 +408,6 @@ $ms-Persona-presenceSizeXl: 28px;
   .presence {
     height: $ms-Persona-presenceSizeXxs;
     width: $ms-Persona-presenceSizeXxs;
-    border: 2px solid $ms-color-white;
-    top: 18px;
 
     &:after {
       display: none;
@@ -449,8 +447,8 @@ $ms-Persona-presenceSizeXl: 28px;
 //== Modifier: Size 28 Persona
 //
 .root.rootIsSize28 {
-  height: $ms-Persona-size28;
-  min-width: $ms-Persona-size28;
+  height: $ms-Persona-size28 + $ms-Persona-presenceBorder;
+  min-width: $ms-Persona-size28 + $ms-Persona-presenceBorder;
   overflow: hidden;
 }
 
@@ -475,8 +473,6 @@ $ms-Persona-presenceSizeXl: 28px;
   .presence {
     height: $ms-Persona-presenceSizeXxs;
     width: $ms-Persona-presenceSizeXxs;
-    border: 2px solid $ms-color-white;
-    top: 18px;
 
     &:after {
       display: none;
@@ -516,8 +512,8 @@ $ms-Persona-presenceSizeXl: 28px;
 //== Modifier: Size 32 Persona
 //
 .root.rootIsSize32 {
-  height: $ms-Persona-size32;
-  min-width: $ms-Persona-size32;
+  height: $ms-Persona-size32 + $ms-Persona-presenceBorder;
+  min-width: $ms-Persona-size32 + $ms-Persona-presenceBorder;
 }
 
 .rootIsSize32 {
@@ -536,6 +532,15 @@ $ms-Persona-presenceSizeXl: 28px;
     font-size: $ms-font-size-m;
     height: $ms-Persona-size32;
     line-height: $ms-Persona-size32;
+  }
+
+  .presence {
+    height: $ms-Persona-presenceSizeXxs;
+    width: $ms-Persona-presenceSizeXxs;
+  }
+
+  .presenceIcon {
+    display: none;
   }
 
   .primaryText {
@@ -561,8 +566,8 @@ $ms-Persona-presenceSizeXl: 28px;
 //== Modifier: Size 40 Persona
 //
 .root.rootIsSize40 {
-  height: $ms-Persona-size40;
-  min-width: $ms-Persona-size40;
+  height: $ms-Persona-size40 + $ms-Persona-presenceBorder;
+  min-width: $ms-Persona-size40 + $ms-Persona-presenceBorder;
 }
 
 .rootIsSize40 {
@@ -586,18 +591,14 @@ $ms-Persona-presenceSizeXl: 28px;
   .primaryText {
     font-size: $ms-font-size-l;
   }
-
-  .presenceIcon {
-    font-size: 6px;
-  }
 }
 
 
 //== Modifier: Size 72 Persona
 //
 .root.rootIsSize72 {
-  height: $ms-Persona-size72;
-  min-width: $ms-Persona-size72;
+  height: $ms-Persona-size72 + $ms-Persona-presenceBorder;
+  min-width: $ms-Persona-size72 + $ms-Persona-presenceBorder;
 }
 
 .rootIsSize72 {
@@ -645,8 +646,8 @@ $ms-Persona-presenceSizeXl: 28px;
 //== Modifier: Size 100 Persona
 //
 .root.rootIsSize100 {
-  height: $ms-Persona-size100;
-  min-width: $ms-Persona-size100;
+  height: $ms-Persona-size100 + $ms-Persona-presenceBorder;
+  min-width: $ms-Persona-size100 + $ms-Persona-presenceBorder;
 }
 
 .rootIsSize100 {
@@ -675,8 +676,6 @@ $ms-Persona-presenceSizeXl: 28px;
   .presenceIcon {
     line-height: $ms-Persona-presenceSizeXl;
     font-size: $ms-font-size-m;
-    position: relative;
-    top: 1px;
   }
 
   .primaryText {

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -111,7 +111,7 @@ export class Persona extends BaseComponent<IPersonaProps, {}> {
         style={ coinSize ? { height: coinSize, minWidth: coinSize } : undefined }
       >
         <PersonaCoin { ...personaCoinProps } />
-        { (!hidePersonaDetails || (size === PersonaSize.size12)) && personaDetails }
+        { (!hidePersonaDetails || (size === PersonaSize.size10)) && personaDetails }
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -19,6 +19,9 @@ import {
   PERSONA_INITIALS_COLOR,
   PERSONA_SIZE
 } from './PersonaConsts';
+import {
+  Icon
+} from '../Icon';
 import * as stylesImport from './Persona.scss';
 const styles: any = stylesImport;
 
@@ -104,7 +107,7 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
         { ...divProps }
         className={ css('ms-Persona-coin', PERSONA_SIZE[size]) }
       >
-        { size !== PersonaSize.tiny && (
+        { size !== PersonaSize.tiny ? (
           <div
             { ...coinProps }
             className={ css('ms-Persona-imageArea', styles.imageArea) }
@@ -140,7 +143,17 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
             />
             <PersonaPresence { ...this.props } />
           </div>
-        ) }
+        ) :
+          (this.props.presence ?
+            <PersonaPresence
+              { ...this.props }
+            /> :
+            <Icon
+              iconName='Contact'
+              style={ { fontSize: '12px' } }
+            />
+          )
+        }
         { this.props.children }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -28,7 +28,7 @@ const styles: any = stylesImport;
 const SIZE_TO_PIXELS = {
   [PersonaSize.size24]: 24,
   [PersonaSize.size28]: 28,
-  [PersonaSize.size12]: 30,
+  [PersonaSize.size10]: 30,
   [PersonaSize.size32]: 32,
   [PersonaSize.size40]: 40,
   [PersonaSize.size48]: 48,
@@ -107,7 +107,7 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
         { ...divProps }
         className={ css('ms-Persona-coin', PERSONA_SIZE[size]) }
       >
-        { size !== PersonaSize.size12 ? (
+        { size !== PersonaSize.size10 ? (
           <div
             { ...coinProps }
             className={ css('ms-Persona-imageArea', styles.imageArea) }
@@ -150,7 +150,7 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
             /> :
             <Icon
               iconName='Contact'
-              style={ { fontSize: '12px' } }
+              className={ styles.size10NoPresenceIcon }
             />
           )
         }

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -28,7 +28,7 @@ const styles: any = stylesImport;
 const SIZE_TO_PIXELS = {
   [PersonaSize.size24]: 24,
   [PersonaSize.size28]: 28,
-  [PersonaSize.size10]: 30,
+  [PersonaSize.size10]: 20,
   [PersonaSize.size32]: 32,
   [PersonaSize.size40]: 40,
   [PersonaSize.size48]: 48,

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaConsts.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaConsts.ts
@@ -8,7 +8,7 @@ const styles: any = stylesImport;
 
 export const PERSONA_SIZE = {
   // All non-numerically named sizes are deprecated, use the numerically named classes below
-  [PersonaSize.tiny]: 'ms-Persona--tiny ' + styles.rootIsTiny + styles.rootIsSize12,
+  [PersonaSize.tiny]: 'ms-Persona--tiny ' + styles.rootIsTiny + styles.rootIssize10,
   [PersonaSize.extraExtraSmall]: 'ms-Persona--xxs ' + styles.rootIsExtraExtraSmall + styles.rootIsSize24,
   [PersonaSize.extraSmall]: 'ms-Persona--xs ' + styles.rootIsExtraSmall + styles.rootIsSize28,
   [PersonaSize.small]: 'ms-Persona--sm ' + styles.rootIsSmall + styles.rootIsSize40,
@@ -18,7 +18,7 @@ export const PERSONA_SIZE = {
 
   [PersonaSize.size28]: 'ms-Persona--size28 ' + styles.rootIsSize28,
   [PersonaSize.size16]: 'ms-Persona--size16 ' + styles.rootIsSize16,
-  [PersonaSize.size12]: 'ms-Persona--size12 ' + styles.rootIsSize12,
+  [PersonaSize.size10]: 'ms-Persona--size10 ' + styles.rootIsSize10,
   [PersonaSize.size24]: 'ms-Persona--size24 ' + styles.rootIsSize24,
   [PersonaSize.size32]: 'ms-Persona--size32 ' + styles.rootIsSize32,
   [PersonaSize.size40]: 'ms-Persona--size40 ' + styles.rootIsSize40,

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPage.tsx
@@ -59,10 +59,10 @@ export class PersonaPage extends React.Component<IComponentDemoPageProps, {}> {
         dos={
           <div>
             <ul>
-              <li>Use XXS size Persona in text fields in read mode or in experiences such as multi-column list view which need compact Persona representations.</li>
-              <li>Use XS size Persona in text fields in edit mode.</li>
-              <li>Use XS, S and M size Personas in menus and list views.</li>
-              <li>Use L and XXL size Personas in profile cards and views.</li>
+              <li>Use Size 24 Persona in text fields in read mode or in experiences such as multi-column list view which need compact Persona representations.</li>
+              <li>Use Size 32 Persona in text fields in edit mode.</li>
+              <li>Use Size 32, Size 40, and Size 48 Personas in menus and list views.</li>
+              <li>Use Size 72 and Size 100 Personas in profile cards and views.</li>
             </ul>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
@@ -59,14 +59,14 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
         <Persona
           { ...examplePersona }
           size={ PersonaSize.size24 }
-          presence={ PersonaPresence.none }
+          presence={ PersonaPresence.online }
           hidePersonaDetails={ !renderPersonaDetails }
         />
         <Label className={ exampleStyles.exampleLabel }>Size 28 Persona</Label>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.size28 }
-          presence={ PersonaPresence.none }
+          presence={ PersonaPresence.online }
           hidePersonaDetails={ !renderPersonaDetails }
         />
         <Label className={ exampleStyles.exampleLabel }>Size 32 Persona</Label>

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
@@ -46,7 +46,13 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
         <Persona
           { ...examplePersona }
           size={ PersonaSize.tiny }
-          presence={ PersonaPresence.offline }
+          presence={ PersonaPresence.online }
+          hidePersonaDetails={ !renderPersonaDetails }
+        />
+        <Label className={ exampleStyles.exampleLabel }>Tiny Persona (12px) - no presense</Label>
+        <Persona
+          { ...examplePersona }
+          size={ PersonaSize.tiny }
           hidePersonaDetails={ !renderPersonaDetails }
         />
         <Label className={ exampleStyles.exampleLabel }>Extra Extra Small Persona (24px)</Label>

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
@@ -42,17 +42,17 @@ export class PersonaBasicExample extends React.Component<React.Props<PersonaBasi
           />
         </div>
 
-        <Label className={ exampleStyles.exampleLabel }>Size 12 Persona</Label>
+        <Label className={ exampleStyles.exampleLabel }>Size 10 Persona, with no presence</Label>
         <Persona
           { ...examplePersona }
-          size={ PersonaSize.size12 }
-          presence={ PersonaPresence.online }
+          size={ PersonaSize.size10 }
           hidePersonaDetails={ !renderPersonaDetails }
         />
-        <Label className={ exampleStyles.exampleLabel }>Tiny Persona (12px) - no presense</Label>
+        <Label className={ exampleStyles.exampleLabel }>Size 10 Persona, with presence</Label>
         <Persona
           { ...examplePersona }
-          size={ PersonaSize.size12 }
+          size={ PersonaSize.size10 }
+          presence={ PersonaPresence.offline }
           hidePersonaDetails={ !renderPersonaDetails }
         />
         <Label className={ exampleStyles.exampleLabel }>Size 24 Persona</Label>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Renamed size12 Persona to size10 to reflect the new pixel size per the toolkit. size12 was only defined today in [this PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/3276) so shouldn't be a breaking change.
- Since a recent PR, size10 (previously 'tiny') Persona was no longer rendering the presence circle. It now renders the circle if a presence prop is defined. If it's not defined, it renders the Contact icon.
- Font and padding size tweaks to match toolkit.
- Some comments needed to be updated with the new numerical PersonaSize names.

**Before:**
![image](https://user-images.githubusercontent.com/16619843/32300776-5178037c-bf18-11e7-9fc1-d4abe25f6e6e.png)
![image](https://user-images.githubusercontent.com/16619843/32300793-5ed83758-bf18-11e7-8db1-d479bc901db5.png)

**After:**
![image](https://user-images.githubusercontent.com/16619843/32343204-f7a9dfac-bfbf-11e7-989d-81432c1b3806.png)
![image](https://user-images.githubusercontent.com/16619843/32343012-69ef463e-bfbf-11e7-9c5c-de909f37d8d6.png)

#### Focus areas to test

(optional)
