### PR TITLE
 Bug Fix: FirstWeekOfYear - with FirstFourDayWeek setting enabled December 2020 has 2 weeks with number 52 #3119

### DIFF
--- a/common/changes/office-ui-fabric-react/fixWeekNumberIssue_2017-12-20-05-55.json
+++ b/common/changes/office-ui-fabric-react/fixWeekNumberIssue_2017-12-20-05-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Changes in Week Number Computation logic for FirstFourDayWeek setting to fix issue 3119",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "manas.misra@outlook.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.test.ts
@@ -344,6 +344,7 @@ describe('DateMath', () => {
     result = DateMath.getWeekNumber(date1, 1, 0);
     expected = 53;
     expect(result).toEqual(expected);
+
   });
 
   // First week of year set to FirstWeekOfYear.FirstFullWeek
@@ -371,6 +372,21 @@ describe('DateMath', () => {
     result = DateMath.getWeekNumber(date1, 1, 1);
     expected = 52;
     expect(result).toEqual(expected);
+
+    // firstDayOfWeek is Sunday
+    date1 = new Date(2021, 0, 1);
+    result = DateMath.getWeekNumber(date1, 0, 1);
+    expected = 52;
+    expect(result).toEqual(expected);
+
+    // firstDayOfWeek is Monday
+    date1 = new Date(2021, 0, 1);
+    result = DateMath.getWeekNumber(date1, 1, 1);
+    expected = 52;
+    expect(result).toEqual(expected);
+
+
+
   });
 
   // First week of year set to FirstWeekOfYear.FirstFourDayWeek
@@ -410,6 +426,19 @@ describe('DateMath', () => {
     result = DateMath.getWeekNumber(date1, 1, 2);
     expected = 52;
     expect(result).toEqual(expected);
+
+    // firstDayOfWeek is Sunday
+    date1 = new Date(2021, 0, 1);
+    result = DateMath.getWeekNumber(date1, 0, 2);
+    expected = 53;
+    expect(result).toEqual(expected);
+
+    // firstDayOfWeek is Monday
+    date1 = new Date(2021, 0, 1);
+    result = DateMath.getWeekNumber(date1, 1, 2);
+    expected = 53;
+    expect(result).toEqual(expected);
+
   });
 
   it('can get the month start and end', () => {

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.test.ts
@@ -434,7 +434,6 @@ describe('DateMath', () => {
     result = DateMath.getWeekNumber(date1, 1, 2);
     expected = 53;
     expect(result).toEqual(expected);
-
   });
 
   it('can get the month start and end', () => {

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.test.ts
@@ -344,7 +344,6 @@ describe('DateMath', () => {
     result = DateMath.getWeekNumber(date1, 1, 0);
     expected = 53;
     expect(result).toEqual(expected);
-
   });
 
   // First week of year set to FirstWeekOfYear.FirstFullWeek
@@ -384,9 +383,6 @@ describe('DateMath', () => {
     result = DateMath.getWeekNumber(date1, 1, 1);
     expected = 52;
     expect(result).toEqual(expected);
-
-
-
   });
 
   // First week of year set to FirstWeekOfYear.FirstFourDayWeek

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
@@ -305,7 +305,7 @@ function getWeekOfYearFullDays(date: Date, firstDayOfWeek: DayOfWeek, numberOfFu
   let dateWeekDay = date.getDay();
   let num = (date.getDay()) - (dayOfYear % TimeConstants.DaysInOneWeek);
 
-  let lastDayOfyear = new Date(date.getFullYear(), MonthOfYear.December, 31);
+  let lastDayOfyear = new Date(date.getFullYear() - 1, MonthOfYear.December, 31);
   let daysInYear = getDayOfYear(lastDayOfyear) - 1;
 
   let adjustedWeekDay = adjustWeekDay(firstDayOfWeek, dateWeekDay);

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
@@ -305,8 +305,8 @@ function getWeekOfYearFullDays(date: Date, firstDayOfWeek: DayOfWeek, numberOfFu
   let dateWeekDay = date.getDay();
   let num = (date.getDay()) - (dayOfYear % TimeConstants.DaysInOneWeek);
 
-  let lastDayOfyear = new Date(date.getFullYear() - 1, MonthOfYear.December, 31);
-  let daysInYear = getDayOfYear(lastDayOfyear) - 1;
+  let lastDayOfPrevYear = new Date(date.getFullYear() - 1, MonthOfYear.December, 31);
+  let daysInYear = getDayOfYear(lastDayOfPrevYear) - 1;
 
   let adjustedWeekDay = adjustWeekDay(firstDayOfWeek, dateWeekDay);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3119
- [x] Include a change request file using `$ npm run change`

#### Description of changes

 Week number computation logic was fixed by referring to last day of previous year correctly.
 Added unit tests.

#### Focus areas to test

(optional)
