### PR TITLE
Reverting: ContextualMenu Tabbing through menu items

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-revertContextualTab_2017-12-04-21-01.json
+++ b/common/changes/office-ui-fabric-react/chiechan-revertContextualTab_2017-12-04-21-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Contextual Tab and Focus Zone - reverted tabbing functionality to avoid tab being captured",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -304,7 +304,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                 className={ this._classNames.root }
                 direction={ arrowDirection }
                 isCircularNavigation={ true }
-                allowTabKey={ true }
               >
                 <ul
                   aria-label={ ariaLabel }
@@ -660,6 +659,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     let submenuCloseKey = getRTL() ? KeyCodes.right : KeyCodes.left;
 
     if (ev.which === KeyCodes.escape
+      || ev.which === KeyCodes.tab
       || (ev.which === submenuCloseKey && this.props.isSubMenu && this.props.arrowDirection === FocusZoneDirection.vertical)) {
       // When a user presses escape, we will try to refocus the previous focused element.
       this._isFocusingPreviousElement = true;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -354,26 +354,6 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           }
           return;
 
-        case KeyCodes.tab:
-          if (this.props.allowTabKey) {
-            if (direction === FocusZoneDirection.vertical) {
-              if (ev.shiftKey) {
-                this._moveFocusUp();
-              } else {
-                this._moveFocusDown();
-              }
-              break;
-            } else if (direction === FocusZoneDirection.horizontal || direction === FocusZoneDirection.bidirectional) {
-              if (ev.shiftKey) {
-                this._moveFocusLeft();
-              } else {
-                this._moveFocusRight();
-              }
-              break;
-            }
-            return;
-          }
-
         case KeyCodes.home:
           if (
             this._isElementInput(ev.target as HTMLElement) &&

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
@@ -102,9 +102,6 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
 
   /** Allow focus to move to root */
   allowFocusRoot?: boolean;
-
-  /** Allows tab key to be handled, a side effect is that users will not be able to tab out of the focus zone */
-  allowTabKey?: boolean;
 }
 
 export enum FocusZoneDirection {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ X] Include a change request file using `$ npm run change`

#### Description of changes
Changes made in this PR: https://github.com/OfficeDev/office-ui-fabric-react/pull/3417/files

Caused a problem with the FocusZone stealing all tabbing actions in other components like OverflowSet.

I've reverted my changes so now we can't tab through menu items, but should be able to tab through menus and other elements that uses the FocusZone

#### Focus areas to test
- OverflowSet and Contextual Menu
