### PR TITLE
DetailsList: Don't set focus to row on mouse click

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsList-mouseDownNoFocusSoAnchorWins_2017-11-13-11-41.json
+++ b/common/changes/office-ui-fabric-react/detailsList-mouseDownNoFocusSoAnchorWins_2017-11-13-11-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: mouse click gives preference to inner links.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-panu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -701,8 +701,9 @@ describe('FocusZone', () => {
     expect(buttonB.tabIndex).toBe(0);
 
     // Clicking on A should enable its tab-index and disable others.
+    // But it doesn't set focus (browser will do it in the default event handler)
     ReactTestUtils.Simulate.mouseDown(buttonAElement);
-    expect(lastFocusedElement).toBe(buttonA);
+    expect(lastFocusedElement).toBe(buttonB);
 
     expect(buttonA.tabIndex).toBe(0);
     expect(buttonB.tabIndex).toBe(-1);

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -179,6 +179,9 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
     if (element) {
       this._setActiveElement(element);
+      if (this._activeElement) {
+        this._activeElement.focus();
+      }
 
       return true;
     }
@@ -267,7 +270,6 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
       }
 
       this._activeElement.tabIndex = 0;
-      this._activeElement.focus();
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3283 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

In **FocusZone**: Only call `focus` on keyboard navigation, it's not necessary on mouse click.
Focus is already set by browser, and the explicit `focus` prevented row inner links to work like described in #3283.

**Note:** After this change, clicked rows won't be scrolled full into view like it happens during keyboard navigation, but this is fine for mouse clicks.

#### Focus areas to test

- `DetailsList`
The bug could be reproduced in the fifth sample, named "Rendering custom item columns with sorting", by clicking on the link of the last row (which is only partially visible). Not anymore after this fix.
- Other `FocusZone` consumers.
Change seems safe as it is restoring behavior previous to commit 5a1d787.