### PR TITLE
ContextualMenu: Pass in item properties like disabled, expanded, and checked into the  getClassNames function for the split button divider

### DIFF
--- a/common/changes/office-ui-fabric-react/split-divider-classnames_2017-11-17-18-36.json
+++ b/common/changes/office-ui-fabric-react/split-divider-classnames_2017-11-17-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Pass in item properties like disabled, expanded, and checked into the  getClassNames function for the split button divider",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/ghdocs/STYLING.md
+++ b/ghdocs/STYLING.md
@@ -72,7 +72,7 @@ class Comp extends React.Component {
 A component should consist of these files:
 
 * `ComponentName.props.ts` - The interfaces for the component. We separate these out for documentation reasons.
-* `ComponentName.base.tsx` - The unstyled component. This renders DOM structure and conrtains logic, MINUS styling opinions.
+* `ComponentName.base.tsx` - The unstyled component. This renders DOM structure and contains logic, MINUS styling opinions.
 * `ComponentName.styles.ts` - Exports a `getStyles` function for the component which takes in `IComponentNameStyleProps` and returns `IComponentNameStyles`.
 
 Once these are defined, you can export the component which ties it all together:
@@ -199,7 +199,7 @@ export const ComponentName = styled(
 
 Note that the component may also intend to provide customized styling for nested components. For example, a `Breadcrumb` component may want to expose the `getStyles` function for nested `Crumb` components.
 
-The extra getStyles function would be added to the outer compoent's props:
+The extra getStyles function would be added to the outer component's props:
 
 ```
 getCrumbStyles?: IStyleFunction<ICrumbStyleProps, ICrumbStyles>;
@@ -232,7 +232,7 @@ export const Breadcrumb = styled(
 The test file should include:
 
 1. A snapshot test locking the component DOM structure down for the important states.
-2. Tests which simulate clicking on things, changing the state of the compoent, and validating things still work.
+2. Tests which simulate clicking on things, changing the state of the component, and validating things still work.
 
 ## Moving styles from scss to ts
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -589,7 +589,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderSplitDivider(item: IContextualMenuItem) {
     let getDividerClassnames = item.getSplitButtonVerticalDividerClassNames || getSplitButtonVerticalDividerClassNames;
-    return <VerticalDivider getClassNames={ getDividerClassnames } />;
+    return <VerticalDivider
+      getClassNames={ theme => getDividerClassnames(theme,
+        !!item.disabled,
+        this.state.expandedMenuItemKey === item.key,
+        !!item.checked) } />;
   }
 
   private _renderMenuItemChildren(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, hasCheckmarks: boolean, hasIcons: boolean) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -589,11 +589,16 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderSplitDivider(item: IContextualMenuItem) {
     let getDividerClassnames = item.getSplitButtonVerticalDividerClassNames || getSplitButtonVerticalDividerClassNames;
-    return <VerticalDivider
-      getClassNames={ theme => getDividerClassnames(theme,
-        !!item.disabled,
-        this.state.expandedMenuItemKey === item.key,
-        !!item.checked) } />;
+
+    return (
+      <VerticalDivider
+        // tslint:disable-next-line:jsx-no-lambda
+        getClassNames={ theme => getDividerClassnames(theme,
+          !!item.disabled,
+          this.state.expandedMenuItemKey === item.key,
+          !!item.checked) }
+      />
+    );
   }
 
   private _renderMenuItemChildren(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, hasCheckmarks: boolean, hasIcons: boolean) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -340,7 +340,10 @@ export interface IContextualMenuItem {
   * Method to provide the classnames to style the Vertical Divider of a split button inside a menu. Default value is the getVerticalDividerClassnames func defined in ContextualMenu.classnames
   * @default getSplitButtonVerticalDividerClassNames
   */
-  getSplitButtonVerticalDividerClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
+  getSplitButtonVerticalDividerClassNames?: (theme: ITheme,
+    disabled: boolean,
+    expanded: boolean,
+    checked: boolean) => IVerticalDividerClassNames;
 
   /**
    *  Properties to apply to render this item as a section.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Allows for more rich styling of split buttons inside contextual menus by plumbing through some of the menu item state used in the getItemClassNames function. This allows for scenarios like setting display:'none' on the divider when the menu is expanded or changing the color when it is disabled. 
