### PR TITLE
Added className to IDetailsRowProps

### DIFF
--- a/common/changes/office-ui-fabric-react/patch-1_2017-11-08-08-11.json
+++ b/common/changes/office-ui-fabric-react/patch-1_2017-11-08-08-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added className to IDetailsRowProps for the root element.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "adtran@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -51,6 +51,7 @@ export interface IDetailsRowProps extends React.Props<DetailsRow> {
   getRowAriaLabel?: (item: any) => string;
   checkButtonAriaLabel?: string;
   checkboxCellClassName?: string;
+  className?: string;
 }
 
 export interface IDetailsRowSelectionState {
@@ -175,6 +176,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
 
   public render() {
     const {
+      className,
       columns,
       dragDropEvents,
       item,
@@ -208,6 +210,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
         aria-label={ ariaLabel }
         className={ css(
           'ms-DetailsRow',
+          className,
           AnimationClassNames.fadeIn400,
           styles.root,
           checkStyles.owner,


### PR DESCRIPTION
Added className to IDetailsRowProps for the root element.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2340
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added className to IDetailsRowProps for the root element to allow user to specify their own class for the row.
