### PR TITLE
Selection: fix bug in setItems

### DIFF
--- a/common/changes/office-ui-fabric-react/kathayer-fixselection_2017-11-08-01-39.json
+++ b/common/changes/office-ui-fabric-react/kathayer-fixselection_2017-11-08-01-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix bug in selection code",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kathayer@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/kathayer-fixselection_2017-11-08-01-39.json
+++ b/common/changes/office-ui-fabric-react/kathayer-fixselection_2017-11-08-01-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fix bug in selection code",
+      "comment": "Selection: calling `setItems` with new items will now invalidate the internal selection array.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -165,6 +165,7 @@ export class Selection implements ISelection {
     this._keyToIndexMap = newKeyToIndexMap;
     this._unselectableIndices = newUnselectableIndices;
     this._items = items || [];
+    this._selectedItems = null;
 
     if (hasSelectionChanged) {
       this._change();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This bug became noticeable when renaming items in a list. The scenario is this: The item set has changed, so we call selection.setItems(). One of the items had some properties updated (such as renaming), but its index in the items array is still the same as before, so hasSelectionChanged evaluates to false. The next time we ask for the current selection by calling selection.getSelection(), we will get a stale copy of this._selectedItems.  The fix is to clear this._selectedItems in setItems so we can refresh the actual item objects.

#### Focus areas to test

(optional)
