### PR TITLE
BaseComponent: methods now have correct typings

### DIFF
--- a/common/changes/@uifabric/utilities/fix-props_2017-11-12-01-30.json
+++ b/common/changes/@uifabric/utilities/fix-props_2017-11-12-01-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "BaseComponent: fixing some typings to be compatible with current React typings.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -68,7 +68,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
    * When the component will receive props, make sure the componentRef is updated.
    */
   // tslint:disable-next-line:no-any
-  public componentWillReceiveProps(newProps?: P, newContext?: any): void {
+  public componentWillReceiveProps(newProps: Readonly<P>, newContext: any): void {
     this._updateComponentRef(this.props, newProps);
   }
 


### PR DESCRIPTION
Noticed VSCode complaining about some typing incompatibilities. Adjusted typings.