### PR TITLE
Export functions to create localized font set

### DIFF
--- a/common/changes/@uifabric/styling/export-default-font-functions_2017-11-15-00-15.json
+++ b/common/changes/@uifabric/styling/export-default-font-functions_2017-11-15-00-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Export functions used to create font sets based upon a given locale code",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -1,148 +1,19 @@
 import {
   fontFace,
-  IRawStyle,
   IFontWeight
 } from '@uifabric/merge-styles/lib/index';
 import {
   IFontStyles
 } from '../interfaces/index';
-
+import { createFontStyles, FontWeights, LocalizedFontFamilies, LocalizedFontNames } from './fonts';
 import { getLanguage } from '@uifabric/utilities/lib/language';
 import { IFabricConfig } from '../interfaces/IFabricConfig';
 
 // Default urls.
 const DefaultBaseUrl = 'https://static2.sharepointonline.com/files/fabric/assets';
 
-// Fallback fonts, if specified system or web fonts are unavailable.
-const FontFamilyFallbacks = `'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif`;
-
-// Font face names to be registered.
-const FontNameArabic = 'Segoe UI Web (Arabic)';
-const FontNameCyrillic = 'Segoe UI Web (Cyrillic)';
-const FontNameEastEuropean = 'Segoe UI Web (East European)';
-const FontNameGreek = 'Segoe UI Web (Greek)';
-const FontNameHebrew = 'Segoe UI Web (Hebrew)';
-const FontNameThai = 'Leelawadee UI Web';
-const FontNameVietnamese = 'Segoe UI Web (Vietnamese)';
-const FontNameWestEuropean = 'Segoe UI Web (West European)';
-const FontNameSelawik = 'Selawik Web';
-
-// Font families with fallbacks, for the general regions.
-const FontFamilyArabic = `'${FontNameArabic}'`;
-const FontFamilyChineseSimplified = `'Microsoft Yahei', Verdana, Simsun`;
-const FontFamilyChineseTraditional = `'Microsoft Jhenghei', Pmingliu`;
-const FontFamilyCyrillic = `'${FontNameCyrillic}'`;
-const FontFamilyEastEuropean = `'${FontNameEastEuropean}'`;
-const FontFamilyGreek = `'${FontNameGreek}'`;
-const FontFamilyHebrew = `'${FontNameHebrew}'`;
-const FontFamilyHindi = `'Nirmala UI'`;
-const FontFamilyJapanese = `'Yu Gothic', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka`;
-const FontFamilyKorean = `'Malgun Gothic', Gulim`;
-const FontFamilySelawik = `'${FontNameSelawik}'`;
-const FontFamilyThai = `'Leelawadee UI Web', 'Kmer UI'`;
-const FontFamilyVietnamese = `'${FontNameVietnamese}'`;
-const FontFamilyWestEuropean = `'${FontNameWestEuropean}'`;
-
-// Mapping of language prefix to to font family.
-const LanguageToFontMap = {
-  'ar': FontFamilyArabic,
-  'bg': FontFamilyCyrillic,
-  'cs': FontFamilyEastEuropean,
-  'el': FontFamilyGreek,
-  'et': FontFamilyEastEuropean,
-  'he': FontFamilyHebrew,
-  'hi': FontFamilyHindi,
-  'hr': FontFamilyEastEuropean,
-  'hu': FontFamilyEastEuropean,
-  'ja': FontFamilyJapanese,
-  'kk': FontFamilyEastEuropean,
-  'ko': FontFamilyKorean,
-  'lt': FontFamilyEastEuropean,
-  'lv': FontFamilyEastEuropean,
-  'pl': FontFamilyEastEuropean,
-  'ru': FontFamilyCyrillic,
-  'sk': FontFamilyEastEuropean,
-  'sr-latn': FontFamilyEastEuropean,
-  'th': FontFamilyThai,
-  'tr': FontFamilyEastEuropean,
-  'uk': FontFamilyCyrillic,
-  'vi': FontFamilyVietnamese,
-  'zh-hans': FontFamilyChineseSimplified,
-  'zh-hant': FontFamilyChineseTraditional,
-};
-
-// Standard font sizes.
-export namespace FontSizes {
-  export const mini = '10px';
-  export const xSmall = '11px';
-  export const small = '12px';
-  export const smallPlus = '13px';
-  export const medium = '14px';
-  export const mediumPlus = '15px';
-  export const icon = '16px';
-  export const large = '17px';
-  export const xLarge = '21px';
-  export const xxLarge = '28px';
-  export const superLarge = '42px';
-  export const mega = '72px';
-}
-
-// Standard font weights.
-export namespace FontWeights {
-  export const light = 100;
-  export const semilight = 300;
-  export const regular = 400;
-  export const semibold = 600;
-  export const bold = 700;
-}
-
-// Standard Icon Sizes.
-export namespace IconFontSizes {
-  export const xSmall = '10px';
-  export const small = '12px';
-  export const medium = '16px';
-  export const large = '20px';
-}
-
 // Standard font styling.
