### PR TITLE
PersonaCoin: For non-latin initials, show a Contact icon instead of empty string

### DIFF
--- a/common/changes/office-ui-fabric-react/persona-coin-initials_2017-11-06-16-14.json
+++ b/common/changes/office-ui-fabric-react/persona-coin-initials_2017-11-06-16-14.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "PersonaCoin: For non-latin initials, show a Contact icon instead of empty string.",
+      "comment": "PersonaCoin: For non-latin characters, if initials returns an empty string, use the Contact icon instead of the empty string.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/persona-coin-initials_2017-11-06-16-14.json
+++ b/common/changes/office-ui-fabric-react/persona-coin-initials_2017-11-06-16-14.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "PersonaCoin: For non-latin characters, if initials returns an empty string, use the Contact icon instead of the empty string.",
+      "comment": "PersonaCoin: For non-latin characters, if initials return an empty string, use the Contact icon instead of the empty string.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/persona-coin-initials_2017-11-06-16-14.json
+++ b/common/changes/office-ui-fabric-react/persona-coin-initials_2017-11-06-16-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "PersonaCoin: For non-latin initials, show a Contact icon instead of empty string.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/persona-coin-initials_2017-11-06-16-14.json
+++ b/common/changes/office-ui-fabric-react/persona-coin-initials_2017-11-06-16-14.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "PersonaCoin: For non-latin initials, show a Contact icon instead of empty string.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -42,9 +42,17 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
               className="ms-Persona-initials ms-Persona-initials--blue undefined"
               style={undefined}
             >
-              <span>
-                
-              </span>
+              <i
+                aria-hidden={true}
+                aria-label={undefined}
+                className=
+                    ms-Icon
+                    {
+                      display: inline-block;
+                    }
+                data-icon-name="Contact"
+                role="presentation"
+              />
             </div>
             <div
               className="ms-Image ms-Persona-image"

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -200,9 +200,7 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
     return (
       imageInitials !== '' ?
         <span>{ imageInitials }</span> :
-        <Icon
-          iconName='Contact'
-        />
+        <Icon iconName='Contact' />
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -198,7 +198,11 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
     imageInitials = imageInitials || getInitials(primaryText, isRTL);
 
     return (
-      <span>{ imageInitials }</span>
+      imageInitials !== '' ?
+        <span>{ imageInitials }</span> :
+        <Icon
+          iconName='Contact'
+        />
     );
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- For non-latin initials, show a Contact icon instead of empty string. 
- Updated DocumentCard snapshot to account for this change.

**Before:**
![image](https://user-images.githubusercontent.com/16619843/32396771-e012b4ce-c0a3-11e7-82a0-d75a0ec528ec.png)

**After:**
![image](https://user-images.githubusercontent.com/16619843/32450916-6164cd78-c2ca-11e7-9c74-aabea4de192c.png)


#### Focus areas to test

(optional)
