### PR TITLE
Toggle: Add label as fall back ariaLabel for screen reader

### DIFF
--- a/common/changes/office-ui-fabric-react/toggle-arialabel_2017-11-15-17-32.json
+++ b/common/changes/office-ui-fabric-react/toggle-arialabel_2017-11-15-17-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: Add label as fall back ariaLabel.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.tsx
@@ -101,7 +101,7 @@ export class Toggle extends BaseComponent<IToggleProps, IToggleState> implements
             ref={ this._resolveRef('_toggleButton') }
             aria-disabled={ disabled }
             aria-pressed={ isChecked }
-            aria-label={ ariaLabel }
+            aria-label={ ariaLabel ? ariaLabel : label }
             data-is-focusable={ true }
             onChange={ this._noop }
             onClick={ this._onClick }

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Toggle renders toggle correctly 1`] = `
   >
     <button
       aria-disabled={undefined}
-      aria-label={undefined}
+      aria-label="Label"
       aria-pressed={false}
       className=
           ms-Toggle-background


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Previously, when `onAriaLabel` and `offAriaLabel` weren't specified, the screen reader would instead read `onText` and `offText`. For this example we show on the website:
```
    <Toggle
      defaultChecked={ false }
      label='Enabled and unchecked'
      onText='On'
      offText='Off'
      onFocus={ () => console.log('onFocus called') }
      onBlur={ () => console.log('onBlur called') }
    /> 
```
the screen reader would say "on, On, button" instead of "on, Enabled and unchecked, button", which is redundant and unclear.

With this change, the screen reader says "on, Enabled and unchecked, button", unless `onAriaLabel` and `offAriaLabel` are specified.

#### Focus areas to test

(optional)
