### PR TITLE
Website: UHF link color override for new button on GetStarted page

### DIFF
--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.module.scss
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.module.scss
@@ -142,6 +142,12 @@
 
   :global(.ms-Button) {
     margin: 12px 0;
+    // The color override is need because of the UHF
+    color: $ms-color-white;
+
+    @include high-contrast {
+      color: Window;
+    }
   }
 
   code {

--- a/common/changes/@uifabric/fabric-website/getstarted-link_2017-12-15-18-13.json
+++ b/common/changes/@uifabric/fabric-website/getstarted-link_2017-12-15-18-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "GetStarted Page: More specific selectors for button with link to deal with UHF styles.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Now that the website has been redeployed, it seems the UHF styles have taken over our button example. More explicitly setting this. Added the same high-contrast color that @kristoferbrown used in this PR: #3301 

#### Focus areas to test

(optional)
