### PR TITLE
give new textfield examples the right max width

### DIFF
--- a/common/changes/office-ui-fabric-react/max-width-fix_2017-11-20-23-53.json
+++ b/common/changes/office-ui-fabric-react/max-width-fix_2017-11-20-23-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "match the max width of the rest of the text field examples",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "sbalentine88@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/max-width-fix_2017-11-20-23-53.json
+++ b/common/changes/office-ui-fabric-react/max-width-fix_2017-11-20-23-53.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "match the max width of the rest of the text field examples",
+      "comment": "TextField example: match the max width for TextFields.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.PrefixAndSuffix.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.PrefixAndSuffix.Example.tsx
@@ -5,7 +5,7 @@ import './TextField.Examples.scss';
 export class TextFieldPrefixAndSuffixExample extends React.Component<any, any> {
   public render() {
     return (
-      <div className='ms-TextFieldExample'>
+      <div className='docs-TextFieldExample'>
         <TextField
           prefix='https://'
           suffix='.com'

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Suffix.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Suffix.Example.tsx
@@ -5,7 +5,7 @@ import './TextField.Examples.scss';
 export class TextFieldSuffixExample extends React.Component<any, any> {
   public render() {
     return (
-      <div className='ms-TextFieldExample'>
+      <div className='docs-TextFieldExample'>
         <TextField
           suffix='.com'
         />


### PR DESCRIPTION
My previous PR (https://github.com/OfficeDev/office-ui-fabric-react/pull/3348) went out around the same time as a change to max width on the text fields in the examples. This makes sure to incorporate those changes as well.

Currently:

<img width="1261" alt="home_-_office_ui_fabric" src="https://user-images.githubusercontent.com/976978/33047339-10dcbe88-ce0a-11e7-8587-41880186d3ad.png">

After fix:

<img width="1335" alt="office_ui_fabric_react_examples" src="https://user-images.githubusercontent.com/976978/33047347-15aa1e4c-ce0a-11e7-9c01-48a9cce42154.png">

