### PR TITLE
Fixes bug with GroupedList losing focus sometimes when item gets removed from list

### DIFF
--- a/common/changes/office-ui-fabric-react/maxlus-arrowKeysPinning_2017-12-08-18-50.json
+++ b/common/changes/office-ui-fabric-react/maxlus-arrowKeysPinning_2017-12-08-18-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes bug with GroupedList losing focus sometimes when item gets removed from list",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "maxlus@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -156,13 +156,16 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       // Item set has changed and previously-focused item is gone.
       // Set focus to item at index of previously-focused item if it is in range,
       // else set focus to the last item.
-      const item = this.state.focusedItemIndex < this.props.items.length
-        ? this.props.items[this.state.focusedItemIndex]
-        : this.props.items[this.props.items.length - 1];
+      const index = this.state.focusedItemIndex < this.props.items.length ?
+        this.state.focusedItemIndex :
+        this.props.items.length - 1;
+      const item = this.props.items[index];
       const itemKey = this._getItemKey(item, this.state.focusedItemIndex);
       const row = this._activeRows[itemKey];
       if (row) {
         this._setFocusToRow(row);
+      } else {
+        this._initialFocusedIndex = index;
       }
     }
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   BaseComponent,
+  IRectangle,
   autobind,
   assign,
   css
@@ -104,6 +105,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
               items={ groups }
               onRenderCell={ this._renderGroup }
               getItemCountForPage={ this._returnOne }
+              getPageSpecification= { this._getPageSpecification }
               usePageCache={ usePageCache }
               onShouldVirtualize={ onShouldVirtualize }
             />
@@ -276,6 +278,19 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
 
       this.forceUpdate();
     }
+  }
+
+  @autobind
+  private _getPageSpecification(itemIndex: number, visibleRect: IRectangle): {
+      itemCount?: number;
+      key?: string;
+  } {
+    const groups = this.state.groups;
+    const pageGroup = groups && groups.filter((group: IGroup) => group.startIndex === itemIndex)[0];
+    return {
+        itemCount: pageGroup && pageGroup.count,
+        key: pageGroup && pageGroup.name
+    };
   }
 
   private _computeIsSomeGroupExpanded(groups: IGroup[] | undefined): boolean {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -286,6 +286,8 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
   } {
     const groups = this.state.groups;
     const pageGroup = groups && groups[itemIndex];
+    // Use the group name for the page key so React doesn't unmount/remount
+    // when a group above it in the list unmounts
     return {
         key: pageGroup && pageGroup.name
     };

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -282,13 +282,11 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
 
   @autobind
   private _getPageSpecification(itemIndex: number, visibleRect: IRectangle): {
-      itemCount?: number;
       key?: string;
   } {
     const groups = this.state.groups;
-    const pageGroup = groups && groups.filter((group: IGroup) => group.startIndex === itemIndex)[0];
+    const pageGroup = groups && groups[itemIndex];
     return {
-        itemCount: pageGroup && pageGroup.count,
         key: pageGroup && pageGroup.name
     };
   }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -286,8 +286,6 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
   } {
     const groups = this.state.groups;
     const pageGroup = groups && groups[itemIndex];
-    // Use the group name for the page key so React doesn't unmount/remount
-    // when a group above it in the list unmounts
     return {
         key: pageGroup && pageGroup.name
     };

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -724,6 +724,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
       const pageSpecification = this._getPageSpecification(itemIndex, allowedRect);
       const pageHeight = pageSpecification.height;
       const pageData = pageSpecification.data;
+      const key = pageSpecification.key;
 
       itemsPerPage = pageSpecification.itemCount;
 
@@ -747,7 +748,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
         }
 
         let itemsInPage = Math.min(itemsPerPage, endIndex - itemIndex);
-        let newPage = this._createPage(undefined, items!.slice(itemIndex, itemIndex + itemsInPage), itemIndex, undefined, undefined, pageData);
+        let newPage = this._createPage(key, items!.slice(itemIndex, itemIndex + itemsInPage), itemIndex, undefined, undefined, pageData);
 
         newPage.top = pageTop;
         newPage.height = pageHeight;
@@ -800,6 +801,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     itemCount: number;
     height: number;
     data?: any;
+    key?: string;
   } {
     const {
       getPageSpecification
@@ -818,7 +820,8 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
       return {
         itemCount: itemCount,
         height: height,
-        data: pageData.data
+        data: pageData.data,
+        key: pageData.key
       };
     } else {
       const itemCount = this._getItemCountForPage(itemIndex, visibleRect);

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -156,4 +156,8 @@ export interface IPageSpecification {
    * Data to pass through to the page when rendering.
    */
   data?: any;
+  /**
+   * The key to use when creating the page.
+   */
+  key?: string;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [*] Include a change request file using `$ npm run change`

#### Description of changes

If an item gets added or removed from a GroupedList such that the group at the top of the list gets removed, focus gets lost on the list. There's a couple core issues at play:

1. If a group unmounts, all groups (and therefore DetailsRow's) below it unmount as well. This is because the page names use the page index as a key. If the index changes because a group (and therefore its page) unmounts, React unmounts them all.
2. DetailsList::ComponentDidUpdate gets called after the DetailsRows unmount but before DetailsRow::ComponentDidMount gets called. This means that it tries to set focus on a row before all rows have been added to _activeRows.
3. If the row that it wants to focus isn't in _activeRows, it loses focus entirely.

This means that if the top group of the list mounts or unmounts (e.g. if the last item from that group is removed), it will try to set focus before it knows about any rows and lose focus.

This change does a couple things to mitigate this. Firstly, it plumbs the group name down to the page to become its key, so that the groups don't unmount and remount en masse. This can still cause the row not to be found if it unmounts and remounts (which can happen if it changes places in the list), so if it can't find the row the focus in ComponentDidUpdate, it sets _initialFocusedIndex to focus the row when it calls its mount callback.

#### Focus areas to test

(optional)
