### PR TITLE
Icon: add ability to show overlays

### DIFF
--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -28,6 +28,7 @@
     "storybook-readme": "=3.0.6"
   },
   "dependencies": {
+    "@uifabric/file-type-icons": ">=0.0.1 <1.0.0",
     "@uifabric/icons": ">=5.2.0 <6.0.0",
     "@uifabric/styling": ">=5.14.0 <6.0.0",
     "office-ui-fabric-react": ">=5.29.1 <6.0.0",

--- a/apps/vr-tests/src/stories/Icon.stories.tsx
+++ b/apps/vr-tests/src/stories/Icon.stories.tsx
@@ -4,6 +4,7 @@ import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Icon, IconType, getIconClassName } from 'office-ui-fabric-react';
+import { getFileTypeIconProps, FileIconType, OverlayType } from '@uifabric/file-type-icons';
 import { TestImages } from '../common/TestImages';
 
 storiesOf('Icon', module)
@@ -41,4 +42,12 @@ storiesOf('Icon', module)
         src: TestImages.iconOne
       } }
     />
+  )).add('Overlays', () => (
+    <div>
+      <Icon {...getFileTypeIconProps({ extension: 'docx', size: 16, overlayType: OverlayType.none })} />
+      <Icon {...getFileTypeIconProps({ extension: 'pptx', size: 20, overlayType: OverlayType.checkout })} />
+      <Icon {...getFileTypeIconProps({ type: FileIconType.folder, size: 32, overlayType: OverlayType.checkoutGrid })} />
+      <Icon {...getFileTypeIconProps({ type: FileIconType.genericFile, size: 40, overlayType: OverlayType.block })} />
+      <Icon {...getFileTypeIconProps({ type: FileIconType.listItem, size: 48, overlayType: OverlayType.notify })} />
+    </div>
   ));

--- a/apps/vr-tests/src/utilities/index.ts
+++ b/apps/vr-tests/src/utilities/index.ts
@@ -1,5 +1,7 @@
 import { initializeIcons } from '@uifabric/icons';
+import { initializeFileTypeIcons } from '@uifabric/file-type-icons';
 
 initializeIcons();
+initializeFileTypeIcons();
 
 export * from './FabricDecorator';

--- a/common/changes/@uifabric/experiments/kathayer-overlays_2017-12-06-19-26.json
+++ b/common/changes/@uifabric/experiments/kathayer-overlays_2017-12-06-19-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Simple example of overlays on file type icons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kathayer@microsoft.com"
+}

--- a/common/changes/@uifabric/file-type-icons/kathayer-overlays_2017-12-06-19-26.json
+++ b/common/changes/@uifabric/file-type-icons/kathayer-overlays_2017-12-06-19-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Add overlays for file type icons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "kathayer@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/kathayer-overlays_2017-12-06-19-26.json
+++ b/common/changes/office-ui-fabric-react/kathayer-overlays_2017-12-06-19-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Icon: add optional overlayName to show overlay",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kathayer@microsoft.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -10,12 +10,12 @@
       "integrity": "sha1-6pn2EhtKjwZbTHH4VZXbJxRJiAc="
     },
     "@microsoft/api-extractor": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-4.3.1.tgz",
-      "integrity": "sha1-HbrVWbuiutL2df2cPofoVs8b+gI=",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-4.3.3.tgz",
+      "integrity": "sha1-gCOWb8fkEWRQAO37nbTxUi7mohA=",
       "requires": {
-        "@microsoft/node-core-library": "0.3.18",
-        "@microsoft/ts-command-line": "2.2.6",
+        "@microsoft/node-core-library": "0.3.20",
+        "@microsoft/ts-command-line": "2.2.8",
         "@types/fs-extra": "0.0.37",
         "@types/node": "6.0.88",
         "@types/z-schema": "3.16.31",
@@ -35,23 +35,23 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.11.tgz",
-      "integrity": "sha1-YXKmzjlXpMXG5mGNxhT5GOWc7D8="
+      "version": "1.7.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.13.tgz",
+      "integrity": "sha1-MDXG1hEg6uc2HSzJ1gXijQ0r+/s="
     },
     "@microsoft/loader-load-themed-styles": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.6.6.tgz",
-      "integrity": "sha1-zZm/Ol89RvGMe/eMr6uRmMMOL90=",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.6.8.tgz",
+      "integrity": "sha1-1Sfmgh5IhvijJdB//zQMweU7oQE=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
+        "@microsoft/load-themed-styles": "1.7.13",
         "loader-utils": "1.1.0"
       }
     },
     "@microsoft/node-core-library": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.18.tgz",
-      "integrity": "sha1-7PxLJIqBT4ty7u4ondUuidMblMc=",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-0.3.20.tgz",
+      "integrity": "sha1-bslI50IHwTwLeC7AqiraLjtIJ3g=",
       "requires": {
         "@types/fs-extra": "0.0.37",
         "@types/node": "6.0.88",
@@ -69,9 +69,9 @@
       }
     },
     "@microsoft/ts-command-line": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.6.tgz",
-      "integrity": "sha1-LgCJ56xnFz/PKQJplAwwao+gBGA=",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-2.2.8.tgz",
+      "integrity": "sha1-I1JBwoCu+9N6poLO6Gklwty4jMo=",
       "requires": {
         "@types/argparse": "1.0.33",
         "@types/node": "6.0.88",
@@ -88,13 +88,13 @@
     },
     "@rush-temp/build": {
       "version": "file:projects/build.tgz",
-      "integrity": "sha1-XpiTxVfrJ8tQX62qbk43XY/vpUY=",
+      "integrity": "sha1-fufKNv4lSy/amOfeRwtZHJy80zw=",
       "requires": {
-        "@microsoft/api-extractor": "4.3.1",
-        "@microsoft/load-themed-styles": "1.7.11",
-        "@microsoft/loader-load-themed-styles": "1.6.6",
-        "autoprefixer": "7.1.6",
-        "awesome-typescript-loader": "3.4.0",
+        "@microsoft/api-extractor": "4.3.3",
+        "@microsoft/load-themed-styles": "1.7.13",
+        "@microsoft/loader-load-themed-styles": "1.6.8",
+        "autoprefixer": "7.2.1",
+        "awesome-typescript-loader": "3.4.1",
         "bundlesize": "0.15.3",
         "chalk": "2.3.0",
         "command-line-args": "4.0.7",
@@ -116,14 +116,14 @@
         "sinon": "4.1.2",
         "source-map-loader": "0.2.3",
         "style-loader": "0.18.2",
-        "ts-jest": "21.2.3",
+        "ts-jest": "21.2.4",
         "tslint": "5.8.0",
         "tslint-microsoft-contrib": "5.0.1",
         "typescript": "2.6.2",
         "uglifyjs-webpack-plugin": "0.4.6",
-        "webpack": "3.8.1",
+        "webpack": "3.10.0",
         "webpack-bundle-analyzer": "2.9.1",
-        "webpack-dev-server": "2.9.5",
+        "webpack-dev-server": "2.9.6",
         "webpack-notifier": "1.5.0",
         "yargs": "6.6.0"
       },
@@ -137,7 +137,7 @@
     },
     "@rush-temp/example-app-base": {
       "version": "file:projects/example-app-base.tgz",
-      "integrity": "sha1-9PS/QcIwhN7giKPF5D43WMy4IQM=",
+      "integrity": "sha1-qVLM3xA8VYmcCsrooyCSp1384C8=",
       "requires": {
         "@types/chai": "3.4.35",
         "@types/enzyme": "2.8.8",
@@ -153,7 +153,7 @@
         "es6-promise": "4.1.1",
         "es6-weak-map": "2.0.2",
         "highlight.js": "9.12.0",
-        "office-ui-fabric-react": "5.27.0",
+        "office-ui-fabric-react": "5.29.4",
         "react": "15.6.2",
         "react-addons-test-utils": "15.6.2",
         "react-dom": "15.6.2",
@@ -162,9 +162,9 @@
     },
     "@rush-temp/experiments": {
       "version": "file:projects/experiments.tgz",
-      "integrity": "sha1-I2dqZ7zbQsTon4Tsgu0yOgx4oWw=",
+      "integrity": "sha1-er9Y5eIQvbylbP5J5SqeyxxHxzY=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
+        "@microsoft/load-themed-styles": "1.7.13",
         "@types/enzyme": "2.8.8",
         "@types/es6-promise": "0.0.32",
         "@types/jest": "21.1.8",
@@ -211,9 +211,9 @@
     },
     "@rush-temp/fabric-website": {
       "version": "file:projects/fabric-website.tgz",
-      "integrity": "sha1-rY4EuxJTdhsO+of/Zmqzl8S2/NU=",
+      "integrity": "sha1-y5aQ++NTWnUJNj13pgiPIuP80z8=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
+        "@microsoft/load-themed-styles": "1.7.13",
         "@types/chai": "3.4.35",
         "@types/enzyme": "2.8.8",
         "@types/es6-promise": "0.0.32",
@@ -231,7 +231,7 @@
         "es6-weak-map": "2.0.2",
         "highlight.js": "9.12.0",
         "json-loader": "0.5.7",
-        "office-ui-fabric-core": "9.2.0",
+        "office-ui-fabric-core": "9.3.0",
         "react": "15.6.2",
         "react-dom": "15.6.2",
         "react-highlight": "0.9.0",
@@ -239,16 +239,24 @@
         "write-file-webpack-plugin": "4.2.0"
       }
     },
