### PR TITLE
SplitButton: Avoid applying selector rest changes when in toggle state

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-SplitButtonToggleState_2017-11-14-23-30.json
+++ b/common/changes/office-ui-fabric-react/malozano-SplitButtonToggleState_2017-11-14-23-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SplitButton: Avoid applying selector rest changes when in toggle state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.classNames.ts
@@ -37,10 +37,10 @@ export const getClassNames = memoizeFunction((
         styles.splitButtonContainerChecked,
         {
           selectors: {
-            ':hover': styles.splitButtonContainerHovered
+            ':hover': styles.splitButtonContainerCheckedHovered
           }
         }],
-      !disabled && [{
+      !disabled && !checked && [{
         selectors: {
           ':hover': styles.splitButtonContainerHovered,
           ':focus': styles.splitButtonContainerFocused


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Avoid applying rest selector visual changes when in toggle state.
