### PR TITLE
TextField: Moved required asterisk to be outside of fieldGroup when there is no label

### DIFF
--- a/common/changes/office-ui-fabric-react/textfield-asterisk_2017-11-09-21-14.json
+++ b/common/changes/office-ui-fabric-react/textfield-asterisk_2017-11-09-21-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: Moved required asterisk to be outside of fieldGroup when no label is present. No longer a need for special styles when icons are present.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -138,22 +138,11 @@ $field-error-color: $errorTextColor;
 .root.rootIsRequiredPlaceholderOnly {
   :global(.ms-TextField-fieldGroup) {
     &::after {
-      content: ' *';
-      color: $ms-color-error;
-      @include ms-padding-right(12px);
-    }
-  }
-}
-
-.root.rootIsRequiredPlaceholderIcon {
-  :global(.ms-Icon) {
-    &::before {
-      content: ' *';
+      content: '*';
       color: $ms-color-error;
       position: absolute;
-      top: -4px;
-      @include ms-right(8px);
-      @include ms-padding-right(12px);
+      top: -5px;
+      @include ms-right(-10px);
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -146,8 +146,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
 
     const textFieldClassName = css('ms-TextField', styles.root, className, {
       ['is-required ' + styles.rootIsRequiredLabel]: this.props.label && required,
-      ['is-required ' + styles.rootIsRequiredPlaceholderOnly]: !this.props.label && required && !iconProps,
-      ['is-required ' + styles.rootIsRequiredPlaceholderIcon]: !this.props.label && required && iconProps,
+      ['is-required ' + styles.rootIsRequiredPlaceholderOnly]: !this.props.label && required,
       ['is-disabled ' + styles.rootIsDisabled]: disabled,
       ['is-active ' + styles.rootIsActive]: isFocused,
       ['ms-TextField--multiline ' + styles.rootIsMultiline]: multiline,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3351  
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Changed the positioning of the TextField's required asterisk to be outside of fieldGroup when there is no label. The previous positioning was interfering with icons and addon.

**Before:**
![image](https://user-images.githubusercontent.com/16619843/32630212-b0605ce8-c550-11e7-96b9-34a98208eecb.png)

**After:**
![image](https://user-images.githubusercontent.com/16619843/32630177-952e476e-c550-11e7-868c-53c73bbb2409.png)

#### Focus areas to test

(optional)