-export const DefaultFontStyles: IFontStyles = {
-  tiny: _createFont(FontSizes.mini, FontWeights.semibold),
-  xSmall: _createFont(FontSizes.xSmall, FontWeights.regular),
-  small: _createFont(FontSizes.small, FontWeights.regular),
-  smallPlus: _createFont(FontSizes.smallPlus, FontWeights.regular),
-  medium: _createFont(FontSizes.medium, FontWeights.regular),
-  mediumPlus: _createFont(FontSizes.mediumPlus, FontWeights.regular),
-  large: _createFont(FontSizes.large, FontWeights.semilight),
-  xLarge: _createFont(FontSizes.xLarge, FontWeights.light),
-  xxLarge: _createFont(FontSizes.xxLarge, FontWeights.light),
-  superLarge: _createFont(FontSizes.superLarge, FontWeights.light),
-  mega: _createFont(FontSizes.mega, FontWeights.light)
-};
-
-function _getFontFamily(): string {
-  let language = getLanguage();
-  let fontFamily = FontFamilyWestEuropean;
-
-  for (let lang in LanguageToFontMap) {
-    if (LanguageToFontMap.hasOwnProperty(lang) && language && lang.indexOf(language) === 0) {
-      // tslint:disable-next-line:no-any
-      fontFamily = (LanguageToFontMap as any)[lang];
-      break;
-    }
-  }
-
-  return `${fontFamily}, ${FontFamilyFallbacks}`;
-}
-
-function _createFont(size: string, weight: IFontWeight): IRawStyle {
-  return {
-    fontFamily: _getFontFamily(),
-    MozOsxFontSmoothing: 'grayscale',
-    WebkitFontSmoothing: 'antialiased',
-    fontSize: size,
-    fontWeight: weight
-  };
-}
+export const DefaultFontStyles: IFontStyles = createFontStyles(getLanguage());
 
 function _registerFontFace(
   fontFamily: string,
@@ -154,8 +25,8 @@ function _registerFontFace(
   fontFace({
     fontFamily,
     src:
-    `url('${url}.woff2') format('woff2'),` +
-    `url('${url}.woff') format('woff')`,
+      `url('${url}.woff2') format('woff2'),` +
+      `url('${url}.woff') format('woff')`,
     fontWeight,
     fontStyle: 'normal'
   });
@@ -175,22 +46,20 @@ function _registerFontFaceSet(
   _registerFontFace(fontFamily, urlBase + '-semibold', FontWeights.semibold);
 }
 
-function _registerDefaultFontFaces(): void {
-  const baseUrl = _getFontBaseUrl();
-
+export function registerDefaultFontFaces(baseUrl: string): void {
   if (baseUrl) {
     const fontUrl = `${baseUrl}/fonts`;
 
     // Produce @font-face definitions for all supported web fonts.
-    _registerFontFaceSet(fontUrl, FontNameThai, 'leelawadeeui-thai', 'leelawadeeui');
-    _registerFontFaceSet(fontUrl, FontNameArabic, 'segoeui-arabic');
-    _registerFontFaceSet(fontUrl, FontNameCyrillic, 'segoeui-cyrillic');
-    _registerFontFaceSet(fontUrl, FontNameEastEuropean, 'segoeui-easteuropean');
-    _registerFontFaceSet(fontUrl, FontNameGreek, 'segoeui-greek');
-    _registerFontFaceSet(fontUrl, FontNameHebrew, 'segoeui-hebrew');
-    _registerFontFaceSet(fontUrl, FontNameVietnamese, 'segoeui-vietnamese');
-    _registerFontFaceSet(fontUrl, FontNameWestEuropean, 'segoeui-westeuropean');
-    _registerFontFaceSet(fontUrl, FontFamilySelawik, 'selawik', 'selawik');
+    _registerFontFaceSet(fontUrl, LocalizedFontNames.Thai, 'leelawadeeui-thai', 'leelawadeeui');
+    _registerFontFaceSet(fontUrl, LocalizedFontNames.Arabic, 'segoeui-arabic');
+    _registerFontFaceSet(fontUrl, LocalizedFontNames.Cyrillic, 'segoeui-cyrillic');
+    _registerFontFaceSet(fontUrl, LocalizedFontNames.EastEuropean, 'segoeui-easteuropean');
+    _registerFontFaceSet(fontUrl, LocalizedFontNames.Greek, 'segoeui-greek');
+    _registerFontFaceSet(fontUrl, LocalizedFontNames.Hebrew, 'segoeui-hebrew');
+    _registerFontFaceSet(fontUrl, LocalizedFontNames.Vietnamese, 'segoeui-vietnamese');
+    _registerFontFaceSet(fontUrl, LocalizedFontNames.WestEuropean, 'segoeui-westeuropean');
+    _registerFontFaceSet(fontUrl, LocalizedFontFamilies.Selawik, 'selawik', 'selawik');
 
     // Leelawadee UI (Thai) does not have a 'light' weight, so we override
     // the font-face generated above to use the 'semilight' weight instead.
@@ -217,4 +86,4 @@ function _getFontBaseUrl(): string {
 /**
  * Register the font faces.
  */
-_registerDefaultFontFaces();
+registerDefaultFontFaces(_getFontBaseUrl());

--- a/packages/styling/src/styles/fonts.ts
+++ b/packages/styling/src/styles/fonts.ts
@@ -1,0 +1,142 @@
+import {
+  IRawStyle,
+  IFontWeight
+} from '@uifabric/merge-styles/lib/index';
+import {
+  IFontStyles
+} from '../interfaces/index';
+
+// Fallback fonts, if specified system or web fonts are unavailable.
+const FontFamilyFallbacks = `'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif`;
+
+// Font face names to be registered.
+export namespace LocalizedFontNames {
+  export const Arabic = 'Segoe UI Web (Arabic)';
+  export const Cyrillic = 'Segoe UI Web (Cyrillic)';
+  export const EastEuropean = 'Segoe UI Web (East European)';
+  export const Greek = 'Segoe UI Web (Greek)';
+  export const Hebrew = 'Segoe UI Web (Hebrew)';
+  export const Thai = 'Leelawadee UI Web';
+  export const Vietnamese = 'Segoe UI Web (Vietnamese)';
+  export const WestEuropean = 'Segoe UI Web (West European)';
+  export const Selawik = 'Selawik Web';
+}
+
+// Font families with fallbacks, for the general regions.
+export namespace LocalizedFontFamilies {
+  export const Arabic = `'${LocalizedFontNames.Arabic}'`;
+  export const ChineseSimplified = `'Microsoft Yahei', Verdana, Simsun`;
+  export const ChineseTraditional = `'Microsoft Jhenghei', Pmingliu`;
+  export const Cyrillic = `'${LocalizedFontNames.Cyrillic}'`;
+  export const EastEuropean = `'${LocalizedFontNames.EastEuropean}'`;
+  export const Greek = `'${LocalizedFontNames.Greek}'`;
+  export const Hebrew = `'${LocalizedFontNames.Hebrew}'`;
+  export const Hindi = `'Nirmala UI'`;
+  export const Japanese = `'Yu Gothic', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka`;
+  export const Korean = `'Malgun Gothic', Gulim`;
+  export const Selawik = `'${LocalizedFontNames.Selawik}'`;
+  export const Thai = `'Leelawadee UI Web', 'Kmer UI'`;
+  export const Vietnamese = `'${LocalizedFontNames.Vietnamese}'`;
+  export const WestEuropean = `'${LocalizedFontNames.WestEuropean}'`;
+}
+
+// Mapping of language prefix to to font family.
+const LanguageToFontMap = {
+  'ar': LocalizedFontFamilies.Arabic,
+  'bg': LocalizedFontFamilies.Cyrillic,
+  'cs': LocalizedFontFamilies.EastEuropean,
+  'el': LocalizedFontFamilies.Greek,
+  'et': LocalizedFontFamilies.EastEuropean,
+  'he': LocalizedFontFamilies.Hebrew,
+  'hi': LocalizedFontFamilies.Hindi,
+  'hr': LocalizedFontFamilies.EastEuropean,
+  'hu': LocalizedFontFamilies.EastEuropean,
+  'ja': LocalizedFontFamilies.Japanese,
+  'kk': LocalizedFontFamilies.EastEuropean,
+  'ko': LocalizedFontFamilies.Korean,
+  'lt': LocalizedFontFamilies.EastEuropean,
+  'lv': LocalizedFontFamilies.EastEuropean,
+  'pl': LocalizedFontFamilies.EastEuropean,
+  'ru': LocalizedFontFamilies.Cyrillic,
+  'sk': LocalizedFontFamilies.EastEuropean,
+  'sr-latn': LocalizedFontFamilies.EastEuropean,
+  'th': LocalizedFontFamilies.Thai,
+  'tr': LocalizedFontFamilies.EastEuropean,
+  'uk': LocalizedFontFamilies.Cyrillic,
+  'vi': LocalizedFontFamilies.Vietnamese,
+  'zh-hans': LocalizedFontFamilies.ChineseSimplified,
+  'zh-hant': LocalizedFontFamilies.ChineseTraditional,
+};
+
+// Standard font sizes.
+export namespace FontSizes {
+  export const mini = '10px';
+  export const xSmall = '11px';
+  export const small = '12px';
+  export const smallPlus = '13px';
+  export const medium = '14px';
+  export const mediumPlus = '15px';
+  export const icon = '16px';
+  export const large = '17px';
+  export const xLarge = '21px';
+  export const xxLarge = '28px';
+  export const superLarge = '42px';
+  export const mega = '72px';
+}
+
+// Standard font weights.
+export namespace FontWeights {
+  export const light = 100;
+  export const semilight = 300;
+  export const regular = 400;
+  export const semibold = 600;
+  export const bold = 700;
+}
+
+// Standard Icon Sizes.
+export namespace IconFontSizes {
+  export const xSmall = '10px';
+  export const small = '12px';
+  export const medium = '16px';
+  export const large = '20px';
+}
+
+export function createFontStyles(localeCode: string | null): IFontStyles {
+  return {
+    tiny: _createFont(FontSizes.mini, FontWeights.semibold, localeCode),
+    xSmall: _createFont(FontSizes.xSmall, FontWeights.regular, localeCode),
+    small: _createFont(FontSizes.small, FontWeights.regular, localeCode),
+    smallPlus: _createFont(FontSizes.smallPlus, FontWeights.regular, localeCode),
+    medium: _createFont(FontSizes.medium, FontWeights.regular, localeCode),
+    mediumPlus: _createFont(FontSizes.mediumPlus, FontWeights.regular, localeCode),
+    large: _createFont(FontSizes.large, FontWeights.semilight, localeCode),
+    xLarge: _createFont(FontSizes.xLarge, FontWeights.light, localeCode),
+    xxLarge: _createFont(FontSizes.xxLarge, FontWeights.light, localeCode),
+    superLarge: _createFont(FontSizes.superLarge, FontWeights.light, localeCode),
+    mega: _createFont(FontSizes.mega, FontWeights.light, localeCode)
+  };
+}
+
+function _getFontFamily(language: string | null): string {
+  let fontFamily = LocalizedFontFamilies.WestEuropean;
+
+  for (let lang in LanguageToFontMap) {
+    if (LanguageToFontMap.hasOwnProperty(lang) && language && lang.indexOf(language) === 0) {
+      // tslint:disable-next-line:no-any
+      fontFamily = (LanguageToFontMap as any)[lang];
+      break;
+    }
+  }
+
+  return `${fontFamily}, ${FontFamilyFallbacks}`;
+}
+
+function _createFont(size: string, weight: IFontWeight, localeCode: string | null): IRawStyle {
+  return {
+    fontFamily: _getFontFamily(localeCode),
+    MozOsxFontSmoothing: 'grayscale',
+    WebkitFontSmoothing: 'antialiased',
+    fontSize: size,
+    fontWeight: weight
+  };
+}

--- a/packages/styling/src/styles/index.ts
+++ b/packages/styling/src/styles/index.ts
@@ -1,6 +1,7 @@
 export { AnimationStyles } from './AnimationStyles';
 export { DefaultPalette } from './DefaultPalette';
-export { DefaultFontStyles, FontSizes, FontWeights, IconFontSizes } from './DefaultFontStyles';
+export { DefaultFontStyles, registerDefaultFontFaces } from './DefaultFontStyles';
+export { FontSizes, FontWeights, IconFontSizes, createFontStyles } from './fonts';
 export { getFocusStyle } from './getFocusStyle';
 export { hiddenContentStyle } from './hiddenContentStyle';
 export {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Outlook.com has need to be able to change the font set during run-time; both because we don't have the user's language when we render the page, and because we allow the user to dynamically change their language while the app is running. This is currently possible by calling `loadTheme()` with a given font set, but currently Fabric's logic to create a localized font set is not exposed to consumers. This change exposes a function to create a localized font set using Fabric's logic, and to (re-)register the @font-face declarations with a baseUrl, if they don't through the IFabricConfig option.
