### PR TITLE
Added typeahead support for dropdowns

### DIFF
--- a/common/changes/office-ui-fabric-react/magellantoo-type-ahead_2017-12-08-01-56.json
+++ b/common/changes/office-ui-fabric-react/magellantoo-type-ahead_2017-12-08-01-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added typeahead for dropdown menus",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/ActionButton/ActionButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/ActionButton/ActionButton.tsx
@@ -11,6 +11,7 @@ export class ActionButton extends BaseComponent<IButtonProps, {}> {
    * Tell BaseComponent to bypass resolution of componentRef.
    */
   protected _shouldUpdateComponentRef = false;
+  private _button: BaseButton;
 
   public render() {
     let { styles, theme } = this.props;
@@ -18,10 +19,17 @@ export class ActionButton extends BaseComponent<IButtonProps, {}> {
     return (
       <BaseButton
         { ...this.props }
+        ref={ button => { if (button) this._button = button; } }
         variantClassName='ms-Button--action ms-Button--command'
         styles={ getStyles(theme!, styles) }
         onRenderDescription={ nullRender }
       />
     );
+  }
+
+  public focus(): void {
+    if (this._button) {
+      this._button.focus();
+    }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -77,6 +77,11 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<HTMLDivEle
    * @deprecated
    */
   isDisabled?: boolean;
+
+  /**
+   * Enable type-ahead support. This allows a user to quickly highlight options by typing.
+   */
+  isTypeAheadEnabled?: boolean;
 }
 
 export interface IDropdownOption extends ISelectableOption {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/DropdownPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/DropdownPage.tsx
@@ -7,11 +7,13 @@ import {
 } from '@uifabric/example-app-base';
 import { DropdownBasicExample } from './examples/Dropdown.Basic.Example';
 import { DropdownCustomExample } from './examples/Dropdown.Custom.Example';
+import { DropdownTypeaheadExample } from './examples/Dropdown.Typeahead.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { DropdownStatus } from './Dropdown.checklist';
 
 const DropdownBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx') as string;
 const DropdownCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx') as string;
+const DropdownTypeaheadExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Typeahead.Example.tsx') as string;
 
 export class DropdownPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -27,6 +29,10 @@ export class DropdownPage extends React.Component<IComponentDemoPageProps, {}> {
 
             <ExampleCard title='Customized Dropdown' code={ DropdownCustomExampleCode }>
               <DropdownCustomExample />
+            </ExampleCard>
+
+            <ExampleCard title='Dropdown with Typeahead' code={ DropdownTypeaheadExampleCode }>
+              <DropdownTypeaheadExample />
             </ExampleCard>
 
           </div>

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Typeahead.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Typeahead.Example.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { Dropdown, IDropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { autobind, BaseComponent } from '../../../Utilities';
+import './Dropdown.Basic.Example.scss';
+
+const states: String[] = [
+  'Alabama',
+  'Alaska',
+  'Arizona',
+  'Arkansas',
+  'California',
+  'Colorado',
+  'Connecticut',
+  'Delaware',
+  'Florida',
+  'Georgia',
+  'Hawaii',
+  'Idaho',
+  'Illinois',
+  'Indiana',
+  'Iowa',
+  'Kansas',
+  'Kentucky',
+  'Louisiana',
+  'Maine',
+  'Maryland',
+  'Massachusetts',
+  'Michigan',
+  'Minnesota',
+  'Mississippi',
+  'Missouri',
+  'Montana',
+  'Nebraska',
+  'Nevada',
+  'New Hampshire',
+  'New Jersey',
+  'New Mexico',
+  'New York',
+  'North Carolina',
+  'North Dakota',
+  'Ohio',
+  'Oklahoma',
+  'Oregon',
+  'Pennsylvania',
+  'Rhode Island',
+  'South Carolina',
+  'South Dakota',
+  'Tennessee',
+  'Texas',
+  'Utah',
+  'Vermont',
+  'Virginia',
+  'Washington',
+  'West Virginia',
+  'Wisconsin',
+  'Wyoming',
+];
+
+export class DropdownTypeaheadExample extends BaseComponent<any, any> {
+  constructor() {
+    super();
+  }
+
+  public render() {
+    return (
+      <div className='DropdownBasicExample'>
+        <Dropdown
+          className='Dropdown-example'
+          placeHolder='Type an Option'
+          label='Typeahead example:'
+          id='Typeaheaddrop1'
+          ariaLabel='Dropdown with typeahead example'
+          options={
+            states.map((name) => {
+              return {
+                key: name,
+                text: name
+              }
+            })
+          }
+          isTypeAheadEnabled={ true }
+        />
+      </div>
+
+    );
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes  #0333
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds typeahead support to dropdown menus.
Users can now quickly search for items in dropdowns by typing.
[HTML Example](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select)

#### Focus areas to test

(optional)
