### PR TITLE
Checkbox: Add getClassNames prop

### DIFF
--- a/common/changes/office-ui-fabric-react/chrisgo-getClassNames_2017-11-14-23-58.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-getClassNames_2017-11-14-23-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Checkbox: Add getClassNames prop to allow complete customization of the component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.classNames.ts
@@ -12,10 +12,10 @@ export interface ICheckboxClassNames {
 
 export const getClassNames = memoizeFunction((
   styles: ICheckboxStyles,
-  className: string,
   disabled: boolean,
   isChecked: boolean,
-  isReversed: boolean
+  isReversed: boolean,
+  className?: string
 ): ICheckboxClassNames => {
   return {
     root: mergeStyles(

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -89,7 +89,7 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
     const isReversed = boxSide !== 'start' ? true : false;
 
     this._classNames = this.props.getClassNames ?
-      this.props.getClassNames(!!disabled, !!isChecked, !!isReversed, className)
+      this.props.getClassNames(theme!, !!disabled, !!isChecked, !!isReversed, className)
       : getClassNames(
         getStyles(theme!, customStyles),
         !!disabled,

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -88,13 +88,15 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
     const isChecked = checked === undefined ? this.state.isChecked : checked;
     const isReversed = boxSide !== 'start' ? true : false;
 
-    this._classNames = getClassNames(
-      getStyles(theme!, customStyles),
-      className!,
-      disabled!,
-      isChecked!,
-      isReversed!
-    );
+    this._classNames = this.props.getClassNames ?
+      this.props.getClassNames(className!, !!disabled, !!isChecked, !!isReversed)
+      : getClassNames(
+        getStyles(theme!, customStyles),
+        className!,
+        !!disabled,
+        !!isChecked,
+        !!isReversed
+      );
 
     return (
       <button

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -89,13 +89,13 @@ export class Checkbox extends BaseComponent<ICheckboxProps, ICheckboxState> impl
     const isReversed = boxSide !== 'start' ? true : false;
 
     this._classNames = this.props.getClassNames ?
-      this.props.getClassNames(className!, !!disabled, !!isChecked, !!isReversed)
+      this.props.getClassNames(!!disabled, !!isChecked, !!isReversed, className)
       : getClassNames(
         getStyles(theme!, customStyles),
-        className!,
         !!disabled,
         !!isChecked,
-        !!isReversed
+        !!isReversed,
+        className
       );
 
     return (

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IStyle, ITheme } from '../../Styling';
 import { IRenderFunction } from '../../Utilities';
 import { IIconProps } from '../Icon/Icon.types';
-import { ICheckboxClassNames } from 'src/components/Checkbox/Checkbox.classNames';
+import { ICheckboxClassNames } from './Checkbox.classNames';
 
 /**
  * Checkbox class interface.

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IStyle, ITheme } from '../../Styling';
 import { IRenderFunction } from '../../Utilities';
 import { IIconProps } from '../Icon/Icon.types';
+import { ICheckboxClassNames } from 'src/components/Checkbox/Checkbox.classNames';
 
 /**
  * Checkbox class interface.
@@ -94,6 +95,15 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
    * Custom styles for this component
    */
   styles?: ICheckboxStyles;
+
+  /**
+   * Custom function for providing the classNames for the checkbox. Can be used to provide
+   * all styles for the component instead of applying them on top of the default styles.
+   */
+  getClassNames?: (className: string,
+    disabled: boolean,
+    isChecked: boolean,
+    isReversed: boolean) => ICheckboxClassNames;
 
   /**
    * Custom render function for the label.

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
@@ -100,7 +100,8 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
    * Custom function for providing the classNames for the checkbox. Can be used to provide
    * all styles for the component instead of applying them on top of the default styles.
    */
-  getClassNames?: (disabled: boolean,
+  getClassNames?: (theme: ITheme,
+    disabled: boolean,
     isChecked: boolean,
     isReversed: boolean,
     className?: string) => ICheckboxClassNames;

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
@@ -100,10 +100,10 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
    * Custom function for providing the classNames for the checkbox. Can be used to provide
    * all styles for the component instead of applying them on top of the default styles.
    */
-  getClassNames?: (className: string,
-    disabled: boolean,
+  getClassNames?: (disabled: boolean,
     isChecked: boolean,
-    isReversed: boolean) => ICheckboxClassNames;
+    isReversed: boolean,
+    className?: string) => ICheckboxClassNames;
 
   /**
    * Custom render function for the label.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Our customizations for checkbox using the style prop were recently broken when updating to a newer version of fabric. Since our version of the checkbox styling is quite different from the default styles, it makes sense for us to provide all the styles rather than a set of style overrides to the component.

The long term solution for this problem appears to be coming in the 6.0 branch, with the concept of base + styled components, but this PR will provide a solution in the 5.0 timeframe
