### PR TITLE
ComboBox: Fix blur from processing when clicking on elements inside of the comboBox

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-FixComboBoxBlurClickIssue_2017-12-07-03-10.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-FixComboBoxBlurClickIssue_2017-12-07-03-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Update onBlur to do nothing if the event came from an element inside of the  comboBox",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -733,7 +733,19 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * and submit any pending value
    */
   @autobind
-  private _onBlur() {
+  private _onBlur(event: React.FocusEvent<HTMLInputElement>) {
+
+    // Do nothing if the blur is coming from something
+    // inside the comboBox root or the comboBox menu since
+    // it we are not really bluring from the whole comboBox
+    if (event.relatedTarget &&
+      (this.refs.root && this.refs.root.contains(event.relatedTarget as HTMLElement) ||
+        this._comboBoxMenu && this._comboBoxMenu.contains(event.relatedTarget as HTMLElement))) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
     if (this.state.focused) {
       this.setState({ focused: false });
       this._submitPendingValue();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

When a user clicks an option in a dropdown menu it would handle the blur from the comboBox input followed by handling the click on the option which could cause some undesired behavior

#### Focus areas to test

Verified that we are not processing the blur if the element that caused it is coming from a comboBox element, but blur from anywhere else continues to work as expected
