### PR TITLE
Magellantoo/dropdown focus fix

### DIFF
--- a/common/changes/office-ui-fabric-react/magellantoo-dropdown_focus_fix_2017-12-12-22-09.json
+++ b/common/changes/office-ui-fabric-react/magellantoo-dropdown_focus_fix_2017-12-12-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix dropdown focus issue for IE",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -764,7 +764,16 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       return;
     }
 
-    this._host.focus();
+    /**
+     * IE11 focus() method forces parents to scroll to top of element.
+     * Edge and IE expose a setActive() function for focusable divs that
+     * sets the page focus but does not scroll the parent element.
+     */
+    if ((this._host as any).setActive) {
+      (this._host as any).setActive();
+    } else {
+      this._host.focus();
+    }
   }
 
   private _onItemMouseDown(item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>) {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -601,7 +601,16 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       return;
     }
 
-    this._host.focus();
+    /**
+     * IE11 focus() method forces parents to scroll to top of element.
+     * Edge and IE expose a setActive() function for focusable divs that
+     * sets the page focus but does not scroll the parent element.
+     */
+    if ((this._host as any).setActive) {
+      (this._host as any).setActive();
+    } else {
+      this._host.focus();
+    }
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3405
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In IE, focusing a div causes the parent to scroll to the top of the child element being focused. 
In our case, the onMouseLeave handler for DropDown items calls `focus` on the dropdown's listwrapper.  
In IE and Edge, there is a `setActive` function which behaves similarly to `focus` but does not scroll the parent element.  
[Vanilla HTML repro](https://codepen.io/anon/pen/LeYXVM)