+    "@rush-temp/file-type-icons": {
+      "version": "file:projects/file-type-icons.tgz",
+      "integrity": "sha1-WqA8E1W6gvhft50ln48WjjjHzu0=",
+      "requires": {
+        "@types/react": "15.6.7",
+        "tslib": "1.8.0"
+      }
+    },
     "@rush-temp/icons": {
       "version": "file:projects/icons.tgz",
-      "integrity": "sha1-2nEDGbwwqJG3pVIU9lbchpuhLnI=",
+      "integrity": "sha1-Ev9Y8LbClWCM1hEDjOzLD9rbSL4=",
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@rush-temp/jest-serializer-merge-styles": {
       "version": "file:projects/jest-serializer-merge-styles.tgz",
-      "integrity": "sha1-JTLTHGH61B5mdJjTPT/vSYP6JPQ=",
+      "integrity": "sha1-ISkHpw5hbC5hN1ecW7M6ZWQEmc0=",
       "requires": {
         "@types/jest": "21.1.0"
       },
@@ -262,7 +270,7 @@
     },
     "@rush-temp/merge-styles": {
       "version": "file:projects/merge-styles.tgz",
-      "integrity": "sha1-N/0gN2hPPIL5uMWNlRy4kquxu9c=",
+      "integrity": "sha1-t8hRjzlJTGA4LL2qqSdRAw4j/+I=",
       "requires": {
         "@types/jest": "21.1.0",
         "tslib": "1.8.0"
@@ -277,9 +285,9 @@
     },
     "@rush-temp/office-ui-fabric-react": {
       "version": "file:projects/office-ui-fabric-react.tgz",
-      "integrity": "sha1-tT9G96ICPXiOe4wV/j7nkIx2v/E=",
+      "integrity": "sha1-p8Ji7rGyGjInSPfjJYalU4aMu/0=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
+        "@microsoft/load-themed-styles": "1.7.13",
         "@types/enzyme": "2.8.8",
         "@types/es6-promise": "0.0.32",
         "@types/jest": "21.1.0",
@@ -295,7 +303,7 @@
         "es6-promise": "4.1.1",
         "es6-weak-map": "2.0.2",
         "highlight.js": "9.12.0",
-        "office-ui-fabric-core": "9.2.0",
+        "office-ui-fabric-core": "9.3.0",
         "prop-types": "15.6.0",
         "react": "15.6.2",
         "react-dom": "15.6.2",
@@ -343,16 +351,16 @@
     },
     "@rush-temp/office-ui-fabric-react-tslint": {
       "version": "file:projects/office-ui-fabric-react-tslint.tgz",
-      "integrity": "sha1-Q+2D1Bv2MtLvBvFsMYPILkwkUeY=",
+      "integrity": "sha1-TrgcWpuFzjveWzdOEK/wBI74SnU=",
       "requires": {
         "tslint-react": "3.2.0"
       }
     },
     "@rush-temp/ssr-tests": {
       "version": "file:projects/ssr-tests.tgz",
-      "integrity": "sha1-cgcOS/4MV3++w6huOUxEIHuhl8M=",
+      "integrity": "sha1-j0BRv8Oq6TgdT9XZnMgsTFzfSQU=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
+        "@microsoft/load-themed-styles": "1.7.13",
         "@types/chai": "3.4.35",
         "@types/enzyme": "2.8.8",
         "@types/es6-promise": "0.0.32",
@@ -364,14 +372,14 @@
         "react": "15.6.2",
         "react-dom": "15.6.2",
         "tslib": "1.8.0",
-        "webpack": "3.8.1"
+        "webpack": "3.10.0"
       }
     },
     "@rush-temp/styling": {
       "version": "file:projects/styling.tgz",
-      "integrity": "sha1-KqHoAUHACIxxQEUTyefVlGw1VWg=",
+      "integrity": "sha1-sMciRHQoOLhSee3VaHusDffR0B0=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
+        "@microsoft/load-themed-styles": "1.7.13",
         "@types/chai": "3.4.35",
         "@types/enzyme": "2.8.8",
         "@types/jest": "21.1.0",
@@ -394,7 +402,7 @@
     },
     "@rush-temp/test-bundle-button": {
       "version": "file:projects/test-bundle-button.tgz",
-      "integrity": "sha1-QBxJIh6t5W3SnHvBcv9DAKY8y14=",
+      "integrity": "sha1-ZdvXwmQG26WEnoH4Rb8cn4NHHPs=",
       "requires": {
         "@types/prop-types": "15.5.1",
         "@types/react": "15.6.7",
@@ -407,9 +415,9 @@
     },
     "@rush-temp/todo-app": {
       "version": "file:projects/todo-app.tgz",
-      "integrity": "sha1-d4y/mihiJri3d59Qo3VC8UmckHo=",
+      "integrity": "sha1-dBiq+8jpvQIXeQuKSCXjVReVFWU=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
+        "@microsoft/load-themed-styles": "1.7.13",
         "@types/chai": "3.4.35",
         "@types/enzyme": "2.8.8",
         "@types/es6-promise": "0.0.32",
@@ -418,7 +426,7 @@
         "@types/react-dom": "15.5.6",
         "@types/webpack-env": "1.13.0",
         "es6-promise": "4.1.1",
-        "immutability-helper": "2.5.1",
+        "immutability-helper": "2.6.0",
         "react": "15.6.2",
         "react-dom": "15.6.2",
         "tslib": "1.8.0",
@@ -427,9 +435,9 @@
     },
     "@rush-temp/utilities": {
       "version": "file:projects/utilities.tgz",
-      "integrity": "sha1-4Y87ZI3UBiw+0oRX2l70mfRlFLs=",
+      "integrity": "sha1-w46DRS7Gk1lVKpp6TOygXTJvwcw=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
+        "@microsoft/load-themed-styles": "1.7.13",
         "@types/enzyme": "2.8.8",
         "@types/jest": "21.1.0",
         "@types/prop-types": "15.5.1",
@@ -473,14 +481,14 @@
     },
     "@rush-temp/vr-tests": {
       "version": "file:projects/vr-tests.tgz",
-      "integrity": "sha1-RkxpzzslcFoclOx6PmJHgxyegDI=",
+      "integrity": "sha1-2SI8zmJ0VLz4PerWujlaVSPxUkY=",
       "requires": {
         "@storybook/addon-options": "3.2.3",
-        "@storybook/react": "3.2.16",
+        "@storybook/react": "3.2.17",
         "@types/react": "15.6.7",
         "@types/react-dom": "15.5.6",
         "@types/storybook__react": "3.0.5",
-        "awesome-typescript-loader": "3.4.0",
+        "awesome-typescript-loader": "3.4.1",
         "css-loader": "0.27.3",
         "file-loader": "0.11.1",
         "postcss-loader": "1.3.3",
@@ -488,7 +496,7 @@
         "react": "15.6.2",
         "react-dom": "15.6.2",
         "screener-runner": "0.6.19",
-        "screener-storybook": "0.9.10",
+        "screener-storybook": "0.9.11",
         "storybook-readme": "3.0.6",
         "style-loader": "0.16.1",
         "tslib": "1.8.0",
@@ -549,7 +557,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -594,11 +602,11 @@
       }
     },
     "@storybook/addon-actions": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.16.tgz",
-      "integrity": "sha512-TXR/H5lDCtPCmc+/nidvVBiTlGsPHxeJ/LMPuGxq/yF7EvzrfXw+CuEuaPNp5qknSioOLm9GngbozNg8HfBgKg==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.17.tgz",
+      "integrity": "sha512-B4++4+p6zWTeTBzqe9lgzT8J0onaMfSZsBRJpa5URoDo3d4kTq+DTDs2qHhhTKJb2Drtu24/JlEgJG7lv0Fb0w==",
       "requires": {
-        "@storybook/addons": "3.2.16",
+        "@storybook/addons": "3.2.17",
         "deep-equal": "1.0.1",
         "json-stringify-safe": "5.0.1",
         "prop-types": "15.6.0",
@@ -607,11 +615,11 @@
       }
     },
     "@storybook/addon-links": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.16.tgz",
