### PR TITLE
Adding api extractor, TypeScript 2.6.1

### DIFF
--- a/common/changes/@uifabric/merge-styles/typescript-bump_2017-11-23-00-15.json
+++ b/common/changes/@uifabric/merge-styles/typescript-bump_2017-11-23-00-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Updating to be built using TypeScript 2.6.1.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/typescript-bump_2017-11-23-00-15.json
+++ b/common/changes/@uifabric/styling/typescript-bump_2017-11-23-00-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Updating to be built using TypeScript 2.6.1.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/typescript-bump_2017-11-23-00-15.json
+++ b/common/changes/@uifabric/utilities/typescript-bump_2017-11-23-00-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Updating to be built using TypeScript 2.6.1.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/typescript-bump_2017-11-23-00-15.json
+++ b/common/changes/office-ui-fabric-react/typescript-bump_2017-11-23-00-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updating to be built using TypeScript 2.6.1.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -9,6 +9,31 @@
       "resolved": "https://registry.npmjs.org/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz",
       "integrity": "sha1-6pn2EhtKjwZbTHH4VZXbJxRJiAc="
     },
+    "@microsoft/api-extractor": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-4.2.6.tgz",
+      "integrity": "sha1-LEQcgMR1AO/lG49ICH+gNkAGC5U=",
+      "requires": {
+        "@microsoft/node-core-library": "0.3.16",
+        "@microsoft/ts-command-line": "2.2.4",
+        "@types/fs-extra": "0.0.37",
+        "@types/node": "6.0.88",
+        "@types/z-schema": "3.16.31",
+        "colors": "1.1.2",
+        "fs-extra": "0.26.7",
+        "jju": "1.3.0",
+        "lodash": "4.15.0",
+        "typescript": "2.4.2",
+        "z-schema": "3.18.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.88",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
+          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ=="
+        }
+      }
+    },
     "@microsoft/load-themed-styles": {
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.9.tgz",
@@ -23,14 +48,53 @@
         "loader-utils": "1.1.0"
       }
     },
+    "@microsoft/node-core-library": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.16.tgz",
+      "integrity": "sha1-zvPzDA/N2fGvIItc6hXCLzd+d0U=",
+      "requires": {
+        "@types/fs-extra": "0.0.37",
+        "@types/node": "6.0.88",
+        "@types/z-schema": "3.16.31",
+        "fs-extra": "0.26.7",
+        "jju": "1.3.0",
+        "z-schema": "3.18.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.88",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
+          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ=="
+        }
+      }
+    },
+    "@microsoft/ts-command-line": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.4.tgz",
+      "integrity": "sha1-yMbdb/zeE0yt0MnVb7sRnB48KUI=",
+      "requires": {
+        "@types/argparse": "1.0.33",
+        "@types/node": "6.0.88",
+        "argparse": "1.0.9",
+        "colors": "1.1.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.88",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
+          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ=="
+        }
+      }
+    },
     "@rush-temp/build": {
       "version": "file:projects/build.tgz",
-      "integrity": "sha1-qAgxZJy8shT0D7xzf+TPeo5Z0g4=",
+      "integrity": "sha1-TRgfbS0nudZ17IoHa4NmsIjx0Z0=",
       "requires": {
+        "@microsoft/api-extractor": "4.2.6",
         "@microsoft/load-themed-styles": "1.7.9",
         "@microsoft/loader-load-themed-styles": "1.6.4",
         "autoprefixer": "7.1.6",
-        "awesome-typescript-loader": "3.3.0",
+        "awesome-typescript-loader": "3.4.0",
         "bundlesize": "0.15.3",
         "chalk": "2.3.0",
         "command-line-args": "4.0.7",
@@ -42,7 +106,7 @@
         "jest": "21.2.1",
         "json-loader": "0.5.7",
         "mustache": "2.3.0",
-        "node-sass": "4.6.1",
+        "node-sass": "4.7.2",
         "open": "0.0.5",
         "postcss": "6.0.14",
         "postcss-loader": "2.0.8",
@@ -52,21 +116,28 @@
         "sinon": "4.1.2",
         "source-map-loader": "0.2.3",
         "style-loader": "0.18.2",
-        "ts-jest": "21.2.2",
+        "ts-jest": "21.2.3",
         "tslint": "5.8.0",
         "tslint-microsoft-contrib": "5.0.1",
-        "typescript": "2.5.3",
+        "typescript": "2.6.1",
         "uglifyjs-webpack-plugin": "0.4.6",
         "webpack": "3.8.1",
         "webpack-bundle-analyzer": "2.9.1",
         "webpack-dev-server": "2.9.4",
         "webpack-notifier": "1.5.0",
         "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+          "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE="
+        }
       }
     },
     "@rush-temp/example-app-base": {
       "version": "file:projects/example-app-base.tgz",
-      "integrity": "sha1-j3ZQBDfqb+5tz7E4dLOSj9Hevxo=",
+      "integrity": "sha1-9Hop4RI3bzoxr0jAX4TX9E30IJ0=",
       "requires": {
         "@types/chai": "3.4.35",
         "@types/enzyme": "2.8.8",
@@ -82,7 +153,7 @@
         "es6-promise": "4.1.1",
         "es6-weak-map": "2.0.2",
         "highlight.js": "9.12.0",
-        "office-ui-fabric-react": "5.21.2",
+        "office-ui-fabric-react": "5.24.2",
         "react": "15.6.2",
         "react-addons-test-utils": "15.6.2",
         "react-dom": "15.6.2",
@@ -91,12 +162,12 @@
     },
     "@rush-temp/experiments": {
       "version": "file:projects/experiments.tgz",
-      "integrity": "sha1-9QTO6I8BclPjMrmY5zBvgPVsb74=",
+      "integrity": "sha1-eLEI9DbVRQigA4SjhrnHrdS+ErA=",
       "requires": {
         "@microsoft/load-themed-styles": "1.7.9",
         "@types/enzyme": "2.8.8",
         "@types/es6-promise": "0.0.32",
-        "@types/jest": "21.1.6",
+        "@types/jest": "21.1.7",
         "@types/prop-types": "15.5.1",
         "@types/react": "15.0.38",
         "@types/react-addons-test-utils": "0.14.18",
@@ -140,7 +211,7 @@
     },
     "@rush-temp/fabric-website": {
       "version": "file:projects/fabric-website.tgz",
-      "integrity": "sha1-k2Ow8JVItV/QdyszUQxdEoPt558=",
+      "integrity": "sha1-cYaZc+HBosM99KLgcFEbf8bbns4=",
       "requires": {
         "@microsoft/load-themed-styles": "1.7.9",
         "@types/chai": "3.4.35",
@@ -170,7 +241,7 @@
     },
     "@rush-temp/icons": {
       "version": "file:projects/icons.tgz",
-      "integrity": "sha1-AkZq7Bs3y6h2vgyK5z23omht6e8=",
+      "integrity": "sha1-h7OLTTPVpcUfPwIKR98SeqB8njg=",
       "requires": {
         "tslib": "1.8.0"
       }
@@ -206,7 +277,7 @@
     },
     "@rush-temp/office-ui-fabric-react": {
       "version": "file:projects/office-ui-fabric-react.tgz",
-      "integrity": "sha1-nlu+RekYUG5BUJls+WEPqMlUGJo=",
+      "integrity": "sha1-RBgeBPk/KmimOVtdh0fwCZRjRKM=",
       "requires": {
         "@microsoft/load-themed-styles": "1.7.9",
         "@types/enzyme": "2.8.8",
@@ -279,7 +350,7 @@
     },
     "@rush-temp/ssr-tests": {
       "version": "file:projects/ssr-tests.tgz",
-      "integrity": "sha1-ZE4/U/YeSLDHlqXOSTp6VpZY4ho=",
+      "integrity": "sha1-3wkrTJjp2wvTG9Df6gof8D89HZA=",
       "requires": {
         "@microsoft/load-themed-styles": "1.7.9",
         "@types/chai": "3.4.35",
@@ -315,7 +386,7 @@
     },
     "@rush-temp/test-bundle-button": {
       "version": "file:projects/test-bundle-button.tgz",
-      "integrity": "sha1-HSXlu7lKD78clB/eJ5Grw5fhhGs=",
+      "integrity": "sha1-1ZKcXDMtabZG9CVhSrQxmJDG1D8=",
       "requires": {
         "@types/prop-types": "15.5.1",
         "@types/react": "15.0.38",
@@ -328,7 +399,7 @@
     },
     "@rush-temp/todo-app": {
       "version": "file:projects/todo-app.tgz",
-      "integrity": "sha1-cgVLRhrg0Pf6/MQDwoH8p1nsuLM=",
+      "integrity": "sha1-qjtY6PAJQdrjvqQR6fCpYBwnzZE=",
       "requires": {
         "@microsoft/load-themed-styles": "1.7.9",
         "@types/chai": "3.4.35",
@@ -344,13 +415,6 @@
         "react-dom": "15.6.2",
         "tslib": "1.8.0",
         "typescript": "2.4.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-          "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ="
-        }
       }
     },
     "@rush-temp/utilities": {
@@ -401,14 +465,14 @@
     },
     "@rush-temp/vr-tests": {
       "version": "file:projects/vr-tests.tgz",
-      "integrity": "sha1-EPzI9nOhBbi5RlMEbMS7C0Fcgw8=",
+      "integrity": "sha1-domhoZ2meWhHgLS9C0zB0LxUB98=",
       "requires": {
         "@storybook/addon-options": "3.2.3",
         "@storybook/react": "3.2.16",
         "@types/react": "15.0.38",
         "@types/react-dom": "15.5.1",
         "@types/storybook__react": "3.0.5",
-        "awesome-typescript-loader": "3.3.0",
+        "awesome-typescript-loader": "3.4.0",
         "css-loader": "0.27.3",
         "file-loader": "0.11.1",
         "postcss-loader": "1.3.3",
@@ -518,11 +582,6 @@
           "requires": {
             "has-flag": "1.0.0"
           }
-        },
-        "typescript": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-          "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ="
         }
       }
     },
@@ -649,7 +708,7 @@
         "util-deprecate": "1.0.2",
         "uuid": "3.1.0",
         "webpack": "3.8.1",
-        "webpack-dev-middleware": "1.12.0",
+        "webpack-dev-middleware": "1.12.1",
         "webpack-hot-middleware": "2.20.0"
       },
       "dependencies": {
@@ -728,11 +787,16 @@
         "qs": "6.5.1",
         "react-icons": "2.2.7",
         "react-inspector": "2.2.1",
-        "react-modal": "3.1.2",
+        "react-modal": "3.1.3",
         "react-split-pane": "0.1.71",
         "react-treebeard": "2.1.0",
         "redux": "3.7.2"
       }
+    },
+    "@types/argparse": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.33.tgz",
+      "integrity": "sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ=="
     },
     "@types/chai": {
       "version": "3.4.35",
@@ -758,6 +822,14 @@
       "resolved": "https://registry.npmjs.org/@types/es6-promise/-/es6-promise-0.0.32.tgz",
       "integrity": "sha1-O89E+x5Cnz33YYjIxth0Rjujcf0="
     },
+    "@types/fs-extra": {
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-0.0.37.tgz",
+      "integrity": "sha1-GV8RvNmhuX2eQSxrZombVFRxofc=",
+      "requires": {
+        "@types/node": "8.0.26"
+      }
+    },
     "@types/highlight.js": {
       "version": "9.1.9",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.1.9.tgz",
@@ -769,9 +841,9 @@
       "integrity": "sha512-+kbOcYW1/noncDwRryRoB9tH87IYcMfdBGvw98iocK39LtTA2DFL7agmk4UHW/GxjzVfwrxfjlLrqrgA7MCtmg=="
     },
     "@types/jest": {
-      "version": "21.1.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.6.tgz",
-      "integrity": "sha512-/qrwhjCeZ8vZy/TPXm56A3baMMUDPfUMkhOGZP3M7dgPCGPZSX/zSieM7jYPuhX3kMcMfsYuvsFIt23u7Ypu2g=="
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.7.tgz",
+      "integrity": "sha512-MTpPJsw5w+FrtdhS2bH5GE4e6wMz/8Tx3vim/9Au04XS4s20sTELugQWrtZUaOZDoZ35cc/d8jsbNSwm4TSqWQ=="
     },
     "@types/mocha": {
       "version": "2.2.39",
@@ -841,12 +913,17 @@
       "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.0.tgz",
       "integrity": "sha1-MEQ4FkfhHulzxa8uklMjkw9pHYA="
     },
