### PR TITLE
ContextualMenu: Undo change to manually set the scrollbar

### DIFF
--- a/common/changes/office-ui-fabric-react/chrisgo-scroll-bar-fix_2017-12-13-02-09.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-scroll-bar-fix_2017-12-13-02-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Undo change to manually set the scrollbar",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.scss
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.scss
@@ -42,6 +42,7 @@ $Callout-smallbeak-slant-width: 16px;
 .main {
   background-color: $ms-color-white;
   overflow-x: hidden;
+  overflow-y: auto;
   position: relative;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`Callout renders Callout correctly 1`] = `
         Object {
           "backgroundColor": undefined,
           "maxHeight": 750,
-          "overflowY": "auto",
         }
       }
     >

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx
@@ -28,8 +28,8 @@ export class ContextualMenuWithScrollBarExample extends React.Component<any, any
                 name: 'New'
               },
               {
-                key: 'rename',
-                name: 'Rename'
+                key: 'item 2',
+                name: 'Item with a very long label text'
               },
               {
                 key: 'edit',

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -55,12 +55,7 @@ export class Popup extends BaseComponent<IPopupProps, {}> {
   }
 
   public render() {
-    let { role, className, ariaLabel, ariaLabelledBy, ariaDescribedBy, style } = this.props;
-
-    let needsVerticalScrollBar = false;
-    if (this.refs.root) {
-      needsVerticalScrollBar = this.refs.root.scrollHeight > this.refs.root.clientHeight;
-    }
+    let { role, className, ariaLabel, ariaLabelledBy, ariaDescribedBy } = this.props;
 
     return (
       <div
@@ -72,7 +67,6 @@ export class Popup extends BaseComponent<IPopupProps, {}> {
         aria-labelledby={ ariaLabelledBy }
         aria-describedby={ ariaDescribedBy }
         onKeyDown={ this._onKeyDown }
-        style={ { ...style, overflowY: needsVerticalScrollBar ? 'scroll' : 'auto' } }
       >
         { this.props.children }
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Revert #3449 since it seems to have introduced a few regressions, especially on high DPI displays in edge, where we are now showing some scrollbars unexpectedly. Living with the clipped content for now seems like the better scenario. 
