### PR TITLE
Revise Signals architecture and add example page

### DIFF
--- a/common/changes/@uifabric/experiments/signals_2017-11-30-20-09.json
+++ b/common/changes/@uifabric/experiments/signals_2017-11-30-20-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Revise Signals and provide example page",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -74,6 +74,9 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
       folderCoverType: type = 'default',
       hideContent = false,
       ref,
+      metadata,
+      signal,
+      children,
       ...divProps
     } = this.props;
 
@@ -96,10 +99,10 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
           src={ assets.back }
         />
         {
-          this.props.children ? (
+          children ? (
             <span className={ css('ms-FolderCover-content', FolderCoverStyles.content) }>
               <span className={ css('ms-FolderCover-frame', FolderCoverStyles.frame) }>
-                { this.props.children }
+                { children }
               </span>
             </span>
           ) : null
@@ -110,19 +113,19 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
           src={ assets.front }
         />
         {
-          this.props.signal ?
+          signal ?
             (
               <span className={ css('ms-FolderCover-signal', FolderCoverStyles.signal, SignalStyles.dark) }>
-                { this.props.signal }
+                { signal }
               </span>
             ) :
             null
         }
         {
-          this.props.metadata ?
+          metadata ?
             (
               <span className={ css('ms-FolderCover-metadata', FolderCoverStyles.metadata) }>
-                { this.props.metadata }
+                { metadata }
               </span>
             ) :
             null

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { IFolderCoverProps, FolderCoverSize, FolderCoverType } from './FolderCover.types';
 import { ISize, css } from '../../Utilities';
 import * as FolderCoverStylesModule from './FolderCover.scss';
-import * as SignalStylesModule from '../signals/Signals.scss';
+import * as SignalStylesModule from '../signals/Signal.scss';
 
 // tslint:disable-next-line:no-any
 const FolderCoverStyles = FolderCoverStylesModule as any;

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -5,7 +5,7 @@ import { Check } from 'office-ui-fabric-react/lib/Check';
 import { SELECTION_CHANGE } from 'office-ui-fabric-react/lib/Selection';
 import { ISize, css, BaseComponent, autobind, getId } from '../../Utilities';
 import * as TileStylesModule from './Tile.scss';
-import * as SignalStylesModule from '../signals/Signals.scss';
+import * as SignalStylesModule from '../signals/Signal.scss';
 import * as CheckStylesModule from 'office-ui-fabric-react/lib/components/Check/Check.scss';
 
 // tslint:disable:no-any

--- a/packages/experiments/src/components/signals/Signal.scss
+++ b/packages/experiments/src/components/signals/Signal.scss
@@ -21,3 +21,7 @@
     @include margin-right(0);
   }
 }
+
+i.signal {
+  top: 0.2em;
+}

--- a/packages/experiments/src/components/signals/Signal.scss
+++ b/packages/experiments/src/components/signals/Signal.scss
@@ -1,0 +1,23 @@
+
+@import '~office-ui-fabric-react/src/common/common';
+
+.signal {
+  display: inline-block;
+  margin: 0 4px;
+  position: relative;
+
+  transition: color 0.2s linear;
+
+  .dark &,
+  .dark.selected {
+    color: $ms-color-white;
+  }
+
+  &:first-child {
+    @include margin-left(0);
+  }
+
+  &:last-child {
+    @include margin-right(0);
+  }
+}

--- a/packages/experiments/src/components/signals/Signal.tsx
+++ b/packages/experiments/src/components/signals/Signal.tsx
@@ -15,6 +15,7 @@ export type Signal = React.StatelessComponent<ISignalProps>;
 export const Signal: Signal = (props: ISignalProps): JSX.Element => {
   const {
     ariaLabel,
+    className,
     ...spanProps
   } = props;
 
@@ -22,7 +23,7 @@ export const Signal: Signal = (props: ISignalProps): JSX.Element => {
     <span
       aria-label={ props.ariaLabel }
       { ...spanProps }
-      className={ css(SignalStyles.signal) }
+      className={ css(SignalStyles.signal, className) }
     >
       { props.children }
     </span>

--- a/packages/experiments/src/components/signals/Signal.tsx
+++ b/packages/experiments/src/components/signals/Signal.tsx
@@ -1,0 +1,30 @@
+
+import * as React from 'react';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import * as SignalStylesModule from './Signal.scss';
+
+// tslint:disable-next-line:no-any
+const SignalStyles: any = SignalStylesModule;
+
+export interface ISignalProps extends React.HTMLAttributes<HTMLSpanElement> {
+  ariaLabel?: string;
+}
+
+export type Signal = React.StatelessComponent<ISignalProps>;
+
+export const Signal: Signal = (props: ISignalProps): JSX.Element => {
+  const {
+    ariaLabel,
+    ...spanProps
+  } = props;
+
+  return (
+    <span
+      aria-label={ props.ariaLabel }
+      { ...spanProps }
+      className={ css(SignalStyles.signal) }
+    >
+      { props.children }
+    </span>
+  );
+};

--- a/packages/experiments/src/components/signals/SignalField.scss
+++ b/packages/experiments/src/components/signals/SignalField.scss
@@ -1,0 +1,15 @@
+
+@import '~office-ui-fabric-react/src/common/common';
+
+.signalField {
+  display: inline-flex;
+  max-width: 100%;
+  flex-direction: row nowrap;
+}
+
+.signalFieldValue {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  text-align: left;
+}

--- a/packages/experiments/src/components/signals/SignalField.tsx
+++ b/packages/experiments/src/components/signals/SignalField.tsx
@@ -1,0 +1,38 @@
+
+import * as React from 'react';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
+import * as SignalFieldStylesModule from './SignalField.scss';
+
+// tslint:disable-next-line:no-any
+const SignalFieldStyles: any = SignalFieldStylesModule;
+
+export interface ISignalFieldProps extends React.HTMLAttributes<HTMLSpanElement> {
+  before?: React.ReactNode | React.ReactNode[];
+  after?: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * Renders a field flanked by signals.
+ * Pass `<Signal />` or related components in for the `before` and `after` fields.
+ * Pass the main value as the children.
+ */
+export const SignalField: React.StatelessComponent<ISignalFieldProps> = (props: ISignalFieldProps): JSX.Element => {
+  const {
+    before,
+    after,
+    className,
+    ...spanProps
+  } = props;
+  return (
+    <span
+      { ...spanProps }
+      className={ css(SignalFieldStyles.signalField, className) }
+    >
+      { props.before }
+      <span className={ SignalFieldStyles.signalFieldValue }>
+        { props.children }
+      </span>
+      { props.after }
+    </span>
+  );
+};

--- a/packages/experiments/src/components/signals/Signals.Props.ts
+++ b/packages/experiments/src/components/signals/Signals.Props.ts
@@ -1,0 +1,4 @@
+
+export { ISignalProps } from './Signal';
+
+export { ISignalFieldProps } from './SignalField';

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -1,13 +1,14 @@
 
 @import '~office-ui-fabric-react/src/common/common';
 
-.centeredSignal {
-    display: inline-flex;
-    flex-direction: column;
-    justify-content: center;
-}
+/*
+Note: For icon alignment, please only use relative positioning in em units.
+Do not change the flex alignment or justification, or use vertical-alignment.
+It is important that Signals scale based on font-size and do not interfere with alternate alignment
+settings used by the parent control.
+*/
 
-.newItem {
+.new {
   width: 0;
   height: 1em;
   position: relative;
@@ -23,9 +24,9 @@
 .newIcon {
   position: absolute;
   bottom: 100%;
-  @include right(-1px);
+  @include right(-0.15em);
   font-size: 0.66em;
-  margin-bottom: -0.75em;
+  margin-bottom: -0.8em;
 }
 
 .comments {
@@ -61,7 +62,6 @@
 
 .shared {
   color: $ms-color-neutralSecondary;
-  top: 0.1em;
 }
 
 .missingMetadata {
@@ -71,8 +71,6 @@
 .mention {
   position: relative;
 
-  top: 0.2em;
-
   color: $ms-color-themePrimary;
 
   .selected & {
@@ -80,33 +78,10 @@
   }
 }
 
-.atp {
+.malwareDetected {
   color: $ms-color-redDark;
-  top: 3px;
 }
 
 .external {
   color: $ms-color-neutralSecondary;
-}
-
-.signal {
-  transition: color 0.2s linear;
-
-  .dark &,
-  .dark.selected {
-    color: $ms-color-white;
-  }
-}
-
-.signalField {
-  display: inline-flex;
-  max-width: 100%;
-  flex-direction: row nowrap;
-}
-
-.signalFieldValue {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  text-align: left;
 }

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -1,20 +1,6 @@
 
 @import '~office-ui-fabric-react/src/common/common';
 
-.signal {
-  display: inline-block;
-  margin: 0 4px;
-  position: relative;
-
-  &:first-child {
-    @include margin-left(0);
-  }
-
-  &:last-child {
-    @include margin-right(0);
-  }
-}
-
 .centeredSignal {
     display: inline-flex;
     flex-direction: column;

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -8,7 +8,7 @@ It is important that Signals scale based on font-size and do not interfere with 
 settings used by the parent control.
 */
 
-.new {
+.newSignal {
   width: 0;
   height: 1em;
   position: relative;

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -96,7 +96,7 @@ export const NewSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <span
       { ...spanProps }
-      className={ css(SignalStyles.signal, SignalsStyles.new) }
+      className={ css(SignalStyles.signal, SignalsStyles.newSignal) }
     >
       <Icon
         ariaLabel={ props.ariaLabel }

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -2,70 +2,23 @@
 import * as React from 'react';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
-import * as SignalStylesModule from './Signals.scss';
+import { Signal, ISignalProps } from './Signal';
+import * as SignalsStylesModule from './Signals.scss';
+import * as SignalStylesModule from './Signal.scss';
 
+// tslint:disable-next-line:no-any
+const SignalsStyles = SignalsStylesModule as any;
 // tslint:disable-next-line:no-any
 const SignalStyles = SignalStylesModule as any;
 
-export interface ISignalFieldProps extends React.HTMLAttributes<HTMLSpanElement> {
-  before?: React.ReactNode | React.ReactNode[];
-  after?: React.ReactNode | React.ReactNode[];
-}
-
-/**
- * Renders a field flanked by signals.
- * Pass `<Signal />` or related components in for the `before` and `after` fields.
- * Pass the main value as the children.
- */
-export const SignalField: React.StatelessComponent<ISignalFieldProps> = (props: ISignalFieldProps): JSX.Element => {
-  const {
-    before,
-    after,
-    className,
-    ...spanProps
-  } = props;
-  return (
-    <span
-      { ...spanProps }
-      className={ css(SignalStyles.signalField, className) }
-    >
-      { props.before }
-      <span className={ SignalStyles.signalFieldValue }>
-        { props.children }
-      </span>
-      { props.after }
-    </span>
-  );
-};
-
-export interface ISignalProps extends React.HTMLAttributes<HTMLSpanElement> {
-  ariaLabel?: string;
-}
-
-export type Signal = React.StatelessComponent<ISignalProps>;
-
-export const Signal: Signal = (props: ISignalProps): JSX.Element => {
-  const {
-    ariaLabel,
-    ...spanProps
-  } = props;
-
-  return (
-    <span
-      aria-label={ props.ariaLabel }
-      { ...spanProps }
-      className={ css(SignalStyles.signal) }
-    >
-      { props.children }
-    </span>
-  );
-};
+export * from './Signal';
+export * from './SignalField';
 
 export const YouCheckedOutSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.youCheckedOutl) }
+      className={ css(SignalStyles.signal, SignalsStyles.youCheckedOutl) }
       iconName=''
     /> // TODO get correct icon
   );
@@ -75,7 +28,7 @@ export const BlockedSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.blocked) }
+      className={ css(SignalStyles.signal, SignalsStyles.blocked) }
       iconName='blocked2'
     />
   );
@@ -85,7 +38,7 @@ export const MissingMetadataSignal: Signal = (props: ISignalProps): JSX.Element 
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.missingMetadata) }
+      className={ css(SignalStyles.signal, SignalsStyles.missingMetadata) }
       iconName='info'
     />
   );
@@ -95,7 +48,7 @@ export const WarningSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.warning) }
+      className={ css(SignalStyles.signal, SignalsStyles.warning) }
       iconName='warning'
     />
   );
