### PR TITLE
Persona: Polished edge cases and variant documentation

### DIFF
--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -42,9 +42,17 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
               className="ms-Persona-initials ms-Persona-initials--blue undefined"
               style={undefined}
             >
-              <span>
-                
-              </span>
+              <i
+                aria-hidden={true}
+                aria-label={undefined}
+                className=
+                    ms-Icon
+                    {
+                      display: inline-block;
+                    }
+                data-icon-name="Contact"
+                role="presentation"
+              />
             </div>
             <div
               className="ms-Image ms-Persona-image"

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -59,6 +59,7 @@ $ms-Persona-presenceSize8: 8px;
 $ms-Persona-presenceSize12: 12px;
 $ms-Persona-presenceSize20: 20px;
 $ms-Persona-presenceSize28: 28px;
+$ms-Persona-presenceSizeFlex: 28%;
 $ms-Persona-presenceBorder: 2px;
 
 .root {
@@ -215,6 +216,17 @@ $ms-Persona-presenceBorder: 2px;
 
     @include high-contrast {
       color: Window;
+    }
+  }
+}
+
+.root.coinSizeWithPresence {
+  .presence {
+    height: $ms-Persona-presenceSizeFlex;
+    width: $ms-Persona-presenceSizeFlex;
+
+    .presenceIcon {
+      display: none;
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -7,7 +7,7 @@ import {
   getNativeProps,
   IRenderFunction
 } from '../../Utilities';
-import { TooltipHost, TooltipOverflowMode } from '../../Tooltip';
+import { TooltipHost, TooltipOverflowMode, DirectionalHint } from '../../Tooltip';
 import { PersonaCoin } from './PersonaCoin';
 import {
   IPersonaProps,
@@ -105,7 +105,8 @@ export class Persona extends BaseComponent<IPersonaProps, {}> {
             className,
             PERSONA_SIZE[size],
             PERSONA_PRESENCE[presence as PersonaPresenceEnum],
-            showSecondaryText && styles.showSecondaryText
+            showSecondaryText && styles.showSecondaryText,
+            coinSize && styles.coinSizeWithPresence
           )
         }
         style={ coinSize ? { height: coinSize, minWidth: coinSize } : undefined }
@@ -122,7 +123,13 @@ export class Persona extends BaseComponent<IPersonaProps, {}> {
       <div className={ className }>
         { render
           ? render(this.props)
-          : <TooltipHost content={ text } overflowMode={ TooltipOverflowMode.Parent }>{ text }</TooltipHost>
+          : <TooltipHost
+            content={ text }
+            overflowMode={ TooltipOverflowMode.Parent }
+            directionalHint={ DirectionalHint.topLeftEdge }
+          >
+            { text }
+          </TooltipHost>
         }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -190,7 +190,11 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
     imageInitials = imageInitials || getInitials(primaryText, isRTL);
 
     return (
-      <span>{ imageInitials }</span>
+      imageInitials !== '' ?
+        <span>{ imageInitials }</span> :
+        <Icon
+          iconName='Contact'
+        />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -192,9 +192,7 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
     return (
       imageInitials !== '' ?
         <span>{ imageInitials }</span> :
-        <Icon
-          iconName='Contact'
-        />
+        <Icon iconName='Contact' />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPage.tsx
@@ -31,10 +31,10 @@ export class PersonaPage extends React.Component<IComponentDemoPageProps, {}> {
             <ExampleCard title='Alternative small personas' code={ PersonaAlternateExampleCode }>
               <PersonaAlternateExample />
             </ExampleCard>
-            <ExampleCard title='Persona in initials' code={ PersonaInitialsExampleCode }>
+            <ExampleCard title='Persona with initials' code={ PersonaInitialsExampleCode }>
               <PersonaInitialsExample />
             </ExampleCard>
-            <ExampleCard title='Rendering custom persona text' code={ PersonaCustomRenderExampleCode }>
+            <ExampleCard title='Rendering custom persona text and custom coin size' code={ PersonaCustomRenderExampleCode }>
               <PersonaCustomRenderExample />
             </ExampleCard>
           </div>

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Alternate.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Alternate.Example.tsx
@@ -5,6 +5,7 @@ import {
   PersonaPresence
 } from 'office-ui-fabric-react/lib/Persona';
 import { TestImages } from '../../../common/TestImages';
+import './PersonaExample.scss';
 
 const examplePersona = {
   imageUrl: TestImages.personaMale,
@@ -28,7 +29,7 @@ export class PersonaAlternateExample extends React.Component<React.Props<Persona
     let { renderPersonaDetails } = this.state;
 
     return (
-      <div>
+      <div className='ms-PersonaExample'>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.size24 }

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.CustomRender.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.CustomRender.Example.tsx
@@ -7,8 +7,10 @@ import {
   PersonaPresence
 } from 'office-ui-fabric-react/lib/Persona';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import './PersonaExample.scss';
 import { TestImages } from '../../../common/TestImages';
+import './PersonaExample.scss';
+import * as exampleStylesImport from '../../../common/_exampleStyles.scss';
+const exampleStyles: any = exampleStylesImport;
 
 const examplePersona = {
   imageUrl: TestImages.personaFemale,
@@ -26,19 +28,19 @@ export class PersonaCustomRenderExample extends React.Component<React.Props<Pers
 
   public render() {
     return (
-      <div>
+      <div className='ms-PersonaExample'>
+        <div className={ exampleStyles.exampleLabel }>Custom icon in secondary text</div>
         <Persona
           { ...examplePersona }
           size={ PersonaSize.size72 }
           presence={ PersonaPresence.offline }
           onRenderSecondaryText={ this._onRenderSecondaryText }
         />
-        <div>custom coin size = 150, Persona size is size100.</div>
+        <div className={ exampleStyles.exampleLabel }>Custom coin size = 150</div>
         <Persona
           { ...examplePersona }
-          size={ PersonaSize.size100 }
           coinSize={ 150 }
-          presence={ PersonaPresence.offline }
+          presence={ PersonaPresence.online }
           onRenderSecondaryText={ this._onRenderSecondaryText }
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Initials.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Initials.Example.tsx
@@ -3,6 +3,7 @@ import {
   Persona,
   PersonaInitialsColor,
 } from 'office-ui-fabric-react/lib/Persona';
+import './PersonaExample.scss';
 
 const examplePersona = {
   secondaryText: 'Designer',
@@ -19,7 +20,7 @@ const personaWithInitials = {
 export class PersonaInitialsExample extends React.Component<any, any> {
   public render() {
     return (
-      <div>
+      <div className='ms-PersonaExample'>
         <Persona
           { ...examplePersona  }
           primaryText='Kat Larrson'

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/PersonaExample.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/PersonaExample.scss
@@ -1,4 +1,8 @@
 :global {
+  .ms-PersonaExample .ms-Persona {
+    margin: 0 0 10px 0;
+  }
+
   .ms-JobIconExample {
     margin-right: 5px;
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Improved spacing between examples.
- Added DirectionalHint for Tooltip so that it can handle wide elements.
- For non-latin initials, show a Contact icon instead of empty string. (updated DocumentCard snapshot to account for this change)
- For custom coinSize, use a presence scaled with percentage instead of the default. (I couldn't find a good way to scale the presence icon, so I set display to none)

# **BEFORE:**
![image](https://user-images.githubusercontent.com/16619843/32396929-a425ca7c-c0a4-11e7-995a-96e1da52f292.png)
![image](https://user-images.githubusercontent.com/16619843/32396761-d653f146-c0a3-11e7-98f9-bf3cdf6411c8.png)
![image](https://user-images.githubusercontent.com/16619843/32396771-e012b4ce-c0a3-11e7-82a0-d75a0ec528ec.png)
![image](https://user-images.githubusercontent.com/16619843/32396777-e7ceefde-c0a3-11e7-8294-042516c35f11.png)

# **AFTER:**
![image](https://user-images.githubusercontent.com/16619843/32396889-7d352ffc-c0a4-11e7-8ecb-4a45f576d0ee.png)
![image](https://user-images.githubusercontent.com/16619843/32396796-011123e0-c0a4-11e7-98f9-8567f799c7aa.png)
![image](https://user-images.githubusercontent.com/16619843/32396804-0d7db03a-c0a4-11e7-8930-163e0c6cba18.png)
![image](https://user-images.githubusercontent.com/16619843/32396810-196b215c-c0a4-11e7-9dcb-f175801faa96.png)

#### Focus areas to test

(optional)
