### PR TITLE
List: Support Ghosting while scrolling

### DIFF
--- a/common/changes/office-ui-fabric-react/magellantoo-list_ghosting_2017-12-08-23-54.json
+++ b/common/changes/office-ui-fabric-react/magellantoo-list_ghosting_2017-12-08-23-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: Support ghosting",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -17,6 +17,8 @@ const RESIZE_DELAY = 16;
 const MIN_SCROLL_UPDATE_DELAY = 100;
 const MAX_SCROLL_UPDATE_DELAY = 500;
 const IDLE_DEBOUNCE_DELAY = 200;
+// The amount of time to wait before declaring that the list isn't scrolling
+const DONE_SCROLLING_WAIT = 500;
 const DEFAULT_ITEMS_PER_PAGE = 10;
 const DEFAULT_PAGE_HEIGHT = 30;
 const DEFAULT_RENDERED_WINDOWS_BEHIND = 2;
@@ -27,6 +29,7 @@ export interface IListState {
 
   /** The last versionstamp for  */
   measureVersion?: number;
+  isScrolling?: boolean;
 }
 
 interface IPageCacheItem {
@@ -126,7 +129,8 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     super(props);
 
     this.state = {
-      pages: []
+      pages: [],
+      isScrolling: false
     };
 
     this._estimatedPageHeight = 0;
@@ -158,6 +162,13 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
       {
         leading: false
       });
+
+    this._onScrollingDone = this._async.debounce(
+      this._onScrollingDone,
+      DONE_SCROLLING_WAIT, {
+        leading: false
+      }
+    )
 
     this._cachedPageHeights = {};
     this._estimatedPageHeight = 0;
@@ -281,6 +292,11 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     let { pages: oldPages } = this.state;
     let { pages: newPages } = newState;
     let shouldComponentUpdate = false;
+
+    // Update if the page stops scrolling
+    if (!newState.isScrolling && this.state.isScrolling) {
+      return true;
+    }
 
     if (newProps.items === this.props.items &&
       oldPages!.length === newPages!.length) {
@@ -446,7 +462,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
           data-list-index={ index }
           data-automationid='ListCell'
         >
-          { onRenderCell && onRenderCell(item, index) }
+          { onRenderCell && onRenderCell(item, index, this.state.isScrolling) }
         </div>
       );
     });
@@ -479,7 +495,11 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
    * we will call onAsyncIdle which will reset it back to it's correct value.
    */
   private _onScroll() {
+    if (!this.state.isScrolling) {
+      this.setState({ isScrolling: true });
+    }
     this._resetRequiredWindows();
+    this._onScrollingDone();
   }
 
   private _resetRequiredWindows() {
@@ -528,6 +548,14 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
       // Async increment on next tick.
       this._onAsyncIdle();
     }
+  }
+
+  /**
+   * Function to call when the list is done scrolling.
+   * This function is debounced.
+   */
+  private _onScrollingDone() {
+    this.setState({ isScrolling: false });
   }
 
   private _onAsyncResize() {

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -168,7 +168,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
       DONE_SCROLLING_WAIT, {
         leading: false
       }
-    )
+    );
 
     this._cachedPageHeights = {};
     this._estimatedPageHeight = 0;

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -31,8 +31,9 @@ export interface IListProps extends React.HTMLAttributes<List | HTMLDivElement> 
 
   /**
    * Method to call when trying to render an item.
-   * isScrolling may be useful to render a lightweight
-   * placeholder if your cells are complex.
+   * @param {any} item - The the data associated with the cell that is being rendered.
+   * @param {number} index - The index of the cell being rendered.
+   * @param {boolean} isScrolling - True if the list is being scrolled. May be useful for rendering a placeholder if your cells are complex.
    */
   onRenderCell?: (item?: any, index?: number, isScrolling?: boolean) => React.ReactNode;
 

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -29,8 +29,12 @@ export interface IListProps extends React.HTMLAttributes<List | HTMLDivElement> 
   /** Items to render. */
   items?: any[];
 
-  /** Method to call when trying to render an item. */
-  onRenderCell?: (item?: any, index?: number) => React.ReactNode;
+  /**
+   * Method to call when trying to render an item.
+   * isScrolling may be useful to render a lightweight
+   * placeholder if your cells are complex.
+   */
+  onRenderCell?: (item?: any, index?: number, isScrolling?: boolean) => React.ReactNode;
 
   /** Optional callback for monitoring when a page is added. */
   onPageAdded?: (page: IPage) => void;

