### PR TITLE
Add a hoverAbove option to DetailsList

### DIFF
--- a/common/changes/office-ui-fabric-react/2017-12-20-23-56.json
+++ b/common/changes/office-ui-fabric-react/2017-12-20-23-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add a hoverAbove prop to DetailsList",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "spelliot@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -245,7 +245,8 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       getKey,
       listProps,
       usePageCache,
-      onShouldVirtualize
+      onShouldVirtualize,
+      hoverAbove = false
     } = this.props;
     let {
       adjustedColumns,
@@ -336,7 +337,10 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
           <div onKeyDown={ this._onContentKeyDown } role='presentation'>
             <FocusZone
               ref={ this._resolveRef('_focusZone') }
-              className={ styles.focusZone }
+              className={ css(
+                styles.focusZone,
+                hoverAbove && 'ms-DetailsList--HoverAbove',
+              ) }
               direction={ FocusZoneDirection.vertical }
               isInnerZoneKeystroke={ isRightArrow }
               onActiveElementChanged={ this._onActiveRowChanged }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -210,6 +210,12 @@ export interface IDetailsListProps extends React.Props<DetailsList>, IWithViewpo
    * Whether or not the selection zone should enter modal state on touch.
    */
   enterModalSelectionOnTouch?: boolean;
+
+  /**
+   * Whether to style rows above the current row in a "hover" state when the cursor is hovering over a row.
+   * @default false
+   */
+  hoverAbove?: boolean;
 }
 
 export interface IColumn {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
@@ -52,6 +52,26 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
   }
 }
 
+/*
+ * When the DetailsList hover mode is "above" and the list is in hover state,
+ * style all rows with "hover" colors by default and
+ * use default colors in rows below the hovered row.
+ */
+:global(.ms-DetailsList--HoverAbove:hover) {
+  .root {
+    background: $detailsList-item-hover-color-background;
+    color: $detailsList-item-hover-meta-text-color;
+  }
+  :global(.ms-List-cell:hover) ~ :global(.ms-List-cell) .root {
+    background: $detailsList-item-default-background-color;
+    color: $detailsList-item-default-meta-text-color;
+  }
+  :global(.ms-List-page:hover) ~ :global(.ms-List-page) .root {
+    background: $detailsList-item-default-background-color;
+    color: $detailsList-item-default-meta-text-color;
+  }
+}
+
 :global(.ms-List-cell:first-child) {
   .root {
     // Don't show border-top for first row's pseudo element

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
@@ -32,6 +32,24 @@
   }
 }
 
+/*
+ * When the DetailsList hover mode is "above" and the list is in hover state,
+ * make all checkboxes visible by default and hide checkboxes in rows below the hovered row.
+ */
+:global(.ms-DetailsList--HoverAbove:hover) {
+  .check {
+    opacity: 1;
+  }
+  :global(.ms-List-cell:hover) ~ :global(.ms-List-cell) {
+    .check {
+      opacity: 0;
+    }
+  }
+  :global(.ms-List-page:hover) ~ :global(.ms-List-page) .check {
+    opacity: 0;
+  }
+}
+
 .owner {
   &.isSelected,
   &.isVisible,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3364
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When passing prop `hoverMode={HoverMode.above}`, the DetailsList will render rows at and _above_ the currently hovered row in a "hovered" style. Omitting the `hoverMode` prop or passing
`hoverMode={HoverMode.normal}` will keep the default behavior.

##### Demo
Using the default selection behavior:
https://youtu.be/sAlp9Tw92o4