### PR TITLE
ComboBox: Fix value submission issues

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxValueSubmissionFix_2017-12-14-00-17.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxValueSubmissionFix_2017-12-14-00-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Fix some issues with submitting values when freeform and autocomplete",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -373,4 +373,38 @@ describe('ComboBox', () => {
     buttonElement.simulate('click');
     expect(returnUndefined.mock.calls.length).toBe(1);
   });
+
+  it('Can type a complete option with autocomplete and allowFreeform on and submit it', () => {
+    let updatedOption;
+    let updatedIndex;
+    let executionCount = 0;
+    let initialOption = { key: '1', text: 'Text' };
+
+    let comboBoxRoot;
+    let inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any>;
+    let wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        options={ [initialOption] }
+        autoComplete='on'
+        allowFreeform={ true }
+        // tslint:disable-next-line:jsx-no-lambda
+        onChanged={ (option?: IComboBoxOption, index?: number) => {
+          updatedOption = option;
+          updatedIndex = index;
+          executionCount++;
+        } }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+    inputElement = comboBoxRoot.find('input');
+    inputElement.simulate('change', { target: { value: 't' } });
+    inputElement.simulate('change', { target: { value: 'e' } });
+    inputElement.simulate('change', { target: { value: 'x' } });
+    inputElement.simulate('change', { target: { value: 't' } });
+    inputElement.simulate('keydown', { which: KeyCodes.enter });
+    expect(executionCount).toEqual(1);
+    expect(updatedOption).toEqual(initialOption);
+    expect(updatedIndex).toEqual(0);
+    expect(inputElement.props().value).toEqual('Text');
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -131,8 +131,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
   private _scrollIdleTimeoutId: number | undefined;
 
-  // private _lastTypedCharacter: string;
-
   // Determines if we should be setting
   // focus back to the input when the menu closes.
   // The general rule of thumb is if the menu was launched
@@ -1414,8 +1412,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       return;
     }
 
-    // this._lastTypedCharacter = '';
-
     switch (ev.which) {
       case KeyCodes.space:
         // If we are not allowing freeform and are not autoComplete
@@ -1429,9 +1425,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         break;
 
       default:
-        // if (ev.which >= KeyCodes.a && ev.which <= 90) {
-        //   this._lastTypedCharacter = String.fromCharCode(ev.which).toLocaleLowerCase();
-        // }
         return;
     }
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -131,6 +131,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
   private _scrollIdleTimeoutId: number | undefined;
 
+  // private _lastTypedCharacter: string;
+
   // Determines if we should be setting
   // focus back to the input when the menu closes.
   // The general rule of thumb is if the menu was launched
@@ -784,7 +786,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   private _submitPendingValue() {
     let {
       onChanged,
-      allowFreeform
+      allowFreeform,
+      autoComplete
     } = this.props;
     let {
       currentPendingValue,
@@ -802,12 +805,15 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         let pendingOptionText: string = currentOptions[currentPendingValueValidIndex].text.toLocaleLowerCase();
 
         // By exact match, that means: our pending value is the same as the the pending option text OR
-        // the peding option starts with the pending value and we have an "autoComplete" selection
-        // where the total lenght is equal to pending option length; update the state
+        // the pending option starts with the pending value and we have an "autoComplete" selection
+        // where the total length is equal to pending option length OR
+        // the live value in the underlying input matches the pending option; update the state
         if (currentPendingValue.toLocaleLowerCase() === pendingOptionText ||
-          (pendingOptionText.indexOf(currentPendingValue.toLocaleLowerCase()) === 0 &&
-            this._comboBox.isValueSelected &&
-            currentPendingValue.length + (this._comboBox.selectionEnd - this._comboBox.selectionStart) === pendingOptionText.length)) {
+          (autoComplete && pendingOptionText.indexOf(currentPendingValue.toLocaleLowerCase()) === 0 &&
+            (this._comboBox.isValueSelected &&
+              currentPendingValue.length + (this._comboBox.selectionEnd - this._comboBox.selectionStart) === pendingOptionText.length) ||
+            (this._comboBox.inputElement.value.toLocaleLowerCase() === pendingOptionText)
+          )) {
           this._setSelectedIndex(currentPendingValueValidIndex);
           this._clearPendingInfo();
           return;
@@ -1364,7 +1370,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         }
 
       default:
-
         // are we processing a function key? if so bail out
         if (ev.which >= 112 /* F1 */ && ev.which <= 123 /* F12 */) {
           return;
@@ -1409,6 +1414,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       return;
     }
 
+    // this._lastTypedCharacter = '';
+
     switch (ev.which) {
       case KeyCodes.space:
         // If we are not allowing freeform and are not autoComplete
@@ -1422,6 +1429,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         break;
 
       default:
+        // if (ev.which >= KeyCodes.a && ev.which <= 90) {
+        //   this._lastTypedCharacter = String.fromCharCode(ev.which).toLocaleLowerCase();
+        // }
         return;
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

There were a few cases when an onChange would not fire resulting in our comboBox state being out of sync with the actual input value. This add a check when submitting a pending value (with autocomplete and allowFreeform on) to check the live value in the input as a last resort

#### Focus areas to test
Verified different variations of submitting values are submitted correctly