+    "@types/z-schema": {
+      "version": "3.16.31",
+      "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz",
+      "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw="
+    },
     "@uifabric/icons": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.2.0.tgz",
       "integrity": "sha512-P5kfPej/wxgR8jZt/GqnU0FqYcz+JH1iCcaaYd6p9L3opmZtu4w5duKeqs+Bc1u7K16r800EQfLgKe76rt6AuA==",
       "requires": {
-        "@uifabric/styling": "5.7.0",
+        "@uifabric/styling": "5.10.0",
         "tslib": "1.8.0"
       }
     },
@@ -859,9 +936,9 @@
       }
     },
     "@uifabric/styling": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.7.0.tgz",
-      "integrity": "sha512-qEq16h2sii7dmxZY2JxG5lbl2n5wftYyaEk09C5Zsu/PVH8Ld60czflXdrgbDdLMhocQomlHJeTTM+cQQ0wtFQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.10.0.tgz",
+      "integrity": "sha512-uaoaRm1WAat23zrS4ztucZUIy1sEKDRrudE5wlD14VYwsQSJDy5cHgQ6t6PvxonjuNj0XQHZCv3ldLx7fKPwHQ==",
       "requires": {
         "@microsoft/load-themed-styles": "1.7.9",
         "@uifabric/merge-styles": "5.6.0",
@@ -953,9 +1030,9 @@
       }
     },
     "ajv": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
+      "integrity": "sha1-MtHPCNvIDEMvQm8S4QslEfa0ZHQ=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -1272,7 +1349,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.15.0"
       }
     },
     "async-each": {
@@ -1311,7 +1388,7 @@
       "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
       "requires": {
         "browserslist": "2.9.0",
-        "caniuse-lite": "1.0.30000765",
+        "caniuse-lite": "1.0.30000769",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.14",
@@ -1319,9 +1396,9 @@
       }
     },
     "awesome-typescript-loader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.3.0.tgz",
-      "integrity": "sha512-BZklPjSHwOF15sQ28Bo25HMzH4WrF1i2CLr105lXe2p/o++F5n4Mi4My3WHJhG8bEpXweqlVN6b03ZFKvANXiA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.4.0.tgz",
+      "integrity": "sha512-sXPUe8HexKO4/NGTOtFP7ue+LbaALphiP22A8FaJCZT2avTtMQj3uVtrPRIvNf/6484i8rgx9d//jewiaqFH0w==",
       "requires": {
         "colors": "1.1.2",
         "enhanced-resolve": "3.3.0",
@@ -1331,6 +1408,13 @@
         "mkdirp": "0.5.1",
         "object-assign": "4.1.1",
         "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "aws-sign2": {
@@ -1348,7 +1432,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
       "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
-        "follow-redirects": "1.2.5",
+        "follow-redirects": "1.2.6",
         "is-buffer": "1.1.6"
       }
     },
@@ -1412,6 +1496,11 @@
         "source-map": "0.5.7"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1438,6 +1527,11 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
         "source-map": {
           "version": "0.5.7",
@@ -1496,6 +1590,13 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "babel-helper-evaluate-path": {
@@ -1591,6 +1692,13 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1787,7 +1895,7 @@
       "integrity": "sha512-11Yxwk8/iEULr+n5DG0BxXD6j/9htpiiR0/hLfi/gtEAK/d6NCNkyKFrC8loQcyMvF3hehPo30SKXG/itSX+hw==",
       "requires": {
         "babel-types": "6.26.0",
-        "lodash": "4.17.4",
+        "lodash": "4.15.0",
         "react-docgen": "2.20.0"
       }
     },
@@ -1949,6 +2057,13 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -2504,6 +2619,13 @@
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "babel-runtime": {
@@ -2532,6 +2654,13 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "babel-traverse": {
@@ -2548,6 +2677,13 @@
         "globals": "9.18.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "babel-types": {
@@ -2559,6 +2695,13 @@
         "esutils": "2.0.2",
         "lodash": "4.17.4",
         "to-fast-properties": "1.0.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "babylon": {
@@ -2610,9 +2753,9 @@
       }
     },
     "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -2658,7 +2801,7 @@
         "deep-equal": "1.0.1",
         "dns-equal": "1.0.0",
         "dns-txt": "2.0.2",
-        "multicast-dns": "6.1.1",
+        "multicast-dns": "6.2.0",
         "multicast-dns-service-types": "1.1.0"
       },
       "dependencies": {
@@ -2710,7 +2853,7 @@
         "repeat-element": "1.1.2",
         "snapdragon": "0.8.1",
         "snapdragon-node": "2.1.1",
-        "split-string": "3.0.2",
+        "split-string": "3.1.0",
         "to-regex": "3.0.1"
       }
     },
@@ -2813,7 +2956,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.0.tgz",
       "integrity": "sha512-vJEBcDTANoDhSHL46NeOEW5hvQw7It9uCqzeFPQhpawXfnOwnpvW5C97vn1eGJ7iCkSg8wWU0nYObE7d/N95Iw==",
       "requires": {
-        "caniuse-lite": "1.0.30000765",
+        "caniuse-lite": "1.0.30000769",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -2871,16 +3014,16 @@
         "commander": "2.11.0",
         "github-build": "1.2.0",
         "glob": "7.1.2",
-        "gzip-size": "4.0.0",
+        "gzip-size": "4.1.0",
         "opencollective": "1.0.3",
         "prettycli": "1.4.3",
         "read-pkg-up": "2.0.0"
       },
       "dependencies": {
         "gzip-size": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.0.0.tgz",
-          "integrity": "sha512-6SWfFRd8r8VTKTpJCR7h/T6IbCaK+jM/n2gB1+pV3IrKcrLO1WTb8ZWdaRy1T/nwOz80cp4gAJf8sujpZxfA1w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
+          "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
           "requires": {
             "duplexer": "0.1.1",
             "pify": "3.0.0"
@@ -2941,7 +3084,7 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000765",
+        "caniuse-db": "1.0.30000769",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -2951,21 +3094,21 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000765",
+            "caniuse-db": "1.0.30000769",
             "electron-to-chromium": "1.3.27"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000765",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000765.tgz",
-      "integrity": "sha1-FVVUMkILqsuxabxR5bbegEyZlLQ="
+      "version": "1.0.30000769",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000769.tgz",
+      "integrity": "sha1-wjC5wbno2z4cDYWMluaFdBuWzBA="
     },
     "caniuse-lite": {
-      "version": "1.0.30000765",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000765.tgz",
-      "integrity": "sha1-qhp1AZJ2tIRjwPyipSV/ufJqfJ0="
+      "version": "1.0.30000769",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000769.tgz",
+      "integrity": "sha1-1oxaoHcuo+rGyX1C4jnJtNMmG5M="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -3025,6 +3168,11 @@
         "supports-color": "4.5.0"
       }
     },
+    "chardet": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.0.tgz",
+      "integrity": "sha1-C74TVaxE16PtSpJXB8TvcPgZD2w="
+    },
     "cheerio": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
@@ -3069,9 +3217,9 @@
       "integrity": "sha512-6NSB3PSw6L7w9vqmlTveD1JpaOhngFYRqhFKNPtSLpx8kpu/3BZwf84Sz8+hsmDzaD+ITuuiNdN6ya5c2DhHWg=="
     },
     "ci-info": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -3897,7 +4045,7 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000765",
+            "caniuse-db": "1.0.30000769",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -3909,7 +4057,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000765",
+            "caniuse-db": "1.0.30000769",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -4371,6 +4519,13 @@
         "object.values": "1.0.4",
         "prop-types": "15.6.0",
         "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "errno": {
@@ -4777,12 +4932,12 @@
       }
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "requires": {
+        "chardet": "0.4.0",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       }
     },
@@ -4976,11 +5131,21 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
     "follow-redirects": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
-      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
+      "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
       "requires": {
-        "debug": "2.6.9"
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -5043,13 +5208,15 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "fs.realpath": {
@@ -5205,7 +5372,7 @@
       "requires": {
         "follow-redirects": "0.0.7",
         "https-proxy-agent": "1.0.0",
-        "mime": "1.4.1",
+        "mime": "1.5.0",
         "netrc": "0.1.4"
       },
       "dependencies": {
@@ -5358,6 +5525,13 @@
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "graceful-fs": {
@@ -5429,7 +5603,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.4.0",
         "har-schema": "2.0.0"
       }
     },
@@ -5722,6 +5896,11 @@
             "is-buffer": "1.1.6"
           }
         },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        },
         "micromatch": {
           "version": "2.3.11",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -5894,9 +6073,9 @@
         "chalk": "1.1.3",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.15.0",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx": "4.1.0",
@@ -5998,7 +6177,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -6024,7 +6203,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "1.1.2"
       }
     },
     "is-data-descriptor": {
@@ -6502,7 +6681,7 @@
             "string-length": "2.0.0",
             "strip-ansi": "4.0.0",
             "which": "1.3.0",
-            "worker-farm": "1.5.1",
+            "worker-farm": "1.5.2",
             "yargs": "9.0.1"
           }
         },
@@ -6640,7 +6819,7 @@
         "jest-docblock": "21.2.0",
         "micromatch": "2.3.11",
         "sane": "2.2.0",
-        "worker-farm": "1.5.1"
+        "worker-farm": "1.5.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -6858,7 +7037,7 @@
         "jest-util": "21.2.1",
         "pify": "3.0.0",
         "throat": "4.1.0",
-        "worker-farm": "1.5.1"
+        "worker-farm": "1.5.2"
       }
     },
     "jest-runtime": {
@@ -7012,6 +7191,11 @@
         "pretty-format": "21.2.1"
       }
     },
+    "jju": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
+    },
     "joi": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
@@ -7042,11 +7226,6 @@
         "argparse": "1.0.9",
         "esprima": "2.7.3"
       }
-    },
-    "jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
     },
     "jsdom": {
       "version": "9.12.0",
@@ -7118,9 +7297,9 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -7162,9 +7341,17 @@
       "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
     },
     "kind-of": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.0.tgz",
-      "integrity": "sha512-sUd5AnFyOPh+RW+ZIHd1FHuwM4OFvhKCPVxxhamLxWLpmv1xQ394lzRMmhLQOiMpXvnB64YRLezWaJi5xGk7Dg=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.1.tgz",
+      "integrity": "sha512-y/15y6w31q9eVnXhVLPQkI7MD6JyuPNqEnetl8bZEc+mngLuonHQJ0x/6BD1WX6ml0Ig/psUlyKZJxz8uUo1xQ=="
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "lazy-cache": {
       "version": "2.0.2",
@@ -7244,9 +7431,9 @@
       "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+      "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
     },
     "lodash-es": {
       "version": "4.17.4",
@@ -7395,6 +7582,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -7476,9 +7668,9 @@
       "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ="
     },
     "lolex": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.0.tgz",
-      "integrity": "sha512-rPO6R1t8PjYL6xbsFUg7aByKkWAql907na6powPBORVs4DCm8aMBUkL4+6CXO0gEIV8vtu3mWV0FB8ZaCYPBmA=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw=="
     },
     "longest": {
       "version": "1.0.1",
@@ -7760,7 +7952,7 @@
         "extend-shallow": "2.0.1",
         "extglob": "2.0.2",
         "fragment-cache": "0.2.1",
-        "kind-of": "6.0.0",
+        "kind-of": "6.0.1",
         "nanomatch": "1.2.5",
         "object.pick": "1.3.0",
         "regex-not": "1.0.0",
@@ -7778,9 +7970,9 @@
       }
     },
     "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.5.0.tgz",
+      "integrity": "sha512-v/jMDoK/qKptnTuC3YUNbIj8uUYvTCIHzVu9BHldKSWja48wusAtfjlcBlqnFrqClu3yf69ScDxBPrIyFnF51g=="
     },
     "mime-db": {
       "version": "1.30.0",
@@ -7952,9 +8144,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
-      "integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.0.tgz",
+      "integrity": "sha512-tnQqWkuWYHCOVRveiWQf+5KjHUnEmtxUycTy1esL4prQjXoT4qpndIS4fH63zObmHNxIHke3YHRnQrXYpXHf2A==",
       "requires": {
         "dns-packet": "1.2.2",
         "thunky": "0.1.0"
@@ -8026,9 +8218,9 @@
       "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
     },
     "ngrok": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-2.2.23.tgz",
-      "integrity": "sha1-dSxID4BWMzUmT3bc6/Tq9DSa90c=",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-2.2.24.tgz",
+      "integrity": "sha512-tz1X/yS3PD5N+Cwijn+bwSrDGNRNPpQPM0TEHtaT8K4sMpFUHFBhRJLlFyoGQyfmSML7Tdq9Fq17AKoEtGaJzw==",
       "requires": {
         "@types/node": "8.0.26",
         "async": "2.6.0",
@@ -8161,9 +8353,9 @@
       }
     },
     "node-sass": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.6.1.tgz",