-      "integrity": "sha512-JFs2p7EGRFpwUkg7xV7Vi3h/zBr4UjmprF9YYHR2L5TQFbztlKJPBhiATRSQtgFyNNAo7zNkSf439Rkrb9k7yQ==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.17.tgz",
+      "integrity": "sha512-AdCH9DsbOfiMDv42/l0Zfk2yhiBrlWuzHk7ubhSwqF3/61sXr+BWFv+SlOx2oFfSWAT7zfg2sC7Wr+us8gs7GQ==",
       "requires": {
-        "@storybook/addons": "3.2.16"
+        "@storybook/addons": "3.2.17"
       }
     },
     "@storybook/addon-options": {
@@ -619,33 +627,33 @@
       "resolved": "https://registry.npmjs.org/@storybook/addon-options/-/addon-options-3.2.3.tgz",
       "integrity": "sha1-6jdA0onUKc52fpaZvzpkfddBWS0=",
       "requires": {
-        "@storybook/addons": "3.2.16"
+        "@storybook/addons": "3.2.17"
       }
     },
     "@storybook/addons": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.16.tgz",
-      "integrity": "sha512-Dxs0XceqqUSG+vao5uCZdphmCAGlpnwDLV0abjYpPH0eKb2QN5Rs/Vrl0MzuOYGghPv8Y1QfhdB6DFh7AuIoTQ=="
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.17.tgz",
+      "integrity": "sha512-1/Ux++3hMfYqAgBwgWbGtGAM0CfSdAchf//wDLBUmX09+E5CjiQvW3YwVplNYzfRuAsSrE1GOYJRAsz639oTYQ=="
     },
     "@storybook/channel-postmessage": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.2.16.tgz",
-      "integrity": "sha512-8D3UeZfb4TarkEp0xMCUxX5rW/m2YghYmlnFDcMCgPhN9R2pRySjxxbCjK+ry0q2hUII4R9Bbck63AUqwcQDow==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.2.17.tgz",
+      "integrity": "sha512-sNlXcHTKM6aIxRsQMaMbowsAToYRlbeP/THqulVxoRRKNDPndNnZe/Lu3eSjBjAfNWBLRFfgX903adt82QAPCA==",
       "requires": {
-        "@storybook/channels": "3.2.16",
+        "@storybook/channels": "3.2.17",
         "global": "4.3.2",
         "json-stringify-safe": "5.0.1"
       }
     },
     "@storybook/channels": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.16.tgz",
-      "integrity": "sha512-zjaDE/0yvlLfOcpzeTIWi1K7d873UykUmGLwFSO2hUIM7hlc+QxCeE0MH+OrQYUWC8gcU8pg+IWAk/6qzWAZsA=="
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.17.tgz",
+      "integrity": "sha512-HIdRmFTFVLcbrwYFf6+LyAlgcd57ki+6DDTmcvXQTHCWrOOCJKwfKjHgn6tbnHlGHiWByA8lAdO1bFcYhHxl4Q=="
     },
     "@storybook/components": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.16.tgz",
-      "integrity": "sha512-+bxwsvwa7TPqwxG6ap2hjjrwSg1g8e2ZGijPQDEGpvNfEnLfbZRyQKXRhfCyeAN3DL8F8Bx95AJuWaYKr0pqpA==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.17.tgz",
+      "integrity": "sha512-pXwNKLavYCu18B2EynFu9EKXlKi0LDo0B/KctbJvidxR5ubzqkZu9h2ti3hPPVomR2DQiRx61Vzqd7cbcyy14w==",
       "requires": {
         "glamor": "2.20.40",
         "glamorous": "4.11.0",
@@ -658,22 +666,22 @@
       "integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
       "requires": {
         "@storybook/react-komposer": "2.0.3",
-        "@storybook/react-simple-di": "1.2.1",
+        "@storybook/react-simple-di": "1.3.0",
         "babel-runtime": "6.26.0"
       }
     },
     "@storybook/react": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.2.16.tgz",
