### PR TITLE
rename addonString to prefix and add suffix to TextField

### DIFF
--- a/apps/vr-tests/src/stories/TextField.stories.tsx
+++ b/apps/vr-tests/src/stories/TextField.stories.tsx
@@ -74,9 +74,14 @@ storiesOf('TextField', module)
       label='Icon'
       iconProps={ { iconName: 'Calendar' } }
     />
-  )).add('Addon', () => (
+  )).add('Prefix', () => (
     <TextField
-      label='Addon'
-      addonString='https://'
+      label='Prefix'
+      prefix='https://'
+    />
+  )).add('Suffix', () => (
+    <TextField
+      label='Suffix'
+      suffix='.com'
     />
   ));

--- a/common/changes/office-ui-fabric-react/append_on_input_2017-11-09-05-23.json
+++ b/common/changes/office-ui-fabric-react/append_on_input_2017-11-09-05-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add suffix to TextField",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "scott.balentine@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -85,7 +85,7 @@ $field-error-color: $errorTextColor;
   }
 }
 
-.fieldAddon {
+.fieldPrefixSuffix {
   background: $ms-color-neutralLighter;
   color: $ms-color-neutralSecondary;
   display: flex;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -50,6 +50,52 @@ describe('TextField', () => {
     expect(labelDOM.textContent).toEqual(exampleLabel);
   });
 
+  it('should render prefix in input element', () => {
+    const examplePrefix: string = 'this is a prefix';
+
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <TextField
+        prefix={ examplePrefix }
+      />
+    );
+
+    // Assert on the prefix
+    const prefixDOM: Element = renderedDOM.getElementsByClassName('ms-TextField-prefix')[0];
+    expect(prefixDOM.textContent).toEqual(examplePrefix);
+  });
+
+  it('should render suffix in input element', () => {
+    const exampleSuffix: string = 'this is a suffix';
+
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <TextField
+        suffix={ exampleSuffix }
+      />
+    );
+
+    // Assert on the suffix
+    const suffixDOM: Element = renderedDOM.getElementsByClassName('ms-TextField-suffix')[0];
+    expect(suffixDOM.textContent).toEqual(exampleSuffix);
+  });
+
+  it('should render both prefix and suffix in input element', () => {
+    const examplePrefix: string = 'this is a prefix';
+    const exampleSuffix: string = 'this is a suffix';
+
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <TextField
+        prefix={ examplePrefix}
+        suffix={ exampleSuffix }
+      />
+    );
+
+    // Assert on the prefix and suffix
+    const prefixDOM: Element = renderedDOM.getElementsByClassName('ms-TextField-prefix')[0];
+    const suffixDOM: Element = renderedDOM.getElementsByClassName('ms-TextField-suffix')[0];
+    expect(prefixDOM.textContent).toEqual(examplePrefix);
+    expect(suffixDOM.textContent).toEqual(exampleSuffix);
+  });
+
   it('should render multiline as text area element', () => {
     const renderedDOM: HTMLElement = renderIntoDocument(
       <TextField value='This\nIs\nMultiline\nText\n' multiline />

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -61,7 +61,9 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     super(props);
 
     this._warnDeprecations({
-      'iconClass': 'iconProps'
+      'iconClass': 'iconProps',
+      'addonString': 'prefix',
+      'onRenderAddon': 'onRenderPrefix'
     });
 
     this._warnMutuallyExclusive({
@@ -135,8 +137,12 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
       required,
       underlined,
       borderless,
-      addonString,
-      onRenderAddon = this._onRenderAddon,
+      addonString, // @deprecated
+      prefix,
+      suffix,
+      onRenderAddon = this._onRenderAddon, // @deprecated
+      onRenderPrefix = this._onRenderPrefix,
+      onRenderSuffix = this._onRenderSuffix,
       onRenderLabel = this._onRenderLabel
     } = this.props;
     let { isFocused } = this.state;
@@ -160,12 +166,22 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
           { onRenderLabel(renderProps, this._onRenderLabel) }
           <div className={ css('ms-TextField-fieldGroup', styles.fieldGroup, isFocused && styles.fieldGroupIsFocused, errorMessage && styles.invalid) }>
             { (addonString !== undefined || this.props.onRenderAddon) && (
-              <div className={ css(styles.fieldAddon) }>
+              <div className={ css('ms-TextField-prefix', styles.fieldPrefixSuffix) }>
                 { onRenderAddon(this.props, this._onRenderAddon) }
+              </div>
+            ) }
+            { (prefix !== undefined || this.props.onRenderPrefix) && (
+              <div className={ css('ms-TextField-prefix', styles.fieldPrefixSuffix) }>
+                { onRenderPrefix(this.props, this._onRenderPrefix) }
               </div>
             ) }
             { multiline ? this._renderTextArea() : this._renderInput() }
             { (iconClass || iconProps) && <Icon className={ css(iconClass, styles.icon) } { ...iconProps } /> }
+            { (suffix !== undefined || this.props.onRenderSuffix) && (
+              <div className={ css('ms-TextField-suffix', styles.fieldPrefixSuffix) }>
+                { onRenderSuffix(this.props, this._onRenderSuffix) }
+              </div>
+            ) }
           </div>
         </div>
         { this._isDescriptionAvailable &&
@@ -282,10 +298,25 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     return null;
   }
 
+  // @deprecated
   private _onRenderAddon(props: ITextFieldProps): JSX.Element {
     let { addonString } = props;
     return (
       <span style={ { paddingBottom: '1px' } }>{ addonString }</span>
+    );
+  }
+
+  private _onRenderPrefix(props: ITextFieldProps): JSX.Element {
+    let { prefix } = props;
+    return (
+      <span style={ { paddingBottom: '1px' } }>{ prefix }</span>
+    );
+  }
+
+  private _onRenderSuffix(props: ITextFieldProps): JSX.Element {
+    let { suffix } = props;
+    return (
+      <span style={ { paddingBottom: '1px' } }>{ suffix }</span>
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -88,14 +88,36 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   description?: string;
 
   /**
-  * String for addon.
-  */
+   * @deprecated
+   * Deprecated; use prefix instead.
+   */
   addonString?: string;
 
   /**
-  * Custom render function for addon
+  * String for prefix
   */
+  prefix?: string;
+
+  /**
+  * String for suffix
+  */
+  suffix?: string;
+
+  /**
+   * @deprecated
+   * Deprecated; use onRenderPrefix instead.
+   */
   onRenderAddon?: IRenderFunction<ITextFieldProps>;
+
+  /**
+  * Custom render function for prefix
+  */
+  onRenderPrefix?: IRenderFunction<ITextFieldProps>;
+
+  /**
+  * Custom render function for suffix
+  */
+  onRenderSuffix?: IRenderFunction<ITextFieldProps>;
 
   /**
    * Optional icon props for an icon.

--- a/packages/office-ui-fabric-react/src/components/TextField/TextFieldPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextFieldPage.tsx
@@ -5,27 +5,31 @@ import {
   IComponentDemoPageProps,
   PropertiesTableSet
 } from '@uifabric/example-app-base';
-import { TextFieldAddonExample } from './examples/TextField.Addon.Example';
+import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { TextFieldBasicExample } from './examples/TextField.Basic.Example';
-import { TextFieldCustomRenderExample } from './examples/TextField.CustomRender.Example';
-import { TextFieldPlaceholderExample } from './examples/TextField.Placeholder.Example';
-import { TextFieldMultilineExample } from './examples/TextField.Multiline.Example';
-import { TextFieldUnderlinedExample } from './examples/TextField.Underlined.Example';
 import { TextFieldBorderlessExample } from './examples/TextField.Borderless.Example';
+import { TextFieldCustomRenderExample } from './examples/TextField.CustomRender.Example';
 import { TextFieldErrorMessageExample } from './examples/TextField.ErrorMessage.Example';
 import { TextFieldIconExample } from './examples/TextField.Icon.Example';
-import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
+import { TextFieldMultilineExample } from './examples/TextField.Multiline.Example';
+import { TextFieldPlaceholderExample } from './examples/TextField.Placeholder.Example';
+import { TextFieldPrefixExample } from './examples/TextField.Prefix.Example';
+import { TextFieldPrefixAndSuffixExample } from './examples/TextField.PrefixAndSuffix.Example';
 import { TextFieldStatus } from './TextField.checklist';
+import { TextFieldSuffixExample } from './examples/TextField.Suffix.Example';
+import { TextFieldUnderlinedExample } from './examples/TextField.Underlined.Example';
 
-const TextFieldAddonExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Addon.Example.tsx') as string;
 const TextFieldBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Basic.Example.tsx') as string;
-const TextFieldCustomRenderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.CustomRender.Example.tsx') as string;
-const TextFieldPlaceholderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Placeholder.Example.tsx') as string;
-const TextFieldMultilineExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Multiline.Example.tsx') as string;
-const TextFieldUnderlinedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Underlined.Example.tsx') as string;
 const TextFieldBorderlessExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Borderless.Example.tsx') as string;
+const TextFieldCustomRenderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.CustomRender.Example.tsx') as string;
 const TextFieldErrorMessageExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.ErrorMessage.Example.tsx') as string;
 const TextFieldIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Icon.Example.tsx') as string;
+const TextFieldMultilineExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Multiline.Example.tsx') as string;
+const TextFieldPlaceholderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Placeholder.Example.tsx') as string;
+const TextFieldPrefixExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Prefix.Example.tsx') as string;
+const TextFieldPrefixAndSuffixExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.PrefixAndSuffix.Example.tsx') as string;
+const TextFieldSuffixExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Suffix.Example.tsx') as string;
+const TextFieldUnderlinedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/TextField/examples/TextField.Underlined.Example.tsx') as string;
 
 export class TextFieldPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -70,10 +74,22 @@ export class TextFieldPage extends React.Component<IComponentDemoPageProps, {}> 
         implementationExampleCards={
           <div>
             <ExampleCard
-              title='Textfield with an addon'
-              code={ TextFieldAddonExampleCode }
+              title='Textfield with a prefix'
+              code={ TextFieldPrefixExampleCode }
             >
-              <TextFieldAddonExample />
+              <TextFieldPrefixExample />
+            </ExampleCard>
+            <ExampleCard
+              title='Textfield with a suffix'
+              code={ TextFieldSuffixExampleCode }
+            >
+              <TextFieldSuffixExample />
+            </ExampleCard>
+            <ExampleCard
+              title='Textfield with a prefix and a suffix'
+              code={ TextFieldPrefixAndSuffixExampleCode }
+            >
+              <TextFieldPrefixAndSuffixExample />
             </ExampleCard>
             <ExampleCard
               title='TextField with an icon'

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Prefix.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Prefix.Example.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import './TextField.Examples.scss';
+
+export class TextFieldPrefixExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <div className='docs-TextFieldExample'>
+        <TextField
+          prefix='https://'
+        />
+      </div>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.PrefixAndSuffix.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.PrefixAndSuffix.Example.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import './TextField.Examples.scss';
 
-export class TextFieldAddonExample extends React.Component<any, any> {
+export class TextFieldPrefixAndSuffixExample extends React.Component<any, any> {
   public render() {
     return (
-      <div className='docs-TextFieldExample'>
+      <div className='ms-TextFieldExample'>
         <TextField
-          addonString='https://'
+          prefix='https://'
+          suffix='.com'
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Suffix.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Suffix.Example.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import './TextField.Examples.scss';
+
+export class TextFieldSuffixExample extends React.Component<any, any> {
+  public render() {
+    return (
+      <div className='ms-TextFieldExample'>
+        <TextField
+          suffix='.com'
+        />
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

In building out prefix/suffix requirements for groups in Yammer and other workloads, we found ourselves in need of not only a prepended label in an input, but also an appended one (for suffix). We decided that the best place for this change would be inside of Fabric since other workloads could take advantage of the feature.

This would allow consumers of TextField to specify a suffix that would render an appended element to the TextField component. I also added tests for the current prefix functionality.

Screenshots below:

<img width="1309" alt="office_ui_fabric_react_examples" src="https://user-images.githubusercontent.com/976978/32674301-844b9282-c607-11e7-9b33-c1ffe9805cc5.png">
<img width="1332" alt="office_ui_fabric_react_examples" src="https://user-images.githubusercontent.com/976978/32674304-87df8a5c-c607-11e7-9ab8-7275abab153f.png">
<img width="1320" alt="office_ui_fabric_react_examples" src="https://user-images.githubusercontent.com/976978/32674307-8af0aff0-c607-11e7-9c8f-57ee157594b0.png">


