### PR TITLE
Fixing some edge cases in mergeStyleSets

### DIFF
--- a/common/changes/@uifabric/merge-styles/merge-styles-fix_2017-12-01-00-44.json
+++ b/common/changes/@uifabric/merge-styles/merge-styles-fix_2017-12-01-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Adding `onInsertNode` callback and adjusting appendChild method for injecting styles to not cause flashes.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -77,7 +77,7 @@ export class Stylesheet {
 
   constructor(config?: IStyleSheetConfig) {
     this._config = {
-      injectionMode: InjectionMode.appendChild,
+      injectionMode: InjectionMode.insertNode,
       ...config
     };
 

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -171,7 +171,12 @@ export class Stylesheet {
         break;
 
       case InjectionMode.appendChild:
-        element!.appendChild(document.createTextNode(rule));
+        const head: HTMLHeadElement = document.getElementsByTagName('head')[0];
+        const styleElement: HTMLStyleElement = document.createElement('style');
+
+        styleElement.type = 'text/css';
+        styleElement.appendChild(document.createTextNode(rule));
+        head.appendChild(styleElement);
         break;
 
       default:

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -31,6 +31,7 @@ export interface IStyleSheetConfig {
    * Injection mode for how rules are inserted.
    */
   injectionMode?: InjectionMode;
+  onInsertRule?: (rule: string) => void;
 }
 
 const STYLESHEET_SETTING = '__stylesheet__';
@@ -76,7 +77,7 @@ export class Stylesheet {
 
   constructor(config?: IStyleSheetConfig) {
     this._config = {
-      injectionMode: InjectionMode.insertNode,
+      injectionMode: InjectionMode.appendChild,
       ...config
     };
 
@@ -182,6 +183,10 @@ export class Stylesheet {
       default:
         this._rules.push(rule);
         break;
+    }
+
+    if (this._config.onInsertRule) {
+      this._config.onInsertRule(rule);
     }
   }
 

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -172,12 +172,7 @@ export class Stylesheet {
         break;
 
       case InjectionMode.appendChild:
-        const head: HTMLHeadElement = document.getElementsByTagName('head')[0];
-        const styleElement: HTMLStyleElement = document.createElement('style');
-
-        styleElement.type = 'text/css';
-        styleElement.appendChild(document.createTextNode(rule));
-        head.appendChild(styleElement);
+        createStyleElement(rule);
         break;
 
       default:
@@ -217,11 +212,21 @@ export class Stylesheet {
 
   private _getElement(): HTMLStyleElement | undefined {
     if (!this._styleElement && typeof document !== 'undefined') {
-      this._styleElement = document.createElement('style');
-      this._styleElement.setAttribute('data-merge-styles', 'true');
-      document.head.appendChild(this._styleElement);
+      this._styleElement = createStyleElement();
     }
-
     return this._styleElement;
   }
+}
+
+function createStyleElement(content?: string): HTMLStyleElement {
+  const styleElement = document.createElement('style');
+
+  styleElement.setAttribute('data-merge-styles', 'true');
+  styleElement.type = 'text/css';
+  if (content) {
+    styleElement.appendChild(document.createTextNode(content));
+  }
+  document.head.appendChild(styleElement);
+
+  return styleElement;
 }

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -172,7 +172,7 @@ export class Stylesheet {
         break;
 
       case InjectionMode.appendChild:
-        createStyleElement(rule);
+        _createStyleElement(rule);
         break;
 
       default:
@@ -212,13 +212,13 @@ export class Stylesheet {
 
   private _getElement(): HTMLStyleElement | undefined {
     if (!this._styleElement && typeof document !== 'undefined') {
-      this._styleElement = createStyleElement();
+      this._styleElement = _createStyleElement();
     }
     return this._styleElement;
   }
 }
 
-function createStyleElement(content?: string): HTMLStyleElement {
+function _createStyleElement(content?: string): HTMLStyleElement {
   const styleElement = document.createElement('style');
 
   styleElement.setAttribute('data-merge-styles', 'true');

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -49,7 +49,7 @@
   "bundlesize": [
     {
       "path": "../apps/test-bundle-button/dist/main.min.js",
-      "maxSize": "42 kB"
+      "maxSize": "42.5 kB"
     }
   ]
 }


### PR DESCRIPTION
See the accompanying unit tests to understand the cases being fixed.

But in short, if you did something like:
```
mergeStyleSets({ root: { selectors: { ':hover $child': { ... } }, child: [ 'a', { ... } ])
```
The selector generated would not be `.root-0:hover .child-1`. Instead, it would be `.root-0:hover .a child-1` which isn't even valid, due to a bug where we were using the "full" class name result for the $child replacement, which was the generated class name concatinated with static classes. Now the selector will be correct in this case.

Also fixed another simple edge case:

```
mergeStyles('a', 'a') // should result in "a", and not "a a"
```