-      "integrity": "sha512-gMS+KrI5u0OTnHYhyLkMLknCQRCyDL3QULXKCYtkUcZ6l2MKvOVSMwwG1VUPWssWtLBvN4Fdx9A+9BxDWLZhpw==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.2.17.tgz",
+      "integrity": "sha512-1bZXP0wGdlTgRiGsTLQ90G0Swx+Re7o3IAblOdobS/E5fREzEC1zEHdSQYC5ROUoWDLourqcF/zo4I9HpKvnZg==",
       "requires": {
-        "@storybook/addon-actions": "3.2.16",
-        "@storybook/addon-links": "3.2.16",
-        "@storybook/addons": "3.2.16",
-        "@storybook/channel-postmessage": "3.2.16",
-        "@storybook/ui": "3.2.16",
-        "airbnb-js-shims": "1.3.0",
-        "autoprefixer": "7.1.6",
+        "@storybook/addon-actions": "3.2.17",
+        "@storybook/addon-links": "3.2.17",
+        "@storybook/addons": "3.2.17",
+        "@storybook/channel-postmessage": "3.2.17",
+        "@storybook/ui": "3.2.17",
+        "airbnb-js-shims": "1.4.0",
+        "autoprefixer": "7.2.1",
         "babel-core": "6.26.0",
         "babel-loader": "7.1.2",
         "babel-plugin-react-docgen": "1.8.1",
@@ -692,6 +700,7 @@
         "configstore": "3.1.1",
         "core-js": "2.5.1",
         "css-loader": "0.28.7",
+        "dotenv-webpack": "1.5.4",
         "express": "4.16.2",
         "file-loader": "1.1.5",
         "find-cache-dir": "1.0.0",
@@ -715,7 +724,7 @@
         "url-loader": "0.6.2",
         "util-deprecate": "1.0.2",
         "uuid": "3.1.0",
-        "webpack": "3.8.1",
+        "webpack": "3.10.0",
         "webpack-dev-middleware": "1.12.2",
         "webpack-hot-middleware": "2.21.0"
       },
@@ -755,12 +764,14 @@
       }
     },
     "@storybook/react-simple-di": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.2.1.tgz",
-      "integrity": "sha512-Sj3JU1KpnTIyBWBp+uAZT3PlZ2IVYrxvOOXgpT92Injcmg2KV2ry1GkZen6XuVZqUfU0vz/sK08aP45boErFnw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/react-simple-di/-/react-simple-di-1.3.0.tgz",
+      "integrity": "sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "hoist-non-react-statics": "1.2.0"
+        "create-react-class": "15.6.2",
+        "hoist-non-react-statics": "1.2.0",
+        "prop-types": "15.6.0"
       }
     },
     "@storybook/react-stubber": {
@@ -772,12 +783,12 @@
       }
     },
     "@storybook/ui": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.16.tgz",
-      "integrity": "sha512-K6DwvT2Oo4GrJkT0ij8EW1GsjX7Sw9U6hDp2II5tnKsV7egnIKgJ6y5xGOZLHNvDDkeo5KS+Ii3GjrUbnZ1QzQ==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.17.tgz",
+      "integrity": "sha512-At0oWWTALJrJhtdnP+0AMANBC5omIBnEg3Pin3M0+yzUy6Poelcvt8+81dQEKLBP6LiyFOVpiDjfqpiHR5l0ow==",
       "requires": {
         "@hypnosphi/fuse.js": "3.0.9",
-        "@storybook/components": "3.2.16",
+        "@storybook/components": "3.2.17",
         "@storybook/mantra-core": "1.7.2",
         "@storybook/react-fuzzy": "0.4.3",
         "@storybook/react-komposer": "2.0.3",
@@ -795,7 +806,7 @@
         "qs": "6.5.1",
         "react-icons": "2.2.7",
         "react-inspector": "2.2.1",
-        "react-modal": "3.1.5",
+        "react-modal": "3.1.7",
         "react-split-pane": "0.1.71",
         "react-treebeard": "2.1.0",
         "redux": "3.7.2"
@@ -927,29 +938,29 @@
       "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw="
     },
     "@uifabric/icons": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.2.0.tgz",
-      "integrity": "sha512-P5kfPej/wxgR8jZt/GqnU0FqYcz+JH1iCcaaYd6p9L3opmZtu4w5duKeqs+Bc1u7K16r800EQfLgKe76rt6AuA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.3.0.tgz",
+      "integrity": "sha512-3jh++ktFidYimHCnnJLMAFHbVvCLABTrU1ikii5FmfdqYpwYL5mOBdRgyCBCAUcQn+w3fXfn+TREM5PXa2Ihzg==",
       "requires": {
-        "@uifabric/styling": "5.11.1",
+        "@uifabric/styling": "5.14.0",
         "tslib": "1.8.0"
       }
     },
     "@uifabric/merge-styles": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.7.0.tgz",
-      "integrity": "sha512-hS8tvkYk48JTkpKfoIF+kUP/ZefDteBjo7UKd2CLTO1eB+hLEUyKQtUEuiNlfi28cuZ/nracoK/lg7PN+Yv0YA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.8.0.tgz",
+      "integrity": "sha512-stjicZel1v/+8KUaxeN8RhGsCvOVcrjr0cVNDlp52IMnTYQqMmAlFUwQfdiDrqiz3T7HEoKxnSSfLFaX3Df9Aw==",
       "requires": {
         "tslib": "1.8.0"
       }
     },
     "@uifabric/styling": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.11.1.tgz",
-      "integrity": "sha512-oTXOjL0l8Ozuk/qeqMM/T+73nRvcXrhuOFoNuoTpNLIiv1PvuEapAd/kJaKA4p5HW70KeZa/CJVNonWBqU2qww==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.14.0.tgz",
+      "integrity": "sha512-xHW/KuMMFbvr5z3+YRzUlz/yizDdUEh9MW2kzF0D1Omg1Jdfjg6qrDTVPifuyNQTbW9nCiAnb2lX4f0DEl/tuQ==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
-        "@uifabric/merge-styles": "5.7.0",
+        "@microsoft/load-themed-styles": "1.7.13",
+        "@uifabric/merge-styles": "5.8.0",
         "@uifabric/utilities": "5.5.0",
         "tslib": "1.8.0"
       }
@@ -959,8 +970,8 @@
       "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.5.0.tgz",
       "integrity": "sha512-+U5gM9s9ue1zKYXlguzOHMl/NSYNvPZre7/LLH5RLfrBYJwkddUZ5AOFDD3xRT6nwpRhb5fPSJaJldAakFVY8Q==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
-        "@uifabric/merge-styles": "5.7.0",
+        "@microsoft/load-themed-styles": "1.7.13",
+        "@uifabric/merge-styles": "5.8.0",
         "prop-types": "15.6.0",
         "tslib": "1.8.0"
       }
@@ -1022,11 +1033,13 @@
       }
     },
     "airbnb-js-shims": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.3.0.tgz",
-      "integrity": "sha512-Y/9jgf3uEdNyeWPUV1N49FowM/qMIiKSTkRUpYT4jpHkSADfTiRVwI8Mm6o4CIxhnBK1uMf4RIYNYKwwILMCAQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-1.4.0.tgz",
+      "integrity": "sha512-KIlW3epMtB1x3PtJr2L7ltkoYvuKzjqrgZPq6mzJUL6Gz+3Y2Oc9FS9ZRzRWym2/jk1r+JsDOOyS2Vavc0E3Pw==",
       "requires": {
         "array-includes": "3.0.3",
+        "array.prototype.flatmap": "1.1.1",
+        "array.prototype.flatten": "1.1.1",
         "es5-shim": "4.5.9",
         "es6-shim": "0.35.3",
         "function.prototype.name": "1.0.3",
@@ -1039,9 +1052,9 @@
       }
     },
     "ajv": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
-      "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -1305,6 +1318,26 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
+    "array.prototype.flatmap": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.1.1.tgz",
+      "integrity": "sha512-LYxij5OIk/e1wxCPu0Ng1Rtqpe3c1FmfQ/uS/2HGk9GfySnzEpJ4N8eKJgnTCI3PSBBsNNwbUORetjs7B+3oLA==",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "array.prototype.flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatten/-/array.prototype.flatten-1.1.1.tgz",
+      "integrity": "sha512-9DM+ZgShl2O01ERvRiEqljn+UAOn5yUwvfdrhM/NBLxuh98+MN/6SyBpvIpJBA0UcUuayRl/5BhmZ4TyjlHqyg==",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
+      }
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -1392,12 +1425,12 @@
       "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI="
     },
     "autoprefixer": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.6.tgz",
