### PR TITLE
ComboBox: Allow for dropdown to automatically fit its content

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxAllowForAutoSizeDropdown_2017-12-01-00-04.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxAllowForAutoSizeDropdown_2017-12-01-00-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Update to allow the dropdown to fit its content",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -805,7 +805,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       onRenderList,
       calloutProps,
       dropdownWidth,
-      onRenderLowerContent = this._onRenderLowerContent
+      onRenderLowerContent = this._onRenderLowerContent,
+      useComboBoxAsMenuWidth
     } = props;
 
     return (
@@ -821,7 +822,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         onDismiss={ this._onDismiss }
         onScroll={ this._onScroll }
         setInitialFocus={ false }
-        calloutWidth={ dropdownWidth === undefined ? this._comboBoxWrapper.clientWidth + 2 : dropdownWidth }
+        calloutWidth={
+          useComboBoxAsMenuWidth ?
+            this._comboBoxWrapper.clientWidth + 2
+            : dropdownWidth }
       >
         <div className={ this._classNames.optionsContainerWrapper } ref={ this._resolveRef('_comboBoxMenu') }>
           { (onRenderList as any)({ ...props }, this._onRenderList) }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -821,7 +821,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         onDismiss={ this._onDismiss }
         onScroll={ this._onScroll }
         setInitialFocus={ false }
-        calloutWidth={ dropdownWidth || this._comboBoxWrapper.clientWidth + 2 }
+        calloutWidth={ dropdownWidth === undefined ? this._comboBoxWrapper.clientWidth + 2 : dropdownWidth }
       >
         <div className={ this._classNames.optionsContainerWrapper } ref={ this._resolveRef('_comboBoxMenu') }>
           { (onRenderList as any)({ ...props }, this._onRenderList) }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -137,7 +137,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     this._warnMutuallyExclusive({
       'defaultSelectedKey': 'selectedKey',
       'value': 'defaultSelectedKey',
-      'selectedKey': 'value'
+      'selectedKey': 'value',
+      'dropdownWidth': 'useComboBoxAsMenuWidth'
     });
 
     this._id = props.id || getId('ComboBox');

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -119,7 +119,8 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   onRenderLowerContent?: IRenderFunction<IComboBoxProps>;
 
   /**
-  * Custom width for dropdown. If value is not defined, width of the input field is used.
+  * Custom width for dropdown. If value is undefined, width of the input field is used.
+  * If value is 0, no width is applied (e.g. the dropdown will be as wide as its content)
   */
   dropdownWidth?: number;
 }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -119,8 +119,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   onRenderLowerContent?: IRenderFunction<IComboBoxProps>;
 
   /**
-  * Custom width for dropdown. If value is 0, width of the input field is used.
-  * @default 0
+  * Custom width for dropdown. If value is not defined, width of the input field is used.
   */
   dropdownWidth?: number;
 }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -119,7 +119,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   onRenderLowerContent?: IRenderFunction<IComboBoxProps>;
 
   /**
-  * Custom width for dropdown. If value is 0, width of the input field is used (unless useComboBoxAsMenuWidth is undefined or false)
+  * Custom width for dropdown (unless useComboBoxAsMenuWidth is undefined or false)
   */
   dropdownWidth?: number;
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -119,10 +119,14 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   onRenderLowerContent?: IRenderFunction<IComboBoxProps>;
 
   /**
-  * Custom width for dropdown. If value is undefined, width of the input field is used.
-  * If value is 0, no width is applied (e.g. the dropdown will be as wide as its content)
+  * Custom width for dropdown. If value is 0, width of the input field is used (unless useComboBoxAsMenuWidth is undefined or false)
   */
   dropdownWidth?: number;
+
+  /**
+   * Whether to use the ComboBoxes width as the menu's width
+   */
+  useComboBoxAsMenuWidth?: boolean;
 }
 
 export interface IComboBoxStyles {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

There was no way to have the dropdown autosize (e.g. not specify a width for the callout)... you either had to specify a width or get the width of the comboBox.

This add the ability to not specify a width for the callout by passing 0 for the dropdownWidth (this aligns with the convention set by callout)

#### Focus areas to test

verified that the default rendering didn't change and that you can now tell the dropdown to grow to fit its contents
