### PR TITLE
Button: new prop splitButtonAriaLabel

### DIFF
--- a/common/changes/office-ui-fabric-react/button-splitButtonAriaLabel_2017-11-20-14-33.json
+++ b/common/changes/office-ui-fabric-react/button-splitButtonAriaLabel_2017-11-20-14-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button: new prop splitButtonAriaLabel.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-panu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -430,7 +430,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
   private _onRenderSplitButtonMenuButton(classNames: ISplitButtonClassNames | undefined): JSX.Element {
     let {
-      menuIconProps
+      menuIconProps,
+      splitButtonAriaLabel
     } = this.props;
 
     if (menuIconProps === undefined) {
@@ -445,7 +446,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'disabled': this.props.disabled,
       'onClick': this._onMenuClick,
       'menuProps': undefined,
-      'iconProps': menuIconProps
+      'iconProps': menuIconProps,
+      'ariaLabel': splitButtonAriaLabel
     };
 
     return <BaseButton {...splitButtonProps} />;

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -117,6 +117,11 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
   menuIconProps?: IIconProps;
 
   /**
+   * The title to announce the dropdown button if this button is split.
+   */
+  splitButtonAriaLabel?: string;
+
+  /**
    * Optional callback when menu is clicked.
    */
   onMenuClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, button?: IButtonProps) => void;

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -117,7 +117,7 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
   menuIconProps?: IIconProps;
 
   /**
-   * The title to announce the dropdown button if this button is split.
+   * Accessible label for the dropdown chevron button if this button is split.
    */
   splitButtonAriaLabel?: string;
 

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -26,6 +26,7 @@ export class ButtonSplitExample extends React.Component<IButtonProps, {}> {
             text='Create account'
             onClick={ alertClicked }
             split={ true }
+            splitButtonAriaLabel={ 'See 2 sample options' }
             style={ { height: '35px' } }
             menuProps={ {
               items: [


### PR DESCRIPTION
#### Description of changes

For accessibility, we need to be able to specify `aria-label` in the dropdown button of a split button, so it's correctly announced by screen readers. Note we may need 2 aria-labels, one for the main button and one for the dropdown.

I've added prop `splitButtonAriaLabel` to fill this gap.

I've discarded a more complete approach like a `splitButtonProps` to specify any other prop of that button, because I didn't want to compromise the button evolution so much. If you think that it is a better approach, I'll be happy to update this PR to it.

#### Focus areas to test

Split button. Added aria-label to the first split button example.
