### PR TITLE
ContextualMenu: Updated styles for expanded menu item to match toolkit

### DIFF
--- a/common/changes/@uifabric/styling/contextualmenu-bug_2017-11-21-19-43.json
+++ b/common/changes/@uifabric/styling/contextualmenu-bug_2017-11-21-19-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/styling",
-      "comment": "Updated menuItemBackgroundChecked for ContextualMenu.",
+      "comment": "Theme: Updated menuItemBackgroundChecked for ContextualMenu.",
       "type": "patch"
     }
   ],

--- a/common/changes/@uifabric/styling/contextualmenu-bug_2017-11-21-19-43.json
+++ b/common/changes/@uifabric/styling/contextualmenu-bug_2017-11-21-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Updated menuItemBackgroundChecked for ContextualMenu.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "lynam.emily@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/contextualmenu-bug_2017-11-21-19-43.json
+++ b/common/changes/office-ui-fabric-react/contextualmenu-bug_2017-11-21-19-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "ContextualMenu: Updated exampanded menu item style to match toolkit.",
+      "comment": "ContextualMenu: Updated expanded menu item style to match toolkit.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/contextualmenu-bug_2017-11-21-19-43.json
+++ b/common/changes/office-ui-fabric-react/contextualmenu-bug_2017-11-21-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Updated exampanded menu item style to match toolkit.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -40,7 +40,7 @@ $buttonTextCheckedHoveredColor: "[theme:buttonTextCheckedHovered, default: #0000
 
 /* Menus */
 $menuItemBackgroundHoveredColor: "[theme:menuItemBackgroundHovered, default: #f8f8f8]";
-$menuItemBackgroundCheckedColor: "[theme:menuItemBackgroundChecked, default: #d0d0d0]";
+$menuItemBackgroundCheckedColor: "[theme:menuItemBackgroundChecked, default: #eaeaea]";
 $menuIconColor: "[theme:menuIcon, default: #0078d7]";
 $menuHeaderColor: "[theme:menuHeader, default: #0078d7]";
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -86,7 +86,6 @@ export const getMenuItemStyles = memoizeFunction((
     rootExpanded: {
       backgroundColor: ContextualMenuItemBackgroundSelectedColor,
       color: semanticColors.bodyTextChecked,
-      fontWeight: FontWeights.semibold,
       ...getItemHighContrastStyles()
     },
     linkContent: {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
@@ -74,7 +74,7 @@ export class ContextualMenuPage extends React.Component<IComponentDemoPageProps,
               title='ContextualMenu with customized submenus'
               code={ ContextualMenuCustomizationExampleCode }
             >
-              <ContextualMenuWithScrollBarExample />
+              <ContextualMenuCustomizationExample />
             </ExampleCard>
             <ExampleCard
               title='ContextualMenu with a scroll bar and fixed direction'

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -120,7 +120,7 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean): ISema
     buttonTextCheckedHovered: p.black,
 
     menuItemBackgroundHovered: p.neutralLighter,
-    menuItemBackgroundChecked: p.neutralQuaternaryAlt,
+    menuItemBackgroundChecked: p.neutralLight,
     menuIcon: p.themePrimary,
     menuHeader: p.themePrimary,
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3242
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Updated styles for expanded menu item to match toolkit.
- The semantic slot update will only effect ContextualMenu. A [PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/3377) I have out for ComboBox removes its reference to that slot.
- Font weight does not change in the expanded state.
- ContextualMenuCustomizationExample was overwritten in a recent PR. Putting it back.

Before
![contextualmenu before](https://user-images.githubusercontent.com/16619843/33093546-1caf1136-ceb2-11e7-8983-3e3ceafba5f4.png)

After
![image](https://user-images.githubusercontent.com/16619843/33093660-6cf9bed4-ceb2-11e7-833d-0108b5ce9fda.png)

#### Focus areas to test

(optional)