-      "integrity": "sha512-0zQQ7tjEK5W8RfW9LiQrkzfo7uLZ0QtZGV69rdKn5cFzdweHLJ14lR6xLPvI6UimkXMO8m0qDsXwUCNdnqV3sA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
+      "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
       "requires": {
         "async-foreach": "0.1.3",
         "chalk": "1.1.3",
@@ -8180,15 +8372,39 @@
         "nan": "2.8.0",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
-        "request": "2.83.0",
+        "request": "2.79.0",
         "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0"
+        "stdout-stream": "1.4.0",
+        "true-case-path": "1.0.2"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
         },
         "chalk": {
           "version": "1.1.3",
@@ -8211,10 +8427,110 @@
             "which": "1.3.0"
           }
         },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.11.0",
+            "is-my-json-valid": "2.16.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+        },
+        "request": {
+          "version": "2.79.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.1.0"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
         }
       }
     },
@@ -8445,14 +8761,14 @@
       "integrity": "sha1-XaNUX43wnxcsbDzXcoj02U1eB88="
     },
     "office-ui-fabric-react": {
-      "version": "5.21.2",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.21.2.tgz",
-      "integrity": "sha512-ERFEVUHVYCKdqmsLTujYkBTRyQNBnWVlAy/UV1qmtvaQVoBOyrMTf9czernWXGeFuVfbB7fSLvyr4IhsVgtDNw==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.24.2.tgz",
+      "integrity": "sha512-0/la7j4C+tAcmjZ3WOO4XyAgQreQrAQTny2wgbj4bzHwLb/XAXk2KczYwiGqB7BxrRCvBKbeodLNBYWAweT1zw==",
       "requires": {
         "@microsoft/load-themed-styles": "1.7.9",
         "@uifabric/icons": "5.2.0",
         "@uifabric/merge-styles": "5.6.0",
-        "@uifabric/styling": "5.7.0",
+        "@uifabric/styling": "5.10.0",
         "@uifabric/utilities": "5.4.0",
         "prop-types": "15.6.0",
         "tslib": "1.8.0"
@@ -9625,7 +9941,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000765",
+            "caniuse-db": "1.0.30000769",
             "electron-to-chromium": "1.3.27"
           }
         },
@@ -10920,9 +11236,9 @@
       }
     },
     "react-modal": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.2.tgz",
-      "integrity": "sha512-a3L2qP0kaqMBy4C1aojs2caUIz3kHRFlnuWJ8zsnuUmh/fKHEDASujVBiQcatn+yUosdE9hViB6JvLfkB0tN2A==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.3.tgz",
+      "integrity": "sha512-FBsaLSV+TsCA1+ULj3r9Wf3xZ3arKjfOsdom8hv3z/Gvwu+FgOFsW3w28leMNqpBBDc76KhqifzXS5LeBPDBug==",
       "requires": {
         "exenv": "1.2.2",
         "prop-types": "15.6.0"
@@ -10942,16 +11258,16 @@
       "integrity": "sha512-c7aK5ffRyeOySSWVeoSEsQHBUrNtzXTB9TFNUnZv/2EM7HEnN1Rfsgxag/bpDcl5GuaY5IuMvq7XySc6nyokog==",
       "requires": {
         "@types/inline-style-prefixer": "3.0.1",
-        "@types/react": "16.0.23",
+        "@types/react": "16.0.25",
         "inline-style-prefixer": "3.0.8",
         "prop-types": "15.6.0",
         "react-style-proptype": "3.1.0"
       },
       "dependencies": {
         "@types/react": {
-          "version": "16.0.23",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.23.tgz",
-          "integrity": "sha512-iWplruxO5ENh7XMEBV6XtL54nrMgM8CrfIJ7+THvnUaddICEssH+EPo1MJoQU209Tz5/rVWTOCvQS8/kRR7zcA=="
+          "version": "16.0.25",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.25.tgz",
+          "integrity": "sha512-K79zMwWRzQ2db+nPoKpi3gA/KmLo6ZQgT4iO2QPEUdBO7as0PcgrmU9KHYzIO3V6lbD7gRjOM0/nUch6xBfOvQ=="
         }
       }
     },
@@ -11129,7 +11445,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
-        "lodash": "4.17.4",
+        "lodash": "4.15.0",
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.0.4"
@@ -11281,7 +11597,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.15.0"
       }
     },
     "require-directory": {
@@ -11419,7 +11735,7 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "requires": {
         "glob": "7.1.2",
-        "lodash": "4.17.4",
+        "lodash": "4.15.0",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
       },
@@ -11583,7 +11899,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
-        "ajv": "5.3.0"
+        "ajv": "5.4.0"
       }
     },
     "screener-runner": {
@@ -11599,7 +11915,7 @@
         "http-proxy": "1.16.2",
         "joi": "9.2.0",
         "lodash": "4.16.6",
-        "ngrok": "2.2.23",
+        "ngrok": "2.2.24",
         "portfinder": "1.0.13",
         "request": "2.78.0",
         "request-promise": "4.1.1"
@@ -12016,6 +12332,11 @@
             "xml-name-validator": "2.0.1"
           }
         },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        },
         "ms": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -12088,7 +12409,7 @@
             "http-proxy": "1.16.2",
             "joi": "9.2.0",
             "lodash": "4.16.6",
-            "ngrok": "2.2.23",
+            "ngrok": "2.2.24",
             "portfinder": "1.0.13",
             "request": "2.78.0",
             "request-promise": "4.1.1"
@@ -12257,6 +12578,13 @@
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+        }
       }
     },
     "serve-favicon": {
@@ -12322,7 +12650,7 @@
         "extend-shallow": "2.0.1",
         "is-extendable": "0.1.1",
         "is-plain-object": "2.0.4",
-        "split-string": "3.0.2"
+        "split-string": "3.1.0"
       }
     },
     "setimmediate": {
@@ -12430,7 +12758,7 @@
         "diff": "3.4.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.0",
+        "lolex": "2.3.1",
         "nise": "1.2.0",
         "supports-color": "4.5.0",
         "type-detect": "4.0.5"
@@ -12680,11 +13008,29 @@
       }
     },
     "split-string": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz",
-      "integrity": "sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.1.tgz",
+          "integrity": "sha512-Fg1xXAv+qXKdwHiJFMcZSqsMcbPlkzsZtf8KkLJ2fqnP+lqg2RjEKgDcSfO9CO1+p4LZKgApDBUUUqKaaRhwZQ==",
+          "requires": {
+            "is-extendable": "1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
       }
     },
     "sprintf-js": {
@@ -13332,15 +13678,38 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
+    "true-case-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+      "requires": {
+        "glob": "6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "ts-jest": {
-      "version": "21.2.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-21.2.2.tgz",
-      "integrity": "sha512-jBkZaC995zeUI+t6N7hvnHMnmkHUk2B+Bf7y8ZIgOe6YBNrUIMwRB3CYJmrJtWOefNUXVCr41W2Hab1ut9dy9w==",
+      "version": "21.2.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-21.2.3.tgz",
+      "integrity": "sha512-/gpl/RUPJMVZmERi360sKu5wzSriAg20HMRZsNgXY7sUWtmSn3iPxQcCBDUi2bmcRPtPOLTSijzWK3ZrlYkUhA==",
       "requires": {
         "babel-core": "6.26.0",
         "babel-plugin-istanbul": "4.1.5",
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-preset-jest": "21.2.0",
+        "cpx": "1.5.0",
         "fs-extra": "4.0.2",
         "jest-config": "21.2.1",
         "jest-util": "21.2.1",
@@ -13349,6 +13718,24 @@
         "yargs": "10.0.3"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
         "source-map-support": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
@@ -13476,9 +13863,9 @@
       }
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w=="
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ="
     },
     "typical": {
       "version": "2.6.1",
@@ -13555,9 +13942,9 @@
       }
     },
     "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "underscore": {
       "version": "1.7.0",
@@ -13692,7 +14079,7 @@
       "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
       "requires": {
         "loader-utils": "1.1.0",
-        "mime": "1.4.1",
+        "mime": "1.5.0",
         "schema-utils": "0.3.0"
       }
     },
@@ -13785,6 +14172,11 @@
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
+    },
+    "validator": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
+      "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA=="
     },
     "vary": {
       "version": "1.1.2",
@@ -13899,7 +14291,7 @@
       "requires": {
         "acorn": "5.2.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.3.0",
+        "ajv": "5.4.0",
         "ajv-keywords": "2.1.1",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
@@ -13979,7 +14371,7 @@
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "opener": "1.4.3",
-        "ws": "3.3.1"
+        "ws": "3.3.2"
       },
       "dependencies": {
         "acorn": {
@@ -14004,6 +14396,11 @@
             "supports-color": "2.0.0"
           }
         },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -14012,12 +14409,12 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
-      "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.1.tgz",
+      "integrity": "sha512-UzyVg/CKBKkymDpqOoQ4mWTs9zQp0DPCY8zbol9K0tPhqoM+JU5knKGXyMQ/Cdrmzb9Cw3eetm67fIsJ7u7ryg==",
       "requires": {
         "memory-fs": "0.4.1",
-        "mime": "1.4.1",
+        "mime": "1.5.0",
         "path-is-absolute": "1.0.1",
         "range-parser": "1.2.0",
         "time-stamp": "2.0.0"
@@ -14053,7 +14450,7 @@
         "spdy": "3.4.7",
         "strip-ansi": "3.0.1",
         "supports-color": "4.5.0",
-        "webpack-dev-middleware": "1.12.0",
+        "webpack-dev-middleware": "1.12.1",
         "yargs": "6.6.0"
       },
       "dependencies": {
@@ -14235,9 +14632,9 @@
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "worker-farm": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.1.tgz",
-      "integrity": "sha512-T5NH6Wqsd8MwGD4AK8BBllUy6LmHaqjEOyo/YIUEegZui6/v5Bqde//3jwyE3PGiGYMmWi06exFBi5LNhhPFNw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "requires": {
         "errno": "0.1.4",
         "xtend": "4.0.1"
@@ -14295,7 +14692,7 @@
         "chalk": "1.1.3",
         "debug": "2.6.9",
         "filesize": "3.5.11",
-        "lodash": "4.17.4",
+        "lodash": "4.15.0",
         "mkdirp": "0.5.1",
         "moment": "2.19.2"
       },
@@ -14325,13 +14722,13 @@
       }
     },
     "ws": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.1.tgz",
-      "integrity": "sha512-8A/uRMnQy8KCQsmep1m7Bk+z/+LIkeF7w+TDMLtX1iZm5Hq9HsUDmgFGaW1ACW5Cj0b2Qo7wCvRhYN2ErUVp/A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
+      "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",
-        "ultron": "1.1.0"
+        "ultron": "1.1.1"
       }
     },
     "xdg-basedir": {
@@ -14502,6 +14899,17 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
         "camelcase": "4.1.0"
+      }
+    },
+    "z-schema": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
+      "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
+      "requires": {
+        "commander": "2.11.0",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
+        "validator": "8.2.0"
       }
     }
   }

--- a/packages/merge-styles/config/api-extractor.js
+++ b/packages/merge-styles/config/api-extractor.js
@@ -1,0 +1,9 @@
+module.exports = {
+  "compiler": {
+    "configType": "tsconfig",
+    "rootFolder": process.cwd()
+  },
+  "project": {
+    "entryPointSourceFile": "src/index.ts"
+  }
+};

--- a/packages/merge-styles/config/api-extractor.json
+++ b/packages/merge-styles/config/api-extractor.json
@@ -1,6 +1,0 @@
-{
-  "enabled": true,
-  "apiReviewFolder": "./api",
-  "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
-}