-      "integrity": "sha512-C9yv/UF3X+eJTi/zvfxuyfxmLibYrntpF3qoJYrMeQwgUJOZrZvpJiMG2FMQ3qnhWtF/be4pYONBBw95ZGe3vA==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.1.tgz",
+      "integrity": "sha512-lTbsa2X03maxG45xCNh30sJaRKDn8JPnanOeQOW3wvD9yPGmIsf041LHqlrZ1lXPF/1M3yTZKXqqYfmxU69xuQ==",
       "requires": {
-        "browserslist": "2.9.1",
-        "caniuse-lite": "1.0.30000775",
+        "browserslist": "2.10.0",
+        "caniuse-lite": "1.0.30000780",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.14",
@@ -1405,9 +1438,9 @@
       }
     },
     "awesome-typescript-loader": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.4.0.tgz",
-      "integrity": "sha512-sXPUe8HexKO4/NGTOtFP7ue+LbaALphiP22A8FaJCZT2avTtMQj3uVtrPRIvNf/6484i8rgx9d//jewiaqFH0w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.4.1.tgz",
+      "integrity": "sha512-fYxBtN6s4Dm6vtsROWi8IQ4I+KcmwRWePAVvhI06mFcHbtHfZopOs4qGNu9LyCPEw403LDROKFA+NVV6ig5yNw==",
       "requires": {
         "colors": "1.1.2",
         "enhanced-resolve": "3.3.0",
@@ -2489,7 +2522,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.9.1",
+        "browserslist": "2.10.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -2961,12 +2994,12 @@
       }
     },
     "browserslist": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
-      "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
+      "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
       "requires": {
-        "caniuse-lite": "1.0.30000775",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-lite": "1.0.30000780",
+        "electron-to-chromium": "1.3.28"
       }
     },
     "bser": {
@@ -3093,7 +3126,7 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000775",
+        "caniuse-db": "1.0.30000780",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -3103,21 +3136,21 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000775",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000780",
+            "electron-to-chromium": "1.3.28"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000775",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000775.tgz",
-      "integrity": "sha1-BLzN0CFO3yW5f2GglmCfetaQQzM="
+      "version": "1.0.30000780",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000780.tgz",
+      "integrity": "sha1-jRl3Vh0A/w8O0ra2YUAyirRQTAo="
     },
     "caniuse-lite": {
-      "version": "1.0.30000775",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000775.tgz",
-      "integrity": "sha1-dNJ/7dxH88hM+8sTDDCSo168LeI="
+      "version": "1.0.30000780",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000780.tgz",
+      "integrity": "sha1-H5CV8u/UlA4LpsWZKreptkzDW6Q="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -3341,7 +3374,7 @@
       "resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
       "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
       "requires": {
-        "marked": "0.3.6",
+        "marked": "0.3.7",
         "marked-terminal": "1.7.0"
       }
     },
@@ -3886,7 +3919,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -4054,7 +4087,7 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000775",
+            "caniuse-db": "1.0.30000780",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -4066,8 +4099,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000775",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000780",
+            "electron-to-chromium": "1.3.28"
           }
         },
         "chalk": {
@@ -4100,7 +4133,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -4444,6 +4477,19 @@
         "is-obj": "1.0.1"
       }
     },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
+    "dotenv-webpack": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.5.4.tgz",
+      "integrity": "sha1-nJLkbkEqHPvGAhftM9adK7/dv58=",
+      "requires": {
+        "dotenv": "4.0.0"
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -4460,9 +4506,9 @@
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "electron-to-chromium": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0="
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -5217,7 +5263,7 @@
     },
     "fs-extra": {
       "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "requires": {
         "graceful-fs": "4.1.11",
@@ -5611,7 +5657,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.0",
+        "ajv": "5.5.1",
         "har-schema": "2.0.0"
       }
     },
@@ -6000,9 +6046,9 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "immutability-helper": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.5.1.tgz",
-      "integrity": "sha512-5bf/qTcnP1LbViXgj845PGW6a6ekQh2kkTf5kBo5zQopHROGHZS7vHGYwfS2y6wjKnmQtCbky0/rNXG6Yk+CrA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.6.0.tgz",
+      "integrity": "sha512-Odw1bdKiHmOlmDWeJ/QY0fX1oZ21DxEhRQDQUdnnaozydt5RYkVoISGJn/LEkGUd4ADVheAU7jMtFU9JrdzvfA==",
       "requires": {
         "invariant": "2.2.2"
       }
@@ -6365,13 +6411,13 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "1.0.2"
       }
@@ -7217,9 +7263,9 @@
       }
     },
     "js-base64": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -7349,9 +7395,9 @@
       "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms="
     },
     "kind-of": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.1.tgz",
-      "integrity": "sha512-y/15y6w31q9eVnXhVLPQkI7MD6JyuPNqEnetl8bZEc+mngLuonHQJ0x/6BD1WX6ml0Ig/psUlyKZJxz8uUo1xQ=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "klaw": {
       "version": "1.3.1",
@@ -7751,9 +7797,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ=="
     },
     "marked-terminal": {
       "version": "1.7.0",
@@ -7960,7 +8006,7 @@
         "extend-shallow": "2.0.1",
         "extglob": "2.0.2",
         "fragment-cache": "0.2.1",
-        "kind-of": "6.0.1",
+        "kind-of": "6.0.2",
         "nanomatch": "1.2.6",
         "object.pick": "1.3.0",
         "regex-not": "1.0.0",
@@ -8764,19 +8810,19 @@
       "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4="
     },
     "office-ui-fabric-core": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-9.2.0.tgz",
-      "integrity": "sha1-XaNUX43wnxcsbDzXcoj02U1eB88="
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-9.3.0.tgz",
+      "integrity": "sha1-FE19kSUBS9+lf41fXmptgl2EJ0I="
     },
     "office-ui-fabric-react": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.27.0.tgz",
-      "integrity": "sha512-qrh/rZncfvYO38HGR27ctVx2Y315ScAnMyQwzJI7LNg/F5Zx/LjEM14/02iYtPzCGKd9VGsho0kqMIxIBuu3hQ==",
+      "version": "5.29.4",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.29.4.tgz",
+      "integrity": "sha512-+Pd9R0E8ZnoBRvuBDF1kW+/KHLyJVD4XSj/NsCZ3qOYjcO55VD++uOHSZiRbGYziKzcGKzmtIJM6Vx+VmGKxmg==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.11",
-        "@uifabric/icons": "5.2.0",
-        "@uifabric/merge-styles": "5.7.0",
-        "@uifabric/styling": "5.11.1",
+        "@microsoft/load-themed-styles": "1.7.13",
+        "@uifabric/icons": "5.3.0",
+        "@uifabric/merge-styles": "5.8.0",
+        "@uifabric/styling": "5.14.0",
         "@uifabric/utilities": "5.5.0",
         "prop-types": "15.6.0",
         "tslib": "1.8.0"
