### PR TITLE
Nav: Added onLinkExpandClick callback to Nav

### DIFF
--- a/common/changes/office-ui-fabric-react/patch-1_2017-11-15-23-16.json
+++ b/common/changes/office-ui-fabric-react/patch-1_2017-11-15-23-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added onLinkExpandClick callback to Nav",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jaebey@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/patch-1_2017-11-15-23-16.json
+++ b/common/changes/office-ui-fabric-react/patch-1_2017-11-15-23-16.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Added onLinkExpandClick callback to Nav",
-      "type": "patch"
+      "comment": "Nav: Added `onLinkExpandClick` callback for getting a callback when an item expanded state is toggled",
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -305,11 +305,13 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
   private _onLinkExpandClicked(link: INavLink, ev: React.MouseEvent<HTMLElement>): void {
     const { onLinkExpandClick } = this.props;
 
-    link.isExpanded = !link.isExpanded;
-    this.setState({ isLinkExpandStateChanged: true });
-
     if (onLinkExpandClick) {
       onLinkExpandClick(ev, link);
+    }
+
+    if (!ev.defaultPrevented) {
+      link.isExpanded = !link.isExpanded;
+      this.setState({ isLinkExpandStateChanged: true });
     }
 
     ev.preventDefault();

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -303,13 +303,13 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
   }
 
   private _onLinkExpandClicked(link: INavLink, ev: React.MouseEvent<HTMLElement>): void {
-    const { onLinkClick } = this.props;
+    const { onLinkExpandClick } = this.props;
 
     link.isExpanded = !link.isExpanded;
     this.setState({ isLinkExpandStateChanged: true });
 
-    if (onLinkClick) {
-      onLinkClick(ev, item);
+    if (onLinkExpandClick) {
+      onLinkExpandClick(ev, link);
     }
 
     ev.preventDefault();

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -303,8 +303,14 @@ export class Nav extends BaseComponent<INavProps, INavState> implements INav {
   }
 
   private _onLinkExpandClicked(link: INavLink, ev: React.MouseEvent<HTMLElement>): void {
+    const { onLinkClick } = this.props;
+
     link.isExpanded = !link.isExpanded;
     this.setState({ isLinkExpandStateChanged: true });
+
+    if (onLinkClick) {
+      onLinkClick(ev, item);
+    }
 
     ev.preventDefault();
     ev.stopPropagation();

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -40,6 +40,11 @@ export interface INavProps {
   onLinkClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
 
   /**
+   * Function callback invoked when the chevron on a link is clicked
+   */
+  onLinkExpandClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
+
+  /**
    * Indicates whether the navigation component renders on top of other content in the UI
    */
   isOnTop?: boolean;


### PR DESCRIPTION
When rendering as a tree, it is useful to have access to an item when it has been expanded.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2354
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add callback when expanded state changes for Nav.

#### Focus areas to test

Nav chevron click raises onLinkExpandClick.
