### PR TITLE
Modifying the combobox dropdown alignment to have the scrollbar align with the target element

### DIFF
--- a/common/changes/office-ui-fabric-react/users-caseyyu2-comboboxDropdownAlignment_2017-11-16-19-43.json
+++ b/common/changes/office-ui-fabric-react/users-caseyyu2-comboboxDropdownAlignment_2017-11-16-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Change the combobox alignment to be the same as the design of dropdown",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xiyu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -25,6 +25,9 @@ import {
   getCaretDownButtonStyles
 } from './ComboBox.styles';
 import {
+  IComboBoxStyles,
+} from './ComboBox.types';
+import {
   IComboBoxClassNames,
   getClassNames,
   getComboBoxOptionClassNames
@@ -255,7 +258,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     let setWidth = isOpen ? (this._comboBoxWrapper.clientWidth - 2) + 'px' : undefined;
 
     this._classNames = getClassNames(
-      getStyles(theme!, customStyles, setWidth),
+      getStyles(theme!, customStyles),
       className!,
       !!isOpen,
       !!disabled,
@@ -800,6 +803,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       onRenderLowerContent = this._onRenderLowerContent
     } = props;
 
+    const dropdownWidth = (this.props.styles) ? this.props.styles.dropdownWidth : 0;
+
     return (
       <Callout
         isBeakVisible={ false }
@@ -812,6 +817,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         target={ this._comboBoxWrapper }
         onDismiss={ this._onDismiss }
         setInitialFocus={ false }
+        calloutWidth={ dropdownWidth || this._comboBoxWrapper.clientWidth }
       >
         <div className={ this._classNames.optionsContainerWrapper } ref={ this._resolveRef('_comboBoxMenu') }>
           { (onRenderList as any)({ ...props }, this._onRenderList) }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -798,10 +798,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     let {
       onRenderList,
       calloutProps,
+      dropdownWidth,
       onRenderLowerContent = this._onRenderLowerContent
     } = props;
-
-    const dropdownWidth = (this.props.styles) ? this.props.styles.dropdownWidth : 0;
 
     return (
       <Callout

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -815,7 +815,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         target={ this._comboBoxWrapper }
         onDismiss={ this._onDismiss }
         setInitialFocus={ false }
-        calloutWidth={ dropdownWidth || this._comboBoxWrapper.clientWidth }
+        calloutWidth={ dropdownWidth || this._comboBoxWrapper.clientWidth + 2 }
       >
         <div className={ this._classNames.optionsContainerWrapper } ref={ this._resolveRef('_comboBoxMenu') }>
           { (onRenderList as any)({ ...props }, this._onRenderList) }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -255,8 +255,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     let hasErrorMessage = (errorMessage && errorMessage.length > 0) ? true : false;
 
-    let setWidth = isOpen ? (this._comboBoxWrapper.clientWidth - 2) + 'px' : undefined;
-
     this._classNames = getClassNames(
       getStyles(theme!, customStyles),
       className!,

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -117,6 +117,12 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * Add additional content below the callout list.
    */
   onRenderLowerContent?: IRenderFunction<IComboBoxProps>;
+
+  /**
+  * Custom width for dropdown. If value is 0, width of the input field is used.
+  * @default 0
+  */
+  dropdownWidth?: number;
 }
 
 export interface IComboBoxStyles {
@@ -209,12 +215,6 @@ export interface IComboBoxStyles {
    * Styles for a divider in the options.
    */
   divider: IStyle;
-
-  /**
-  * Custom width for dropdown. If value is 0, width of the input field is used.
-  * @default 0
-  */
-  dropdownWidth?: number;
 }
 
 export interface IComboBoxOptionStyles extends IButtonStyles {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -209,6 +209,12 @@ export interface IComboBoxStyles {
    * Styles for a divider in the options.
    */
   divider: IStyle;
+
+  /**
+  * Custom width for dropdown. If value is 0, width of the input field is used.
+  * @default 0
+  */
+  dropdownWidth?: number;
 }
 
 export interface IComboBoxOptionStyles extends IButtonStyles {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #3400 

#### Description of changes
Dropdown control and combobox control use different mechanisms to set the width for their dropdown.
Dropdown renders a callout setting the calloutWidth by getting the target reference
clientWdith calloutWidth={ dropdownWidth || this._dropDown.clientWidth }

Combobox is getting the width set using the similar mechanism where it's getting width from this._comboBoxWrapper.clientWidth - 2. However, this width is not set at the callout component level, it's setting inside the optionsContainerWrapper, which cause the scrollbar overflow the whole width.

So I updated the combobox dropdown to be the same as the dropdown mechanism

#### Focus areas to test

Click on combobox
Expected
the scrollbar should be aligned at the end of the target element.

Before alignment fix (it's between combobox and dropdown)
![combobox dropdown](https://user-images.githubusercontent.com/8844898/32912029-b92a0208-cac2-11e7-919f-1548897b5f65.gif)

After fix combobox
![combobox fixed1](https://user-images.githubusercontent.com/8844898/32922936-a3124e18-cae9-11e7-8dc5-4832038d21a6.gif)

