### PR TITLE
Allow for a broader range of the prop-type dependency

### DIFF
--- a/common/changes/@uifabric/experiments/prop-types-deps_2017-12-18-22-06.json
+++ b/common/changes/@uifabric/experiments/prop-types-deps_2017-12-18-22-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Broaden the range of allowed prop-type versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "<christianjordangonzalez@gmail.com>"
+}

--- a/common/changes/@uifabric/utilities/prop-types-deps_2017-12-18-22-06.json
+++ b/common/changes/@uifabric/utilities/prop-types-deps_2017-12-18-22-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Broaden the range of allowed prop-type versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "<christianjordangonzalez@gmail.com>"
+}

--- a/common/changes/office-ui-fabric-react/prop-types-deps_2017-12-18-22-06.json
+++ b/common/changes/office-ui-fabric-react/prop-types-deps_2017-12-18-22-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Broaden the range of allowed prop-type versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "<christianjordangonzalez@gmail.com>"
+}

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -46,7 +46,7 @@
     "@microsoft/load-themed-styles": "^1.7.13",
     "office-ui-fabric-react": ">=5.34.1 <6.0.0",
     "@uifabric/icons": ">=5.3.0 <6.0.0",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.5.10",
     "tslib": "^1.7.1"
   },
   "peerDependencies": {

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -51,7 +51,7 @@
     "@uifabric/merge-styles": ">=5.9.0 <6.0.0",
     "@uifabric/styling": ">=5.15.0 <6.0.0",
     "@uifabric/utilities": ">=5.6.0 <6.0.0",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.5.10",
     "tslib": "^1.7.1"
   },
   "peerDependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.7.13",
     "@uifabric/merge-styles": ">=5.9.0 <6.0.0",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.5.10",
     "tslib": "^1.7.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The React 16 upgrade made the minimum required version of prop-types be version 15.6. This did not appear to be necessary and has resulted in Office Online pulling in two versions of prop-types to satisfy all our dependencies. Making it allow 15.5.10 will allow things to work as expected while we upgrade our other dependencies to allow the use of 15.6.0+
