### PR TITLE
Contextual menu up/down arrow key behavior - preventing defaults

### DIFF
--- a/common/changes/office-ui-fabric-react/contextualMenuKeyBoarding_2017-11-17-22-47.json
+++ b/common/changes/office-ui-fabric-react/contextualMenuKeyBoarding_2017-11-17-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Prevent default while handling up/down arrow keys on a contextual menu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -672,6 +672,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
     if (elementToFocus) {
       elementToFocus.focus();
+      ev.preventDefault();
+      ev.stopPropagation();
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
@@ -12,6 +12,7 @@ import { ContextualMenuSubmenuExample } from './examples/ContextualMenu.Submenu.
 import { ContextualMenuCheckmarksExample } from './examples/ContextualMenu.Checkmarks.Example';
 import { ContextualMenuDirectionalExample } from './examples/ContextualMenu.Directional.Example';
 import { ContextualMenuCustomizationExample } from './examples/ContextualMenu.Customization.Example';
+import { ContextualMenuWithScrollBarExample } from './examples/ContextualMenu.ScrollBar.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { ContextualMenuStatus } from './ContextualMenu.checklist';
 
@@ -22,6 +23,8 @@ const ContextualMenuSubmenuExampleCode = require('!raw-loader!office-ui-fabric-r
 const ContextualMenuCheckmarksExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx') as string;
 const ContextualMenuDirectionalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx') as string;
 const ContextualMenuCustomizationExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx') as string;
+const ContextualMenuWithScrollBarExampleCode = require
+  ('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx') as string;
 
 export class ContextualMenuPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -71,8 +74,15 @@ export class ContextualMenuPage extends React.Component<IComponentDemoPageProps,
               title='ContextualMenu with customized submenus'
               code={ ContextualMenuCustomizationExampleCode }
             >
-              <ContextualMenuCustomizationExample />
+              <ContextualMenuWithScrollBarExample />
             </ExampleCard>
+            <ExampleCard
+              title='ContextualMenu with a scroll bar and fixed direction'
+              code={ ContextualMenuWithScrollBarExampleCode }
+            >
+              <ContextualMenuWithScrollBarExample />
+            </ExampleCard>
+
           </div>
         }
         propertiesTables={

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { DirectionalHint, ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import './ContextualMenuExample.scss';
+
+export class ContextualMenuWithScrollBarExample extends React.Component<any, any> {
+
+  constructor() {
+    super();
+    this.state = {
+      showCallout: false
+    };
+  }
+
+  public render() {
+    return (
+      <div>
+        <DefaultButton
+          id='ContextualMenuButton1'
+          text='Click for ContextualMenu'
+          menuProps={ {
+            shouldFocusOnMount: true,
+            directionalHint: DirectionalHint.bottomRightEdge,
+            directionalHintFixed: true,
+            items: [
+              {
+                key: 'newItem',
+                name: 'New'
+              },
+              {
+                key: 'rename',
+                name: 'Rename'
+              },
+              {
+                key: 'edit',
+                name: 'Edit'
+              },
+              {
+                key: 'properties',
+                name: 'Properties'
+              },
+              {
+                key: 'disabled',
+                name: 'Disabled item',
+                disabled: true
+              }
+            ],
+            calloutProps: {
+              calloutMaxHeight: 65
+            }
+          } }
+        />
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Contextual menus were allowing for browser default behavior to happen on up/down arrow keys after 
focusing on the last/first element. This did not really affect normal contextual menus, but resulted in content jumps for contextual menus with a scroll bar.

The change fixes this by preventing browser default behavior when we have a element that we want to shift focus to.

#### Behavior before (Only user input after opening the contextual menu = Down Arrow):
Notice that even though the focus is set correctly, the scroll does not look correct
![contextualmenubefore](https://user-images.githubusercontent.com/2162858/32972336-c0ba093e-cba6-11e7-87e8-bc01d78070f8.gif)

#### Behavior after (Only user input after opening the contextual menu = Down Arrow):
![contextualmenuafter](https://user-images.githubusercontent.com/2162858/32972342-c957aa10-cba6-11e7-89b8-1e07852026ed.gif)


#### Focus areas to test
I tested to see that components which currently use the contextual menu do not exhibit weird behavior as a result of this change. 
