### PR TITLE
In Panel component, allow user to override all focus zone props.

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-focus-zone-props_2017-12-13-06-46.json
+++ b/common/changes/office-ui-fabric-react/panel-focus-zone-props_2017-12-13-06-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Enhance Panel component props to allow all of FocusTrapZone props overrides.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "sllynn8907@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -42,6 +42,12 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
   constructor(props: IPanelProps) {
     super(props);
 
+    this._warnDeprecations({
+      'ignoreExternalFocusing': 'focusTrapZoneProps',
+      'forceFocusInsideTrap': 'focusTrapZoneProps',
+      'firstFocusableSelector': 'focusTrapZoneProps'
+    });
+
     this.state = {
       isFooterSticky: false,
       isOpen: false,

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -72,11 +72,9 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     let {
       className = '',
       elementToFocusOnDismiss,
-      firstFocusableSelector,
-      forceFocusInsideTrap,
+      focusTrapZoneProps,
       hasCloseButton,
       headerText,
-      ignoreExternalFocusing,
       isBlocking,
       isLightDismiss,
       isHiddenOnDismiss,
@@ -151,6 +149,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
           >
             { overlay }
             <FocusTrapZone
+              { ...focusTrapZoneProps }
               className={
                 css(
                   'ms-Panel-main',
@@ -163,9 +162,6 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
               style={ customWidthStyles }
               elementToFocusOnDismiss={ elementToFocusOnDismiss }
               isClickableOutsideFocusTrap={ isLightDismiss || isHiddenOnDismiss }
-              ignoreExternalFocusing={ ignoreExternalFocusing }
-              forceFocusInsideTrap={ forceFocusInsideTrap }
-              firstFocusableSelector={ firstFocusableSelector }
             >
               <div className={ css('ms-Panel-commands') } data-is-visible={ true } >
                 { onRenderNavigation(renderProps, this._onRenderNavigation) }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -72,9 +72,12 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     let {
       className = '',
       elementToFocusOnDismiss,
+      firstFocusableSelector,
       focusTrapZoneProps,
+      forceFocusInsideTrap,
       hasCloseButton,
       headerText,
+      ignoreExternalFocusing,
       isBlocking,
       isLightDismiss,
       isHiddenOnDismiss,
@@ -149,6 +152,9 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
           >
             { overlay }
             <FocusTrapZone
+              ignoreExternalFocusing={ ignoreExternalFocusing }
+              forceFocusInsideTrap={ forceFocusInsideTrap }
+              firstFocusableSelector={ firstFocusableSelector }
               { ...focusTrapZoneProps }
               className={
                 css(

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -164,6 +164,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
                   isOpen && isAnimating && isOnRightSide && AnimationClassNames.slideLeftIn40,
                   !isOpen && isAnimating && !isOnRightSide && AnimationClassNames.slideLeftOut40,
                   !isOpen && isAnimating && isOnRightSide && AnimationClassNames.slideRightOut40,
+                  focusTrapZoneProps ? focusTrapZoneProps.className : undefined
                 ) }
               style={ customWidthStyles }
               elementToFocusOnDismiss={ elementToFocusOnDismiss }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Panel } from './Panel';
 import { IRenderFunction } from '../../Utilities';
 import { ILayerProps } from '../../Layer';
+import { IFocusTrapZoneProps } from '../../FocusTrapZone';
 
 export interface IPanel {
   /**
@@ -106,21 +107,9 @@ export interface IPanelProps extends React.Props<Panel> {
   elementToFocusOnDismiss?: HTMLElement;
 
   /**
-   * Indicates if this Panel will ignore keeping track of HTMLElement that activated the Zone.
-   * @default false
+   * Optional props to pass to the FocusTrapZone component to manage focus in the panel.
    */
-  ignoreExternalFocusing?: boolean;
-
-  /**
-  * Indicates whether Panel should force focus inside the focus trap zone
-  * @default true
-  */
-  forceFocusInsideTrap?: boolean;
-
-  /**
-  * Indicates the selector for first focusable item
-  */
-  firstFocusableSelector?: string;
+  focusTrapZoneProps?: IFocusTrapZoneProps;
 
   /**
    * Optional props to pass to the Layer component hosting the panel.

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -107,6 +107,30 @@ export interface IPanelProps extends React.Props<Panel> {
   elementToFocusOnDismiss?: HTMLElement;
 
   /**
+    * Indicates if this Panel will ignore keeping track of HTMLElement that activated the Zone.
+    * Optional props to pass to the FocusTrapZone component to manage focus in the panel.
+    * Deprecated, use focusTrapZoneProps.
+    * @default false
+    * @deprecated
+    */
+  ignoreExternalFocusing?: boolean;
+
+  /**
+   * Indicates whether Panel should force focus inside the focus trap zone
+   * Deprecated, use focusTrapZoneProps.
+   * @default true
+   * @deprecated
+   */
+  forceFocusInsideTrap?: boolean;
+
+  /**
+   * Indicates the selector for first focusable item.
+   * Deprecated, use focusTrapZoneProps.
+   * @deprecated
+   */
+  firstFocusableSelector?: string;
+
+  /**
    * Optional props to pass to the FocusTrapZone component to manage focus in the panel.
    */
   focusTrapZoneProps?: IFocusTrapZoneProps;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -108,7 +108,6 @@ export interface IPanelProps extends React.Props<Panel> {
 
   /**
     * Indicates if this Panel will ignore keeping track of HTMLElement that activated the Zone.
-    * Optional props to pass to the FocusTrapZone component to manage focus in the panel.
     * Deprecated, use focusTrapZoneProps.
     * @default false
     * @deprecated


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In Panel component, allow consumers to override all FocusTrapZone props. This change removes the few props that were only used for the FocusTrapZone. I'm not sure what the breaking change policy is, but I'm happy to modify this to meet the qualifications needed.