### PR TITLE
[Merge styles]: Add a setting to change the default prefix

### DIFF
--- a/common/changes/@uifabric/merge-styles/mergeStyles_2017-12-15-14-15.json
+++ b/common/changes/@uifabric/merge-styles/mergeStyles_2017-12-15-14-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Added a setting to Stylesheet which allows overriding the default prefix",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "jawerne@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.test.ts
+++ b/packages/merge-styles/src/Stylesheet.test.ts
@@ -1,0 +1,22 @@
+import {
+  InjectionMode,
+  Stylesheet
+} from './Stylesheet';
+
+import { styleToClassName } from './styleToClassName';
+
+const _stylesheet: Stylesheet = Stylesheet.getInstance();
+_stylesheet.setConfig({ injectionMode: InjectionMode.none, defaultPrefix: "myCss" });
+
+describe('Stylesheet', () => {
+  beforeEach(() => {
+    _stylesheet.reset();
+  });
+
+  it('supports overriding the default prefix', () => {
+    let className = styleToClassName({ background: 'red' });
+
+    expect(className).toEqual('myCss-0');
+    expect(_stylesheet.getRules()).toEqual('.myCss-0{background:red;}');
+  });
+});

--- a/packages/merge-styles/src/Stylesheet.test.ts
+++ b/packages/merge-styles/src/Stylesheet.test.ts
@@ -6,7 +6,7 @@ import {
 import { styleToClassName } from './styleToClassName';
 
 const _stylesheet: Stylesheet = Stylesheet.getInstance();
-_stylesheet.setConfig({ injectionMode: InjectionMode.none, defaultPrefix: "myCss" });
+_stylesheet.setConfig({ injectionMode: InjectionMode.none, defaultPrefix: 'myCss' });
 
 describe('Stylesheet', () => {
   beforeEach(() => {
@@ -14,7 +14,7 @@ describe('Stylesheet', () => {
   });
 
   it('supports overriding the default prefix', () => {
-    let className = styleToClassName({ background: 'red' });
+    const className = styleToClassName({ background: 'red' });
 
     expect(className).toEqual('myCss-0');
     expect(_stylesheet.getRules()).toEqual('.myCss-0{background:red;}');

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -31,6 +31,10 @@ export interface IStyleSheetConfig {
    * Injection mode for how rules are inserted.
    */
   injectionMode?: InjectionMode;
+  /**
+   * Falls back to "css".
+   */
+  defaultPrefix?: string;
   onInsertRule?: (rule: string) => void;
 }
 
@@ -78,6 +82,7 @@ export class Stylesheet {
   constructor(config?: IStyleSheetConfig) {
     this._config = {
       injectionMode: InjectionMode.insertNode,
+      defaultPrefix: 'css',
       ...config
     };
 
@@ -100,7 +105,7 @@ export class Stylesheet {
    * @param displayName - Optional value to use as a prefix.
    */
   public getClassName(displayName?: string): string {
-    const prefix = displayName || 'css';
+    const prefix = displayName || this._config.defaultPrefix;
 
     return `${prefix}-${this._counter++}`;
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3578
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In mergeStyles, if we merge styles without a displayName, it will fall back to "css". This PR introduces a setting to Stylesheet allowing to override this default prefix.

#### Focus areas to test

(optional)
