### PR TITLE
SwatchColorPicker Color Cells: Adding Gray Border Around White Color Cells

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-whiteCellBorder_2017-11-18-02-13.json
+++ b/common/changes/office-ui-fabric-react/chiechan-whiteCellBorder_2017-11-18-02-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ColorCells: Adding gray border to white color cells",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
@@ -133,6 +133,7 @@
   padding: 0px;
   border: 1px solid #D2D2D2;
   margin: 4px;
+
   &.circle {
     border-radius: 100%;
   }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
@@ -71,6 +71,11 @@
       width: 12px;
       height: 12px;
       border: 4px solid $ms-color-neutralTertiaryAlt;
+
+      &.whitColoreCell {
+        padding: 4px;
+        margin: 0px;
+      }
     }
   }
 
@@ -83,6 +88,11 @@
   &:active .svg {
     width: 12px;
     height: 12px;
+
+    &.whitColoreCell {
+      padding: 4px;
+      margin: 0px;
+    }
   }
 
   &:hover .svg,
@@ -116,6 +126,17 @@
     cursor: default;
     pointer-events: none;
     opacity: .3;
+  }
+}
+
+.whitColoreCell {
+  width: 18px;
+  height: 18px;
+  padding: 0px;
+  border: 1px solid #d2d2d2;
+  margin: 4px;
+  &.circle {
+    border-radius: 100%;
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
@@ -72,9 +72,9 @@
       height: 12px;
       border: 4px solid $ms-color-neutralTertiaryAlt;
 
-      &.whitColoreCell {
+      &.whiteColorCell {
         padding: 4px;
-        margin: 0px;
+        margin: 0;
       }
     }
   }
@@ -89,9 +89,9 @@
     width: 12px;
     height: 12px;
 
-    &.whitColoreCell {
+    &.whiteColorCell {
       padding: 4px;
-      margin: 0px;
+      margin: 0;
     }
   }
 
@@ -129,8 +129,8 @@
   }
 }
 
