### PR TITLE
SwatchColorPicker: Update scss to make colorpicker meet redlines.

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-ColorPicker_2017-11-07-18-45.json
+++ b/common/changes/office-ui-fabric-react/malozano-ColorPicker_2017-11-07-18-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SwatchColorPicker: Tweak hovering circle size and spacing between cells to meet redlines",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
@@ -58,11 +58,6 @@
   height: 24px;
 
   &.cellIsSelected {
-    &:hover .svg,
-    &:active .svg {
-      box-shadow: 0 0 0 1px #969696;
-    }
-
     &:focus .svg,
     & .svg {
       &.circle {
@@ -74,10 +69,6 @@
       border: 2px solid $ms-color-neutralTertiaryAlt;
     }
   }
-
-   &:focus .svg {
-      box-shadow: 0 0 0 1px #969696;
-   }
 
   &:hover .svg,
   &:focus .svg,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
@@ -58,6 +58,11 @@
   height: 24px;
 
   &.cellIsSelected {
+    &:hover .svg,
+    &:active .svg {
+      box-shadow: 0 0 0 1px #969696;
+    }
+
     &:focus .svg,
     & .svg {
       &.circle {
@@ -69,6 +74,10 @@
       border: 2px solid $ms-color-neutralTertiaryAlt;
     }
   }
+
+   &:focus .svg {
+      box-shadow: 0 0 0 1px #969696;
+   }
 
   &:hover .svg,
   &:focus .svg,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
@@ -55,6 +55,7 @@
 .cell {
   padding: 0px;
   overflow: visible;
+  height: 24px;
 
   &.cellIsSelected {
     &:hover .svg,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
@@ -7,7 +7,7 @@
 .svg {
   width: 20px;
   height: 20px;
-  padding: 4px;
+  padding: 2px;
   box-sizing: content-box;
 }
 
@@ -68,9 +68,9 @@
         border-radius: 100%;
       }
 
-      width: 12px;
-      height: 12px;
-      border: 4px solid $ms-color-neutralTertiaryAlt;
+      width: 16px;
+      height: 16px;
+      border: 2px solid $ms-color-neutralTertiaryAlt;
     }
   }
 
@@ -81,17 +81,17 @@
   &:hover .svg,
   &:focus .svg,
   &:active .svg {
-    width: 12px;
-    height: 12px;
+    width: 16px;
+    height: 16px;
   }
 
   &:hover .svg,
   &:focus .svg {
-      border: 4px solid $ms-color-neutralQuaternaryAlt;
+      border: 2px solid $ms-color-neutralQuaternaryAlt;
    }
 
   &:active .svg {
-  border: 4px solid $ms-color-neutralTertiaryAlt;
+  border: 2px solid $ms-color-neutralTertiaryAlt;
   }
 
   &:hover .svg.circle,
@@ -101,7 +101,7 @@
   }
 
   &:active .svg {
-    border: 4px solid #969696;
+    border: 2px solid #969696;
 
     // This is for a transform issue in IE
     // where the edge of the SVG becomes hidden


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Before these changes, the SwatchColorPicker looked this way:

![beforecolorpicker](https://user-images.githubusercontent.com/3754893/32511672-53bfec90-c3a9-11e7-9569-9ea4bfdc98a0.gif)

In this gif we can see three problems:
1. There is a lot of spacing between the cells in the grid.
2. The redlines call for the circles to be 20px in an unselected state. In a selected state, circle should become 16px because inner border/padding trim circle by 2px. Before the change, the circles were being trimmed to 12px and the inner  border/padding was 4px.

After these changes, these is how the SwatchColorPicker looks like now:

![aftercolorpickerkeyboard](https://user-images.githubusercontent.com/3754893/32514354-9a1cb990-c3b1-11e7-836c-1e6aae4bb283.gif)

Important Note: For visibility of styling changes the gifs are in a browser with a 400% zoom
