### PR TITLE
[List] Only measure pages if getPageHeight was not provided

### DIFF
--- a/common/changes/office-ui-fabric-react/alebet-dontMeasurePages_2017-12-12-21-55.json
+++ b/common/changes/office-ui-fabric-react/alebet-dontMeasurePages_2017-12-12-21-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Only perform list measurements if we absolutely need to",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "alexbettadapur@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -591,6 +591,9 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
           // Enqueue an idle bump.
           this._onAsyncIdle();
         }
+      } else {
+        // Enqueue an idle bump
+        this._onAsyncIdle();
       }
     });
   }

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -573,21 +573,24 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     let oldListPages = this.state.pages;
 
     this.setState(newListState, () => {
-      // If measured version is invalid since we've updated the DOM
-      const heightsChanged = this._updatePageMeasurements(oldListPages as IPage[], newListState.pages as IPage[]);
+      // If we weren't provided with the page height, measure the pages
+      if (!props.getPageHeight) {
+        // If measured version is invalid since we've updated the DOM
+        const heightsChanged = this._updatePageMeasurements(oldListPages as IPage[], newListState.pages as IPage[]);
 
-      // On first render, we should re-measure so that we don't get a visual glitch.
-      if (heightsChanged) {
-        this._materializedRect = null;
-        if (!this._hasCompletedFirstRender) {
-          this._hasCompletedFirstRender = true;
-          this._updatePages(props);
+        // On first render, we should re-measure so that we don't get a visual glitch.
+        if (heightsChanged) {
+          this._materializedRect = null;
+          if (!this._hasCompletedFirstRender) {
+            this._hasCompletedFirstRender = true;
+            this._updatePages(props);
+          } else {
+            this._onAsyncScroll();
+          }
         } else {
-          this._onAsyncScroll();
+          // Enqueue an idle bump.
+          this._onAsyncIdle();
         }
-      } else {
-        // Enqueue an idle bump.
-        this._onAsyncIdle();
       }
     });
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3293 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
When the getPageHeight method is provided, we should never update the pages after render, as they are always correct. This fixes a layout reflow that shouldn't occur when we know the page height.
