### PR TITLE
Fix experiment imports for FloatingPicker and ExtendedPicker

### DIFF
--- a/common/changes/@uifabric/experiments/fixExperimentImports_2017-11-15-17-42.json
+++ b/common/changes/@uifabric/experiments/fixExperimentImports_2017-11-15-17-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fix experiment imports for FloatingPicker and ExtendedPicker components",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "amyngu@microsoft.com"
+}

--- a/packages/experiments/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/experiments/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -13,8 +13,8 @@ import { BaseAutoFill } from 'office-ui-fabric-react/lib/components/pickers/Auto
 import { IPickerItemProps, IInputProps } from 'office-ui-fabric-react/lib/Pickers';
 import * as stylesImport from './BaseExtendedPicker.scss';
 import { IBaseExtendedPickerProps, IBaseExtendedPicker } from './BaseExtendedPicker.types';
-import { IBaseFloatingPickerProps, BaseFloatingPicker } from 'experiments/lib/FloatingPicker';
-import { BaseSelectedItemsList, IBaseSelectedItemsListProps } from 'experiments/lib/SelectedItemsList';
+import { IBaseFloatingPickerProps, BaseFloatingPicker } from '../../FloatingPicker';
+import { BaseSelectedItemsList, IBaseSelectedItemsListProps } from '../../SelectedItemsList';
 // tslint:disable-next-line:no-any
 const styles: any = stylesImport;
 

--- a/packages/experiments/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/experiments/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseAutoFill, IInputProps } from 'office-ui-fabric-react/lib/Pickers';
-import { IBaseFloatingPickerProps } from 'experiments/lib/FloatingPicker';
-import { IBaseSelectedItemsListProps } from 'experiments/lib/SelectedItemsList';
+import { IBaseFloatingPickerProps } from '../../FloatingPicker';
+import { IBaseSelectedItemsListProps } from '../../SelectedItemsList';
 
 export interface IBaseExtendedPicker<T> {
   /** Forces the picker to resolve */

--- a/packages/experiments/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.tsx
+++ b/packages/experiments/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.tsx
@@ -2,7 +2,7 @@
 import { IPickerItemProps, ValidationState } from 'office-ui-fabric-react/lib/Pickers';
 /* tslint:enable */
 
-import { IExtendedPersonaProps } from 'experiments/lib/SelectedItemsList';
+import { IExtendedPersonaProps } from '../../../SelectedItemsList';
 import './ExtendedPeoplePicker.scss';
 import { BaseExtendedPicker } from '../BaseExtendedPicker';
 import { IBaseExtendedPickerProps } from '../BaseExtendedPicker.types';

--- a/packages/experiments/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
+++ b/packages/experiments/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
@@ -13,9 +13,9 @@ import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { IPersonaWithMenu } from 'office-ui-fabric-react/lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.types';
 import { people, mru, groupOne, groupTwo } from './PeopleExampleData';
 import './ExtendedPeoplePicker.Basic.Example.scss';
-import { FloatingPeoplePicker, IBaseFloatingPickerProps } from 'experiments/lib/FloatingPicker';
+import { FloatingPeoplePicker, IBaseFloatingPickerProps } from '../../FloatingPicker';
 import { IBaseSelectedItemsListProps, IExtendedPersonaProps, ISelectedPeopleProps, SelectedPeopleList }
-  from 'experiments/lib/SelectedItemsList';
+  from '../../SelectedItemsList';
 
 export interface IPeoplePickerExampleState {
   peopleList: IPersonaProps[];

--- a/packages/experiments/src/components/ExtendedPicker/examples/PeopleExampleData.ts
+++ b/packages/experiments/src/components/ExtendedPicker/examples/PeopleExampleData.ts
@@ -1,5 +1,5 @@
 import { PersonaPresence } from 'office-ui-fabric-react/lib/Persona';
-import { IExtendedPersonaProps } from 'experiments/lib/SelectedItemsList';
+import { IExtendedPersonaProps } from '../../SelectedItemsList';
 import { TestImages } from 'office-ui-fabric-react/lib/common/TestImages';
 
 export const people: (IExtendedPersonaProps & { key: string | number })[] = [

--- a/packages/experiments/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/experiments/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 /* tslint:enable */
 import { css, getId } from '../../../../Utilities';
 import { Persona, PersonaSize, PersonaPresence } from 'office-ui-fabric-react/lib/Persona';
-import { IPeoplePickerItemProps } from 'experiments/lib/ExtendedPicker';
+import { IPeoplePickerItemProps } from '../../../ExtendedPicker';
 import { ValidationState } from 'office-ui-fabric-react/lib/Pickers';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import * as stylesImport from './PickerItemsDefault.scss';

--- a/packages/experiments/src/components/FloatingPicker/PeoplePicker/examples/FloatingPeoplePicker.Basic.Example.tsx
+++ b/packages/experiments/src/components/FloatingPicker/PeoplePicker/examples/FloatingPeoplePicker.Basic.Example.tsx
@@ -11,7 +11,7 @@ import { IBasePickerSuggestionsProps, ValidationState, SuggestionsController } f
 import { IBaseFloatingPicker } from '../../BaseFloatingPicker.types';
 import { FloatingPeoplePicker } from '../FloatingPeoplePicker';
 import { IPersonaWithMenu } from 'office-ui-fabric-react/lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.types';
-import { people, mru } from 'experiments/lib/ExtendedPicker';
+import { people, mru } from '../../../ExtendedPicker';
 import './FloatingPeoplePicker.Basic.Example.scss';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 

--- a/packages/experiments/src/components/SelectedItemsList/examples/SelectedPeopleList.Basic.Example.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/examples/SelectedPeopleList.Basic.Example.tsx
@@ -6,7 +6,7 @@ import {
   autobind
 } from 'office-ui-fabric-react/lib/Utilities';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import { people, groupOne, groupTwo } from 'experiments/lib/ExtendedPicker';
+import { people, groupOne, groupTwo } from '../../ExtendedPicker';
 import 'office-ui-fabric-react/lib/components/Pickers/PeoplePicker/examples/PeoplePicker.Types.Example.scss';
 import { IBaseSelectedItemsListProps } from '../BaseSelectedItemsList.types';
 import { IExtendedPersonaProps, SelectedPeopleList } from '../SelectedPeopleList/SelectedPeopleList';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue:
- [x] Include a change request file using `$ npm run change`

#### Description of changes

FloatingPicker and ExtendedPicker components import from other experiment components. Using experiments/lib/... worked inside of the repo, but not in the npm public package 
