### PR TITLE
DatePicker date boundaries

### DIFF
--- a/common/changes/office-ui-fabric-react/datepicker-minmax_2017-11-08-21-54.json
+++ b/common/changes/office-ui-fabric-react/datepicker-minmax_2017-11-08-21-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow optional minimum and maximum date boundaries on DatePicker component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "evlevy@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.Props.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.Props.ts
@@ -80,7 +80,7 @@ export interface IDatePickerProps extends React.Props<DatePicker> {
   /**
     * Value of today. If null, current time in client machine will be used.
     */
-    today?: Date;
+  today?: Date;
 
   /**
    * Default value of the DatePicker, if any
@@ -149,6 +149,16 @@ export interface IDatePickerProps extends React.Props<DatePicker> {
   * Apply additional formating to dates, for example localized date formatting.
   */
   dateTimeFormatter?: ICalendarFormatDateCallbacks;
+
+  /**
+   * The minimum allowable date.
+   */
+  minDate?: Date;
+
+  /**
+   * The maximum allowable date.
+   */
+  maxDate?: Date;
 }
 
 export interface IDatePickerStrings {
@@ -190,6 +200,11 @@ export interface IDatePickerStrings {
    * Error message to render for TextField if input date string parsing fails.
    */
   invalidInputErrorMessage?: string;
+
+  /**
+   * Error message to render for TextField if date boundary (minDate, maxDate) validation fails.
+   */
+  isOutOfBoundsErrorMessage?: string;
 
   /**
    * Aria-label for the "previous month" button.

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { Calendar, ICalendarStrings } from '../Calendar';
 import { DatePicker } from './DatePicker';
+import { IDatePickerStrings } from './DatePicker.Props';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
-import { shallow } from 'enzyme';
+import { shallow, mount, ReactWrapper } from 'enzyme';
 
 describe('DatePicker', () => {
   it('renders default DatePicker correctly', () => {
@@ -55,16 +56,16 @@ describe('DatePicker', () => {
 
     const datePicker = shallow(
       <DatePicker
-        isMonthPickerVisible={false}
-        showMonthPickerAsOverlay={true}
-        value={value}
-        today={today}
-        firstDayOfWeek={2}
-        highlightCurrentMonth={true}
-        showWeekNumbers={true}
-        firstWeekOfYear={FirstWeekOfYear.FirstFullWeek}
-        showGoToToday={false}
-        dateTimeFormatter={dateTimeFormatter}
+        isMonthPickerVisible={ false }
+        showMonthPickerAsOverlay={ true }
+        value={ value }
+        today={ today }
+        firstDayOfWeek={ 2 }
+        highlightCurrentMonth={ true }
+        showWeekNumbers={ true }
+        firstWeekOfYear={ FirstWeekOfYear.FirstFullWeek }
+        showGoToToday={ false }
+        dateTimeFormatter={ dateTimeFormatter }
       />
     );
     datePicker.setState({ isDatePickerShown: true });
@@ -109,6 +110,111 @@ describe('DatePicker', () => {
 
     it('renders Calendar with same dateTimeFormatter', () => {
       expect(calendarProps.dateTimeFormatter).toBe(dateTimeFormatter);
+    });
+  });
+
+  describe('when date boundaries are specified', () => {
+    const defaultDate = new Date('Dec 15 2017');
+    const minDate = new Date('Jan 1 2017');
+    const maxDate = new Date('Dec 31 2017');
+    const strings: IDatePickerStrings = {
+      months: [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December'
+      ],
+      shortMonths: [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec'
+      ],
+      days: [
+        'Sunday',
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday'
+      ],
+      shortDays: [
+        'S',
+        'M',
+        'T',
+        'W',
+        'T',
+        'F',
+        'S'
+      ],
+      goToToday: 'Go to today',
+      isOutOfBoundsErrorMessage: 'out of bounds'
+    };
+    let datePicker: ReactWrapper<any, any>;
+
+    beforeEach(() => {
+      datePicker = mount(
+        <DatePicker
+          allowTextInput={ true }
+          minDate={ minDate }
+          maxDate={ maxDate }
+          value={ defaultDate }
+          strings={ strings }
+        />);
+    });
+
+    afterEach(() => {
+      datePicker.unmount();
+    });
+
+    it('should throw validation error for date outside boundary', () => {
+      // before minDate
+      datePicker.find('input')
+        .simulate('change', { target: { value: 'Jan 1 2010' } })
+        .simulate('blur');
+      expect(datePicker.state('errorMessage')).toBe('out of bounds');
+
+      // after maxDate
+      datePicker.find('input')
+        .simulate('change', { target: { value: 'Jan 1 2020' } })
+        .simulate('blur');
+      expect(datePicker.state('errorMessage')).toBe('out of bounds');
+    });
+
+    it('should not throw validation error for date inside boundary', () => {
+      // in boundary
+      datePicker.find('input')
+        .simulate('change', { target: { value: 'Dec 16 2017' } })
+        .simulate('blur');
+      expect(datePicker.state('errorMessage')).toBeFalsy();
+
+      // on boundary
+      datePicker.find('input')
+        .simulate('change', { target: { value: 'Jan 1 2017' } })
+        .simulate('blur');
+      expect(datePicker.state('errorMessage')).toBeFalsy();
+    });
+
+    it('should throw validation error if boundaries are moved to intersect selected date', () => {
+      datePicker.setProps({ minDate: new Date('Dec 16 2017') });
+      expect(datePicker.state('errorMessage')).toBe('out of bounds');
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -17,7 +17,7 @@ import {
   KeyCodes,
   css
 } from '../../Utilities';
-import { compareDates } from '../../utilities/dateMath/DateMath';
+import { compareDates, compareDatePart } from '../../utilities/dateMath/DateMath';
 import * as stylesImport from './DatePicker.scss';
 const styles: any = stylesImport;
 
@@ -143,8 +143,12 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   }
 
   public componentWillReceiveProps(nextProps: IDatePickerProps) {
-    let { formatDate, isRequired, strings, value } = nextProps;
-    const errorMessage = (isRequired && !value) ? (strings!.isRequiredErrorMessage || '*') : undefined;
+    let { formatDate, isRequired, strings, value, minDate, maxDate } = nextProps;
+    let errorMessage = (isRequired && !value) ? (strings!.isRequiredErrorMessage || '*') : undefined;
+
+    if (!errorMessage && value) {
+      errorMessage = this._isDateOutOfBounds(value!, minDate, maxDate) ? strings!.isOutOfBoundsErrorMessage || '*' : undefined;
+    }
 
     // Set error message
     this.setState({
@@ -176,7 +180,9 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       placeholder,
       allowTextInput,
       borderless,
-      className
+      className,
+      minDate,
+      maxDate
     } = this.props;
     const { isDatePickerShown, formattedDate, selectedDate, errorMessage } = this.state;
 
@@ -240,6 +246,8 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
               firstWeekOfYear={ this.props.firstWeekOfYear }
               showGoToToday={ this.props.showGoToToday }
               dateTimeFormatter={ this.props.dateTimeFormatter }
+              minDate={ minDate }
+              maxDate={ maxDate }
               ref={ this._resolveRef('_calendar') }
             />
           </Callout>
@@ -392,7 +400,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
 
   @autobind
   private _validateTextInput() {
-    let { isRequired, allowTextInput, strings, parseDateFromString, onSelectDate, formatDate } = this.props;
+    const { isRequired, allowTextInput, strings, parseDateFromString, onSelectDate, formatDate, minDate, maxDate } = this.props;
     const inputValue = this.state.formattedDate;
 
     // Do validation only if DatePicker's popup is dismissed
@@ -425,10 +433,17 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
               errorMessage: strings!.invalidInputErrorMessage || '*'
             });
           } else {
-            this.setState({
-              selectedDate: date,
-              errorMessage: ''
-            });
+            // Check against optional date boundaries
+            if (this._isDateOutOfBounds(date, minDate, maxDate)) {
+              this.setState({
+                errorMessage: strings!.isOutOfBoundsErrorMessage || '*'
+              });
+            } else {
+              this.setState({
+                selectedDate: date,
+                errorMessage: ''
+              });
+            }
           }
         }
       } else {
@@ -445,5 +460,9 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
         onSelectDate(date);
       }
     }
+  }
+
+  private _isDateOutOfBounds(date: Date, minDate?: Date, maxDate?: Date): boolean {
+    return ((!!minDate && compareDatePart(minDate!, date) > 0) || (!!maxDate && compareDatePart(maxDate!, date) < 0));
   }
 }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePickerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePickerPage.tsx
@@ -10,6 +10,7 @@ import { DatePickerWeekNumbersExample } from './examples/DatePicker.WeekNumbers.
 import { DatePickerRequiredExample } from './examples/DatePicker.Required.Example';
 import { DatePickerInputExample } from './examples/DatePicker.Input.Example';
 import { DatePickerFormatExample } from './examples/DatePicker.Format.Example';
+import { DatePickerBoundedExample } from './examples/DatePicker.Bounded.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { DatePickerStatus } from './DatePicker.checklist';
 
@@ -18,7 +19,9 @@ const DatePickerWeekNumbersExampleCode = require('!raw-loader!office-ui-fabric-r
 const DatePickerRequiredExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx') as string;
 const DatePickerInputExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx') as string;
 const DatePickerFormatExampleCode = require
-('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx') as string;
+  ('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx') as string;
+const DatePickerBoundedExampleCode = require
+  ('!raw-loader!office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx') as string;
 
 export class DatePickerPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -42,6 +45,9 @@ export class DatePickerPage extends React.Component<IComponentDemoPageProps, {}>
             </ExampleCard>
             <ExampleCard title='DatePicker allows dates to be formatted' code={ DatePickerFormatExampleCode }>
               <DatePickerFormatExample />
+            </ExampleCard>
+            <ExampleCard title='DatePicker with date boundary (minDate, maxDate)' code={ DatePickerBoundedExampleCode }>
+              <DatePickerBoundedExample />
             </ExampleCard>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import {
+  DatePicker,
+  DayOfWeek,
+  IDatePickerStrings
+} from 'office-ui-fabric-react/lib/DatePicker';
+import { addMonths, addYears } from '../../../utilities/dateMath/DateMath';
+
+const today: Date = new Date(Date.now());
+const minDate: Date = addMonths(today, -1);
+const maxDate: Date = addYears(today, 1);
+const description = `When date boundaries are set (via minDate and maxDate props) the DatePicker will not allow out-of-bounds dates to be picked or entered. In this example, the allowed dates are ${minDate.toLocaleDateString()}-${maxDate.toLocaleDateString()}`;
+
+const DayPickerStrings: IDatePickerStrings = {
+  months: [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December'
+  ],
+
+  shortMonths: [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec'
+  ],
+
+  days: [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday'
+  ],
+
+  shortDays: [
+    'S',
+    'M',
+    'T',
+    'W',
+    'T',
+    'F',
+    'S'
+  ],
+
+  goToToday: 'Go to today',
+  prevMonthAriaLabel: 'Go to previous month',
+  nextMonthAriaLabel: 'Go to next month',
+  prevYearAriaLabel: 'Go to previous year',
+  nextYearAriaLabel: 'Go to next year',
+
+  isRequiredErrorMessage: 'Field is required.',
+
+  invalidInputErrorMessage: 'Invalid date format.',
+
+  isOutOfBoundsErrorMessage: `Date must be between ${minDate.toLocaleDateString()}-${maxDate.toLocaleDateString()}`
+};
+
+export interface IDatePickerRequiredExampleState {
+  firstDayOfWeek?: DayOfWeek;
+}
+
+export class DatePickerBoundedExample extends React.Component<any, IDatePickerRequiredExampleState> {
+  public constructor() {
+    super();
+
+    this.state = {
+      firstDayOfWeek: DayOfWeek.Sunday
+    };
+  }
+
+  public render() {
+    let { firstDayOfWeek } = this.state;
+
+    return (
+      <div>
+        <p>{ description }</p>
+        <DatePicker
+          isRequired={ false }
+          firstDayOfWeek={ firstDayOfWeek }
+          strings={ DayPickerStrings }
+          placeholder='Select a date...'
+          minDate={ minDate }
+          maxDate={ maxDate }
+          allowTextInput={ true }
+        />
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add support for date boundaries to DatePicker component. Already [supported](https://github.com/OfficeDev/office-ui-fabric-react/pull/3253) in Calendar component.

- Throw validation if user attempts to type in a date that is out-of-bounds
- Throw validation if a date boundary is moved to intersect the selected date
- Example

![image](https://user-images.githubusercontent.com/33076550/32577222-1b0804e2-c4a7-11e7-9ba7-6cdd0350637d.png)
