### PR TITLE
FocusZone: Fix focus-in behavior when children are added asynchronously. (#3442)

### DIFF
--- a/common/changes/office-ui-fabric-react/focuszone_2017-11-21-19-15.json
+++ b/common/changes/office-ui-fabric-react/focuszone_2017-11-21-19-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: Fix focus-in behavior when children are added asynchronously.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dawilson@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -51,7 +51,10 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
   private _root: HTMLElement;
   private _id: string;
+  /** The most recently focused child element. */
   private _activeElement: HTMLElement | null;
+  /** The child element with tabindex=0. */
+  private _defaultFocusElement: HTMLElement | null;
   private _focusAlignment: IPoint;
   private _isInnerZone: boolean;
 
@@ -675,6 +678,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
   private _updateTabIndexes(element?: HTMLElement) {
     if (!element) {
+      this._defaultFocusElement = null;
       element = this._root;
       if (this._activeElement && !elementContains(element, this._activeElement)) {
         this._activeElement = null;
@@ -701,8 +705,8 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         if (isElementTabbable(child)) {
           if (this.props.disabled) {
             child.setAttribute(TABINDEX, '-1');
-          } else if (!this._isInnerZone && (!this._activeElement || this._activeElement === child)) {
-            this._activeElement = child;
+          } else if (!this._isInnerZone && ((!this._activeElement && !this._defaultFocusElement) || this._activeElement === child)) {
+            this._defaultFocusElement = child;
             if (child.getAttribute(TABINDEX) !== '0') {
               child.setAttribute(TABINDEX, '0');
             }
@@ -714,8 +718,8 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           child.setAttribute('focusable', 'false');
         }
       } else if (child.getAttribute(IS_FOCUSABLE_ATTRIBUTE) === 'true') {
-        if (!this._isInnerZone && (!this._activeElement || this._activeElement === child)) {
-          this._activeElement = child;
+        if (!this._isInnerZone && ((!this._activeElement && !this._defaultFocusElement) || this._activeElement === child)) {
+          this._defaultFocusElement = child;
           if (child.getAttribute(TABINDEX) !== '0') {
             child.setAttribute(TABINDEX, '0');
           }


### PR DESCRIPTION
#### Pull request checklist

- [ x] Addresses an existing issue: Fixes #3442 
- [x ] Include a change request file using `$ npm run change`

#### Description of changes

Change FocusZone to track defaultFocusElement separately from activeElement so that when more items are added to the FocusZone, we can find a new defaultFocusElement (but don't change the activeElement if one exists)

#### Focus areas to test

(optional)
