### PR TITLE
Public remeasure method for ResizeGroup and Experiments CommandBar

### DIFF
--- a/common/changes/@uifabric/experiments/staylo-ResizeGroupPublicRemeasureAPI_2017-12-11-17-30.json
+++ b/common/changes/@uifabric/experiments/staylo-ResizeGroupPublicRemeasureAPI_2017-12-11-17-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add remeasure public method to CommandBar",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "staylo@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/staylo-ResizeGroupPublicRemeasureAPI_2017-12-11-17-30.json
+++ b/common/changes/office-ui-fabric-react/staylo-ResizeGroupPublicRemeasureAPI_2017-12-11-17-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add remeasure public method to ResizeGroup",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "staylo@microsoft.com"
+}

--- a/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
@@ -14,7 +14,7 @@ import {
 } from './CommandBar.types';
 import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
 import { OverflowSet, IOverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
-import { ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
+import { ResizeGroup, IResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import {
   classNamesFunction
@@ -55,6 +55,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   };
 
   private _overflowSet: IOverflowSet;
+  private _resizeGroup: IResizeGroup;
   private _classNames: {[key in keyof ICommandBarStyles]: string };
 
   public render(): JSX.Element {
@@ -86,6 +87,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
     return (
       <ResizeGroup
+        componentRef={ this._resolveRef('_resizeGroup') }
         className={ className }
         data={ commandBardata }
         onReduceData={ onReduceData }
@@ -132,6 +134,10 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   public focus(): void {
     this._overflowSet.focus();
+  }
+
+  public remeasure(): void {
+    this._resizeGroup.remeasure();
   }
 
   private _computeCacheKey(primaryItems: ICommandBarItemProps[], farItems: ICommandBarItemProps[], overflow: boolean): string {

--- a/packages/experiments/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/experiments/src/components/CommandBar/CommandBar.types.ts
@@ -12,6 +12,11 @@ export interface ICommandBar {
    * Sets focus to the active command in the list.
    */
   focus(): void;
+
+  /**
+   * Remeasures the available space.
+   */
+  remeasure(): void;
 }
 
 export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/experiments/src/components/CommandBar/CommandBarPage.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBarPage.tsx
@@ -10,7 +10,7 @@ import { ICommandBarProps } from './CommandBar.types';
 import { CommandBarBasicExample } from './examples/CommandBar.Basic.Example';
 
 const CommandBarBasicExampleCode = require(
-  '!raw-loader!office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx'
+  '!raw-loader!experiments/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx'
 ) as string;
 
 export class CommandBarPage extends React.Component<IComponentDemoPageProps, {}> {
@@ -31,7 +31,7 @@ export class CommandBarPage extends React.Component<IComponentDemoPageProps, {}>
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts'),
+              require<string>('!raw-loader!experiments/src/components/CommandBar/CommandBar.types.ts'),
               require<string>('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts')
             ] }
           />

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
@@ -325,6 +325,12 @@ export class ResizeGroup extends BaseComponent<IResizeGroupProps, IResizeGroupSt
     this._afterComponentRendered();
   }
 
+  public remeasure(): void {
+    if (this._root) {
+      this.setState({ measureContainer: true });
+    }
+  }
+
   private _afterComponentRendered() {
     this._async.requestAnimationFrame(() => {
       let containerWidth = undefined;

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { ResizeGroup } from './ResizeGroup';
 
 export interface IResizeGroup {
-
+  /**
+   * Remeasures the available space.
+   */
+  remeasure(): void;
 }
 
 export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroup | HTMLElement> {


### PR DESCRIPTION
## Pull request checklist

- [ ] Addresses an existing issue: 
- [x] Include a change request file using `$ npm run change`

## Description of changes

#### office-ui-fabric-react:
- Add remeasure public method to ResizeGroup.
#### experiments:
- Store ref to ResizeGroup in CommandBar
- Add remeasure public method to CommandBar that calls the new remeasure method on its ResizeGroup




