### PR TITLE
Panel: Don't render Overlay component unless Panel isOpen

### DIFF
--- a/common/changes/office-ui-fabric-react/v-edwliu-fixHiddenOnDismissPanel_2017-12-13-23-35.json
+++ b/common/changes/office-ui-fabric-react/v-edwliu-fixHiddenOnDismissPanel_2017-12-13-23-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Don't render Overlay unless Panel prop isOpen is true",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-edwliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -102,7 +102,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     }
 
     let overlay;
-    if (isBlocking) {
+    if (isBlocking && isOpen) {
       overlay = (
         <Overlay
           className={ css(


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3575
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fixes Panel page on fabric website.  Previously the HiddenOnDismiss variant would not render the Panel, but would render the Overlay still, which disables scrolling on the body element.

#### Focus areas to test

(optional)
