### PR TITLE
Fix getIconClassName to return inline-block styling.

### DIFF
--- a/apps/vr-tests/src/stories/Icon.stories.tsx
+++ b/apps/vr-tests/src/stories/Icon.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Icon, IconType } from 'office-ui-fabric-react';
+import { Icon, IconType, getIconClassName } from 'office-ui-fabric-react';
 import { TestImages } from '../common/TestImages';
 
 storiesOf('Icon', module)
@@ -18,7 +18,18 @@ storiesOf('Icon', module)
       { story() }
     </Screener>
   )).add('Root', () => (
-    <Icon iconName='CompassNW' />
+    <div>
+      <div>
+        <Icon iconName='CompassNW' />
+        <Icon iconName='Upload' />
+        <Icon iconName='Share' />
+      </div>
+      <div>
+        <Icon className={ getIconClassName('CompassNW') } />
+        <Icon className={ getIconClassName('Upload') } />
+        <Icon className={ getIconClassName('Share') } />
+      </div>
+    </div>
   )).add('Color', () => (
     // tslint:disable-next-line:jsx-ban-props
     <Icon iconName={ 'CompassNW' } style={ { color: 'red' } } />

--- a/common/changes/@uifabric/styling/fixGetIconCN_2017-11-08-19-42.json
+++ b/common/changes/@uifabric/styling/fixGetIconCN_2017-11-08-19-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Updating `getIconClassName` to return display: inline-block to be consistent with the styled used by `ms-Icon ms-Icon--*`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/styling/src/utilities/getIconClassName.ts
+++ b/packages/styling/src/utilities/getIconClassName.ts
@@ -3,6 +3,10 @@ import {
 } from '@uifabric/merge-styles/lib/index';
 import { getIcon } from './icons';
 
+const defaultIconStyles = {
+  display: 'inline-block'
+};
+
 /**
  * Gets an icon classname. You should be able to add this classname to an I tag with no
  * additional classnames, and render the icon.
@@ -16,6 +20,7 @@ export function getIconClassName(name: string): string {
   if (icon) {
     className = mergeStyles(
       icon.subset.className,
+      defaultIconStyles,
       {
         selectors: {
           '::before': {


### PR DESCRIPTION
In order to be consistent with ms-Icon styling, getIconClassName should be returning a class name with `display: inline-block` set.