### PR TITLE
support contextualMenuItemType in CommandBar:

### DIFF
--- a/apps/vr-tests/src/stories/CommandBar.stories.tsx
+++ b/apps/vr-tests/src/stories/CommandBar.stories.tsx
@@ -3,7 +3,10 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTall } from '../utilities';
-import { CommandBar } from 'office-ui-fabric-react';
+import {
+  CommandBar,
+  ContextualMenuItemType
+} from 'office-ui-fabric-react';
 
 const items = [
   {
@@ -26,6 +29,10 @@ const items = [
     },
   },
   {
+    key: 'divider_1',
+    itemType: ContextualMenuItemType.Divider
+  },
+  {
     key: 'upload',
     name: 'Upload',
     icon: 'Upload'
@@ -39,6 +46,10 @@ const items = [
     key: 'download',
     name: 'Download',
     icon: 'Download'
+  },
+  {
+    key: 'divider_1',
+    itemType: ContextualMenuItemType.Divider
   },
   {
     key: 'disabled',

--- a/common/changes/office-ui-fabric-react/magellantoo-CommandBar_divider_2017-12-11-21-31.json
+++ b/common/changes/office-ui-fabric-react/magellantoo-CommandBar_divider_2017-12-11-21-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added dividers for commandbar",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
@@ -193,10 +193,6 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
   padding: 0 7px;
 }
 
-.divider {
-  border-right: 1px solid $ms-color-neutralQuaternaryAlt;
-}
-
 // CommandBarSearch needs to replaced with SearchBox component, and hence following styles revisited/cleaned.
 .search {
   @include float(left);

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
@@ -194,8 +194,7 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
 }
 
 .divider {
-  background-color: $ms-color-neutralLight;
-  min-width: 1px;
+  border-right: 1px solid $ms-color-neutralQuaternaryAlt;
 }
 
 // CommandBarSearch needs to replaced with SearchBox component, and hence following styles revisited/cleaned.

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
@@ -193,6 +193,11 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
   padding: 0 7px;
 }
 
+.divider {
+  background-color: $ms-color-neutralLight;
+  min-width: 1px;
+}
+
 // CommandBarSearch needs to replaced with SearchBox component, and hence following styles revisited/cleaned.
 .search {
   @include float(left);

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -24,6 +24,7 @@ import {
   Icon,
   IIconProps
 } from '../../Icon';
+import { VerticalDivider } from '../../Divider';
 import { FontClassNames } from '../../Styling';
 import { TooltipHost } from '../../Tooltip';
 import * as stylesImport from './CommandBar.scss';
@@ -304,10 +305,12 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     const itemKey = item.key || String(index);
     return (
       <div
-        className={ css('ms-CommandBarDivider', styles.divider, item.className) }
+        className={ item.className }
         key={ itemKey }
         ref={ itemKey }
-      />
+      >
+        <VerticalDivider />
+      </div>
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/data.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/data.ts
@@ -1,3 +1,5 @@
+import { ContextualMenuItemType } from '../../ContextualMenu/index';
+
 export const items = [
   {
     key: 'newItem',
@@ -22,6 +24,10 @@ export const items = [
     },
   },
   {
+    key: 'divider_1',
+    itemType: ContextualMenuItemType.Divider
+  },
+  {
     key: 'upload',
     name: 'Upload',
     icon: 'Upload',
@@ -39,6 +45,10 @@ export const items = [
     name: 'Download',
     icon: 'Download',
     onClick: () => { return; }
+  },
+  {
+    key: 'divider_2',
+    itemType: ContextualMenuItemType.Divider
   },
   {
     key: 'disabled',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -43,8 +43,7 @@ export const getMenuItemStyles = memoizeFunction((
       }],
     divider: {
       display: 'block',
-      height: '1px',
-      backgroundColor: semanticColors.bodyDivider,
+      borderBottom: '1px solid ' + semanticColors.bodyDivider,
       position: 'relative'
     },
     root: [


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2749 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Allows users to pass ContextMenuItemType to CommandBar items to render dividers (section and headers still unsupported)  
May require additional design for the divider color.  
![divider color](https://user-images.githubusercontent.com/6496608/33854798-d1c018ca-de77-11e7-9096-2b91f228e088.png)  
Screenshot (above):  
Top: `ms-color-neutralQuaternaryAlt`  
Bottom: `ms-color-neutralLight`  

The ContextMenu divider uses white as its background color and `ms-color-neutralLight` as its divider color. Since the background color of the CommandBar is darker than ContextMenu, we might want to make CommandBar dividers darker than ContextMenu dividers. 
