### PR TITLE
Toggle: Split out a separate example for on and offAriaLabel

### DIFF
--- a/common/changes/office-ui-fabric-react/toggle-examples_2017-11-17-18-11.json
+++ b/common/changes/office-ui-fabric-react/toggle-examples_2017-11-17-18-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: Split out a new example for on and offAriaLabels to clarify the experince.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/TogglePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/TogglePage.tsx
@@ -6,11 +6,13 @@ import {
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 import { ToggleBasicExample } from './examples/Toggle.Basic.Example';
+import { ToggleAriaLabelExample } from './examples/Toggle.AriaLabel.Example';
 import { FontClassNames } from '../../Styling';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { ToggleStatus } from './Toggle.checklist';
 
 const ToggleBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx') as string;
+const ToggleAriaLabelExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Toggle/examples/Toggle.AriaLabel.Example.tsx') as string;
 
 export class TogglePage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -19,9 +21,20 @@ export class TogglePage extends React.Component<IComponentDemoPageProps, {}> {
         title='Toggle'
         componentName='ToggleExample'
         exampleCards={
-          <ExampleCard title='Default Toggles' code={ ToggleBasicExampleCode }>
-            <ToggleBasicExample />
-          </ExampleCard>
+          <div>
+            <ExampleCard
+              title='Default Toggles'
+              code={ ToggleBasicExampleCode }
+            >
+              <ToggleBasicExample />
+            </ExampleCard>
+            <ExampleCard
+              title='Toggle with specialized aria labels for the screen-reader to announce when the toggle is on and off'
+              code={ ToggleAriaLabelExampleCode }
+            >
+              <ToggleAriaLabelExample />
+            </ExampleCard>
+          </div>
         }
         propertiesTables={
           <PropertiesTableSet

--- a/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.AriaLabel.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.AriaLabel.Example.tsx
@@ -1,0 +1,20 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+
+// tslint:disable:jsx-no-lambda
+export const ToggleAriaLabelExample = () => (
+  <div style={ { padding: '2px' } }>
+    <Toggle
+      defaultChecked={ true }
+      label='Enabled and checked'
+      onAriaLabel='This toggle is checked. Press to uncheck.'
+      offAriaLabel='This toggle is unchecked. Press to check.'
+      onText='On'
+      offText='Off'
+      onFocus={ () => console.log('onFocus called') }
+      onBlur={ () => console.log('onBlur called') }
+    />
+  </div>
+);

--- a/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx
@@ -9,8 +9,6 @@ export const ToggleBasicExample = () => (
     <Toggle
       defaultChecked={ true }
       label='Enabled and checked'
-      onAriaLabel='This toggle is checked. Press to uncheck.'
-      offAriaLabel='This toggle is unchecked. Press to check.'
       onText='On'
       offText='Off'
       onFocus={ () => console.log('onFocus called') }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Split out a new example just for on and offAriaLabel. This keeps the default Toggle example more crisp and explains the aria label variation more clearly.

#### Focus areas to test

(optional)