@@ -105,7 +58,7 @@ export const AwaitingApprovalSignal: Signal = (props: ISignalProps): JSX.Element
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.awaitingApproval) }
+      className={ css(SignalStyles.signal, SignalsStyles.awaitingApproval) }
       iconName='documentmanagement'
     /> // TODO get correct icon
   );
@@ -127,7 +80,7 @@ export const SomeoneCheckedOutSignal: Signal = (props: ISignalProps): JSX.Elemen
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.someoneCheckedOut) }
+      className={ css(SignalStyles.signal, SignalsStyles.someoneCheckedOut) }
       iconName='navigateforward'
     /> // TODO get correct icon
   );
@@ -145,11 +98,11 @@ export const NewSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <span
       { ...spanProps }
-      className={ css(SignalStyles.signal, SignalStyles.newItem) }
+      className={ css(SignalStyles.signal, SignalsStyles.newItem) }
     >
       <Icon
         ariaLabel={ props.ariaLabel }
-        className={ css(SignalStyles.newIcon) }
+        className={ css(SignalsStyles.newIcon) }
         iconName='glimmer'
       />
     </span>
@@ -161,18 +114,15 @@ export const NewSignal: Signal = (props: ISignalProps): JSX.Element => {
  */
 export const LiveEditSignal: Signal = (props: ISignalProps): JSX.Element => {
   const {
-    ariaLabel,
+    className,
     ...spanProps
   } = props;
 
   return (
-    <span
-      aria-label={ ariaLabel }
+    <Signal
+      className={ css(className, SignalsStyles.liveEdit) }
       { ...spanProps }
-      className={ css(SignalStyles.signal, SignalStyles.liveEdit) }
-    >
-      { props.children }
-    </span>
+    />
   );
 };
 
@@ -180,7 +130,7 @@ export const MentionSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.mention) }
+      className={ css(SignalStyles.signal, SignalsStyles.mention) }
       iconName='accounts'
     />
   );