--- a/packages/merge-styles/etc/merge-styles.api.ts
+++ b/packages/merge-styles/etc/merge-styles.api.ts
@@ -1,0 +1,64 @@
+// @public
+export function concatStyleSets < T extends object >(...args: (T | false | null | undefined)[]): T;
+
+// @public
+export function fontFace(font: IFontFace): void;
+
+// @public
+interface IFontFace extends IRawFontStyle {
+  fontFeatureSettings?: string;
+  src?: string;
+  unicodeRange?: ICSSRule | string;
+}
+
+// @public
+enum InjectionMode {
+  appendChild = 2,
+  insertNode = 1,
+  none = 0
+}
+
+// @public
+interface IRawStyle extends IRawStyleBase {
+  displayName?: string;
+  selectors?: {
+    [ key: string ]: IStyle;
+  }
+}
+
+// @public
+interface IStyleSheetConfig {
+  injectionMode?: InjectionMode;
+}
+
+// @public
+export function keyframes(timeline: { [key: string]: {} }): string;
+
+// @public
+export function mergeStyles(...args: (IStyle | IStyle[] | false | null | undefined)[]): string;
+
+// @public
+export function mergeStyleSets < T >(...cssSets: ({[P in keyof T]?: IStyle } | null | undefined)[]): T;
+
+// @public
+class Stylesheet {
+  constructor(config?: IStyleSheetConfig);
+  public argsFromClassName(className: string): IStyle[] | undefined;
+  public cacheClassName(className: string,
+      key: string,
+      args: IStyle[],
+      rules: string[]): void;
+  public classNameFromKey(key: string): string | undefined;
+  public getClassName(displayName?: string): string;
+  public static getInstance(): Stylesheet;
+  public getRules(): string;
+  public insertedRulesFromClassName(className: string): string[] | undefined;
+  public insertRule(rule: string): void;
+  public reset(): void;
+  public setConfig(config?: IStyleSheetConfig): void;
+}
+
+// WARNING: Unsupported export: IStyle
+// WARNING: Unsupported export: IStyleSet
+// WARNING: Unsupported export: IFontWeight
+// (No packageDescription for this package)

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -76,7 +76,6 @@ export class Stylesheet {
 
   constructor(config?: IStyleSheetConfig) {
     this._config = {
-      async: false,
       injectionMode: InjectionMode.insertNode,
       ...config
     };

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -25,7 +25,7 @@ import {
 import * as stylesImport from './Persona.scss';
 const styles: any = stylesImport;
 
-const SIZE_TO_PIXELS = {
+const SIZE_TO_PIXELS: { [key: number]: number } = {
   [PersonaSize.tiny]: 20,
   [PersonaSize.extraExtraSmall]: 24,
   [PersonaSize.extraSmall]: 28,

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaConsts.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaConsts.ts
@@ -6,7 +6,7 @@ import {
 import * as stylesImport from './Persona.scss';
 const styles: any = stylesImport;
 
-export const PERSONA_SIZE = {
+export const PERSONA_SIZE: { [key: number]: string } = {
   // All non-numerically named sizes are deprecated, use the numerically named classes below
   [PersonaSize.tiny]: 'ms-Persona--tiny ' + styles.rootIsSize10,
   [PersonaSize.extraExtraSmall]: 'ms-Persona--xxs ' + styles.rootIsSize24,
@@ -27,7 +27,7 @@ export const PERSONA_SIZE = {
   [PersonaSize.size100]: 'ms-Persona--size100 ' + styles.rootIsSize100
 };
 
-export const PERSONA_PRESENCE = {
+export const PERSONA_PRESENCE: { [key: number]: string } = {
   [PersonaPresence.offline]: 'ms-Persona--offline ' + styles.rootIsOffline,
   [PersonaPresence.online]: 'ms-Persona--online ',
   [PersonaPresence.away]: 'ms-Persona--away ' + styles.rootIsAway,
@@ -36,7 +36,7 @@ export const PERSONA_PRESENCE = {
   [PersonaPresence.busy]: 'ms-Persona--busy ' + styles.rootIsBusy
 };
 
-export const PERSONA_INITIALS_COLOR = {
+export const PERSONA_INITIALS_COLOR: { [key: number]: string } = {
   [PersonaInitialsColor.lightBlue]: 'ms-Persona-initials--lightBlue ' + styles.initialsIsLightBlue,
   [PersonaInitialsColor.blue]: 'ms-Persona-initials--blue ' + styles.initialsIsBlue,
   [PersonaInitialsColor.darkBlue]: 'ms-Persona-initials--darkBlue ' + styles.initialsIsDarkBlue,

--- a/packages/styling/config/api-extractor.js
+++ b/packages/styling/config/api-extractor.js
@@ -1,0 +1,9 @@
+module.exports = {
+  "compiler": {
+    "configType": "tsconfig",
+    "rootFolder": process.cwd()
+  },
+  "project": {
+    "entryPointSourceFile": "src/index.ts"
+  }
+};

--- a/packages/styling/config/api-extractor.json
+++ b/packages/styling/config/api-extractor.json
@@ -1,6 +1,0 @@
-{
-  "enabled": true,
-  "apiReviewFolder": "./api",
-  "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
-}

--- a/packages/styling/etc/styling.api.ts
+++ b/packages/styling/etc/styling.api.ts
@@ -1,0 +1,423 @@
+// @public
+export function buildClassMap < T >(styles: T): {[key in keyof T]?: string };
+
+// @public
+export function classNamesFunction < TStyleProps extends {}, TStyles extends {} >(): (
+  getStyles?: IStyleFunction<TStyleProps, TStyles>,
+  styleProps?: TStyleProps
+) => IClassNames<TStyles>;
+
+// @public
+export declare function concatStyleSets < T extends object >(...args: (T | false | null | undefined)[]): T;
+
+// @public
+export function createFontStyles(localeCode: string | null): IFontStyles;
+
+// @public
+export function createTheme(theme: IPartialTheme): ITheme;
+
+// @public
+export declare function fontFace(font: IFontFace): void;
+
+// WARNING: Export "mini" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "xSmall" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "small" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "smallPlus" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "medium" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "mediumPlus" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "icon" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "large" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "xLarge" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "xxLarge" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "superLarge" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "mega" must specify and be of type"string", "number" or "boolean"
+// @public
+module FontSizes {
+}
+
+// WARNING: Export "light" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "semilight" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "regular" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "semibold" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "bold" must specify and be of type"string", "number" or "boolean"
+// @public
+module FontWeights {
+}
+
+// @public
+export function getFocusStyle(theme: ITheme,
+  inset: number = 0,
+  position: 'relative' | 'absolute' = 'relative'): IRawStyle;
+
+// @public
+export function getIcon(name?: string): IIconRecord | undefined;
+
+// @public
+export function getIconClassName(name: string): string;
+
+// @public
+export function getTheme(): ITheme;
+
+// @public
+interface IAnimationStyles {
+  // (undocumented)
+  fadeIn100: IRawStyle;
+  // (undocumented)
+  fadeIn200: IRawStyle;
+  // (undocumented)
+  fadeIn400: IRawStyle;
+  // (undocumented)
+  fadeIn500: IRawStyle;
+  // (undocumented)
+  fadeOut100: IRawStyle;
+  // (undocumented)
+  fadeOut200: IRawStyle;
+  // (undocumented)
+  fadeOut400: IRawStyle;
+  // (undocumented)
+  fadeOut500: IRawStyle;
+  // (undocumented)
+  rotate90deg: IRawStyle;
+  // (undocumented)
+  rotateN90deg: IRawStyle;
+  // (undocumented)
+  scaleDownIn100: IRawStyle;
+  // (undocumented)
+  scaleDownOut98: IRawStyle;
+  // (undocumented)
+  scaleUpIn100: IRawStyle;
+  // (undocumented)
+  scaleUpOut103: IRawStyle;
+  // (undocumented)
+  slideDownIn10: IRawStyle;
+  // (undocumented)
+  slideDownIn20: IRawStyle;
+  // (undocumented)
+  slideDownOut10: IRawStyle;
+  // (undocumented)
+  slideDownOut20: IRawStyle;
+  // (undocumented)
+  slideLeftIn10: IRawStyle;
+  // (undocumented)
+  slideLeftIn20: IRawStyle;
+  // (undocumented)
+  slideLeftIn40: IRawStyle;
+  // (undocumented)
+  slideLeftIn400: IRawStyle;
+  // (undocumented)
+  slideLeftOut10: IRawStyle;
+  // (undocumented)
+  slideLeftOut20: IRawStyle;
+  // (undocumented)
+  slideLeftOut40: IRawStyle;
+  // (undocumented)
+  slideLeftOut400: IRawStyle;
+  // (undocumented)
+  slideRightIn10: IRawStyle;
+  // (undocumented)
+  slideRightIn20: IRawStyle;
+  // (undocumented)
+  slideRightIn40: IRawStyle;
+  // (undocumented)
+  slideRightIn400: IRawStyle;
+  // (undocumented)
+  slideRightOut10: IRawStyle;
+  // (undocumented)
+  slideRightOut20: IRawStyle;
+  // (undocumented)
+  slideRightOut40: IRawStyle;
+  // (undocumented)
+  slideRightOut400: IRawStyle;
+  // (undocumented)
+  slideUpIn10: IRawStyle;
+  // (undocumented)
+  slideUpIn20: IRawStyle;
+  // (undocumented)
+  slideUpOut10: IRawStyle;
+  // (undocumented)
+  slideUpOut20: IRawStyle;
+}
+
+// WARNING: Export "xSmall" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "small" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "medium" must specify and be of type"string", "number" or "boolean"
+// WARNING: Export "large" must specify and be of type"string", "number" or "boolean"
+// @public
+module IconFontSizes {
+}
+
+// @public
+interface IFontFace extends IRawFontStyle {
+  fontFeatureSettings?: string;
+  src?: string;
+  unicodeRange?: ICSSRule | string;
+}
+
+// @public
+interface IFontStyles {
+  // (undocumented)
+  large?: IRawStyle;
+  // (undocumented)
+  medium?: IRawStyle;
+  // (undocumented)
+  mediumPlus?: IRawStyle;
+  // (undocumented)
+  mega?: IRawStyle;
+  // (undocumented)
+  small?: IRawStyle;
+  // (undocumented)
+  smallPlus?: IRawStyle;
+  // (undocumented)
+  superLarge?: IRawStyle;
+  // (undocumented)
+  tiny?: IRawStyle;
+  // (undocumented)
+  xLarge?: IRawStyle;
+  // (undocumented)
+  xSmall?: IRawStyle;
+  // (undocumented)
+  xxLarge?: IRawStyle;
+}
+
+// @public
+interface IIconOptions {
+  // (undocumented)
+  disableWarnings: boolean;
+  // (undocumented)
+  warnOnMissingIcons: boolean;
+}
+
+// @public
+interface IIconRecord {
+  // (undocumented)
+  code: string | undefined;
+  // (undocumented)
+  subset: IIconSubsetRecord;
+}
+
+// @public
+interface IIconSubset {
+  // (undocumented)
+  fontFace?: IFontFace;
+  // (undocumented)
+  icons: {
+    [ key: string ]: string | JSX.Element;
+  }
+  // (undocumented)
+  style?: IRawStyle;
+}
+
+// @public
+enum InjectionMode {
+  appendChild = 2,
+  insertNode = 1,
+  none = 0
+}
+
+// @public
+interface IPalette {
+  accent: string;
+  black: string;
+  blackTranslucent40: string;
+  blue: string;
+  blueDark: string;
+  blueLight: string;
+  blueMid: string;
+  green: string;
+  greenDark: string;
+  greenLight: string;
+  magenta: string;
+  magentaDark: string;
+  magentaLight: string;
+  neutralDark: string;
+  neutralLight: string;
+  neutralLighter: string;
+  neutralLighterAlt: string;
+  neutralPrimary: string;
+  neutralPrimaryAlt: string;
+  neutralQuaternary: string;
+  neutralQuaternaryAlt: string;
+  neutralSecondary: string;
+  neutralTertiary: string;
+  neutralTertiaryAlt: string;
+  orange: string;
+  orangeLight: string;
+  orangeLighter: string;
+  purple: string;
+  purpleDark: string;
+  purpleLight: string;
+  red: string;
+  redDark: string;
+  teal: string;
+  tealDark: string;
+  tealLight: string;
+  themeDark: string;
+  themeDarkAlt: string;
+  themeDarker: string;
+  themeLight: string;
+  themeLighter: string;
+  themeLighterAlt: string;
+  themePrimary: string;
+  themeSecondary: string;
+  themeTertiary: string;
+  white: string;
+  yellow: string;
+  yellowLight: string;
+}
+
+// @public
+interface IPropsWithStyles<TStyleProps, TStyles> {
+  // (undocumented)
+  getStyles?: IStyleFunction<TStyleProps, TStyles>;
+  // (undocumented)
+  subComponents?: {
+    [ key: string ]: IStyleFunction<{}, {}>;
+  }
+}
+
+// @public
+interface IRawStyle extends IRawStyleBase {
+  displayName?: string;
+  selectors?: {
+    [ key: string ]: IStyle;
+  }
+}
+
+// @public
+interface ISemanticColors {
+  blockingBackground: string;
+  bodyBackground: string;
+  bodyDivider: string;
+  bodySubtext: string;
+  bodyText: string;
+  bodyTextChecked: string;
+  buttonBackground: string;
+  buttonBackgroundChecked: string;
+  buttonBackgroundCheckedHovered: string;
+  buttonBackgroundHovered: string;
+  buttonBorder: string;
+  buttonText: string;
+  buttonTextChecked: string;
+  buttonTextCheckedHovered: string;
+  buttonTextHovered: string;
+  disabledBackground: string;
+  disabledBodyText: string;
+  disabledSubtext: string;
+  disabledText: string;
+  errorBackground: string;
+  errorText: string;
+  focusBorder: string;
+  inputBackgroundChecked: string;
+  inputBackgroundCheckedHovered: string;
+  inputBorder: string;
+  inputBorderHovered: string;
+  inputFocusBorderAlt: string;
+  inputForegroundChecked: string;
+  listBackground: string;
+  listItemBackgroundChecked: string;
+  listItemBackgroundCheckedHovered: string;
+  listItemBackgroundHovered: string;
+  listTextColor: string;
+  menuHeader: string;
+  menuIcon: string;
+  // @deprecated (undocumented)
+  menuItemBackgroundChecked: string;
+  menuItemBackgroundHovered: string;
+  successBackground: string;
+  warningBackground: string;
+  warningHighlight: string;
+  warningText: string;
+}
+
+// @public
+interface IStyleSheetConfig {
+  injectionMode?: InjectionMode;
+}
+
+// @public
+interface ITheme {
+  // (undocumented)
+  fonts: IFontStyles;
+  // (undocumented)
+  isInverted: boolean;
+  // (undocumented)
+  palette: IPalette;
+  // (undocumented)
+  semanticColors: ISemanticColors;
+}
+
+// @public
+export declare function keyframes(timeline: {
+    [key: string]: {};
+}): string;
+
+// @public
+export function loadTheme(theme: IPartialTheme): ITheme;
+
+// @public
+export declare function mergeStyles(...args: (IStyle | IStyle[] | false | null | undefined)[]): string;
+
+// @public
+export declare function mergeStyleSets < T >(...cssSets: ({
+    [P in keyof T]?: IStyle;
+} | null | undefined)[]): T;
+
+// @public
+export function registerDefaultFontFaces(baseUrl: string): void;
+
+// @public
+export function registerIconAlias(iconName: string, mappedToName: string): void;
+
+// @public
+export function registerIcons(iconSubset: IIconSubset): void;
+
+// @public
+export function setIconOptions(options: Partial<IIconOptions>): void;
+
+// @public
+export function styled < TComponentProps extends IPropsWithStyles<TStyleProps, TStyles>, TStyleProps, TStyles >(Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>,
+  getBaseStyles: (props: TStyleProps) => TStyles,
+  getProps?: (props: TComponentProps) => Partial<TComponentProps>): (props: TComponentProps) => JSX.Element;
+
+// @public
+class Stylesheet {
+  constructor(config?: IStyleSheetConfig);
+  argsFromClassName(className: string): IStyle[] | undefined;
+  cacheClassName(className: string, key: string, args: IStyle[], rules: string[]): void;
+  classNameFromKey(key: string): string | undefined;
+  getClassName(displayName?: string): string;
+  static getInstance(): Stylesheet;
+  getRules(): string;
+  insertedRulesFromClassName(className: string): string[] | undefined;
+  insertRule(rule: string): void;
+  reset(): void;
+  setConfig(config?: IStyleSheetConfig): void;
+}
+
+// WARNING: Unsupported export: AnimationClassNames
+// WARNING: Unsupported export: FontClassNames
+// WARNING: Unsupported export: ColorClassNames
+// WARNING: Unsupported export: AnimationStyles
+// WARNING: Unsupported export: DefaultPalette
+// WARNING: Unsupported export: DefaultFontStyles
+// WARNING: Unsupported export: hiddenContentStyle
+// WARNING: Unsupported export: ThemeSettingName
+// WARNING: Unsupported export: HighContrastSelector
+// WARNING: Unsupported export: ScreenWidthMinSmall
+// WARNING: Unsupported export: ScreenWidthMinMedium
+// WARNING: Unsupported export: ScreenWidthMinLarge
+// WARNING: Unsupported export: ScreenWidthMinXLarge
+// WARNING: Unsupported export: ScreenWidthMinXXLarge
+// WARNING: Unsupported export: ScreenWidthMinXXXLarge
+// WARNING: Unsupported export: ScreenWidthMaxSmall
+// WARNING: Unsupported export: ScreenWidthMaxMedium
+// WARNING: Unsupported export: ScreenWidthMaxLarge
+// WARNING: Unsupported export: ScreenWidthMaxXLarge
+// WARNING: Unsupported export: ScreenWidthMaxXXLarge
+// WARNING: Unsupported export: IPartialTheme
+// WARNING: Unsupported export: IClassNames
+// WARNING: Unsupported export: IStyleFunction
+// WARNING: Unsupported export: IFontWeight
+// WARNING: Unsupported export: IStyle
+// WARNING: Unsupported export: IStyleSet
+// (No packageDescription for this package)

--- a/packages/styling/src/interfaces/IAnimationStyles.ts
+++ b/packages/styling/src/interfaces/IAnimationStyles.ts
@@ -3,6 +3,8 @@ import { IRawStyle } from '@uifabric/merge-styles/lib/index';
 /**
  * All Fabric standard animations, exposed as json objects referencing predefined
  * keyframes. These objects can be mixed in with other class definitions.
+ *
+ * @public
  */
 export interface IAnimationStyles {
   slideRightIn10: IRawStyle;

--- a/packages/styling/src/interfaces/IFontStyles.ts
+++ b/packages/styling/src/interfaces/IFontStyles.ts
@@ -2,6 +2,8 @@ import { IRawStyle } from '@uifabric/merge-styles/lib/index';
 
 /**
  * UI Fabric font set.
+ *
+ * @public
  */
 export interface IFontStyles {
   tiny?: IRawStyle;

--- a/packages/styling/src/interfaces/IPalette.ts
+++ b/packages/styling/src/interfaces/IPalette.ts
@@ -1,5 +1,7 @@
 /**
  * UI Fabric color palette.
+ *
+ * @public
  */
 export interface IPalette {
   /**

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -45,6 +45,8 @@
  * Lists differ from menus in that they are designed to show infinite amounts of items, often scroll,
  * and have a large and complex interaction surface.
  * This category covers all kinds of lists, whether they're typical one-item-per-row lists (like DetailsList) or ones with a tiled layout.
+ *
+ * @public
  */
 export interface ISemanticColors {
   /* ANY ADDITIONS/REMOVALS HERE MUST ALSO BE MADE TO \packages\office-ui-fabric-react\src\common\_semanticSlots.scss */

--- a/packages/styling/src/interfaces/ITheme.ts
+++ b/packages/styling/src/interfaces/ITheme.ts
@@ -2,6 +2,11 @@ import { IPalette } from './IPalette';
 import { IFontStyles } from './IFontStyles';
 import { ISemanticColors } from './ISemanticColors';
 
+/**
+ * The theme object.
+ *
+ * @public
+ */
 export interface ITheme {
   palette: IPalette;
   fonts: IFontStyles;
@@ -9,9 +14,9 @@ export interface ITheme {
   isInverted: boolean;
 }
 
-export interface IPartialTheme {
-  palette?: Partial<IPalette>;
-  fonts?: Partial<IFontStyles>;
-  semanticColors?: Partial<ISemanticColors>;
-  isInverted?: boolean;
-}
+/**
+ * Partial theme.
+ *
+ * @public
+ */
+export type IPartialTheme = Partial<ITheme>;

--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -46,6 +46,13 @@ function _registerFontFaceSet(
   _registerFontFace(fontFamily, urlBase + '-semibold', FontWeights.semibold);
 }
 
+/**
+ * Registers default font faces, given an optional base url.
+ *
+ * @param baseUrl - The baseUrl which contains the 'fonts' folder.
+ *
+ * @public
+ */
 export function registerDefaultFontFaces(baseUrl: string): void {
   if (baseUrl) {
     const fontUrl = `${baseUrl}/fonts`;

--- a/packages/styling/src/styles/fonts.ts
+++ b/packages/styling/src/styles/fonts.ts
@@ -68,7 +68,11 @@ const LanguageToFontMap = {
   'zh-hant': LocalizedFontFamilies.ChineseTraditional,
 };
 
-// Standard font sizes.
+/**
+ * Standard font sizes.
+ *
+ * @public
+ */
 export namespace FontSizes {
   export const mini = '10px';
   export const xSmall = '11px';
@@ -84,7 +88,11 @@ export namespace FontSizes {
   export const mega = '72px';
 }
 
-// Standard font weights.
+/**
+ * Standard font weights.
+ *
+ * @public
+ */
 export namespace FontWeights {
   export const light = 100;
   export const semilight = 300;
@@ -93,7 +101,11 @@ export namespace FontWeights {
   export const bold = 700;
 }
 
-// Standard Icon Sizes.
+/**
+ * Standard Icon Sizes.
+ *
+ * @public
+ */
 export namespace IconFontSizes {
   export const xSmall = '10px';
   export const small = '12px';
@@ -101,6 +113,13 @@ export namespace IconFontSizes {
   export const large = '20px';
 }
 
+/**
+ * Creates the font styles object, given a language code.
+ *
+ * @param localeCode - The language code. Example: "en"
+ *
+ * @public
+ */
 export function createFontStyles(localeCode: string | null): IFontStyles {
   return {
     tiny: _createFont(FontSizes.mini, FontWeights.semibold, localeCode),

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -10,6 +10,8 @@ import { ITheme } from '../interfaces/index';
  * @param position - The positioning applied to the container. Must
  * be 'relative' or 'absolute' so that the focus border can live around it.
  * @returns The style object.
+ *
+ * @public
  */
 export function getFocusStyle(
   theme: ITheme,

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -20,6 +20,9 @@ let _theme: ITheme = {
   isInverted: false
 };
 
+/**
+ * The theme setting name used in Customizations.
+ */
 export const ThemeSettingName = 'theme';
 
 if (!Customizations.getSettings([ThemeSettingName]).theme) {
@@ -37,6 +40,8 @@ if (!Customizations.getSettings([ThemeSettingName]).theme) {
 
 /**
  * Gets the theme object.
+ *
+ * @public
  */
 export function getTheme(): ITheme {
   return _theme;
@@ -44,6 +49,8 @@ export function getTheme(): ITheme {
 
 /**
  * Applies the theme, while filling in missing slots.
+ *
+ * @public
  */
 export function loadTheme(theme: IPartialTheme): ITheme {
   _theme = createTheme(theme);
@@ -58,6 +65,8 @@ export function loadTheme(theme: IPartialTheme): ITheme {
 
 /**
  * Creates a custom theme definition which can be used with the Customizer.
+ *
+ * @public
  */
 export function createTheme(theme: IPartialTheme): ITheme {
   let newPalette = { ...DefaultPalette, ...theme.palette };

--- a/packages/styling/src/utilities/buildClassMap.ts
+++ b/packages/styling/src/utilities/buildClassMap.ts
@@ -5,6 +5,8 @@ import { mergeStyles } from '../MergeStyles';
  *
  * @param styles - Map of unprocessed styles.
  * @returns Map of property name to class name.
+ *
+ * @public
  */
 export function buildClassMap<T>(styles: T): {[key in keyof T]?: string } {
   let classes: {[key in keyof T]?: string } = {};

--- a/packages/styling/src/utilities/classNamesFunction.ts
+++ b/packages/styling/src/utilities/classNamesFunction.ts
@@ -7,13 +7,14 @@ import {
 /**
  * Creates a getClassNames function which calls getStyles given the props, and injects them
  * into mergeStyleSets.
+ *
+ * @public
  */
 export function classNamesFunction<TStyleProps extends {}, TStyles extends {}>(): (
   getStyles?: IStyleFunction<TStyleProps, TStyles>,
   styleProps?: TStyleProps
 ) => IClassNames<TStyles> {
 
-  // TODO: memoize.
   return (
     getStyles?: IStyleFunction<TStyleProps, TStyles>,
     styleProps?: TStyleProps

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -11,6 +11,11 @@ import {
   mergeStyles
 } from '@uifabric/merge-styles/lib/index';
 
+/**
+ * An icon subset.
+ *
+ * @public
+ */
 export interface IIconSubset {
   fontFace?: IFontFace;
   icons: {
@@ -20,21 +25,41 @@ export interface IIconSubset {
   style?: IRawStyle;
 }
 
+/**
+ * An icon subset record.
+ *
+ * @public
+ */
 export interface IIconSubsetRecord extends IIconSubset {
   isRegistered?: boolean;
   className?: string;
 }
 
+/**
+ * An icon record.
+ *
+ * @public
+ */
 export interface IIconRecord {
   code: string | undefined;
   subset: IIconSubsetRecord;
 }
 
+/**
+ * Icon options.
+ *
+ * @public
+ */
 export interface IIconOptions {
   disableWarnings: boolean;
   warnOnMissingIcons: boolean;
 }
 
+/**
+ * All icon records.
+ *
+ * @public
+ */
 export interface IIconRecords {
   __options: IIconOptions;
   __remapped: { [key: string]: string };
@@ -54,6 +79,8 @@ const _icons = GlobalSettings.getValue<IIconRecords>(ICON_SETTING_NAME, {
  * Registers a given subset of icons.
  *
  * @param iconSubset - the icon subset definition.
+ *
+ * @public
  */
 export function registerIcons(iconSubset: IIconSubset): void {
   let subset = {
@@ -82,6 +109,8 @@ export function registerIcons(iconSubset: IIconSubset): void {
 
 /**
  * Remaps one icon name to another.
+ *
+ * @public
  */
 export function registerIconAlias(iconName: string, mappedToName: string): void {
   _icons.__remapped[iconName.toLowerCase()] = mappedToName.toLowerCase();

--- a/packages/styling/src/utilities/styled.tsx
+++ b/packages/styling/src/utilities/styled.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 import { concatStyleSets } from '../MergeStyles';
 import { IStyleFunction } from '../interfaces/index';
 
+/**
+ * Props with styles.
+ * @public
+ */
 export interface IPropsWithStyles<TStyleProps, TStyles> {
   getStyles?: IStyleFunction<TStyleProps, TStyles>;
   subComponents?: {
@@ -22,6 +26,7 @@ export interface IPropsWithStyles<TStyleProps, TStyles> {
  * );
  * ```
  *
+ * @public
  */
 export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyles>, TStyleProps, TStyles>(
   Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>,

--- a/packages/utilities/config/api-extractor.js
+++ b/packages/utilities/config/api-extractor.js
@@ -1,0 +1,9 @@
+module.exports = {
+  "compiler": {
+    "configType": "tsconfig",
+    "rootFolder": process.cwd()
+  },
+  "project": {
+    "entryPointSourceFile": "src/index.ts"
+  }
+};

--- a/packages/utilities/config/api-extractor.json
+++ b/packages/utilities/config/api-extractor.json
@@ -1,6 +1,0 @@
-{
-  "enabled": true,
-  "apiReviewFolder": "./api",
-  "apiJsonFolder": "./temp",
-  "entry": "src/index.ts"
-}

--- a/packages/utilities/etc/utilities.api.ts
+++ b/packages/utilities/etc/utilities.api.ts
@@ -1,0 +1,649 @@
+// @public
+export function addElementAtIndex < T >(array: T[], index: number, itemToAdd: T): T[];
+
+// @public
+export function assertNever(x: never): never;
+
+// @public
+export function assign(target: any, ...args: any[]): any;
+
+// @public
+class Async {
+  constructor(parent?: React.ReactNode, onError?: (e: any) => void);
+  // (undocumented)
+  protected _logError(e: any): void;
+  // (undocumented)
+  public cancelAnimationFrame(id: number): void;
+  public clearImmediate(id: number): void;
+  public clearInterval(id: number): void;
+  public clearTimeout(id: number): void;
+  public debounce < T extends Function >(func: T, wait?: number, options?: {
+      leading?: boolean;
+      maxWait?: number;
+      trailing?: boolean;
+    }): ICancelable<T> & (() => void);
+  public dispose(): void;
+  // (undocumented)
+  public requestAnimationFrame(callback: () => void): number;
+  public setImmediate(callback: () => void): number;
+  public setInterval(callback: () => void, duration: number): number;
+  public setTimeout(callback: () => void, duration: number): number;
+  public throttle < T extends Function >(func: T, wait?: number, options?: {
+      leading?: boolean;
+      trailing?: boolean;
+    }): T | (() => void);
+}
+
+// @public
+export function autobind < T extends Function >(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): {
+  configurable: boolean;
+  get(): T;
+  // tslint:disable-next-line:no-any
+  set(newValue: any): void;
+} | void;
+
+// @public
+class AutoScroll {
+  constructor(element: HTMLElement);
+  // (undocumented)
+  public dispose(): void;
+}
+
+// @public
+class BaseComponent<TProps extends IBaseProps, TState = {}> extends React.Component<TProps, TState> {
+  constructor(props?: TProps, context?: any);
+  protected readonly _async: Async;
+  protected readonly _disposables: IDisposable[];
+  protected readonly _events: EventGroup;
+  protected _resolveRef(refName: string): (ref: React.ReactNode) => React.ReactNode;
+  protected _shouldUpdateComponentRef: boolean;
+  protected _updateComponentRef(currentProps: IBaseProps | undefined, newProps: IBaseProps = {}): void;
+  protected _warnConditionallyRequiredProps(requiredProps: string[], conditionalPropName: string, condition: boolean): void;
+  protected _warnDeprecations(deprecationMap: ISettingsMap<TProps>): void;
+  protected _warnMutuallyExclusive(mutuallyExclusiveMap: ISettingsMap<TProps>): void;
+  public readonly className: string;
+  public componentDidMount(): void;
+  public componentWillReceiveProps(newProps: TProps, newContext: any): void;
+  public componentWillUnmount(): void;
+  public static onError: ((errorMessage?: string, ex?: any) => void);
+}
+
+// @public
+export function createArray < T >(size: number, getItem: (index: number) => T): T[];
+
+// @public
+export function css(...args: ICssInput[]): string;
+
+// @public
+export function customizable(scope: string,
+  fields: string[]): <P, S>(ComposedComponent: new (props: P, ...args: any[]) => React.Component<P, S>) => any;
+
+// @public
+class Customizations {
+  // (undocumented)
+  public static applyScopedSettings(scopeName: string, settings: { [key: string]: any }): void;
+  // (undocumented)
+  public static applySettings(settings: { [key: string]: any }): void;
+  // (undocumented)
+  public static getSettings(properties: string[],
+      scopeName?: string,
+      localSettings: ICustomizations = NO_CUSTOMIZATIONS): any;
+  // (undocumented)
+  public static observe(onChange: () => void): void;
+  // (undocumented)
+  public static reset(): void;
+  // (undocumented)
+  public static unobserve(onChange: () => void): void;
+}
+
+// @public
+class Customizer extends BaseComponent<ICustomizerProps, ICustomizerContext> {
+  constructor(props: ICustomizerProps, context: any);
+  // (undocumented)
+  public static childContextTypes: {
+    customizations: PropTypes.Requireable<{}>;
+  }
+  // (undocumented)
+  public componentWillReceiveProps(newProps: any, newContext: any): void;
+  // (undocumented)
+  public static contextTypes: {
+    customizations: PropTypes.Requireable<{}>;
+  }
+  // (undocumented)
+  public getChildContext(): ICustomizerContext;
+  // (undocumented)
+  public render(): React.ReactElement<{}>;
+}
+
+// WARNING: defaultProps has incomplete type information
+// @public
+class DelayedRender extends React.Component<IDelayedRenderProps, IDelayedRenderState> {
+  constructor(props: IDelayedRenderProps);
+  // (undocumented)
+  public componentDidMount(): void;
+  // (undocumented)
+  public componentWillUnmount(): void;
+  // (undocumented)
+  public render(): React.ReactElement<{}> | null;
+}
+
+// @public
+export function disableBodyScroll(): void;
+
+// @public
+export function doesElementContainFocus(element: HTMLElement): boolean;
+
+// @public
+export function elementContains(parent: HTMLElement | null, child: HTMLElement | null, allowVirtualParents: boolean = true): boolean;
+
+// @public
+export function enableBodyScroll(): void;
+
+// @public
+class EventGroup {
+  public constructor(parent: any);
+  public declare(event: string | string[]): void;
+  // (undocumented)
+  public dispose(): void;
+  public static isDeclared(target: any, eventName: string): boolean;
+  // (undocumented)
+  public static isObserved(target: any, eventName: string): boolean;
+  // (undocumented)
+  public off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void;
+  public on(target: any, eventName: string, callback: (args?: any) => void, useCapture?: boolean): void;
+  public onAll(target: any, events: { [key: string]: (args?: any) => void; }, useCapture?: boolean): void;
+  public static raise(target: any,
+      eventName: string,
+      // tslint:disable-next-line:no-any
+      eventArgs?: any,
+      bubbleEvent?: boolean): boolean | undefined;
+  // (undocumented)
+  public static stopPropagation(event: any): void;
+}
+
+// @public
+class FabricPerformance {
+  public static measure(name: string, func: () => void): void;
+  // (undocumented)
+  public static reset(): void;
+  // (undocumented)
+  public static setPeriodicReset(): void;
+  // (undocumented)
+  public static summary: IPerfSummary;
+}
+
+// @public
+export function filteredAssign(isAllowed: (propName: string) => boolean, target: any, ...args: any[]): any;
+
+// @public
+export function find < T >(array: T[], cb: (item: T, index: number) => boolean): T | undefined;
+
+// @public
+export function findIndex < T >(array: T[], cb: (item: T, index: number) => boolean): number;
+
+// @public
+export function findScrollableParent(startingElement: HTMLElement): HTMLElement | null;
+
+// @public
+export function fitContentToBounds(options: IFitContentToBoundsOptions): ISize;
+
+// @public
+export function flatten < T >(array: (T | T[])[]): T[];
+
+// @public
+export function focusFirstChild(rootElement: HTMLElement): boolean;
+
+// @public
+export function format(s: string, ...values: any[]): string;
+
+// @public
+export function getChildren(parent: HTMLElement, allowVirtualChildren: boolean = true): HTMLElement[];
+
+// @public
+export function getDistanceBetweenPoints(point1: IPoint, point2: IPoint): number;
+
+// @public
+export function getDocument(rootElement?: HTMLElement): Document | undefined;
+
+// @public
+export function getFirstFocusable(rootElement: HTMLElement,
+  currentElement: HTMLElement,
+  includeElementsInFocusZones?: boolean): HTMLElement | null;
+
+// @public
+export function getId(prefix?: string): string;
+
+// @public
+export function getInitials(displayName: string | undefined | null, isRtl: boolean): string;
+
+// @public
+export function getLanguage(): string | null;
+
+// @public
+export function getLastFocusable(rootElement: HTMLElement,
+  currentElement: HTMLElement,
+  includeElementsInFocusZones?: boolean): HTMLElement | null;
+
+// @public
+export function getLastTabbable(rootElement: HTMLElement,
+  currentElement: HTMLElement,
+  includeElementsInFocusZones?: boolean): HTMLElement | null;
+
+// @public
+export function getNativeProps < T >(props: {}, allowedPropNames: string[], excludedPropNames?: string[]): T;
+
+// @public
+export function getNextElement(rootElement: HTMLElement,
+  currentElement: HTMLElement | null,
+  checkNode?: boolean,
+  suppressParentTraversal?: boolean,
+  suppressChildTraversal?: boolean,
+  includeElementsInFocusZones?: boolean,
+  allowFocusRoot?: boolean): HTMLElement | null;
+
+// @public
+export function getParent(child: HTMLElement, allowVirtualParents: boolean = true): HTMLElement | null;
+
+// @public
+export function getPreviousElement(rootElement: HTMLElement,
+  currentElement: HTMLElement | null,
+  checkNode?: boolean,
+  suppressParentTraversal?: boolean,
+  traverseChildren?: boolean,
+  includeElementsInFocusZones?: boolean,
+  allowFocusRoot?: boolean,
+  tabbable?: boolean): HTMLElement | null;
+
+// @public
+export function getRect(element: HTMLElement | Window | null): IRectangle | undefined;
+
+// @public
+export function getResourceUrl(url: string): string;
+
+// @public
+export function getRTL(): boolean;
+
+// @public
+export function getRTLSafeKeyCode(key: number): number;
+
+// @public
+export function getScrollbarWidth(): number;
+
+// @public
+export function getVirtualParent(child: HTMLElement): HTMLElement | undefined;
+
+// @public
+export function getWindow(rootElement?: HTMLElement): Window | undefined;
+
+// @public
+class GlobalSettings {
+  // (undocumented)
+  public static addChangeListener(cb: IChangeEventCallback): void;
+  // (undocumented)
+  public static getValue < T >(key: string, defaultValue?: T | (() => T)): T;
+  // (undocumented)
+  public static removeChangeListener(cb: IChangeEventCallback): void;
+  // (undocumented)
+  public static setValue < T >(key: string, value: T): T;
+}
+
+// @public
+export function hasHorizontalOverflow(element: HTMLElement): boolean;
+
+// @public
+export function hasOverflow(element: HTMLElement): boolean;
+
+// @public
+export function hasVerticalOverflow(element: HTMLElement): boolean;
+
+// @public
+export function hoistMethods(destination: any, source: any, exclusions: string[] = REACT_LIFECYCLE_EXCLUSIONS): string[];
+
+// @public
+interface IBaseProps {
+  // (undocumented)
+  componentRef?: (ref: React.ReactNode | null) => (void | React.ReactNode);
+}
+
+// @public
+interface IChangeDescription {
+  // (undocumented)
+  key: string;
+  // (undocumented)
+  oldValue: any;
+  // (undocumented)
+  value: any;
+}
+
+// @public
+interface IChangeEventCallback {
+  // (undocumented)
+  ___id__?: string;
+  // (undocumented)
+  (changeDescription?: IChangeDescription): void;
+}
+
+// @public
+interface ICustomizations {
+  // (undocumented)
+  scopedSettings: {
+    __index: {
+      [ key: string ]: any
+    }
+  }
+  // (undocumented)
+  settings: {
+    [ key: string ]: any
+  }
+}
+
+// @public
+interface ICustomizerContext {
+  // (undocumented)
+  customizations: ICustomizations;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IDeclaredEventsByName {
+  // (undocumented)
+  [ eventName: string ]: boolean;
+}
+
+// @public
+interface IDelayedRenderProps extends React.Props<{}> {
+  delay?: number;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IDelayedRenderState {
+  isRendered: boolean;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IDictionary {
+  // (undocumented)
+  [ className: string ]: boolean;
+}
+
+// @public
+interface IDisposable {
+  // (undocumented)
+  dispose: () => void;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IEventRecord {
+  // (undocumented)
+  callback: (args?: any) => void;
+  // (undocumented)
+  elementCallback?: (...args: any[]) => void;
+  // (undocumented)
+  eventName: string;
+  // (undocumented)
+  objectCallback?: (args?: any) => void;
+  // (undocumented)
+  parent: any;
+  // (undocumented)
+  target: any;
+  // (undocumented)
+  useCapture: boolean;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IEventRecordList {
+  // (undocumented)
+  [ id: string ]: IEventRecord[] | number;
+  // (undocumented)
+  count: number;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IEventRecordsByName {
+  // (undocumented)
+  [ eventName: string ]: IEventRecordList;
+}
+
+// @public
+interface IFitContentToBoundsOptions {
+  boundsSize: ISize;
+  contentSize: ISize;
+  maxScale?: number;
+  mode: FitMode;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IPerfData {
+  // (undocumented)
+  duration: number;
+  // (undocumented)
+  timeStamp: number;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IPerfMeasurement {
+  // (undocumented)
+  all: IPerfData[];
+  // (undocumented)
+  count: number;
+  // (undocumented)
+  totalDuration: number;
+}
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface IPerfSummary {
+  // (undocumented)
+  [ key: string ]: IPerfMeasurement;
+}
+
+// @public
+interface IPoint {
+  // (undocumented)
+  x: number;
+  // (undocumented)
+  y: number;
+}
+
+// @public
+interface IRectangle {
+  // (undocumented)
+  bottom?: number;
+  // (undocumented)
+  height: number;
+  // (undocumented)
+  left: number;
+  // (undocumented)
+  right?: number;
+  // (undocumented)
+  top: number;
+  // (undocumented)
+  width: number;
+}
+
+// @public
+interface IRenderFunction<P> {
+  // (undocumented)
+  (props?: P, defaultRender?: (props?: P) => JSX.Element | null): JSX.Element | null;
+}
+
+// @public
+export function isElementFocusSubZone(element?: HTMLElement): boolean;
+
+// @public
+export function isElementFocusZone(element?: HTMLElement): boolean;
+
+// @public
+export function isElementTabbable(element: HTMLElement, checkTabIndex?: boolean): boolean;
+
+// @public
+export function isElementVisible(element: HTMLElement | undefined | null): boolean;
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+interface ISerializableObject {
+  // (undocumented)
+  toString?: () => string;
+}
+
+// @public
+interface ISize {
+  // (undocumented)
+  height: number;
+  // (undocumented)
+  width: number;
+}
+
+// @public
+enum KeyCodes {
+  // (undocumented)
+  a = 65,
+  // (undocumented)
+  backspace = 8,
+  // (undocumented)
+  comma = 188,
+  // (undocumented)
+  del = 46,
+  // (undocumented)
+  down = 40,
+  // (undocumented)
+  end = 35,
+  // (undocumented)
+  enter = 13,
+  // (undocumented)
+  escape = 27,
+  // (undocumented)
+  home = 36,
+  // (undocumented)
+  left = 37,
+  // (undocumented)
+  pageDown = 34,
+  // (undocumented)
+  pageUp = 33,
+  // (undocumented)
+  right = 39,
+  // (undocumented)
+  semicolon = 186,
+  // (undocumented)
+  space = 32,
+  // (undocumented)
+  tab = 9,
+  // (undocumented)
+  up = 38
+}
+
+// @public
+export function mapEnumByName < T >(theEnum: any,
+  callback: (name?: string, value?: string | number) => T | undefined): (T | undefined)[] | undefined;
+
+// @public
+export function memoize < T extends Function >(target: any,
+  key: string,
+  descriptor: TypedPropertyDescriptor<T>): {
+    configurable: boolean;
+    get(): T;
+  };
+
+// @public
+export function memoizeFunction < T extends (...args: any[]) => RET_TYPE, RET_TYPE >(cb: T,
+  maxCacheSize: number = 100): T;
+
+// @public
+export function nullRender(): JSX.Element | null;
+
+// @public
+class Rectangle {
+  constructor(left: number = 0, right: number = 0, top: number = 0, bottom: number = 0);
+  // (undocumented)
+  public bottom: number;
+  public equals(rect: Rectangle): boolean;
+  readonly height: number;
+  // (undocumented)
+  public left: number;
+  // (undocumented)
+  public right: number;
+  // (undocumented)
+  public top: number;
+  readonly width: number;
+}
+
+// @public
+export function removeIndex < T >(array: T[], index: number): T[];
+
+// @public
+export function replaceElement < T >(array: T[], newElement: T, index: number): T[];
+
+// @public
+export function setBaseUrl(baseUrl: string): void;
+
+// @public
+export function setLanguage(language: string, avoidPersisting: boolean = false): void;
+
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
+export function setMemoizeWeakMap(weakMap: any): void;
+
+// @public
+export function setRTL(isRTL: boolean, persistSetting: boolean = false): void;
+
+// @public
+export function setSSR(isEnabled: boolean): void;
+
+// @public
+export function setVirtualParent(child: HTMLElement, parent: HTMLElement): void;
+
+// @public
+export function setWarningCallback(warningCallback?: (message: string) => void): void;
+
+// @public
+export function shallowCompare < TA, TB >(a: TA, b: TB): boolean;
+
+// @public
+export function toMatrix < T >(items: T[], columnCount: number): T[][];
+
+// @public
+export function unhoistMethods(source: any, methodNames: string[]): void;
+
+// @public
+export function warn(message: string): void;
+
+// @public
+export function warnConditionallyRequiredProps < P >(componentName: string,
+  props: P,
+  requiredProps: string[],
+  conditionalPropName: string,
+  condition: boolean): void;
+
+// @public
+export function warnDeprecations < P >(componentName: string,
+  props: P,
+  deprecationMap: ISettingsMap<P>): void;
+
+// @public
+export function warnMutuallyExclusive < P >(componentName: string,
+  props: P,
+  exclusiveMap: ISettingsMap<P>): void;
+
+// WARNING: Unsupported export: ICancelable
+// WARNING: Unsupported export: ICustomizerProps
+// WARNING: Unsupported export: ICssInput
+// WARNING: Unsupported export: FitMode
+// WARNING: Unsupported export: baseElementEvents
+// WARNING: Unsupported export: baseElementProperties
+// WARNING: Unsupported export: htmlElementProperties
+// WARNING: Unsupported export: anchorProperties
+// WARNING: Unsupported export: buttonProperties
+// WARNING: Unsupported export: divProperties
+// WARNING: Unsupported export: inputProperties
+// WARNING: Unsupported export: textAreaProperties
+// WARNING: Unsupported export: imageProperties
+// WARNING: Unsupported export: DATA_IS_SCROLLABLE_ATTRIBUTE
+// WARNING: Unsupported export: ISettingsMap
+// (No packageDescription for this package)

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -18,7 +18,7 @@ export interface IBaseProps {
  *
  * @public
  */
-export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component<P, S> {
+export class BaseComponent<TProps extends IBaseProps, TState = {}> extends React.Component<TProps, TState> {
   /**
    * External consumers should override BaseComponent.onError to hook into error messages that occur from
    * exceptions thrown from within components.
@@ -47,7 +47,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
    * @param context - The context for the component.
    */
   // tslint:disable-next-line:no-any
-  constructor(props?: P, context?: any) {
+  constructor(props?: TProps, context?: any) {
     super(props, context);
 
     this._shouldUpdateComponentRef = true;
@@ -68,7 +68,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
    * When the component will receive props, make sure the componentRef is updated.
    */
   // tslint:disable-next-line:no-any
-  public componentWillReceiveProps(newProps: Readonly<P>, newContext: any): void {
+  public componentWillReceiveProps(newProps: TProps, newContext: any): void {
     this._updateComponentRef(this.props, newProps);
   }
 
@@ -192,7 +192,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
    * @param deprecationMap - The map of deprecations, where key is the prop name and the value is
    * either null or a replacement prop name.
    */
-  protected _warnDeprecations(deprecationMap: ISettingsMap<P>): void {
+  protected _warnDeprecations(deprecationMap: ISettingsMap<TProps>): void {
     warnDeprecations(this.className, this.props, deprecationMap);
   }
 
@@ -201,7 +201,7 @@ export class BaseComponent<P extends IBaseProps, S = {}> extends React.Component
    *
    * @param mutuallyExclusiveMap - The map of mutually exclusive props.
    */
-  protected _warnMutuallyExclusive(mutuallyExclusiveMap: ISettingsMap<P>): void {
+  protected _warnMutuallyExclusive(mutuallyExclusiveMap: ISettingsMap<TProps>): void {
     warnMutuallyExclusive(this.className, this.props, mutuallyExclusiveMap);
   }
 

--- a/packages/utilities/src/Customizations.ts
+++ b/packages/utilities/src/Customizations.ts
@@ -5,6 +5,11 @@ import {
   EventGroup
 } from './EventGroup';
 
+/**
+ * Customizations structure stored in global settings.
+ *
+ * @public
+ */
 export interface ICustomizations {
   // tslint:disable-next-line:no-any
   settings: { [key: string]: any };
@@ -22,6 +27,12 @@ let _allSettings = GlobalSettings.getValue<ICustomizations>(CustomizationsGlobal
 
 const _events = new EventGroup(_allSettings);
 
+/**
+ * Helper for providing global customizations which can be accessed by the customizable
+ * decorators.
+ *
+ * @public
+ */
 export class Customizations {
   public static reset(): void {
     _allSettings.settings = {};

--- a/packages/utilities/src/Customizer.tsx
+++ b/packages/utilities/src/Customizer.tsx
@@ -3,6 +3,11 @@ import * as PropTypes from 'prop-types';
 import { BaseComponent, IBaseProps } from './BaseComponent';
 import { ICustomizations } from './Customizations';
 
+/**
+ * Customizer context.
+ *
+ * @public
+ */
 export interface ICustomizerContext {
   customizations: ICustomizations;
 }
@@ -25,8 +30,8 @@ export class Customizer extends BaseComponent<ICustomizerProps, ICustomizerConte
   public static contextTypes: {
     customizations: PropTypes.Requireable<{}>;
   } = {
-    customizations: PropTypes.object
-  };
+      customizations: PropTypes.object
+    };
 
   public static childContextTypes: {
     customizations: PropTypes.Requireable<{}>;

--- a/packages/utilities/src/ISize.ts
+++ b/packages/utilities/src/ISize.ts
@@ -1,4 +1,8 @@
-
+/**
+ * Size interface.
+ *
+ * @public
+ */
 export interface ISize {
   width: number;
   height: number;

--- a/packages/utilities/src/array.ts
+++ b/packages/utilities/src/array.ts
@@ -23,6 +23,8 @@ export function findIndex<T>(array: T[], cb: (item: T, index: number) => boolean
  * Helper to find the first item within an array that satisfies the callback.
  * @param array - Array to search
  * @param cb - Callback which returns true on matches
+ *
+ * @public
  */
 export function find<T>(array: T[], cb: (item: T, index: number) => boolean): T | undefined {
   let index = findIndex(array, cb);
@@ -37,9 +39,10 @@ export function find<T>(array: T[], cb: (item: T, index: number) => boolean): T 
 /**
  * Creates an array of a given size and helper method to populate.
  *
- * @public
  * @param size - Size of array.
  * @param getItem - Callback to populate given cell index.
+ *
+ * @public
  */
 export function createArray<T>(size: number, getItem: (index: number) => T): T[] {
   let array: T[] = [];
@@ -55,10 +58,11 @@ export function createArray<T>(size: number, getItem: (index: number) => T): T[]
  * Convert the given array to a matrix with columnCount number
  * of columns.
  *
- * @public
  * @param items - The array to convert
  * @param columnCount - The number of columns for the resulting matrix
  * @returns {any[][]} - A matrix of items
+ *
+ * @public
  */
 export function toMatrix<T>(items: T[], columnCount: number): T[][] {
   return items.reduce((rows: T[][], currentValue: T, index: number) => {
@@ -75,6 +79,8 @@ export function toMatrix<T>(items: T[], columnCount: number): T[][] {
  * Given an array, it returns a new array that does not contain the item at the given index.
  * @param array - The array to operate on
  * @param index - The index of the element to remove
+ *
+ * @public
  */
 export function removeIndex<T>(array: T[], index: number): T[] {
   return array.filter((_: T, i: number) => index !== i);
@@ -85,6 +91,8 @@ export function removeIndex<T>(array: T[], index: number): T[] {
  * @param array - The array to operate on
  * @param newElement - The element that will be placed in the new array
  * @param index - The index of the element that should be replaced
+ *
+ * @public
  */
 export function replaceElement<T>(array: T[], newElement: T, index: number): T[] {
   const copy = array.slice();
@@ -97,6 +105,8 @@ export function replaceElement<T>(array: T[], newElement: T, index: number): T[]
  * @param array - The array to operate on
  * @param index - The index where an element should be inserted
  * @param itemToAdd - The element to insert
+ *
+ * @public
  */
 export function addElementAtIndex<T>(array: T[], index: number, itemToAdd: T): T[] {
   const copy = array.slice();
@@ -107,6 +117,8 @@ export function addElementAtIndex<T>(array: T[], index: number, itemToAdd: T): T
 /**
  * Given an array where each element is of type T or T[], flatten it into an array of T
  * @param array - The array where each element can optionally also be an array
+ *
+ * @public
  */
 export function flatten<T>(array: (T | T[])[]): T[] {
   let result: T[] = [];

--- a/packages/utilities/src/autobind.ts
+++ b/packages/utilities/src/autobind.ts
@@ -1,6 +1,8 @@
 /**
  * Autobind is a utility for binding methods in a class. This simplifies tagging methods as being "bound" to the this pointer
  * so that they can be used in scenarios that simply require a function callback.
+ *
+ * @public
  */
 // tslint:disable-next-line:no-any
 export function autobind<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): {

--- a/packages/utilities/src/customizable.tsx
+++ b/packages/utilities/src/customizable.tsx
@@ -2,6 +2,16 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { Customizations } from './Customizations';
 
+/**
+ * Decorator used to provide cutomizations exposed either using defaults provided to the
+ * Customizations helper, or scoped via the Customizer component.
+ *
+ * @param scope - The name of the scope which can be targeted using scopedSettings provided
+ * to the Customizer.
+ * @param fields - Fields which are customizable, and allowed ot be injected.
+ *
+ * @public
+ */
 export function customizable(
   scope: string,
   fields: string[]
@@ -20,8 +30,8 @@ export function customizable(
       public static contextTypes: {
         customizations: PropTypes.Requireable<{}>;
       } = {
-        customizations: PropTypes.object
-      };
+          customizations: PropTypes.object
+        };
 
       // tslint:disable-next-line:no-any
       constructor(props: P, context: any) {

--- a/packages/utilities/src/dom.ts
+++ b/packages/utilities/src/dom.ts
@@ -84,8 +84,8 @@ export function getParent(child: HTMLElement, allowVirtualParents: boolean = tru
  * Gets the elements which are child elements of the given element.
  * If `allowVirtualChildren` is `true`, this method enumerates virtual child elements
  * after the original children.
- * @param parent
- * @param allowVirtualChildren
+ *
+ * @public
  */
 export function getChildren(parent: HTMLElement, allowVirtualChildren: boolean = true): HTMLElement[] {
   const children: HTMLElement[] = [];

--- a/packages/utilities/src/math.ts
+++ b/packages/utilities/src/math.ts
@@ -20,38 +20,29 @@ export type FitMode = 'contain' | 'cover';
 /**
  * Options for fitting content sizes into bounding sizes.
  *
- * @export
- * @interface IFitContentToBoundsOptions
+ * @public
  */
 export interface IFitContentToBoundsOptions {
+
   /**
    * The size of the content to fit to the bounds.
    * The output will be proportional to this value.
-   *
-   * @type {ISize}
-   * @memberof IFitContentToBoundsOptions
    */
   contentSize: ISize;
+
   /**
    * The size of the bounds.
-   *
-   * @type {ISize}
-   * @memberof IFitContentToBoundsOptions
    */
   boundsSize: ISize;
+
   /**
    * The fit mode to apply, either 'contain' or 'cover'.
-   *
-   * @type {FitMode}
-   * @memberof IFitContentToBoundsOptions
    */
   mode: FitMode;
+
   /**
    * An optional maximum scale factor to apply. The default is 1.
    * Use Infinity for an unbounded resize.
-   *
-   * @type {number}
-   * @memberof IFitContentToBoundsOptions
    */
   maxScale?: number;
 }
@@ -65,7 +56,7 @@ export interface IFitContentToBoundsOptions {
  * With `cover`, the output size must be the smallest it can be while completely around the `boundsSize`.
  * By default, there is a `maxScale` value of 1, which prevents the `contentSize` from being scaled larger.
  *
- * @param options the options for the bounds fit operation
+ * @public
  */
 export function fitContentToBounds(options: IFitContentToBoundsOptions): ISize {
   const {

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -91,10 +91,13 @@ export function getId(prefix?: string): string {
   return (prefix || DEFAULT_ID_STRING) + index;
 }
 
-/* Takes an enum and iterates over each value of the enum (as a string), running the callback on each, returning a mapped array.
+/**
+ * Takes an enum and iterates over each value of the enum (as a string), running the callback on each, returning a mapped array.
  * The callback takes as a first parameter the string that represents the name of the entry, and the second parameter is the
  * value of that entry, which is the value you'd normally use when using the enum (usually a number).
- * */
+ *
+ * @public
+ **/
 export function mapEnumByName<T>(
   // tslint:disable-next-line:no-any
   theEnum: any,

--- a/packages/utilities/src/properties.ts
+++ b/packages/utilities/src/properties.ts
@@ -215,7 +215,7 @@ export const htmlElementProperties = baseElementProperties.concat(baseElementEve
  *
  * @public
  */
-export const anchorProperties = htmlElementProperties.concat([
+export const anchorProperties: string[] = htmlElementProperties.concat([
   'href',
   'target'
 ]);

--- a/packages/utilities/src/resources.ts
+++ b/packages/utilities/src/resources.ts
@@ -1,11 +1,17 @@
 let _baseUrl = '';
 
-/** Sets the current base url used for fetching images. */
+/**
+ * Sets the current base url used for fetching images.
+ * @public
+ **/
 export function getResourceUrl(url: string): string {
   return _baseUrl + url;
 }
 
-/** Gets the current base url used for fetching images. */
+/**
+ * Gets the current base url used for fetching images.
+ * @public
+ **/
 export function setBaseUrl(baseUrl: string): void {
   _baseUrl = baseUrl;
 }

--- a/packages/utilities/src/rtl.ts
+++ b/packages/utilities/src/rtl.ts
@@ -9,6 +9,8 @@ let _isRTL: boolean | undefined;
 
 /**
  * Gets the rtl state of the page (returns true if in rtl.)
+ *
+ * @public
  */
 export function getRTL(): boolean {
   if (_isRTL === undefined) {
@@ -30,6 +32,8 @@ export function getRTL(): boolean {
 
 /**
  * Sets the rtl state of the page (by adjusting the dir attribute of the html element.)
+ *
+ * @public
  */
 export function setRTL(isRTL: boolean, persistSetting: boolean = false): void {
   let doc = getDocument();
@@ -46,6 +50,8 @@ export function setRTL(isRTL: boolean, persistSetting: boolean = false): void {
 
 /**
  * Returns the given key, but flips right/left arrows if necessary.
+ *
+ * @public
  */
 export function getRTLSafeKeyCode(key: number): number {
   if (getRTL()) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,6 +14,7 @@ const isProduction = process.argv.indexOf('--production') > -1;
 let tasks = [
   'copy',
   'sass',
+  'api-extractor',
   'tslint',
   'ts',
   'jest',

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,7 @@
     "bundlesize": "bundlesize --debug"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "^4.2.6",
     "@microsoft/load-themed-styles": "^1.7.5",
     "@microsoft/loader-load-themed-styles": "^1.6.0",
     "@uifabric/merge-styles": ">=5.6.0 <6.0.0",
@@ -35,9 +36,9 @@
     "sinon": "^4.0.1",
     "source-map-loader": "^0.2.1",
     "style-loader": "^0.18.2",
-    "tslint": "^5.7.0",
+    "tslint": "^5.8.0",
     "tslint-microsoft-contrib": "^5.0.1",
-    "typescript": "2.5.3",
+    "typescript": "2.6.1",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "webpack": "^3.7.1",
     "webpack-bundle-analyzer": "^2.9.0",

--- a/scripts/tasks/api-extractor.js
+++ b/scripts/tasks/api-extractor.js
@@ -1,0 +1,24 @@
+module.exports = function (options) {
+  const path = require('path');
+  const fs = require('fs');
+  const configPath = path.resolve(process.cwd(), 'config/api-extractor.js');
+  const isVerbose = process.argv.indexOf('--verbose') >= 0;
+
+  if (fs.existsSync(configPath)) {
+    const { Extractor } = require('@microsoft/api-extractor');
+    const config = require(configPath);
+    const options = {
+      localBuild: process.argv.indexOf('--production') < 0,
+      customLogger: {
+        logVerbose: (message) => {
+          if (isVerbose) {
+            console.log(message);
+          }
+        }
+      }
+    };
+    const extractor = new Extractor(config, options);
+
+    extractor.analyzeProject();
+  }
+};


### PR DESCRIPTION
This re-enables `api-extractor` which gives us better visibility over types exported.

I needed to adjust a few things in comments, as well as a few typings.