### PR TITLE
Persona: Initials high contrast color

### DIFF
--- a/common/changes/office-ui-fabric-react/persona-initials-a11y_2017-12-18-18-03.json
+++ b/common/changes/office-ui-fabric-react/persona-initials-a11y_2017-12-18-18-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Persona: Set initials color for high contrast mode.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -101,6 +101,7 @@ $ms-Persona-presenceBorder: 2px;
     border: 1px solid WindowText;
     -ms-high-contrast-adjust: none;
     color: WindowText;
+    box-sizing: border-box;
     // Using important to override all of the more specific initialsIsColor rules
     background-color: Window !important;
   }

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -100,6 +100,7 @@ $ms-Persona-presenceBorder: 2px;
   @include high-contrast {
     border: 1px solid WindowText;
     -ms-high-contrast-adjust: none;
+    color: WindowText;
     // Using important to override all of the more specific initialsIsColor rules
     background-color: Window !important;
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Initials weren't showing up in high contrast mode. Piggy-backed off of existing high contrast settings to fix it.  Fixed border cut-off issue, too.

Before:
![persona initials before](https://user-images.githubusercontent.com/16619843/34120573-fde4c3ca-e3da-11e7-9cd2-09554d05adcc.PNG)

After:
![image](https://user-images.githubusercontent.com/16619843/34121251-3b941886-e3dd-11e7-823b-535b4e1c5bbf.png)

#### Focus areas to test

(optional)
