### PR TITLE
Panel: apply hidden css to popup instead of the panel itself

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -96,7 +96,6 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     const headerTextId = id + '-headerText';
     const customWidthStyles = (type === PanelType.custom) ? { width: customWidth } : {};
     const renderProps: IPanelProps = { ...this.props, componentId: id };
-    isLightDismiss = isHiddenOnDismiss || isLightDismiss;
 
     if (!isOpen && !isAnimating && !isHiddenOnDismiss) {
       return null;
@@ -123,6 +122,11 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
           role='dialog'
           ariaLabelledBy={ headerText && headerTextId }
           onDismiss={ this.dismiss }
+          className={
+            css(
+              !isOpen && !isAnimating && isHiddenOnDismiss && styles.hiddenPanel
+            )
+          }
         >
           <div
             className={
@@ -158,7 +162,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
                 ) }
               style={ customWidthStyles }
               elementToFocusOnDismiss={ elementToFocusOnDismiss }
-              isClickableOutsideFocusTrap={ isLightDismiss }
+              isClickableOutsideFocusTrap={ isLightDismiss || isHiddenOnDismiss }
               ignoreExternalFocusing={ ignoreExternalFocusing }
               forceFocusInsideTrap={ forceFocusInsideTrap }
               firstFocusableSelector={ firstFocusableSelector }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -40,7 +40,7 @@ export interface IPanelProps extends React.Props<Panel> {
   isLightDismiss?: boolean;
 
   /**
-  * Whether the panel is hidden on dismiss, instead of destroyed in the DOM. This will override isLightDismiss to true.
+  * Whether the panel is hidden on dismiss, instead of destroyed in the DOM.
   * @default false
   */
   isHiddenOnDismiss?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.HiddenOnDismiss.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.HiddenOnDismiss.Example.tsx
@@ -24,7 +24,7 @@ export class PanelHiddenOnDismissExample extends React.Component<any, any> {
           headerText='Hidden on Dismiss Panel'
           onDismiss={ this._hidePanel }
         >
-          <span>When dismissed, this panel will be hidden instead of destroyed. LightDismiss is overridden and enabled.</span>
+          <span>When dismissed, this panel will be hidden instead of destroyed.</span>
         </Panel>
       </div>
     );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Panel: apply hidden css to popup instead of the panel itself. No longer override value of isLightDismiss when isHiddenOnDismiss is true

#### Focus areas to test

Panel
