### PR TITLE
Context Menu, do not nest button elements (#3521)

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -214,6 +214,25 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       onRenderMenuIcon = this._onRenderMenuIcon
     } = props;
 
+    if (menuProps && menuProps.doNotLayer) {
+      return React.createElement(
+        'div',
+        undefined,
+        React.createElement(
+          tag,
+          buttonProps,
+          React.createElement(
+            'div' as any,
+            { className: this._classNames.flexContainer },
+            onRenderIcon(props, this._onRenderIcon),
+            this._onRenderTextContents(),
+            onRenderAriaDescription(props, this._onRenderAriaDescription),
+            onRenderChildren(props, this._onRenderChildren),
+            !this._isSplitButton && (menuProps || menuIconProps || this.props.onRenderMenuIcon) && onRenderMenuIcon(this.props, this._onRenderMenuIcon))),
+        this.state.menuProps && onRenderMenu(menuProps, this._onRenderMenu)
+      );
+    }
+
     return React.createElement(
       tag,
       buttonProps,
@@ -226,7 +245,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         onRenderChildren(props, this._onRenderChildren),
         !this._isSplitButton && (menuProps || menuIconProps || this.props.onRenderMenuIcon) && onRenderMenuIcon(this.props, this._onRenderMenuIcon),
         this.state.menuProps && onRenderMenu(menuProps, this._onRenderMenu)
-      ));
+    ));
   }
 
   @autobind

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -245,7 +245,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         onRenderChildren(props, this._onRenderChildren),
         !this._isSplitButton && (menuProps || menuIconProps || this.props.onRenderMenuIcon) && onRenderMenuIcon(this.props, this._onRenderMenuIcon),
         this.state.menuProps && onRenderMenu(menuProps, this._onRenderMenu)
-    ));
+      ));
   }
 
   @autobind


### PR DESCRIPTION
#### Description of changes

When we display a context menu in a DefaultButton with the prop doNotLayer=true, we create a div to don't nest the context menu in the button.