### PR TITLE
Preserve focus in DetailsList when items change

### DIFF
--- a/common/changes/office-ui-fabric-react/spelliot-details-list-focus_2017-11-06-23-41.json
+++ b/common/changes/office-ui-fabric-react/spelliot-details-list-focus_2017-11-06-23-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Preserve focus in DetailsList when items change",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "spelliot@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3325
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When DetailsList `props.items` changes and the currently-focused item
is removed, restore focus to the item which is now at the index of the
previously-focused item. If the index of the previously-focused item is
out of range, select the last item.

This provides a better user experience for
those who use the keyboard to navigate.

##### Demo
https://1drv.ms/v/s!AsHCnfWR8tzoi5oSf_9o0TtUpwnlRA

In the above recording, I am setting the state on the parent `DetailsListBasicExample` component, omitting `items[1]` from the new state. Observe:
* When `items[1]` (i.e. "Item 1", the second row in the list) is focused and subsequently removed, focus is restored to the item which is now the second row in the list ("Item 2").
* When `items[3]` ("Item 4") is focused and `item[1]` ("Item 2") is removed, focus remains on "Item 4".
* When an element outside of the DetailsList is focused, focus is _not_ restored to the DetailsList.
