### PR TITLE
[hover card] fix bug for quickly enter/leave card cannot dismiss card correctly

### DIFF
--- a/common/changes/office-ui-fabric-react/lingge-hover-card-open-and-dismiss_2017-12-20-08-33.json
+++ b/common/changes/office-ui-fabric-react/lingge-hover-card-open-and-dismiss_2017-12-20-08-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fix hover card dismiss issue",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lingge@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3605 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

1. setState cannot be used in componentWillUpdate
2. did not clear dismiss timer correctly
3. setState according to prev state should be done in callback function in setState.

#### Focus areas to test

tested on local build branch
