### PR TITLE
Kchau/merge styles

### DIFF
--- a/common/changes/@uifabric/merge-styles/kchau-merge-styles_2017-11-30-22-44.json
+++ b/common/changes/@uifabric/merge-styles/kchau-merge-styles_2017-11-30-22-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "merge-styles: Fixes injection mode of appendNode by adding style tags rather than modifying the tag (fixes flashes)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -171,7 +171,10 @@ export class Stylesheet {
         break;
 
       case InjectionMode.appendChild:
-        element!.appendChild(document.createTextNode(rule));
+        const styleElement = document.createElement('style');
+        styleElement.type = 'text/css';
+        styleElement.appendChild(document.createTextNode(rule));
+        document.getElementsByTagName('head')[0].appendChild(styleElement);
         break;
 
       default:


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes
Currently injection mode of appendNode will cause visual flashes. This is because text is changing inside same style tag. This change makes it so it adds new style tags rather than appending.

#### Focus areas to test

(optional)
