### PR TITLE
Theming: Fix listText semantic slot name

### DIFF
--- a/common/changes/@uifabric/styling/phkuo-fixListText_2017-11-16-03-20.json
+++ b/common/changes/@uifabric/styling/phkuo-fixListText_2017-11-16-03-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Theming: fix listText semantic slot",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
@@ -481,7 +481,7 @@ export class ThemeGeneratorPage extends BaseComponent<any, IThemeGeneratorPageSt
     }
     document.body.style.backgroundColor = themeAsJson.backgroundColor;
     document.body.style.color = themeAsJson.bodyText;
-    loadTheme({ palette: themeAsJson });
+    console.log('Full theme... ', loadTheme({ palette: themeAsJson }));
   }
 
   @autobind

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -238,7 +238,7 @@ export interface ISemanticColors {
   /**
    * The default text color for list item titles and text in column fields.
    */
-  listTextColor: string;
+  listText: string;
 
   /**
    * The background color of a hovered list item.

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -254,4 +254,10 @@ export interface ISemanticColors {
    * The background color of a checked and hovered list item.
    */
   listItemBackgroundCheckedHovered: string;
+
+  //// DEPRECATED SLOTS
+  // Do not use these slots, they are only maintained for backwards compatibility.
+
+  /** DEPRECATED use listText instead */
+  listTextColor: string;
 }

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -66,21 +66,26 @@ export function createTheme(theme: IPartialTheme): ITheme {
     newPalette.accent = newPalette.themePrimary;
   }
 
+  // mix in custom overrides with good slots first, since custom overrides might be used in fixing deprecated slots
+  let newSemanticColors = { ..._makeSemanticColorsFromPalette(newPalette, !!theme.isInverted), ...theme.semanticColors };
+  newSemanticColors = { ..._fixDeprecatedSlots(newSemanticColors), ...theme.semanticColors };
+
   return {
     palette: newPalette,
     fonts: {
       ...DefaultFontStyles,
       ...theme.fonts
     },
-    semanticColors: { ..._makeSemanticColorsFromPalette(newPalette, !!theme.isInverted), ...theme.semanticColors },
+    semanticColors: newSemanticColors,
     isInverted: !!theme.isInverted
   } as ITheme;
 }
 
 // Generates all the semantic slot colors based on the Fabric palette.
 // We'll use these as fallbacks for semantic slots that the passed in theme did not define.
+// This does NOT fix deprecated slots.
 function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean): ISemanticColors {
-  return {
+  let toReturn: ISemanticColors = {
     bodyBackground: p.white,
     bodyText: p.neutralPrimary,
     bodyTextChecked: p.black,
@@ -128,6 +133,17 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean): ISema
     listText: p.neutralPrimary,
     listItemBackgroundHovered: p.neutralLighter,
     listItemBackgroundChecked: p.neutralLight,
-    listItemBackgroundCheckedHovered: p.neutralQuaternaryAlt
+    listItemBackgroundCheckedHovered: p.neutralQuaternaryAlt,
+
+    // Deprecated slots, fixed by _fixDeprecatedSlots()
+    listTextColor: ''
   };
+
+  return toReturn;
+}
+
+function _fixDeprecatedSlots(s: ISemanticColors): ISemanticColors {
+  s.listTextColor = s.listText;
+
+  return s;
 }

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -125,7 +125,7 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean): ISema
     menuHeader: p.themePrimary,
 
     listBackground: p.white,
-    listTextColor: p.neutralPrimary,
+    listText: p.neutralPrimary,
     listItemBackgroundHovered: p.neutralLighter,
     listItemBackgroundChecked: p.neutralLight,
     listItemBackgroundCheckedHovered: p.neutralQuaternaryAlt


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix incorrect naming convention for the listText semantic slot which is not theming right now because it is incorrectly named.
Added framework for "deprecating" semantic slots.

#### Focus areas to test

(optional)
