### PR TITLE
Updated codeowners to support subfolders and explicit ownership of PersonaCoin files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,87 +13,88 @@
 
 # You can also use email addresses if you prefer. They'll be used to look up
 # users just like we do for commit author emails.
-# docs/*  docs@example.com
+# docs/  docs@example.com
 
 #### Apps
-# component-demo/*
-# fabric-website/*
-# ssr-tests/*
-# test-bundle-button/*
-# todo-app/*
+# component-demo/
+# fabric-website/
+# ssr-tests/
+# test-bundle-button/
+# todo-app/
 
 #### Packages
-# packages/example-app-base/*
-# packages/example-component/*
+# packages/example-app-base/
+# packages/example-component/
 
   ### Fabric
-  # packages/office-ui-fabric-react/src/common/*
+  # packages/office-ui-fabric-react/src/common/
   packages/office-ui-fabric-react/src/common/_semanticSlots.scss  @phkuo
   packages/office-ui-fabric-react/src/common/_themeOverrides.scss @phkuo
   packages/office-ui-fabric-react/src/common/_common.scss @phkuo
 
     ## Components
-    # packages/office-ui-fabric-react/src/components/ActivityItem/*
-    # packages/office-ui-fabric-react/src/components/Breadcrumb/*
-    # packages/office-ui-fabric-react/src/components/Button/*
-    packages/office-ui-fabric-react/src/components/Calendar/*   @johannao76 @lorejoh12@gmail.com @jolore@microsoft.com
-    # packages/office-ui-fabric-react/src/components/Callout/*
-    # packages/office-ui-fabric-react/src/components/Check/*
-    # packages/office-ui-fabric-react/src/components/Checkbox/*
-    # packages/office-ui-fabric-react/src/components/ChoiceGroup/*
-    # packages/office-ui-fabric-react/src/components/ColorPicker/*
-    # packages/office-ui-fabric-react/src/components/ComboBox/*
-    packages/office-ui-fabric-react/src/components/CommandBar/*   @micahgodbolt
-    # packages/office-ui-fabric-react/src/components/ContextualMenu/*
-    packages/office-ui-fabric-react/src/components/DatePicker/*   @johannao76 @lorejoh12@gmail.com @jolore@microsoft.com
-    # packages/office-ui-fabric-react/src/components/DetailsList/*
-    # packages/office-ui-fabric-react/src/components/Dialog/*
-    # packages/office-ui-fabric-react/src/components/DocumentCard/*
-    # packages/office-ui-fabric-react/src/components/Dropdown/*
-    # packages/office-ui-fabric-react/src/components/Fabric/*
-    # packages/office-ui-fabric-react/src/components/FacePile/*
-    # packages/office-ui-fabric-react/src/components/FocusTrapZone/*
-    # packages/office-ui-fabric-react/src/components/FocusZone/*
-    # packages/office-ui-fabric-react/src/components/GroupedList/*
-    packages/office-ui-fabric-react/src/components/HoverCard/*   @atneik @Jahnp
-    # packages/office-ui-fabric-react/src/components/Icon/*
-    # packages/office-ui-fabric-react/src/components/Image/*
-    # packages/office-ui-fabric-react/src/components/Label/*
-    # packages/office-ui-fabric-react/src/components/Layer/*
-    # packages/office-ui-fabric-react/src/components/Link/*
-    packages/office-ui-fabric-react/src/components/List/*  @cschleiden
-    # packages/office-ui-fabric-react/src/components/MarqueeSelection/*
-    # packages/office-ui-fabric-react/src/components/MessageBar/*
-    # packages/office-ui-fabric-react/src/components/Modal/*
-    # packages/office-ui-fabric-react/src/components/Nav/*
-    packages/office-ui-fabric-react/src/components/OverflowSet/*  @micahgodbolt
-    # packages/office-ui-fabric-react/src/components/Overlay/*
-    # packages/office-ui-fabric-react/src/components/Panel/*
-    # packages/office-ui-fabric-react/src/components/Persona/*
-    packages/office-ui-fabric-react/src/components/Persona/PersonaCo* @mtennoe @jakob101
-    # packages/office-ui-fabric-react/src/components/pickers/*
-    # packages/office-ui-fabric-react/src/components/Pivot/*
-    # packages/office-ui-fabric-react/src/components/Popup/*
-    # packages/office-ui-fabric-react/src/components/ProgressIndicator/*
-    packages/office-ui-fabric-react/src/components/Rating/*  @cschleiden
-    packages/office-ui-fabric-react/src/components/ResizeGroup/*  @micahgodbolt
-    # packages/office-ui-fabric-react/src/components/SearchBox/*
-    # packages/office-ui-fabric-react/src/components/Slider/*
-    # packages/office-ui-fabric-react/src/components/SpinButton/*
-    # packages/office-ui-fabric-react/src/components/Spinner/*
-    # packages/office-ui-fabric-react/src/components/SwatchColorPicker/*
-    packages/office-ui-fabric-react/src/components/TeachingBubble/*   @micahgodbolt
-    # packages/office-ui-fabric-react/src/components/TextField/*
-    # packages/office-ui-fabric-react/src/components/Theme/*
-    packages/office-ui-fabric-react/src/components/Toggle/*  @phkuo
-    packages/office-ui-fabric-react/src/components/Tooltip/*  @micahgodbolt
+    # packages/office-ui-fabric-react/src/components/ActivityItem/
+    # packages/office-ui-fabric-react/src/components/Breadcrumb/
+    # packages/office-ui-fabric-react/src/components/Button/
+    packages/office-ui-fabric-react/src/components/Calendar/   @johannao76 @lorejoh12@gmail.com @jolore@microsoft.com
+    # packages/office-ui-fabric-react/src/components/Callout/
+    # packages/office-ui-fabric-react/src/components/Check/
+    # packages/office-ui-fabric-react/src/components/Checkbox/
+    # packages/office-ui-fabric-react/src/components/ChoiceGroup/
+    # packages/office-ui-fabric-react/src/components/ColorPicker/
+    # packages/office-ui-fabric-react/src/components/ComboBox/
+    packages/office-ui-fabric-react/src/components/CommandBar/   @micahgodbolt
+    # packages/office-ui-fabric-react/src/components/ContextualMenu/
+    packages/office-ui-fabric-react/src/components/DatePicker/   @johannao76 @lorejoh12@gmail.com @jolore@microsoft.com
+    # packages/office-ui-fabric-react/src/components/DetailsList/
+    # packages/office-ui-fabric-react/src/components/Dialog/
+    # packages/office-ui-fabric-react/src/components/DocumentCard/
+    # packages/office-ui-fabric-react/src/components/Dropdown/
+    # packages/office-ui-fabric-react/src/components/Fabric/
+    # packages/office-ui-fabric-react/src/components/FacePile/
+    # packages/office-ui-fabric-react/src/components/FocusTrapZone/
+    # packages/office-ui-fabric-react/src/components/FocusZone/
+    # packages/office-ui-fabric-react/src/components/GroupedList/
+    packages/office-ui-fabric-react/src/components/HoverCard/   @atneik @Jahnp
+    # packages/office-ui-fabric-react/src/components/Icon/
+    # packages/office-ui-fabric-react/src/components/Image/
+    # packages/office-ui-fabric-react/src/components/Label/
+    # packages/office-ui-fabric-react/src/components/Layer/
+    # packages/office-ui-fabric-react/src/components/Link/
+    packages/office-ui-fabric-react/src/components/List/  @cschleiden
+    # packages/office-ui-fabric-react/src/components/MarqueeSelection/
+    # packages/office-ui-fabric-react/src/components/MessageBar/
+    # packages/office-ui-fabric-react/src/components/Modal/
+    # packages/office-ui-fabric-react/src/components/Nav/
+    packages/office-ui-fabric-react/src/components/OverflowSet/  @micahgodbolt
+    # packages/office-ui-fabric-react/src/components/Overlay/
+    # packages/office-ui-fabric-react/src/components/Panel/
+    # packages/office-ui-fabric-react/src/components/Persona/
+    packages/office-ui-fabric-react/src/components/Persona/PersonaCoin.tsx @mtennoe @jakob101
+    packages/office-ui-fabric-react/src/components/Persona/PersonaConsts.tsx @mtennoe @jakob101
+    # packages/office-ui-fabric-react/src/components/pickers/
+    # packages/office-ui-fabric-react/src/components/Pivot/
+    # packages/office-ui-fabric-react/src/components/Popup/
+    # packages/office-ui-fabric-react/src/components/ProgressIndicator/
+    packages/office-ui-fabric-react/src/components/Rating/  @cschleiden
+    packages/office-ui-fabric-react/src/components/ResizeGroup/  @micahgodbolt
+    # packages/office-ui-fabric-react/src/components/SearchBox/
+    # packages/office-ui-fabric-react/src/components/Slider/
+    # packages/office-ui-fabric-react/src/components/SpinButton/
+    # packages/office-ui-fabric-react/src/components/Spinner/
+    # packages/office-ui-fabric-react/src/components/SwatchColorPicker/
+    packages/office-ui-fabric-react/src/components/TeachingBubble/   @micahgodbolt
+    # packages/office-ui-fabric-react/src/components/TextField/
+    # packages/office-ui-fabric-react/src/components/Theme/
+    packages/office-ui-fabric-react/src/components/Toggle/  @phkuo
+    packages/office-ui-fabric-react/src/components/Tooltip/  @micahgodbolt
 
-  # packages/office-ui-fabric-react/src/demo/*
-  # packages/office-ui-fabric-react/src/utilities/*
-  # packages/office-ui-fabric-react/src/visualtest/*
+  # packages/office-ui-fabric-react/src/demo/
+  # packages/office-ui-fabric-react/src/utilities/
+  # packages/office-ui-fabric-react/src/visualtest/
 
-# packages/office-ui-fabric-react-tslint/*
-packages/styling/*  @dzearing
-packages/styling/src/interfaces/* @phkuo
-packages/styling/src/styles/* @phkuo
-# packages/utilities/*
+# packages/office-ui-fabric-react-tslint/
+packages/styling/  @dzearing
+packages/styling/src/interfaces/ @phkuo
+packages/styling/src/styles/ @phkuo
+# packages/utilities/


### PR DESCRIPTION
Based on the following docs from the [codeowners docs](https://help.github.com/articles/about-codeowners/) I've updated all of the selectors to target deeply nested files. 

```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com

# In this example, @doctocat owns any file in the `/docs`
# directory in the root of your repository.
/docs/ @doctocat
```