### PR TITLE
ContextualMenu: Expose onMenuDismiss function to invoke when menu is being removed from DOM

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-ExposeOnDimiss_2017-12-01-00-36.json
+++ b/common/changes/office-ui-fabric-react/malozano-ExposeOnDimiss_2017-12-01-00-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Expose callback hook when menu is being removed from DOM",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -183,6 +183,10 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       setTimeout(() => this._previousActiveElement!.focus(), 0);
     }
 
+    if (this.props.onMenuDismissed) {
+      this.props.onMenuDismissed(this.props);
+    }
+
     this._events.dispose();
     this._async.dispose();
   }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -186,6 +186,11 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
   onMenuOpened?: (contextualMenu?: IContextualMenuProps) => void;
 
   /**
+   * Callback for when the contextualmenu is being closed (removing from the DOM)
+   */
+  onMenuDismissed?: (contextualMenu?: IContextualMenuProps) => void;
+
+  /**
    * Pass in custom callout props
    */
   calloutProps?: ICalloutProps;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Expose onMenuDismiss function to invoke when menu is being removed from DOM