@@ -192,27 +142,29 @@ export const MentionSignal: Signal = (props: ISignalProps): JSX.Element => {
 export const CommentsSignal: Signal = (props: ISignalProps): JSX.Element => {
   const {
     ariaLabel,
+    className,
+    children,
     ...spanProps
   } = props;
 
   return (
-    <span
+    <Signal
+      className={ css(SignalsStyles.comments, className) }
       { ...spanProps }
-      className={ css(SignalStyles.signal, SignalStyles.comments) }
     >
       <Icon
         ariaLabel={ props.ariaLabel }
-        className={ css(SignalStyles.commentsIcon) }
+        className={ css(SignalsStyles.commentsIcon) }
         iconName='MessageFill'
       />
       {
-        props.children ? (
-          <span className={ css(SignalStyles.commentsCount) }>
-            { props.children }
+        children ? (
+          <span className={ css(SignalsStyles.commentsCount) }>
+            { children }
           </span>
         ) : null
       }
-    </span>
+    </Signal>
   );
 };
 
@@ -220,7 +172,7 @@ export const UnseenEditSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.unseenEdit) }
+      className={ css(SignalStyles.signal, SignalsStyles.unseenEdit) }
       iconName='edit'
     /> // TODO get correct icon
   );
@@ -230,7 +182,7 @@ export const ReadOnlySignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.readOnly) }
+      className={ css(SignalStyles.signal, SignalsStyles.readOnly) }
       iconName=''
     /> // TODO get correct icon
   );