--- a/packages/office-ui-fabric-react/src/components/List/ListPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/ListPage.tsx
@@ -8,6 +8,7 @@ import {
 import { ListBasicExample } from './examples/List.Basic.Example';
 import { ListGridExample } from './examples/List.Grid.Example';
 import { ListScrollingExample } from './examples/List.Scrolling.Example';
+import { ListGhostingExample } from './examples/List.Ghosting.Example';
 import { createListItems } from '@uifabric/example-app-base';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { ListStatus } from './List.checklist';
@@ -15,6 +16,7 @@ import { ListStatus } from './List.checklist';
 const ListBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx') as string;
 const ListGridExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx') as string;
 const ListScrollingExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.tsx') as string;
+const ListGhostingExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx') as string;
 
 let _cachedItems: any;
 
@@ -40,6 +42,9 @@ export class ListPage extends React.Component<IComponentDemoPageProps, {}> {
             </ExampleCard>
             <ExampleCard title='Scrolling items into view' isOptIn={ true } code={ ListScrollingExampleCode }>
               <ListScrollingExample items={ _cachedItems } />
+            </ExampleCard>
+            <ExampleCard title='Rendering ghost items while the list is scrolling' isOptIn={ true } code={ ListGhostingExampleCode }>
+              <ListGhostingExample items={ _cachedItems } />
             </ExampleCard>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.scss
@@ -1,0 +1,54 @@
+@import '../../../common/common';
+
+:global {
+  .ms-ListGhostingExample {
+    &-container {
+      overflow: auto;
+      max-height: 500px;
+    }
+
+    &-itemCell {
+      @include focus-border();
+
+      min-height: 54px;
+      padding: 10px;
+      box-sizing: border-box;
+      border-bottom: 1px solid $bodyDividerColor;
+      display: flex;
+      &:hover {
+        background: #EEE;
+      }
+    }
+
+    &-itemImage {
+      flex-shrink: 0;
+    }
+
+    &-itemContent {
+      @include margin-left(10px);
+      overflow: hidden;
+      flex-grow: 1;
+    }
+
+    &-itemName {
+      @include ms-font-xl;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    &-itemIndex {
+      font-size: $ms-font-size-s;
+      color: $ms-color-neutralTertiary;
+      margin-bottom: 10px;
+    }
+
+    &-chevron {
+      align-self: center;
+      @include margin-left(10px);
+      color: $ms-color-neutralTertiary;
+      font-size: $ms-font-size-l;
+      flex-shrink: 0;
+    }
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import {
+  FocusZone,
+  FocusZoneDirection
+} from 'office-ui-fabric-react/lib/FocusZone';
+import { List } from 'office-ui-fabric-react/lib/List';
+import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
+import './List.Ghosting.Example.scss';
+
+export interface IListGhostingExampleProps {
+  items: any[];
+}
+
+export class ListGhostingExample extends React.Component<IListGhostingExampleProps, {}> {
+  constructor(props: IListGhostingExampleProps) {
+    super(props);
+  }
+
+  public render() {
+    let { items } = this.props;
+
+    return (
+      <FocusZone direction={ FocusZoneDirection.vertical }>
+        <div className='ms-ListGhostingExample-container' data-is-scrollable={ true }>
+          <List
+            items={ items }
+            onRenderCell={ this._onRenderCell }
+          />
+        </div>
+      </FocusZone>
+    );
+  }
+
+  private _onRenderCell(item: any, index: number, isScrolling: boolean): JSX.Element {
+    return (
+      <div className='ms-ListGhostingExample-itemCell' data-is-focusable={ true }>
+        <Image
+          className='ms-ListGhostingExample-itemImage'
+          src={ isScrolling ? undefined : item.thumbnail }
+          width={ 50 }
+          height={ 50 }
+          imageFit={ ImageFit.cover }
+        />
+        <div className='ms-ListGhostingExample-itemContent'>
+          <div className='ms-ListGhostingExample-itemName'>{ item.name }</div>
+          <div className='ms-ListGhostingExample-itemIndex'>{ `Item ${index}` }</div>
+        </div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2997 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds an isScrolling parameter to the onRenderCell function that lets an item know if the list is currently scrolling.
This is useful for if a cell is complex, a lightweight placeholder can be rendered while the list is scrolling. 

#### Focus areas to test

(optional)
