### PR TITLE
ContextualMenu: Add a prop for setting the min width to be equal to the width of the target

### DIFF
--- a/common/changes/office-ui-fabric-react/MenuMinWidth_2017-11-20-15-20.json
+++ b/common/changes/office-ui-fabric-react/MenuMinWidth_2017-11-20-15-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Add a prop for setting the min width to be equal to the width of the target",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -203,6 +203,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       target,
       bounds,
       useTargetWidth,
+      useTargetAsMinWidth,
       directionalHintFixed,
       shouldFocusOnMount,
       title,
@@ -240,11 +241,17 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
      */
     let contextMenuStyle;
     let targetAsHtmlElement = this._target as HTMLElement;
-    if (useTargetWidth && targetAsHtmlElement && targetAsHtmlElement.offsetWidth) {
-      let contextMenuWidth = targetAsHtmlElement.offsetWidth;
-      contextMenuStyle = {
-        width: contextMenuWidth
-      };
+    if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement && targetAsHtmlElement.offsetWidth) {
+      let targetWidth = targetAsHtmlElement.offsetWidth;
+      if (useTargetWidth) {
+        contextMenuStyle = {
+          width: targetWidth
+        };
+      } else if (useTargetAsMinWidth) {
+        contextMenuStyle = {
+          minWidth: targetWidth
+        };
+      }
     }
 
     // The menu should only return if items were provided, if no items were provided then it should not appear.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -72,6 +72,12 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
   useTargetWidth?: boolean;
 
   /**
+   * If true the context menu will have a minimum width equal to the width of the target element
+   * @default false
+   */
+  useTargetAsMinWidth?: boolean;
+
+  /**
    * The bounding rectangle for which the contextual menu can appear in.
    */
   bounds?: IRectangle;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
It is often desired that menus are never narrower than the button that launched them. An example of the undesired situation is shown below:
![image](https://user-images.githubusercontent.com/1581488/33025383-b1cdbcb8-cdc2-11e7-9fff-3441b8454cf9.png)

This change adds a new optional prop "useTargetAsMinWidth" which will use the offset width of the target element as the minimum width of the menu, resulting in something like this:

![image](https://user-images.githubusercontent.com/1581488/33025513-0d577524-cdc3-11e7-8ff8-4c10398a198a.png)

This is different from the useTargetWidth prop, as useTargetAsMinWidth allows the width of the menu to be wider than that of the target.