@@ -9222,7 +9268,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9287,7 +9333,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9351,7 +9397,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9414,7 +9460,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9477,7 +9523,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9540,7 +9586,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9603,7 +9649,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9667,7 +9713,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9731,7 +9777,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9844,7 +9890,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9907,7 +9953,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -9949,8 +9995,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000775",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "1.0.30000780",
+            "electron-to-chromium": "1.3.28"
           }
         },
         "chalk": {
@@ -9983,7 +10029,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10053,7 +10099,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10117,7 +10163,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10183,7 +10229,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10249,7 +10295,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10358,7 +10404,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10424,7 +10470,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10488,7 +10534,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10552,7 +10598,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10615,7 +10661,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10680,7 +10726,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10756,7 +10802,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10821,7 +10867,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10891,7 +10937,7 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.3.2",
+            "js-base64": "2.4.0",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11187,7 +11233,7 @@
       "dependencies": {
         "babylon": {
           "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "resolved": "http://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
           "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
         }
       }
@@ -11244,12 +11290,13 @@
       }
     },
     "react-modal": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.5.tgz",
-      "integrity": "sha512-EjM32L9JPVibJJgu22QySo9d+tl0POaRTmuM7LmsVkx0U+G9tl4LGLrs2DLNOQp0Oko/5nEF/Rwp/h2noucMAw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.7.tgz",
+      "integrity": "sha512-pIVKqhPZxXqnewkQnjN0VJT0hn1XGJV2pwDJmKwAxPbfXZ1cAX79uO/Z3kYkpnb+2gAAusooK/AvnBjWuKQrRA==",
       "requires": {
         "exenv": "1.2.2",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
       }
     },
     "react-remarkable": {
@@ -11266,16 +11313,16 @@
       "integrity": "sha512-c7aK5ffRyeOySSWVeoSEsQHBUrNtzXTB9TFNUnZv/2EM7HEnN1Rfsgxag/bpDcl5GuaY5IuMvq7XySc6nyokog==",
       "requires": {
         "@types/inline-style-prefixer": "3.0.1",
-        "@types/react": "16.0.25",
+        "@types/react": "16.0.27",
         "inline-style-prefixer": "3.0.8",
         "prop-types": "15.6.0",
         "react-style-proptype": "3.1.0"
       },
       "dependencies": {
         "@types/react": {
-          "version": "16.0.25",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.25.tgz",
-          "integrity": "sha512-K79zMwWRzQ2db+nPoKpi3gA/KmLo6ZQgT4iO2QPEUdBO7as0PcgrmU9KHYzIO3V6lbD7gRjOM0/nUch6xBfOvQ=="
+          "version": "16.0.27",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.27.tgz",
+          "integrity": "sha512-7lGRcNEI0Iit54ferTJvsNQdY7m97fQmmhFT/3lxpC31b/qshkDoIKTXcVMLteVEza4F+ReEyZIZqSuk4LRb4A=="
         }
       }
     },
@@ -11918,7 +11965,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
-        "ajv": "5.5.0"
+        "ajv": "5.5.1"
       }
     },
     "screener-runner": {
@@ -12137,9 +12184,9 @@
       }
     },
     "screener-storybook": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/screener-storybook/-/screener-storybook-0.9.10.tgz",
