### PR TITLE
Changed inline-block stories to be inside fixed width container

### DIFF
--- a/apps/vr-tests/src/stories/ComboBox.stories.tsx
+++ b/apps/vr-tests/src/stories/ComboBox.stories.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorTall } from '../utilities';
+import { FabricDecoratorTallFixedWdith } from '../utilities';
 import { ComboBox, SelectableOptionMenuItemType } from 'office-ui-fabric-react';
 
 let testOptions = [
@@ -45,7 +45,7 @@ let onRenderFontOption = (item) => {
 };
 
 storiesOf('ComboBox', module)
-  .addDecorator(FabricDecoratorTall)
+  .addDecorator(FabricDecoratorTallFixedWdith)
   .addDecorator(story => (
     <Screener
       steps={ new Screener.Steps()

--- a/apps/vr-tests/src/stories/DatePicker.stories.tsx
+++ b/apps/vr-tests/src/stories/DatePicker.stories.tsx
@@ -2,12 +2,12 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities';
+import { FabricDecoratorFixedWidth } from '../utilities';
 import { DatePicker } from 'office-ui-fabric-react';
 
 const date = new Date(2010, 1, 12);
 storiesOf('DatePicker', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(FabricDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={ new Screener.Steps()

--- a/apps/vr-tests/src/stories/SearchBox.stories.tsx
+++ b/apps/vr-tests/src/stories/SearchBox.stories.tsx
@@ -25,7 +25,7 @@ storiesOf('SearchBox', module)
     </Screener>
   )).add('Root', () => (
     <Fabric style={ { display: 'flex' } }>
-      <div className='testWrapper' style={ { padding: '10px', overflow: 'hidden' } }>
+      <div className='testWrapper' style={ { padding: '10px', overflow: 'hidden', width: '300px' } }>
         <SearchBox />
       </div>
     </Fabric>

--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities';
+import { FabricDecoratorFixedWidth } from '../utilities';
 import { SpinButton } from 'office-ui-fabric-react';
 import { Position } from 'office-ui-fabric-react/lib/utilities/positioning';
 
@@ -15,7 +15,7 @@ let props = {
 };
 
 storiesOf('SpinButton', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(FabricDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={ new Screener.Steps()

--- a/apps/vr-tests/src/stories/TextField.stories.tsx
+++ b/apps/vr-tests/src/stories/TextField.stories.tsx
@@ -2,11 +2,11 @@
 import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities';
+import { FabricDecoratorFixedWidth } from '../utilities';
 import { TextField } from 'office-ui-fabric-react';
 
 storiesOf('TextField', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(FabricDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={ new Screener.Steps()

--- a/apps/vr-tests/src/utilities/FabricDecorator.tsx
+++ b/apps/vr-tests/src/utilities/FabricDecorator.tsx
@@ -20,3 +20,19 @@ export const FabricDecoratorTall = (story) => (
     </div>
   </Fabric>
 );
+
+export const FabricDecoratorTallFixedWdith = (story) => (
+  <Fabric style={ { display: 'flex' } }>
+    <div className='testWrapper' style={ { padding: '10px 10px 120px', width: '300px' } }>
+      { story() }
+    </div>
+  </Fabric>
+);
+
+export const FabricDecoratorFixedWidth = (story) => (
+  <Fabric style={ { display: 'flex' } }>
+    <div className='testWrapper' style={ { padding: '10px', width: '300px' } }>
+      { story() }
+    </div>
+  </Fabric>
+);


### PR DESCRIPTION
test of input fields were flickering because 100% width inline-block elements were sitting in flex containers. There's a race condition to determine the actual width of the parent element, and sometimes it was calculated differently in screener.

This fix provides some fixed width Fabric Decorators so that these elements can be constrained to a set width while not affecting other non 100% width items. 