@@ -240,7 +192,7 @@ export const SharedSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.shared) }
+      className={ css(SignalStyles.signal, SignalsStyles.shared) }
       iconName='people'
     />
   );

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -66,13 +66,11 @@ export const AwaitingApprovalSignal: Signal = (props: ISignalProps): JSX.Element
 
 export const TrendingSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
-    <span className={ css(SignalStyles.signal, SignalStyles.centeredSignal) }>
-      <Icon
-        ariaLabel={ props.ariaLabel }
-        className={ css(SignalStyles.signal, SignalStyles.trending) }
-        iconName='market'
-      />
-    </span>
+    <Icon
+      ariaLabel={ props.ariaLabel }
+      className={ css(SignalStyles.signal, SignalsStyles.trending) }
+      iconName='market'
+    />
   );
 };
 
@@ -98,7 +96,7 @@ export const NewSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <span
       { ...spanProps }
-      className={ css(SignalStyles.signal, SignalsStyles.newItem) }
+      className={ css(SignalStyles.signal, SignalsStyles.new) }
     >
       <Icon
         ariaLabel={ props.ariaLabel }
@@ -198,15 +196,17 @@ export const SharedSignal: Signal = (props: ISignalProps): JSX.Element => {
   );
 };
 
-export const ATPSignal: Signal = (props: ISignalProps): JSX.Element => {
+export const MalwareDetectedSignal: Signal = (props: ISignalProps): JSX.Element => {
   return (
     <Icon
       ariaLabel={ props.ariaLabel }
-      className={ css(SignalStyles.signal, SignalStyles.atp) }
+      className={ css(SignalStyles.signal, SignalsStyles.malwareDetected) }
       iconName='ATPLogo'
     />
   );
 };
+
+export const ATPSignal: Signal = MalwareDetectedSignal; // TODO Delete on next major version.
 
 /**
  * Renders a signal for an external item.

--- a/packages/experiments/src/components/signals/SignalsPage.tsx
+++ b/packages/experiments/src/components/signals/SignalsPage.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import {
+  ExampleCard,
+  IComponentDemoPageProps,
+  ComponentPage,
+  PropertiesTableSet
+} from '@uifabric/example-app-base';
+
+/* tslint:disable:max-line-length */
+import { SignalsBasicExample } from './examples/Signals.Basic.Example';
+const SignalsBasicExampleCode = require(
+  '!raw-loader!experiments/src/components/signals/examples/Signals.Basic.Example.tsx'
+) as string;
+
+export class SignalsPage extends React.Component<IComponentDemoPageProps, {}> {
+  public render(): JSX.Element {
+    return (
+      <ComponentPage
+        title='Signals'
+        componentName='SignalsBasicExample'
+        exampleCards={
+          <div>
+            <ExampleCard title='Basic signals usage' isOptIn={ true } code={ SignalsBasicExampleCode }>
+              <SignalsBasicExample />
+            </ExampleCard>
+          </div>
+        }
+        propertiesTables={
+          <PropertiesTableSet
+            sources={ [
+              require<string>('!raw-loader!experiments/src/components/signals/Signals.Props.ts')
+            ] }
+          />
+        }
+        overview={
+          <div>
+            <p>A <code>Signal</code> is a combination of an <code>Icon</code> with a color and optional metadata which carries a standardized, semantic meaning.</p>
+            <p>A <code>SignalField</code> is a layout component which nicely arranges <code>Signal</code> and text elements for presentation.</p>
+          </div>
+        }
+        bestPractices={
+          <div />
+        }
+        dos={
+          <div>
+            <ul>
+              <li>Use them to associate a document with a specific state.</li>
+              <li>Assign localized <code>aria-label</code> attributes to the <code>Signal</code> elements which align with their meaning.</li>
+            </ul>
+          </div>
+        }
+        donts={
+          <div>
+            <ul>
+              <li>Use them just for their icon, or re-assign their colors.</li>
+            </ul>
+          </div>
+        }
+        isHeaderVisible={ this.props.isHeaderVisible }
+      />
+    );
+  }
+}

--- a/packages/experiments/src/components/signals/examples/Signals.Basic.Example.tsx
+++ b/packages/experiments/src/components/signals/examples/Signals.Basic.Example.tsx
@@ -1,0 +1,176 @@
+
+import * as React from 'react';
+import {
+  SignalField,
+  YouCheckedOutSignal,
+  BlockedSignal,
+  MissingMetadataSignal,
+  WarningSignal,
+  AwaitingApprovalSignal,
+  TrendingSignal,
+  SomeoneCheckedOutSignal,
+  NewSignal,
+  LiveEditSignal,
+  MentionSignal,
+  CommentsSignal,
+  UnseenEditSignal,
+  ReadOnlySignal,
+  SharedSignal
+} from '../Signals';
+import { ChoiceGroup, IChoiceGroupOption, Checkbox } from 'office-ui-fabric-react';
+import { css, autobind } from 'office-ui-fabric-react/lib/Utilities';
+import { lorem } from '@uifabric/example-app-base';
+import * as SignalStylesModule from '../Signal.scss';
+import * as SignalsExampleStylesModule from './Signals.Example.scss';
+
+// tslint:disable-next-line:no-any
+const SignalStyles: any = SignalStylesModule;
+// tslint:disable-next-line:no-any
+const SignalsExampleStyles: any = SignalsExampleStylesModule;
+
+interface ISignalExampleProps {
+  name: string;
+  signal: React.ReactNode;
+}
+
+const SignalExample: React.StatelessComponent<ISignalExampleProps> = (props: ISignalExampleProps): JSX.Element => {
+  return (
+    <div>
+      <h3>{ props.name }</h3>
+      <SignalField before={ props.signal }>{ lorem(4) }</SignalField>
+    </div>
+  );
+};
+
+export interface ISignalsBasicExampleState {
+  fontSize: 'small' | 'medium' | 'large';
+  isDark: boolean;
+}
+
+export class SignalsBasicExample extends React.Component<{}, ISignalsBasicExampleState> {
+  constructor() {
+    super();
+
+    this.state = {
+      fontSize: 'small',
+      isDark: false
+    };
+  }
+
+  public render(): JSX.Element | null {
+    const {
+      fontSize,
+      isDark
+    } = this.state;
+
+    return (
+      <div>
+        <p>
+          <ChoiceGroup
+            label='Font size'
+            defaultSelectedKey={ fontSize }
+            onChanged={ this._onFontSizeChoiceChanged }
+            options={
+              [{
+                key: 'small',
+                text: 'Small'
+              }, {
+                key: 'medium',
+                text: 'Medium'
+              }, {
+                key: 'large',
+                text: 'Large'
+              }]
+            }
+          />
+        </p>
+        <p>
+          <Checkbox
+            label='Dark?'
+            defaultChecked={ isDark }
+            onChange={ this._onIsDarkChanged }
+          />
+        </p>
+        <div
+          className={ css(SignalsExampleStyles.example, {
+            [SignalsExampleStyles.small]: fontSize === 'small',
+            [SignalsExampleStyles.medium]: fontSize === 'medium',
+            [SignalsExampleStyles.large]: fontSize === 'large',
+            [`${SignalsExampleStyles.dark} ${SignalStyles.dark}`]: isDark,
+          }) }
+        >
+          <SignalExample
+            name='You checked out'
+            signal={ <YouCheckedOutSignal /> }
+          />
+          <SignalExample
+            name='Blocked'
+            signal={ <BlockedSignal /> }
+          />
+          <SignalExample
+            name='Missing metadata'
+            signal={ <MissingMetadataSignal /> }
+          />
+          <SignalExample
+            name='Warning'
+            signal={ <WarningSignal /> }
+          />
+          <SignalExample
+            name='Awaiting approval'
+            signal={ <AwaitingApprovalSignal /> }
+          />
+          <SignalExample
+            name='Trending'
+            signal={ <TrendingSignal /> }
+          />
+          <SignalExample
+            name='Someone checked out'
+            signal={ <SomeoneCheckedOutSignal /> }
+          />
+          <SignalExample
+            name='New'
+            signal={ <NewSignal /> }
+          />
+          <SignalExample
+            name='Live edit'
+            signal={ <LiveEditSignal /> }
+          />
+          <SignalExample
+            name='Mention'
+            signal={ <MentionSignal /> }
+          />
+          <SignalExample
+            name='Comments'
+            signal={ <CommentsSignal /> }
+          />
+          <SignalExample
+            name='Unseen edit'
+            signal={ <UnseenEditSignal /> }
+          />
+          <SignalExample
+            name='Read-only'
+            signal={ <ReadOnlySignal /> }
+          />
+          <SignalExample
+            name='Shared'
+            signal={ <SharedSignal /> }
+          />
+        </div>
+      </div>
+    );
+  }
+
+  @autobind
+  private _onFontSizeChoiceChanged(option: IChoiceGroupOption): void {
+    this.setState({
+      fontSize: option.key as ISignalsBasicExampleState['fontSize']
+    });
+  }
+
+  @autobind
+  private _onIsDarkChanged(ev: React.FormEvent<HTMLElement>, checked: boolean): void {
+    this.setState({
+      isDark: checked
+    });
+  }
+}

--- a/packages/experiments/src/components/signals/examples/Signals.Basic.Example.tsx
+++ b/packages/experiments/src/components/signals/examples/Signals.Basic.Example.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import {
   SignalField,
   YouCheckedOutSignal,
+  MalwareDetectedSignal,
   BlockedSignal,
   MissingMetadataSignal,
   WarningSignal,
@@ -31,13 +32,18 @@ const SignalsExampleStyles: any = SignalsExampleStylesModule;
 interface ISignalExampleProps {
   name: string;
   signal: React.ReactNode;
+  text?: string;
 }
 
 const SignalExample: React.StatelessComponent<ISignalExampleProps> = (props: ISignalExampleProps): JSX.Element => {
+  const {
+    text = lorem(4)
+  } = props;
+
   return (
     <div>
       <h3>{ props.name }</h3>
-      <SignalField before={ props.signal }>{ lorem(4) }</SignalField>
+      <SignalField before={ props.signal }>{ text }</SignalField>
     </div>
   );
 };
@@ -104,6 +110,10 @@ export class SignalsBasicExample extends React.Component<{}, ISignalsBasicExampl
             signal={ <YouCheckedOutSignal /> }
           />
           <SignalExample
+            name='Malware detected'
+            signal={ <MalwareDetectedSignal /> }
+          />
+          <SignalExample
             name='Blocked'
             signal={ <BlockedSignal /> }
           />
@@ -132,6 +142,11 @@ export class SignalsBasicExample extends React.Component<{}, ISignalsBasicExampl
             signal={ <NewSignal /> }
           />
           <SignalExample
+            name='New (positioning)'
+            signal={ <NewSignal /> }
+            text='O'
+          />
+          <SignalExample
             name='Live edit'
             signal={ <LiveEditSignal /> }
           />
@@ -142,6 +157,10 @@ export class SignalsBasicExample extends React.Component<{}, ISignalsBasicExampl
           <SignalExample
             name='Comments'
             signal={ <CommentsSignal /> }
+          />
+          <SignalExample
+            name='Comments (count)'
+            signal={ <CommentsSignal>2</CommentsSignal> }
           />
           <SignalExample
             name='Unseen edit'

--- a/packages/experiments/src/components/signals/examples/Signals.Example.scss
+++ b/packages/experiments/src/components/signals/examples/Signals.Example.scss
@@ -1,0 +1,25 @@
+
+@import '~office-ui-fabric-react/src/common/common';
+
+.example {
+  padding: 8px;
+
+  transition: color 0.2s linear, background-color 0.2s linear;
+}
+
+.small {
+  font-size: $ms-font-size-s;
+}
+
+.medium {
+  font-size: $ms-font-size-m;
+}
+
+.large {
+  font-size: $ms-font-size-l;
+}
+
+.dark {
+  background-color: $ms-color-neutralDark;
+  color: $ms-color-white;
+}

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -35,6 +35,12 @@ export const AppDefinition: IAppDefinition = {
           url: '#/examples/layoutgroup'
         },
         {
+          component: require<any>('../components/signals/SignalsPage').SignalsPage,
+          key: 'Signals',
+          name: 'Signals',
+          url: '#/examples/signals'
+        },
+        {
           component: require<any>('../components/Tile/TilePage').TilePage,
           key: 'Tile',
           name: 'Tile',


### PR DESCRIPTION
# Overview

This change revises the modules for `Signals`, splitting `Signal` and `SignalField` out of the original `Signals` module. However, for backwards-compatibility, they are mixed back in using `export *`.

This change fixes the visual alignments of signals to work better when in-line with text.

This change also adds an example page for `Signals` to show them in various states.