### PR TITLE
DatePicker: Default Value should be undefined, not new Date()

### DIFF
--- a/common/changes/office-ui-fabric-react/alebet-datePickerUndefined_2017-12-13-21-54.json
+++ b/common/changes/office-ui-fabric-react/alebet-datePickerUndefined_2017-12-13-21-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker: Default selectedDate should be undefined, not new Date()",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "alexbettadapur@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -22,8 +22,6 @@ import * as stylesImport from './DatePicker.scss';
 const styles: any = stylesImport;
 
 export interface IDatePickerState {
-  /** The currently focused date in the drop down, but not necessarily selected */
-  navigatedDate?: Date;
   selectedDate?: Date;
   formattedDate?: string;
   isDatePickerShown?: boolean;
@@ -133,7 +131,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     let { formatDate, value } = props;
 
     this.state = {
-      selectedDate: value || new Date(),
+      selectedDate: value || undefined,
       formattedDate: (formatDate && value) ? formatDate(value) : '',
       isDatePickerShown: false,
       errorMessage: undefined
@@ -162,7 +160,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     let oldValue = this.state.selectedDate;
     if (!compareDates(oldValue!, value!) || this.props.formatDate !== formatDate) {
       this.setState({
-        selectedDate: value || new Date(),
+        selectedDate: value || undefined,
         formattedDate: (formatDate && value) ? formatDate(value) : '',
       });
     }
@@ -365,7 +363,6 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       this._focusOnSelectedDateOnUpdate = true;
       this.setState({
         isDatePickerShown: true,
-        navigatedDate: this.state.selectedDate,
         errorMessage: ''
       });
     }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -96,7 +96,7 @@ export interface IDatePickerProps extends React.Props<DatePicker> {
    * Optional method to format the chosen date to a string to display in the DatePicker
    * @defaultvalue date.toString()
    */
-  formatDate?: (date: Date) => string;
+  formatDate?: (date?: Date) => string;
 
   /**
    * Optional method to parse the text input value to date, it is only useful when allowTextInput is set to true


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3574 #3683
- [x] Include a change request file using `$ npm run change`

#### Description of changes

* `selectedDate` defaults to undefined in constructor and willReceiveProps
* `navigatedDate` state was removed because it was unused