-      "integrity": "sha1-FFYWymnkLpi87NTpArXn/xxDVog=",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/screener-storybook/-/screener-storybook-0.9.11.tgz",
+      "integrity": "sha1-1Qe1zBm4jowQy1+C080bbv2lS+U=",
       "requires": {
         "bluebird": "3.4.7",
         "colors": "1.1.2",
@@ -12153,7 +12200,7 @@
         "react-dom": "15.4.2",
         "request": "2.81.0",
         "requestretry": "1.12.2",
-        "screener-runner": "0.7.7"
+        "screener-runner": "0.7.8"
       },
       "dependencies": {
         "acorn": {
@@ -12417,9 +12464,9 @@
           }
         },
         "screener-runner": {
-          "version": "0.7.7",
-          "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.7.7.tgz",
-          "integrity": "sha1-RPnGR7sD13g/E7kWi+NfXsK/30U=",
+          "version": "0.7.8",
+          "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.7.8.tgz",
+          "integrity": "sha1-yV4MJJInEsfT7OYwGhQVtOLBxSg=",
           "requires": {
             "bluebird": "3.4.7",
             "colors": "1.1.2",
@@ -12548,7 +12595,7 @@
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "requires": {
-        "js-base64": "2.3.2",
+        "js-base64": "2.4.0",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -13721,27 +13768,26 @@
       }
     },
     "ts-jest": {
-      "version": "21.2.3",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-21.2.3.tgz",
-      "integrity": "sha512-/gpl/RUPJMVZmERi360sKu5wzSriAg20HMRZsNgXY7sUWtmSn3iPxQcCBDUi2bmcRPtPOLTSijzWK3ZrlYkUhA==",
+      "version": "21.2.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-21.2.4.tgz",
+      "integrity": "sha512-Plk49Us+DcncpQcC8fhYwDUdhW96QB0Dv02etOLhzq+2HAvXfrEUys3teZ/BeyQ+r1rHxfGdNj4dB0Q5msZR3g==",
       "requires": {
         "babel-core": "6.26.0",
         "babel-plugin-istanbul": "4.1.5",
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-preset-jest": "21.2.0",
         "cpx": "1.5.0",
-        "fs-extra": "4.0.2",
+        "fs-extra": "4.0.3",
         "jest-config": "21.2.1",
-        "jest-util": "21.2.1",
         "pkg-dir": "2.0.0",
         "source-map-support": "0.5.0",
         "yargs": "10.0.3"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "4.0.0",
@@ -14305,13 +14351,13 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webpack": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
-      "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "requires": {
         "acorn": "5.2.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.0",
+        "ajv": "5.5.1",
         "ajv-keywords": "2.1.1",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
@@ -14441,9 +14487,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.5.tgz",
-      "integrity": "sha512-o0lS6enIxyOPiRJTh8vcgK5TsGNTn7lH1q/pNniAgs46mCE8sQYeqv7Y/oAIh/+u4kiBsFizLJo5EWC+ezz6FQ==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.6.tgz",
+      "integrity": "sha512-cxk/h18Z/1qWOBTMup5PxvZ9N+vBRmmbh1/TCiCJnjGtLsvYtg7gTrjAmaa9J3kdkmxx6K5jwk6F0aZ+oOrAyA==",
       "requires": {
         "ansi-html": "0.0.7",
         "array-includes": "3.0.3",

--- a/packages/experiments/src/components/FileTypeIcon/examples/FileTypeIcon.Basic.Example.tsx
+++ b/packages/experiments/src/components/FileTypeIcon/examples/FileTypeIcon.Basic.Example.tsx
@@ -1,7 +1,7 @@
 
 import * as React from 'react';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { getFileTypeIconProps, FileIconType } from '@uifabric/file-type-icons';
+import { getFileTypeIconProps, FileIconType, OverlayType } from '@uifabric/file-type-icons';
 
 export class FileTypeIconBasicExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
@@ -41,6 +41,12 @@ export class FileTypeIconBasicExample extends React.Component<{}, {}> {
         <Icon {...getFileTypeIconProps({ type: FileIconType.listItem, size: 48, imageFileType: 'svg' }) } />
         <h3>Size 96 sharedfolder icon as .png</h3>
         <Icon {...getFileTypeIconProps({ type: FileIconType.sharedFolder, size: 96, imageFileType: 'png' }) } />
+        <h3>Checkout overlay</h3>
+        <Icon {...getFileTypeIconProps({ extension: 'docx', size: 20, imageFileType: 'png', overlayType: OverlayType.checkout }) } />
+        <h3>Block overlay</h3>
+        <Icon iconName='folder20_svg' overlayName='blockoverlay' />
+        <h3>Notify overlay</h3>
+        <Icon iconName='notifyoverlay' />
       </div>
     );
   }

--- a/packages/experiments/src/components/FileTypeIcon/examples/FileTypeIcon.Basic.Example.tsx
+++ b/packages/experiments/src/components/FileTypeIcon/examples/FileTypeIcon.Basic.Example.tsx
@@ -42,11 +42,13 @@ export class FileTypeIconBasicExample extends React.Component<{}, {}> {
         <h3>Size 96 sharedfolder icon as .png</h3>
         <Icon {...getFileTypeIconProps({ type: FileIconType.sharedFolder, size: 96, imageFileType: 'png' }) } />
         <h3>Checkout overlay</h3>
-        <Icon {...getFileTypeIconProps({ extension: 'docx', size: 20, imageFileType: 'png', overlayType: OverlayType.checkout }) } />
+        <Icon {...getFileTypeIconProps({ extension: 'docx', size: 16, overlayType: OverlayType.checkout }) } />
+        <h3>Checkout overlay grid</h3>
+        <Icon {...getFileTypeIconProps({ extension: 'pptx', size: 20, imageFileType: 'png', overlayType: OverlayType.checkoutGrid }) } />
         <h3>Block overlay</h3>
-        <Icon iconName='folder20_svg' overlayName='blockoverlay' />
+        <Icon {...getFileTypeIconProps({ type: FileIconType.folder, size: 32, overlayType: OverlayType.block }) } />
         <h3>Notify overlay</h3>
-        <Icon iconName='notifyoverlay' />
+        <Icon {...getFileTypeIconProps({ extension: 'xlsx', size: 96, imageFileType: 'png', overlayType: OverlayType.notify }) } />
       </div>
     );
   }

--- a/packages/file-type-icons/src/OverlayType.ts
+++ b/packages/file-type-icons/src/OverlayType.ts
@@ -7,5 +7,6 @@ export const enum OverlayType {
     none = 0,
     block = 1,
     checkout = 2,
-    notify = 3
+    checkoutGrid = 3,
+    notify = 4
 }

--- a/packages/file-type-icons/src/OverlayType.ts
+++ b/packages/file-type-icons/src/OverlayType.ts
@@ -1,0 +1,11 @@
+/**
+ * Enumerates the different overlays you can place
+ * over a file type icon.
+ */
+
+export const enum OverlayType {
+    none = 0,
+    block = 1,
+    checkout = 2,
+    notify = 3
+}

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -1,5 +1,6 @@
 import { FileTypeIconMap } from './FileTypeIconMap';
 import { FileIconType } from './FileIconType';
+import { OverlayType } from './OverlayType';
 
 let _extensionToIconName: { [key: string]: string };
 
@@ -9,6 +10,10 @@ const SHARED_FOLDER = 'sharedfolder';
 const DOCSET_FOLDER = 'docset';
 const LIST_ITEM = 'listitem';
 const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
+
+const BLOCK_OVERLAY = 'blockoverlay';
+const CHECKOUT_OVERLAY = 'checkoutoverlay';
+const NOTIFY_OVERLAY = 'notifyoverlay';
 
 export type FileTypeIconSize = 16 | 20 | 32 | 40 | 48 | 96;
 export type ImageFileType = 'svg' | 'png';
@@ -35,6 +40,11 @@ export interface IFileTypeIconOptions {
    * Defaults to svg.
    */
   imageFileType?: ImageFileType;
+  /**
+   * The type of overlay, if any, to place over the file type icon.
+   * Overlays sit in the bottom right hand corner of the icon.
+   */
+  overlayType?: OverlayType;
 }
 
 /**
@@ -45,7 +55,7 @@ export interface IFileTypeIconOptions {
  *
  * @param options
  */
-export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName: string } {
+export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName: string, overlayName?: string } {
 
   // First, obtain the base name of the icon using the extension or type.
   let iconBaseName: string = GENERIC_FILE;
@@ -73,7 +83,10 @@ export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName:
   let size: FileTypeIconSize = options.size || DEFAULT_ICON_SIZE;
   let suffix: string = _getFileTypeIconSuffix(size, options.imageFileType);
 
-  return { iconName: iconBaseName + suffix };
+  // Finally, get the name of the overlay, if any.
+  let overlayName: string = _getOverlayNameFromType(options.overlayType);
+
+  return { iconName: iconBaseName + suffix, overlayName: overlayName || undefined };
 
 }
 
@@ -127,4 +140,21 @@ function _getFileTypeIconSuffix(size: FileTypeIconSize, imageFileType: ImageFile
   }
 
   return size + devicePixelRatioSuffix + '_' + imageFileType;
+}
+
+function _getOverlayNameFromType(overlayType?: OverlayType): string {
+  let overlayName = '';
+  if (overlayType) {
+    switch (overlayType) {
+      case OverlayType.block:
+        overlayName = BLOCK_OVERLAY;
+        break;
+      case OverlayType.checkout:
+        overlayName = CHECKOUT_OVERLAY;
+        break;
+      case OverlayType.notify:
+        overlayName = NOTIFY_OVERLAY;
+    }
+  }
+  return overlayName;
 }

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -13,6 +13,7 @@ const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 
 const BLOCK_OVERLAY = 'blockoverlay';
 const CHECKOUT_OVERLAY = 'checkoutoverlay';
+const CHECKOUT_OVERLAY_GRID = 'checkoutoverlaygrid';
 const NOTIFY_OVERLAY = 'notifyoverlay';
 
 export type FileTypeIconSize = 16 | 20 | 32 | 40 | 48 | 96;
