### PR TITLE
[ToolTip] Positioning fix for IE

### DIFF
--- a/common/changes/office-ui-fabric-react/dev-tool_tip_position_fix_2017-12-18-17-51.json
+++ b/common/changes/office-ui-fabric-react/dev-tool_tip_position_fix_2017-12-18-17-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Changed ToolTipHost to inline-block",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/dev-tool_tip_position_fix_2017-12-18-17-51.json
+++ b/common/changes/office-ui-fabric-react/dev-tool_tip_position_fix_2017-12-18-17-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Changed ToolTipHost to inline-block",
+      "comment": "ToolTop: Changed ToolTipHost to inline-block",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.scss
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.scss
@@ -7,5 +7,5 @@
 // TooltipHost styles
 
 .host {
-  display: inline;
+  display: inline-block;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3411 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Bug Repro: https://codepen.io/anon/pen/goamNR
Changing tooltiphost to inline-block fixes how the tooltip is positioned in IE. 

#### Focus areas to test

Ensure that changing the display of tooltip host doesn't break how the tooltip is displayed in all scenarios. 