### PR TITLE
Website: FabricCore version documentation update

### DIFF
--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -8,6 +8,7 @@ import * as stylesImport from './GetStartedPage.module.scss';
 const styles: any = stylesImport;
 const pageStyles: any = require('../PageStyles.module.scss');
 const corePackageData = require('../../../node_modules/office-ui-fabric-core/package.json');
+const corePackageVersion: string = corePackageData && corePackageData.version || '9.2.0';
 
 export class GetStartedPage extends React.Component<any, any> {
   public render() {
@@ -186,7 +187,7 @@ initializeIcons('https://my.cdn.com/path/to/icons/');`
               <p>Add the following line to the &lt;head&gt; of your webpage:</p>
               <CodeBlock language='html' isLightTheme={ true }>
                 {
-                  `<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/${corePackageData.version}/css/fabric.min.css">`
+                  `<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/${corePackageVersion}/css/fabric.min.css">`
                 }
               </CodeBlock>
             </li>

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -7,6 +7,7 @@ const diagramStyles: any = require('./GetStartedPage.diagram.module.scss');
 import * as stylesImport from './GetStartedPage.module.scss';
 const styles: any = stylesImport;
 const pageStyles: any = require('../PageStyles.module.scss');
+const corePackageData = require('../../../node_modules/office-ui-fabric-core/package.json');
 
 export class GetStartedPage extends React.Component<any, any> {
   public render() {
@@ -185,7 +186,7 @@ initializeIcons('https://my.cdn.com/path/to/icons/');`
               <p>Add the following line to the &lt;head&gt; of your webpage:</p>
               <CodeBlock language='html' isLightTheme={ true }>
                 {
-                  `<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.2.0/css/fabric.min.css">`
+                  `<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/${corePackageData.version}/css/fabric.min.css">`
                 }
               </CodeBlock>
             </li>

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -185,7 +185,7 @@ initializeIcons('https://my.cdn.com/path/to/icons/');`
               <p>Add the following line to the &lt;head&gt; of your webpage:</p>
               <CodeBlock language='html' isLightTheme={ true }>
                 {
-                  `<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.0.0/css/fabric.min.css">`
+                  `<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.2.0/css/fabric.min.css">`
                 }
               </CodeBlock>
             </li>

--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -145,5 +145,5 @@ function addCSSToHeader(fileName: string) {
   headEl.appendChild(linkEl);
 }
 
-const corePackageData = require('../../../node_modules/office-ui-fabric-core/package.json');
+const corePackageData = require('../node_modules/office-ui-fabric-core/package.json');
 addCSSToHeader('https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/' + corePackageData.version + '/css/fabric.min.css');

--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -145,4 +145,5 @@ function addCSSToHeader(fileName: string) {
   headEl.appendChild(linkEl);
 }
 
-addCSSToHeader('https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.0.0/css/fabric.min.css');
+const corePackageData = require('../../../node_modules/office-ui-fabric-core/package.json');
+addCSSToHeader('https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/' + corePackageData.version + '/css/fabric.min.css');

--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -13,6 +13,7 @@ import WindowWidthUtility from './utilities/WindowWidthUtility';
 import './styles/styles.scss';
 import { initializeIcons } from '@uifabric/icons/lib/index';
 const corePackageData = require('../node_modules/office-ui-fabric-core/package.json');
+const corePackageVersion: string = corePackageData && corePackageData.version || '9.2.0';
 
 initializeIcons();
 
@@ -145,4 +146,4 @@ function addCSSToHeader(fileName: string) {
   headEl.appendChild(linkEl);
 }
 
-addCSSToHeader('https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/' + corePackageData.version + '/css/fabric.min.css');
+addCSSToHeader('https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/' + corePackageVersion + '/css/fabric.min.css');

--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -11,8 +11,8 @@ import { setBaseUrl } from 'office-ui-fabric-react/lib/Utilities';
 import { HomePage } from './pages/HomePage/HomePage';
 import WindowWidthUtility from './utilities/WindowWidthUtility';
 import './styles/styles.scss';
-
 import { initializeIcons } from '@uifabric/icons/lib/index';
+const corePackageData = require('../node_modules/office-ui-fabric-core/package.json');
 
 initializeIcons();
 
@@ -145,5 +145,4 @@ function addCSSToHeader(fileName: string) {
   headEl.appendChild(linkEl);
 }
 
-const corePackageData = require('../node_modules/office-ui-fabric-core/package.json');
 addCSSToHeader('https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/' + corePackageData.version + '/css/fabric.min.css');

--- a/common/changes/@uifabric/fabric-website/core-versioning_2017-11-21-20-33.json
+++ b/common/changes/@uifabric/fabric-website/core-versioning_2017-11-21-20-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Updated referenced FabricCore versions.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}

--- a/ghdocs/README.md
+++ b/ghdocs/README.md
@@ -124,7 +124,7 @@ You can specify the default direction in your `index.html`. Add the `dir` attrib
 Load Office UI Fabric styles by linking to the Office UI Fabric CDN. Add the following to the `<head`> element:
 
 ```html
-<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.0.0/css/fabric.min.css">
+<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.2.0/css/fabric.min.css">
 ```
 
 Save the file.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Added a reference to node modules that will pull the version of FabricCore that the website is using so that we can avoid bugs like [this](https://github.com/OfficeDev/office-ui-fabric-core/issues/1066) when FabricCore updates.
- Updated hardcoded version in GetStarted page and Readme.

Before (A mix of most recent FabricCore9.2.0 and FabricCore9.0.0):
![2017-11-21-12-43-developer microsoft com](https://user-images.githubusercontent.com/16619843/33095748-9c0325f6-ceb9-11e7-9d1d-2f42f54f18bb.png)

After:
![2017-11-21-12-32-localhost_4321](https://user-images.githubusercontent.com/16619843/33095754-9fd6ae1e-ceb9-11e7-96c6-be608dc51367.png)

#### Focus areas to test

(optional)