@@ -151,6 +152,9 @@ function _getOverlayNameFromType(overlayType?: OverlayType): string {
         break;
       case OverlayType.checkout:
         overlayName = CHECKOUT_OVERLAY;
+        break;
+      case OverlayType.checkoutGrid:
+        overlayName = CHECKOUT_OVERLAY_GRID;
         break;
       case OverlayType.notify:
         overlayName = NOTIFY_OVERLAY;

--- a/packages/file-type-icons/src/index.ts
+++ b/packages/file-type-icons/src/index.ts
@@ -8,3 +8,4 @@ export {
 } from './getFileTypeIconProps';
 
 export { FileIconType } from './FileIconType';
+export { OverlayType } from './OverlayType';

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,22 +5,26 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/';
+const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/';
 const ICON_SIZES: number[] = [16, 20, 32, 40, 48, 96];
+const OVERLAY_NAMES: string[] = ['blockoverlay', 'checkoutoverlay', 'notifyoverlay'];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL): void {
   ICON_SIZES.forEach((size: number) => {
     _initializeIcons(baseUrl, size);
   });
+
+  _initializeOverlays(baseUrl);
 }
 
 function _initializeIcons(baseUrl: string, size: number): void {
+  const baseUrlItemTypes = baseUrl + 'item-types/';
   const iconTypes: string[] = Object.keys(FileTypeIconMap);
   const fileTypeIcons: { [key: string]: JSX.Element } = {};
 
   iconTypes.forEach((type: string) => {
-    fileTypeIcons[type + size + PNG_SUFFIX] = <img src={ baseUrl + size + '/' + type + '.png' } />;
-    fileTypeIcons[type + size + SVG_SUFFIX] = <img src={ baseUrl + size + '/' + type + '.svg' } />;
+    fileTypeIcons[type + size + PNG_SUFFIX] = <img src={ baseUrlItemTypes + size + '/' + type + '.png' } />;
+    fileTypeIcons[type + size + SVG_SUFFIX] = <img src={ baseUrlItemTypes + size + '/' + type + '.svg' } />;
 
     // For high resolution screens, register additional versions
     // Apply height=100% and width=100% to force image to fit into containing element
@@ -30,23 +34,23 @@ function _initializeIcons(baseUrl: string, size: number): void {
     // Remove if statements when missing image files for sizes 20 and 40 are provided.
     if (size !== 20) {
       fileTypeIcons[type + size + '_1.5x' + PNG_SUFFIX] = (
-        <img src={ baseUrl + size + '_1.5x/' + type + '.png' } height='100%' width='100%' />
+        <img src={ baseUrlItemTypes + size + '_1.5x/' + type + '.png' } height='100%' width='100%' />
       );
       if (size !== 40) {
         fileTypeIcons[type + size + '_1.5x' + SVG_SUFFIX] = (
-          <img src={ baseUrl + size + '_1.5x/' + type + '.svg' } height='100%' width='100%' />
+          <img src={ baseUrlItemTypes + size + '_1.5x/' + type + '.svg' } height='100%' width='100%' />
         );
       }
     }
 
     fileTypeIcons[type + size + '_2x' + PNG_SUFFIX] = (
-      <img src={ baseUrl + size + '_2x/' + type + '.png' } height='100%' width='100%' />
+      <img src={ baseUrlItemTypes + size + '_2x/' + type + '.png' } height='100%' width='100%' />
     );
     fileTypeIcons[type + size + '_3x' + PNG_SUFFIX] = (
-      <img src={ baseUrl + size + '_3x/' + type + '.png' } height='100%' width='100%' />
+      <img src={ baseUrlItemTypes + size + '_3x/' + type + '.png' } height='100%' width='100%' />
     );
     fileTypeIcons[type + size + '_4x' + PNG_SUFFIX] = (
-      <img src={ baseUrl + size + '_4x/' + type + '.png' } height='100%' width='100%' />
+      <img src={ baseUrlItemTypes + size + '_4x/' + type + '.png' } height='100%' width='100%' />
     );
   });
 
@@ -58,5 +62,21 @@ function _initializeIcons(baseUrl: string, size: number): void {
       overflow: 'hidden'
     },
     icons: fileTypeIcons
+  });
+}
+
+function _initializeOverlays(baseUrl: string): void {
+  // Initialize file type icon overlays
+  const baseUrlOverlayIcons = baseUrl + 'overlays/';
+  const overlayIcons: { [key: string]: JSX.Element } = {};
+
+  OVERLAY_NAMES.forEach((overlayName: string) => {
+    overlayIcons[overlayName] = <img src={ baseUrlOverlayIcons + overlayName + '.svg'} />;
+  });
+
+  registerIcons({
+    fontFace: {},
+    style: {},
+    icons: overlayIcons
   });
 }

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -7,7 +7,7 @@ const SVG_SUFFIX = '_svg';
 
 const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/';
 const ICON_SIZES: number[] = [16, 20, 32, 40, 48, 96];
-const OVERLAY_NAMES: string[] = ['blockoverlay', 'checkoutoverlay', 'notifyoverlay'];
+const OVERLAY_NAMES: string[] = ['blockoverlay', 'checkoutoverlay', 'checkoutoverlaygrid', 'notifyoverlay'];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL): void {
   ICON_SIZES.forEach((size: number) => {
@@ -71,7 +71,7 @@ function _initializeOverlays(baseUrl: string): void {
   const overlayIcons: { [key: string]: JSX.Element } = {};
 
   OVERLAY_NAMES.forEach((overlayName: string) => {
-    overlayIcons[overlayName] = <img src={ baseUrlOverlayIcons + overlayName + '.svg'} />;
+    overlayIcons[overlayName] = <img src={ baseUrlOverlayIcons + overlayName + '.svg'} height='100%' width='100%' />;
   });
 
   registerIcons({

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.classNames.ts
@@ -10,22 +10,41 @@ export interface IIconClassNames {
   root?: string;
   rootHasPlaceHolder?: string;
   imageContainer?: string;
+  overlay?: string;
 }
 
 export const getClassNames = memoizeFunction((
-  customStyles?: IIconStyles
+  customStyles?: IIconStyles,
+  hasOverlay?: boolean
 ): IIconClassNames => {
 
   return mergeStyleSets(
     {
-      root: {
-        display: 'inline-block'
-      },
+      root: [
+        {
+          display: 'inline-block'
+        },
+        hasOverlay && {
+          position: 'relative'
+        }
+      ],
       rootHasPlaceHolder: {
         width: '1em'
       },
       imageContainer: {
         overflow: 'hidden'
+      },
+      overlay: {
+        position: 'absolute',
+        bottom: '0px',
+        right: '0px',
+        height: '45%',
+        width: '45%',
+        selectors: {
+          '&>img': {
+            display: 'block'
+          }
+        }
       }
     },
     customStyles

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -69,12 +69,7 @@ export const Icon = (props: IIconProps): JSX.Element => {
       code: undefined
     };
 
-    let overlayDefinition = getIcon(overlayName) || {
-      subset: {
-        className: undefined
-      },
-      code: undefined
-    };
+    let overlayDefinition = getIcon(overlayName);
 
     return (
       <i
@@ -94,11 +89,11 @@ export const Icon = (props: IIconProps): JSX.Element => {
           ) }
       >
         { iconDefinition.code }
-        { overlayDefinition.code && (
+        { overlayDefinition && overlayDefinition.code && (
           <i
             className={
               css(
-                overlayDefinition.subset.className,
+                overlayDefinition.subset && overlayDefinition.subset.className,
                 classNames.overlay
               ) }
           >

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -16,10 +16,12 @@ export const Icon = (props: IIconProps): JSX.Element => {
     ariaLabel,
     className,
     styles,
-    iconName
+    iconName,
+    overlayName
    } = props;
   let classNames = getClassNames(
-    styles
+    styles,
+    !!overlayName
   );
 
   if (props.iconType === IconType.image || props.iconType === IconType.Image) {
@@ -67,6 +69,13 @@ export const Icon = (props: IIconProps): JSX.Element => {
       code: undefined
     };
 
+    let overlayDefinition = getIcon(overlayName) || {
+      subset: {
+        className: undefined
+      },
+      code: undefined
+    };
+
     return (
       <i
         aria-label={ ariaLabel }
@@ -85,6 +94,17 @@ export const Icon = (props: IIconProps): JSX.Element => {
           ) }
       >
         { iconDefinition.code }
+        { overlayDefinition.code && (
+          <i
+            className={
+              css(
+                overlayDefinition.subset.className,
+                classNames.overlay
+              ) }
+          >
+            { overlayDefinition.code }
+          </i>
+        ) }
       </i>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.types.ts
@@ -41,6 +41,11 @@ export interface IIconProps extends React.HTMLAttributes<HTMLElement> {
   iconName?: string;
 
   /**
+   * The name of the icon to use as an overlay in the bottom right corner. If string is empty, no overlay will be rendered.
+   */
+  overlayName?: string;
+
+  /**
    * Optional styling for the elements within the Icon.
    */
   styles?: IIconStyles;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

We would like to be able to place overlays on icons. For example, an overlay on top of a file type icon could indicate a checked out file. I have added the optional overlayName property to Icon and also added four possible overlays to the file-type-icons package.

#### Focus areas to test

(optional)

#### Screenshot of examples
![overlays](https://user-images.githubusercontent.com/20978630/33693458-e571a09c-daa7-11e7-8e82-0e9c80647f46.PNG)
