### PR TITLE
trying to enable second codeowner for calendar components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@
     # packages/office-ui-fabric-react/src/components/ActivityItem/*
     # packages/office-ui-fabric-react/src/components/Breadcrumb/*
     # packages/office-ui-fabric-react/src/components/Button/*
-    packages/office-ui-fabric-react/src/components/Calendar/*   @johannao76 @lorejoh12
+    packages/office-ui-fabric-react/src/components/Calendar/*   @johannao76 @lorejoh12@gmail.com @jolore@microsoft.com
     # packages/office-ui-fabric-react/src/components/Callout/*
     # packages/office-ui-fabric-react/src/components/Check/*
     # packages/office-ui-fabric-react/src/components/Checkbox/*
@@ -45,7 +45,7 @@
     # packages/office-ui-fabric-react/src/components/ComboBox/*
     packages/office-ui-fabric-react/src/components/CommandBar/*   @micahgodbolt
     # packages/office-ui-fabric-react/src/components/ContextualMenu/*
-    packages/office-ui-fabric-react/src/components/DatePicker/*   @johannao76 @lorejoh12
+    packages/office-ui-fabric-react/src/components/DatePicker/*   @johannao76 @lorejoh12@gmail.com @jolore@microsoft.com
     # packages/office-ui-fabric-react/src/components/DetailsList/*
     # packages/office-ui-fabric-react/src/components/Dialog/*
     # packages/office-ui-fabric-react/src/components/DocumentCard/*


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

trying to enable second codeowner for calendar components. not touching the API

#### Focus areas to test

(optional)
