### PR TITLE
Added optional callback for getting image load state change events from PersonaCoin through Persona component

### DIFF
--- a/common/changes/office-ui-fabric-react/mariust-personacoin_image_load_events_2017-12-15-13-19.json
+++ b/common/changes/office-ui-fabric-react/mariust-personacoin_image_load_events_2017-12-15-13-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added optional callback for getting image load state change events from personacoin through Persona component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mariust@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -56,7 +56,8 @@ export class Persona extends BaseComponent<IPersonaProps, {}> {
       primaryText,
       imageShouldFadeIn,
       imageShouldStartVisible,
-      showSecondaryText
+      showSecondaryText,
+      onPhotoLoadingStateChange
      } = this.props;
 
     let personaCoinProps = {
@@ -70,7 +71,8 @@ export class Persona extends BaseComponent<IPersonaProps, {}> {
       primaryText,
       imageShouldFadeIn,
       imageShouldStartVisible,
-      size
+      size,
+      onPhotoLoadingStateChange
     };
 
     let divProps = getNativeProps(this.props, divProperties);

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { IRenderFunction } from '../../Utilities';
 import { Persona } from './Persona';
+import { ImageLoadState } from '../../Image';
 
 export interface IPersona {
 
@@ -61,6 +62,11 @@ export interface IPersonaProps extends React.HTMLAttributes<Persona> {
    * Optional custom renderer for the initials
    */
   onRenderInitials?: IRenderFunction<IPersonaProps>;
+
+  /**
+   * Optional callback for when loading state of the photo changes
+   */
+  onPhotoLoadingStateChange?: (loadSucceeded: ImageLoadState) => void;
 
   /**
    * The background color when the user's initials are displayed.

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -66,7 +66,7 @@ export interface IPersonaProps extends React.HTMLAttributes<Persona> {
   /**
    * Optional callback for when loading state of the photo changes
    */
-  onPhotoLoadingStateChange?: (loadSucceeded: ImageLoadState) => void;
+  onPhotoLoadingStateChange?: (newImageLoadState: ImageLoadState) => void;
 
   /**
    * The background color when the user's initials are displayed.

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx
@@ -167,5 +167,9 @@ export class PersonaCoin extends React.Component<IPersonaProps, IPersonaState> {
       isImageLoaded: loadState === ImageLoadState.loaded,
       isImageError: loadState === ImageLoadState.error
     });
+
+    if (this.props.onPhotoLoadingStateChange) {
+      this.props.onPhotoLoadingStateChange(loadState);
+    }
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 (no existing issue)
- [x] Include a change request file using `$ npm run change`

#### Description of changes

I needed to know the loading state changes of the photo inside a Persona component, so I simply expose an optional onPhotoLoadingStateChange from Persona down to the PersonaCoin, which already listens to image load state changes, meaning the change is minimal

#### Focus areas to test

Nothing special
