### PR TITLE
Add invariant semantic slot for signal

### DIFF
--- a/common/changes/@uifabric/experiments/v-edwliu-unthemeingNewSignal_2017-11-11-00-17.json
+++ b/common/changes/@uifabric/experiments/v-edwliu-unthemeingNewSignal_2017-11-11-00-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Change newItem signal to use invariant semantic slot 'signal'",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/v-edwliu-unthemeingNewSignal_2017-11-11-00-19.json
+++ b/common/changes/@uifabric/styling/v-edwliu-unthemeingNewSignal_2017-11-11-00-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Theming: Add invariant semantic slot 'signal' to semantic colors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/v-edwliu-unthemeingNewSignal_2017-11-11-00-19.json
+++ b/common/changes/office-ui-fabric-react/v-edwliu-unthemeingNewSignal_2017-11-11-00-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add 'signal' invariant semantic slot",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -27,7 +27,7 @@
   position: relative;
   @include margin-right(0);
   line-height: 1em;
-  color: $ms-color-themePrimary;
+  color: $signal;
 
   .selected & {
     color: $ms-color-themeDark;

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -18,6 +18,7 @@ $blockingBackgroundColor: "[theme:blockingBackground, default: rgba(234,67,0,.2)
 $warningBackgroundColor: "[theme:warningBackground, default: rgba(255,185,0,.2)]";
 $warningHighlightColor: "[theme:warningHighlight, default: #ffb900]";
 $successBackgroundColor: "[theme:successBackground, default: rgba(186,216,10,.2)]";
+$signal: "[theme:signal, default: #0078d7]";
 
 /* Input controls */
 $inputBorderColor: "[theme:inputBorder, default: #a6a6a6]";

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -131,6 +131,10 @@ export interface ISemanticColors {
    * Background for success
    */
   successBackground: string;
+  /**
+   * The color for signals
+   */
+  signal: string;
 
   //// Input controls slots (text fields, checkboxes, radios...)
 

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -101,6 +101,7 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean): ISema
     warningBackground: !isInverted ? 'rgba(255, 185, 0, .2)' : 'rgba(255, 251, 0, .6)',
     warningHighlight: !isInverted ? '#ffb900' : '#fff100',
     successBackground: !isInverted ? 'rgba(186, 216, 10, .2)' : 'rgba(186, 216, 10, .4)',
+    signal: '#0078d7',
 
     inputBorder: p.neutralTertiary,
     inputBorderHovered: p.neutralPrimary,


### PR DESCRIPTION
Change newSignal color to themePrimary

![screen shot 2017-11-10 at 4 03 56 pm](https://user-images.githubusercontent.com/1291968/32683717-407b5fe4-c632-11e7-82c9-2829e46b4f74.png)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

- Adds invariant semantic slot for signal.
- Change color of newItem signal

#### Focus areas to test

(optional)
