### PR TITLE
BaseButton: Explicitly dismiss the menu when the contextual menu is dismissed rather than calling toggleMenu

### DIFF
--- a/common/changes/office-ui-fabric-react/chrisgo-dismiss-combo-box_2017-12-12-03-26.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-dismiss-combo-box_2017-12-12-03-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BaseButton: Explicitly dismiss the menu when the contextual menu is dismissed rather than calling toggleMEnu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -376,7 +376,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
   @autobind
   private _onRenderMenu(menuProps: IContextualMenuProps): JSX.Element {
-    const { onDismiss = this._onToggleMenu } = menuProps;
+    const { onDismiss = this._dismissMenu } = menuProps;
 
     return (
       <ContextualMenu
@@ -389,6 +389,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         onDismiss={ onDismiss }
       />
     );
+  }
+
+  @autobind
+  private _dismissMenu(): void {
+    this.setState({ menuProps: null });
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Inside Office Online, we're seeing a bug where the menu for a base button opens again when trying to dismiss it. This was tracked down to a few scenarios where the document canvas takes focus while the menu is being dismissed, which in result causes calloutContent._dismissMenu to be called twice. Inside of BaseButton, this results in 2 calls to toggleMenu which results in the menu closing and then opening again.

This changes the behavior to explicitly dismiss the menu rather than toggle it. I'm going to investigate further to see if I can prevent the multiple dismiss calls. 