-.whitColoreCell {
-  padding: 0px;
+.whiteColorCell {
+  padding: 0;
   border: 1px solid #D2D2D2;
   margin: 4px;
 

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.scss
@@ -130,10 +130,8 @@
 }
 
 .whitColoreCell {
-  width: 18px;
-  height: 18px;
   padding: 0px;
-  border: 1px solid #d2d2d2;
+  border: 1px solid #D2D2D2;
   margin: 4px;
   &.circle {
     border-radius: 100%;

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -179,9 +179,8 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
   @autobind
   private _onRenderColorOption(colorOption: IColorCellProps): JSX.Element {
     // Build an SVG for the cell with the given shape and color properties
-    let color = colorOption.color as string;
     return (
-      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', (color && color.toLowerCase() === '#ffffff') ? styles.whiteColorCell : '') } viewBox='0 0 20 20' fill={ getColorFromString(color)!.str } >
+      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', this.getWhiteCellStyle(colorOption.color as string)) } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
         {
           this.props.cellShape === 'circle' ?
             <circle cx='50%' cy='50%' r='50%' /> :
@@ -213,6 +212,23 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
       this.setState({
         selectedIndex: index
       });
+    }
+  }
+
+  /**
+   * Get the white color cell style
+   * @param inputColor - The color of the current cell
+   * @returns - The White color cell style if the current style is white, empty otherwise
+   */
+  private getWhiteCellStyle(inputColor: string): string {
+    if (inputColor) {
+      return '';
+    }
+
+    if (inputColor.toLocaleLowerCase() !== "#ffffff") {
+      return '';
+    } else {
+      return styles.whiteColorCell
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -180,7 +180,7 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
   private _onRenderColorOption(colorOption: IColorCellProps): JSX.Element {
     // Build an SVG for the cell with the given shape and color properties
     return (
-      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', this.getWhiteCellStyle(colorOption.color as string)) } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
+      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', this._getWhiteCellStyle(colorOption.color as string)) } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
         {
           this.props.cellShape === 'circle' ?
             <circle cx='50%' cy='50%' r='50%' /> :
@@ -220,11 +220,11 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
    * @param inputColor - The color of the current cell
    * @returns - The White color cell style if the current style is white, empty otherwise
    */
-  private getWhiteCellStyle(inputColor: string): string {
-    if (inputColor || inputColor.toLocaleLowerCase() !== "#ffffff") {
+  private _getWhiteCellStyle(inputColor: string): string {
+    if (inputColor || inputColor.toLocaleLowerCase() !== '#ffffff') {
       return '';
     } else {
-      return styles.whiteColorCell
+      return styles.whiteColorCell;
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -221,11 +221,7 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
    * @returns - The White color cell style if the current style is white, empty otherwise
    */
   private getWhiteCellStyle(inputColor: string): string {
-    if (inputColor) {
-      return '';
-    }
-
-    if (inputColor.toLocaleLowerCase() !== "#ffffff") {
+    if (inputColor || inputColor.toLocaleLowerCase() !== "#ffffff") {
       return '';
     } else {
       return styles.whiteColorCell

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -180,7 +180,7 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
   private _onRenderColorOption(colorOption: IColorCellProps): JSX.Element {
     // Build an SVG for the cell with the given shape and color properties
     return (
-      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', this._getWhiteCellStyle(colorOption.color as string)) } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
+      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', this._getWhiteCellStyle(colorOption.color)) } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
         {
           this.props.cellShape === 'circle' ?
             <circle cx='50%' cy='50%' r='50%' /> :
@@ -220,8 +220,8 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
    * @param inputColor - The color of the current cell
    * @returns - The White color cell style if the current style is white, empty otherwise
    */
-  private _getWhiteCellStyle(inputColor: string): string {
-    if (inputColor || inputColor.toLocaleLowerCase() !== '#ffffff') {
+  private _getWhiteCellStyle(inputColor: string | undefined): string {
+    if (inputColor || inputColor!.toLocaleLowerCase() !== '#ffffff') {
       return '';
     } else {
       return styles.whiteColorCell;

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -115,6 +115,11 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
     return selectedIndex >= 0 ? selectedIndex : undefined;
   }
 
+  private _getHoveredIndex(items: IColorCellProps[], selectedId: string): number | undefined {
+    let selectedIndex = findIndex(items, (item => (item.id === selectedId)));
+    return selectedIndex >= 0 ? selectedIndex : undefined;
+  }
+
   /**
    * Render a color cell
    * @param item - The item to render
@@ -179,8 +184,9 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
   @autobind
   private _onRenderColorOption(colorOption: IColorCellProps): JSX.Element {
     // Build an SVG for the cell with the given shape and color properties
+    let stroke = colorOption.label === 'white' ? styles.whiteCell : "";
     return (
-      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '') } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
+      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', stroke) } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
         {
           this.props.cellShape === 'circle' ?
             <circle cx='50%' cy='50%' r='50%' /> :

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -115,11 +115,6 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
     return selectedIndex >= 0 ? selectedIndex : undefined;
   }
 
-  private _getHoveredIndex(items: IColorCellProps[], selectedId: string): number | undefined {
-    let selectedIndex = findIndex(items, (item => (item.id === selectedId)));
-    return selectedIndex >= 0 ? selectedIndex : undefined;
-  }
-
   /**
    * Render a color cell
    * @param item - The item to render

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -181,7 +181,7 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
     // Build an SVG for the cell with the given shape and color properties
     let color = colorOption.color as string;
     return (
-      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', color.toLowerCase() === '#ffffff' ? styles.whitColoreCell : '') } viewBox='0 0 20 20' fill={ getColorFromString(color)!.str } >
+      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', (color && color.toLowerCase() === '#ffffff') ? styles.whiteColorCell : '') } viewBox='0 0 20 20' fill={ getColorFromString(color)!.str } >
         {
           this.props.cellShape === 'circle' ?
             <circle cx='50%' cy='50%' r='50%' /> :

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -184,9 +184,9 @@ export class SwatchColorPicker extends BaseComponent<ISwatchColorPickerProps, IS
   @autobind
   private _onRenderColorOption(colorOption: IColorCellProps): JSX.Element {
     // Build an SVG for the cell with the given shape and color properties
-    let stroke = colorOption.label === 'white' ? styles.whiteCell : "";
+    let color = colorOption.color as string;
     return (
-      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', stroke) } viewBox='0 0 20 20' fill={ getColorFromString(colorOption.color as string)!.str } >
+      <svg className={ css(styles.svg, this.props.cellShape, this.props.cellShape === 'circle' ? styles.circle : '', color.toLowerCase() === '#ffffff' ? styles.whitColoreCell : '') } viewBox='0 0 20 20' fill={ getColorFromString(color)!.str } >
         {
           this.props.cellShape === 'circle' ?
             <circle cx='50%' cy='50%' r='50%' /> :

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/examples/SwatchColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/examples/SwatchColorPicker.Basic.Example.tsx
@@ -21,27 +21,29 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
       <div>
         <div>Simple circle swatch color picker:</div>
         <SwatchColorPicker
-          columnCount={ 4 }
+          columnCount={ 5 }
           cellShape={ 'circle' }
           colorCells={
             [
               { id: 'a', label: 'green', color: '#00ff00' },
               { id: 'b', label: 'orange', color: '#ffa500' },
               { id: 'c', label: 'blue', color: '#0000ff' },
-              { id: 'd', label: 'red', color: '#ff0000' }
+              { id: 'd', label: 'red', color: '#ff0000' },
+              { id: 'e', label: 'white', color: '#ffffff' }
             ]
           }
         />
         <div>Simple square swatch color picker:</div>
         <SwatchColorPicker
-          columnCount={ 4 }
+          columnCount={ 5 }
           cellShape={ 'square' }
           colorCells={
             [
               { id: 'a', label: 'green', color: '#00ff00' },
               { id: 'b', label: 'orange', color: '#ffa500' },
               { id: 'c', label: 'blue', color: '#0000ff' },
-              { id: 'd', label: 'red', color: '#ff0000' }
+              { id: 'd', label: 'red', color: '#ff0000' },
+              { id: 'e', label: 'white', color: '#ffffff' }
             ]
           }
         />
@@ -76,14 +78,15 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
         <div>Simple disabled circle swatch color picker:</div>
         <SwatchColorPicker
           disabled={ true }
-          columnCount={ 4 }
+          columnCount={ 5 }
           cellShape={ 'circle' }
           colorCells={
             [
               { id: 'a', label: 'green', color: '#00ff00' },
               { id: 'b', label: 'orange', color: '#ffa500' },
               { id: 'c', label: 'blue', color: '#0000ff' },
-              { id: 'd', label: 'red', color: '#ff0000' }
+              { id: 'd', label: 'red', color: '#ff0000' },
+              { id: 'e', label: 'white', color: '#ffffff' }
             ]
           }
         />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X ] Include a change request file using `$ npm run change`

#### Description of changes

Problem:
Right now, if we have a white color cell, we won't be able to see it and there would be no indication that anything is there. 

Solution:
I added a border around the white color cell for circles and squares so that we will be able to the color cell.

![white color cell](https://user-images.githubusercontent.com/5695630/32976022-7be074fc-cbc3-11e7-853c-1d1c7c388449.gif)

#### Focus areas to test

The Swatch Color Picker page, unfortunately the only way to test it would be to add a white color cell in like I have.