### PR TITLE
SwatchColorPicker: Enable subcomponent styling by exposting ColorCell getStyles

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-ExposeGetStylesColorPicker_2017-11-29-21-00.json
+++ b/common/changes/office-ui-fabric-react/malozano-ExposeGetStylesColorPicker_2017-11-29-21-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SwatchColorPicker: Expose getStyles of colorCell subcomponent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -142,6 +142,7 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
         item={ item }
         id={ id }
         color={ item.color }
+        getStyles={ this.props.getColorGridCellStyles }
         disabled={ this.props.disabled }
         onClick={ this._onCellClick }
         onHover={ this._onGridCellHovered }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -1,6 +1,7 @@
 import { IStyle, ITheme } from '../../Styling';
 import { IStyleFunction } from '../../Utilities';
-import { IColorCellProps } from './ColorPickerGridCell.types';
+import { IColorCellProps, IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from './ColorPickerGridCell.types';
+
 export interface ISwatchColorPicker { }
 
 export interface ISwatchColorPickerProps {
@@ -95,6 +96,11 @@ export interface ISwatchColorPickerProps {
    * Optional styles for the component.
    */
   getStyles?: IStyleFunction<ISwatchColorPickerStyleProps, ISwatchColorPickerStyles>;
+
+  /**
+  * Optional styles for the component.
+  */
+  getColorGridCellStyles?: IStyleFunction<IColorPickerGridCellStyleProps, IColorPickerGridCellStyles>;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Enable subcomponent styling by exposing ColorCell getStyles in the parent component


