### PR TITLE
Dropdown: Add parameter to focus interface to allow open dropdown after set focus.

### DIFF
--- a/common/changes/office-ui-fabric-react/yimwu-dropdownfocus_2017-11-16-04-48.json
+++ b/common/changes/office-ui-fabric-react/yimwu-dropdownfocus_2017-11-16-04-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Update dropdown interface to allow open dropdown after focus and remove extra focus border for dropdown option.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "yimwu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -195,8 +195,6 @@ $DropDown-item-height: 32px;
     color: inherit;
   }
 
-  @include focus-border();
-
   &:focus {
     background-color: $ms-color-neutralLighter;
     @include highContrastListItemState;
@@ -221,8 +219,6 @@ $DropDown-item-height: 32px;
 .item.itemIsSelected {
   background-color: $Dropdown-selectedItem-bg;
   color: $ms-color-black;
-
-  @include focus-border();
 
   @include highContrastListItemState;
 }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -212,9 +212,14 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
     );
   }
 
-  public focus() {
+  public focus(shouldOpenOnFocus?: boolean) {
     if (this._dropDown && this._dropDown.tabIndex !== -1) {
       this._dropDown.focus();
+      if (shouldOpenOnFocus) {
+        this.setState({
+          isOpen: true
+        });
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -6,7 +6,7 @@ import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 export { SelectableOptionMenuItemType as DropdownMenuItemType } from '../../utilities/selectableOption/SelectableOption.types';
 
 export interface IDropdown {
-  focus: () => void;
+  focus: (shouldOpenOnFocus?: boolean) => void;
 }
 
 export interface IDropdownProps extends ISelectableDroppableTextProps<HTMLDivElement> {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import { Dropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { autobind } from '../../../Utilities';
+import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { Dropdown, IDropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { autobind, BaseComponent } from '../../../Utilities';
 import './Dropdown.Basic.Example.scss';
 
-export class DropdownBasicExample extends React.Component<any, any> {
+export class DropdownBasicExample extends BaseComponent<any, any> {
+  private _basicDropDown: IDropdown;
   constructor() {
     super();
     this.state = {
@@ -42,8 +44,12 @@ export class DropdownBasicExample extends React.Component<any, any> {
           }
           onFocus={ this._log('onFocus called') }
           onBlur={ this._log('onBlur called') }
+          componentRef={ this._resolveRef('_basicDropDown') }
         />
-
+        <PrimaryButton
+          text='Set focus'
+          onClick={ this._onSetFocusButtonClicked }
+        />
         <Dropdown
           className='Dropdown-example'
           label='Disabled uncontrolled example with defaultSelectedKey:'
@@ -154,6 +160,13 @@ export class DropdownBasicExample extends React.Component<any, any> {
       </div>
 
     );
+  }
+
+  @autobind
+  private _onSetFocusButtonClicked() {
+    if (this._basicDropDown) {
+      this._basicDropDown.focus(true);
+    }
   }
 
   @autobind

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -163,13 +163,6 @@ export class DropdownBasicExample extends BaseComponent<any, any> {
   }
 
   @autobind
-  private _onSetFocusButtonClicked() {
-    if (this._basicDropdown) {
-      this._basicDropdown.focus(true);
-    }
-  }
-
-  @autobind
   public changeState(item: IDropdownOption) {
     console.log('here is the things updating...' + item.key + ' ' + item.text + ' ' + item.selected);
     this.setState({ selectedItem: item });
@@ -199,6 +192,13 @@ export class DropdownBasicExample extends BaseComponent<any, any> {
       newArray[i] = array[i];
     }
     return newArray;
+  }
+
+  @autobind
+  private _onSetFocusButtonClicked() {
+    if (this._basicDropdown) {
+      this._basicDropdown.focus(true);
+    }
   }
 
   private _log(str: string): () => void {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -5,7 +5,7 @@ import { autobind, BaseComponent } from '../../../Utilities';
 import './Dropdown.Basic.Example.scss';
 
 export class DropdownBasicExample extends BaseComponent<any, any> {
-  private _basicDropDown: IDropdown;
+  private _basicDropdown: IDropdown;
   constructor() {
     super();
     this.state = {
@@ -44,7 +44,7 @@ export class DropdownBasicExample extends BaseComponent<any, any> {
           }
           onFocus={ this._log('onFocus called') }
           onBlur={ this._log('onBlur called') }
-          componentRef={ this._resolveRef('_basicDropDown') }
+          componentRef={ this._resolveRef('_basicDropdown') }
         />
         <PrimaryButton
           text='Set focus'
@@ -164,8 +164,8 @@ export class DropdownBasicExample extends BaseComponent<any, any> {
 
   @autobind
   private _onSetFocusButtonClicked() {
-    if (this._basicDropDown) {
-      this._basicDropDown.focus(true);
+    if (this._basicDropdown) {
+      this._basicDropdown.focus(true);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
1. Add parameter to focus interface to allow open dropdown after set focus.
2. Remove extra focus border for dropdown option.
before:
![image](https://user-images.githubusercontent.com/9662034/32874497-72d45fcc-ca47-11e7-9fd7-2cabdcc51120.png)

after: 
![image](https://user-images.githubusercontent.com/9662034/32874451-2f57d350-ca47-11e7-90e2-622b1422d2d2.png)

#### Focus areas to test

(optional)
