### PR TITLE
ContextualMenu: Menus Dismiss on Tab

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-contextualMenuTab_2017-11-17-03-11.json
+++ b/common/changes/office-ui-fabric-react/chiechan-contextualMenuTab_2017-11-17-03-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Contextual Menu: made it so we can tab through items",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -640,7 +640,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     let submenuCloseKey = getRTL() ? KeyCodes.right : KeyCodes.left;
 
     if (ev.which === KeyCodes.escape
-      // || ev.which === KeyCodes.tab
       || (ev.which === submenuCloseKey && this.props.isSubMenu && this.props.arrowDirection === FocusZoneDirection.vertical)) {
       // When a user presses escape, we will try to refocus the previous focused element.
       this._isFocusingPreviousElement = true;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -289,6 +289,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                 className={ this._classNames.root }
                 direction={ arrowDirection }
                 isCircularNavigation={ true }
+                allowTabKey={ true }
               >
                 <ul
                   aria-label={ ariaLabel }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -640,7 +640,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     let submenuCloseKey = getRTL() ? KeyCodes.right : KeyCodes.left;
 
     if (ev.which === KeyCodes.escape
-      || ev.which === KeyCodes.tab
+      // || ev.which === KeyCodes.tab
       || (ev.which === submenuCloseKey && this.props.isSubMenu && this.props.arrowDirection === FocusZoneDirection.vertical)) {
       // When a user presses escape, we will try to refocus the previous focused element.
       this._isFocusingPreviousElement = true;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -358,14 +358,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
                 this._moveFocusDown();
               }
               break;
-            } else if (direction === FocusZoneDirection.horizontal) {
-              if (ev.shiftKey) {
-                this._moveFocusLeft();
-              } else {
-                this._moveFocusRight();
-              }
-              break;
-            } else if (direction === FocusZoneDirection.bidirectional) {
+            } else if (direction === FocusZoneDirection.horizontal || direction === FocusZoneDirection.bidirectional) {
               if (ev.shiftKey) {
                 this._moveFocusLeft();
               } else {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -350,22 +350,24 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           return;
 
         case KeyCodes.tab:
-          if (direction === FocusZoneDirection.vertical) {
-            if (ev.shiftKey) {
-              this._moveFocusUp();
-            } else {
-              this._moveFocusDown();
+          if (this.props.allowTabKey) {
+            if (direction === FocusZoneDirection.vertical) {
+              if (ev.shiftKey) {
+                this._moveFocusUp();
+              } else {
+                this._moveFocusDown();
+              }
+              break;
+            } else if (direction === FocusZoneDirection.horizontal) {
+              if (ev.shiftKey) {
+                this._moveFocusLeft();
+              } else {
+                this._moveFocusRight();
+              }
+              break;
             }
-            break;
-          } else if (direction === FocusZoneDirection.horizontal) {
-            if (ev.shiftKey) {
-              this._moveFocusLeft();
-            } else {
-              this._moveFocusRight();
-            }
-            break;
+            return;
           }
-          return;
 
         case KeyCodes.home:
           if (

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -349,7 +349,6 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           }
           return;
 
-
         case KeyCodes.tab:
           if (direction === FocusZoneDirection.vertical) {
             if (ev.shiftKey) {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -365,6 +365,13 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
                 this._moveFocusRight();
               }
               break;
+            } else if (direction === FocusZoneDirection.bidirectional) {
+              if (ev.shiftKey) {
+                this._moveFocusLeft();
+              } else {
+                this._moveFocusRight();
+              }
+              break;
             }
             return;
           }

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -349,6 +349,25 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           }
           return;
 
+
+        case KeyCodes.tab:
+          if (direction === FocusZoneDirection.vertical) {
+            if (ev.shiftKey) {
+              this._moveFocusUp();
+            } else {
+              this._moveFocusDown();
+            }
+            break;
+          } else if (direction === FocusZoneDirection.horizontal) {
+            if (ev.shiftKey) {
+              this._moveFocusLeft();
+            } else {
+              this._moveFocusRight();
+            }
+            break;
+          }
+          return;
+
         case KeyCodes.home:
           if (
             this._isElementInput(ev.target as HTMLElement) &&

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
@@ -103,7 +103,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
   /** Allow focus to move to root */
   allowFocusRoot?: boolean;
 
-  /** Allows tab key to be handled */
+  /** Allows tab key to be handled, a side effect is that users will not be able to tab out of the focus zone */
   allowTabKey?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
@@ -102,6 +102,9 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
 
   /** Allow focus to move to root */
   allowFocusRoot?: boolean;
+
+  /** Allows tab key to be handled */
+  allowTabKey?: boolean;
 }
 
 export enum FocusZoneDirection {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue:  
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Before: When we open a contextual menu and hit tab, we would select the first item and then if we hit tab again, we would dismiss our menu.

After: Now we would go to the next item. I also added functionality to allow us to go to the previous menu item.

![tab next item](https://user-images.githubusercontent.com/5695630/32927954-5eea6c28-cb04-11e7-8c7a-b75b8b305443.gif)

#### Focus areas to test

Tested in the Contextual Menu component page.