### PR TITLE
ContextualMenu: Make it possible for split buttons in menus to open when hovered

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-SBMenuHover_2017-11-25-04-02.json
+++ b/common/changes/office-ui-fabric-react/malozano-SBMenuHover_2017-11-25-04-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Add ability to open splitButton chevron menu, when they are inside menus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -589,7 +589,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
     return React.createElement('button',
       assign({}, getNativeProps(itemProps, buttonProperties), {
-        onKeyDown: this._onItemKeyDown.bind(this, item)
+        onKeyDown: this._onItemKeyDown.bind(this, item),
+        onMouseEnter: this._onItemMouseEnter.bind(this, item),
+        onMouseLeave: this._onMouseItemLeave.bind(this, item),
+        onMouseDown: (ev: any) => this._onItemMouseDown(item, ev),
+        onMouseMove: this._onItemMouseMove.bind(this, item)
       }),
       this._renderMenuItemChildren(itemProps, classNames, index, false, false));
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Right now to open the menu of a split button inside a menu, we have to click the item. With this change, we are making it possible for the menus to be opened when hovered over.

![opensbinmenu](https://user-images.githubusercontent.com/3754893/33227212-e7f7f0d6-d152-11e7-8514-76cfc9edfeee.gif)
