### PR TITLE
Grid: Convert grid to getStyles to enable grid customization

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-GridCustomStyling_2017-12-20-23-07.json
+++ b/common/changes/office-ui-fabric-react/malozano-GridCustomStyling_2017-12-20-23-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Grid: Enable styling customization to grid through getStyles",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -4,7 +4,8 @@ import {
   BaseComponent,
   findIndex,
   getId,
-  customizable
+  customizable,
+  classNamesFunction
 } from '../../Utilities';
 import {
   ISwatchColorPicker,
@@ -16,7 +17,6 @@ import { Grid } from '../../utilities/grid/Grid';
 import { IColorCellProps } from './ColorPickerGridCell.types';
 import { ColorPickerGridCell } from './ColorPickerGridCell';
 import { mergeStyleSets } from '../../Styling';
-import { classNamesFunction } from '../../Utilities';
 
 export interface ISwatchColorPickerState {
   selectedIndex?: number;
@@ -98,6 +98,7 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
         shouldFocusCircularNavigate={ shouldFocusCircularNavigate }
         doNotContainWithinFocusZone={ doNotContainWithinFocusZone }
         onBlur={ this._onSwatchColorPickerBlur }
+        getStyles={ getStyles }
         containerClassName={ classNames.root }
       />);
   }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -98,6 +98,7 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
         shouldFocusCircularNavigate={ shouldFocusCircularNavigate }
         doNotContainWithinFocusZone={ doNotContainWithinFocusZone }
         onBlur={ this._onSwatchColorPickerBlur }
+        theme={ this.props.theme! }
         getStyles={ getStyles }
         containerClassName={ classNames.root }
       />);

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -98,9 +98,12 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
         shouldFocusCircularNavigate={ shouldFocusCircularNavigate }
         doNotContainWithinFocusZone={ doNotContainWithinFocusZone }
         onBlur={ this._onSwatchColorPickerBlur }
-        theme={ this.props.theme! }
-        getStyles={ getStyles }
-        containerClassName={ classNames.root }
+        // tslint:disable-next-line:jsx-no-lambda
+        getStyles={ (props) => ({
+          root: classNames.root,
+          tableCell: classNames.tableCell,
+          focusedContainer: classNames.focusedContainer
+        }) }
       />);
   }
 

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -98,6 +98,7 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
         shouldFocusCircularNavigate={ shouldFocusCircularNavigate }
         doNotContainWithinFocusZone={ doNotContainWithinFocusZone }
         onBlur={ this._onSwatchColorPickerBlur }
+        theme={ this.props.theme! }
         // tslint:disable-next-line:jsx-no-lambda
         getStyles={ (props) => ({
           root: classNames.root,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.styles.ts
@@ -8,8 +8,16 @@ export const getStyles = (props: ISwatchColorPickerStyleProps): ISwatchColorPick
   } = props;
 
   const { semanticColors, fonts } = theme;
+
   return {
-    root: [
+    root: {
+      padding: 2,
+      outline: 'none'
+    },
+    tableCell: {
+      padding: 0
+    },
+    focusedContainer: [
       'ms-swatchColorPickerBodyContainer',
       {
         clear: 'both',

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -123,11 +123,17 @@ export interface ISwatchColorPickerStyleProps {
  */
 export interface ISwatchColorPickerStyles {
   /**
-   * Style applied to the container of the swatchColorPicker
+   * Style applied to the container grid of the swatchColorPicker
    */
   root: IStyle;
 
+  /**
+  * Style for the table cells of the grid.
+  */
   tableCell: IStyle;
 
+  /**
+  * Optional, style for the FocusZone container for the grid
+  */
   focusedContainer?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -126,4 +126,8 @@ export interface ISwatchColorPickerStyles {
    * Style applied to the container of the swatchColorPicker
    */
   root: IStyle;
+
+  tableCell: IStyle;
+
+  focusedContainer?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -22,26 +22,32 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
   <table
     aria-posinset={undefined}
     aria-setsize={undefined}
+    className=
+
+        {
+          outline: none;
+          padding-bottom: 2px;
+          padding-left: 2px;
+          padding-right: 2px;
+          padding-top: 2px;
+        }
     id="id__2"
     role="grid"
-    style={
-      Object {
-        "outline": "none",
-        "padding": "2px",
-      }
-    }
   >
     <tbody>
       <tr
         role="row"
       >
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -217,12 +223,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -398,12 +407,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -579,12 +591,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -764,12 +779,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
         role="row"
       >
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -945,12 +963,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -1126,12 +1147,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -1307,12 +1331,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -1492,12 +1519,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
         role="row"
       >
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -1673,12 +1703,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -1854,12 +1887,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}
@@ -2035,12 +2071,15 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           </button>
         </td>
         <td
+          className=
+
+              {
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="presentation"
-          style={
-            Object {
-              "padding": "0px",
-            }
-          }
         >
           <button
             aria-describedby={null}

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import {
+  BaseComponent,
+  getId,
+  toMatrix,
+  classNamesFunction
+} from '../../Utilities';
+import { FocusZone } from '../../FocusZone';
+import { IGrid, IGridProps, IGridStyleProps, IGridStyles } from './Grid.types';
+import { getStyles as getBaseStyles } from './Grid.styles';
+
+const getClassNames = classNamesFunction<IGridStyleProps, IGridStyles>();
+
+export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
+
+  private _id: string;
+
+  constructor(props: IGridProps) {
+    super(props);
+    this._id = getId();
+  }
+
+  public render() {
+    let {
+      items,
+      columnCount,
+      onRenderItem,
+      positionInSet,
+      setSize,
+      getStyles
+    } = this.props;
+
+    const classNames = getClassNames(getStyles!);
+
+    // Array to store the cells in the correct row index
+    let rowsOfItems: any[][] = toMatrix(items, columnCount);
+
+    let content = (
+      <table
+        id={ this._id }
+        role={ 'grid' }
+        aria-posinset={ positionInSet }
+        aria-setsize={ setSize }
+        className={ classNames.root }
+      >
+        <tbody>
+          {
+            rowsOfItems.map((rows: any[], rowIndex) => {
+              return (
+                <tr
+                  role={ 'row' }
+                  key={ this._id + '-' + rowIndex + '-row' }
+                >
+                  { rows.map((cell, cellIndex) => {
+                    return (
+                      <td
+                        role={ 'presentation' }
+                        key={ this._id + '-' + cellIndex + '-cell' }
+                        className={ classNames.tableCell }
+                      >
+                        { onRenderItem(cell, cellIndex) }
+                      </td>
+                    );
+                  }) }
+                </tr>
+              );
+            })
+          }
+        </tbody>
+      </table >
+    );
+
+    // Create the table/grid
+    return (
+      this.props.doNotContainWithinFocusZone ? content : (
+        <FocusZone
+          isCircularNavigation={ this.props.shouldFocusCircularNavigate }
+          className={ classNames.focusedContainer }
+          onBlur={ this.props.onBlur }
+        >
+          { content }
+        </FocusZone>
+      ));
+  }
+}

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -7,7 +7,6 @@ import {
 } from '../../Utilities';
 import { FocusZone } from '../../FocusZone';
 import { IGrid, IGridProps, IGridStyleProps, IGridStyles } from './Grid.types';
-import { getStyles as getBaseStyles } from './Grid.styles';
 
 const getClassNames = classNamesFunction<IGridStyleProps, IGridStyles>();
 

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -29,7 +29,7 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
       getStyles
     } = this.props;
 
-    const classNames = getClassNames(getStyles!);
+    const classNames = getClassNames(getStyles!, { theme: this.props.theme! });
 
     // Array to store the cells in the correct row index
     let rowsOfItems: any[][] = toMatrix(items, columnCount);

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.styles.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.styles.ts
@@ -1,0 +1,13 @@
+import { IGridStyleProps, IGridStyles } from './Grid.types';
+
+export const getStyles = (props: IGridStyleProps): IGridStyles => {
+  return {
+    root: {
+      padding: 2,
+      outline: 'none'
+    },
+    tableCell: {
+      padding: 0
+    }
+  };
+};

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.test.tsx
@@ -24,7 +24,7 @@ describe('Grid', () => {
     let wrapper = shallow(
       <Grid
         items={ DEFAULT_ITEMS }
-        columnnCount={ 4 }
+        columnCount={ 4 }
         getStyles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         onRenderItem={ (item: any, index: number) => { return <DefaultButton role='gridcell'>item.text</DefaultButton>; } }

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.test.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 /* tslint:enable:no-unused-variable */
-import { Grid } from './Grid';
+import { GridBase } from './Grid.base';
 import { getStyles } from './Grid.styles';
 import { DefaultButton } from '../../Button';
 import { shallow } from 'enzyme';
@@ -22,7 +22,7 @@ describe('Grid', () => {
 
   it('Can render a grid with width of four', () => {
     let wrapper = shallow(
-      <Grid
+      <GridBase
         items={ DEFAULT_ITEMS }
         columnCount={ 4 }
         getStyles={ getStyles }
@@ -38,7 +38,7 @@ describe('Grid', () => {
   });
   it('Can render a grid with width of 2', () => {
     let wrapper = shallow(
-      <Grid
+      <GridBase
         items={ DEFAULT_ITEMS }
         columnCount={ 2 }
         getStyles={ getStyles }
@@ -54,7 +54,7 @@ describe('Grid', () => {
   });
   it('Can render a grid with posInSet and setSize', () => {
     let wrapper = shallow(
-      <Grid
+      <GridBase
         items={ DEFAULT_ITEMS }
         columnCount={ 2 }
         getStyles={ getStyles }

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 /* tslint:enable:no-unused-variable */
 import { Grid } from './Grid';
+import { getStyles } from './Grid.styles';
 import { DefaultButton } from '../../Button';
 import { shallow } from 'enzyme';
 
@@ -23,7 +24,8 @@ describe('Grid', () => {
     let wrapper = shallow(
       <Grid
         items={ DEFAULT_ITEMS }
-        columnCount={ 4 }
+        columnnCount={ 4 }
+        getStyles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         onRenderItem={ (item: any, index: number) => { return <DefaultButton role='gridcell'>item.text</DefaultButton>; } }
       />
@@ -39,6 +41,7 @@ describe('Grid', () => {
       <Grid
         items={ DEFAULT_ITEMS }
         columnCount={ 2 }
+        getStyles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         onRenderItem={ (item: any, index: number) => { return <DefaultButton role='gridcell'>item.text</DefaultButton>; } }
       />
@@ -54,6 +57,7 @@ describe('Grid', () => {
       <Grid
         items={ DEFAULT_ITEMS }
         columnCount={ 2 }
+        getStyles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         onRenderItem={ (item: any, index: number) => { return <DefaultButton role='gridcell'>item.text</DefaultButton>; } }
         positionInSet={ 1 }

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
@@ -1,85 +1,12 @@
 import * as React from 'react';
 import {
-  BaseComponent,
-  getId,
-  toMatrix,
-  classNamesFunction
+  styled
 } from '../../Utilities';
-import { FocusZone } from '../../FocusZone';
-import { IGrid, IGridProps, IGridStyleProps, IGridStyles } from './Grid.types';
-import { getStyles as getBaseStyles } from './Grid.styles';
+import { GridBase } from './Grid.base';
+import { IGridProps } from './Grid.types';
+import { getStyles } from './Grid.styles';
 
-const getClassNames = classNamesFunction<IGridStyleProps, IGridStyles>();
-
-export class Grid extends BaseComponent<IGridProps, {}> implements IGrid {
-
-  private _id: string;
-
-  constructor(props: IGridProps) {
-    super(props);
-    this._id = getId();
-  }
-
-  public render() {
-    let {
-      items,
-      columnCount,
-      onRenderItem,
-      positionInSet,
-      setSize,
-    } = this.props;
-
-    let getStyles = this.props.getStyles || getBaseStyles;
-    const classNames = getClassNames(getStyles!);
-
-    // Array to store the cells in the correct row index
-    let rowsOfItems: any[][] = toMatrix(items, columnCount);
-
-    let content = (
-      <table
-        id={ this._id }
-        role={ 'grid' }
-        aria-posinset={ positionInSet }
-        aria-setsize={ setSize }
-        className={ classNames.root }
-      >
-        <tbody>
-          {
-            rowsOfItems.map((rows: any[], rowIndex) => {
-              return (
-                <tr
-                  role={ 'row' }
-                  key={ this._id + '-' + rowIndex + '-row' }
-                >
-                  { rows.map((cell, cellIndex) => {
-                    return (
-                      <td
-                        role={ 'presentation' }
-                        key={ this._id + '-' + cellIndex + '-cell' }
-                        className={ classNames.tableCell }
-                      >
-                        { onRenderItem(cell, cellIndex) }
-                      </td>
-                    );
-                  }) }
-                </tr>
-              );
-            })
-          }
-        </tbody>
-      </table >
-    );
-
-    // Create the table/grid
-    return (
-      this.props.doNotContainWithinFocusZone ? content : (
-        <FocusZone
-          isCircularNavigation={ this.props.shouldFocusCircularNavigate }
-          className={ classNames.focusedContainer }
-          onBlur={ this.props.onBlur }
-        >
-          { content }
-        </FocusZone>
-      ));
-  }
-}
+export const Grid = styled(
+  GridBase,
+  getStyles
+);

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
@@ -3,7 +3,6 @@ import {
   BaseComponent,
   getId,
   toMatrix,
-  customizable,
   classNamesFunction
 } from '../../Utilities';
 import { FocusZone } from '../../FocusZone';
@@ -31,7 +30,7 @@ export class Grid extends BaseComponent<IGridProps, {}> implements IGrid {
     } = this.props;
 
     let getStyles = this.props.getStyles || getBaseStyles;
-    const classNames = getClassNames(getStyles!, { theme: this.props.theme! });
+    const classNames = getClassNames(getStyles!);
 
     // Array to store the cells in the correct row index
     let rowsOfItems: any[][] = toMatrix(items, columnCount);

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
@@ -2,11 +2,17 @@ import * as React from 'react';
 import {
   BaseComponent,
   getId,
-  toMatrix
+  toMatrix,
+  customizable,
+  classNamesFunction
 } from '../../Utilities';
 import { FocusZone } from '../../FocusZone';
-import { IGridProps } from './Grid.types';
+import { IGridProps, IGridStyleProps, IGridStyles } from './Grid.types';
+import { getStyles as getBaseStyles } from './Grid.styles';
 
+const getClassNames = classNamesFunction<IGridStyleProps, IGridStyles>();
+
+@customizable('Grid', ['theme'])
 export class Grid extends BaseComponent<IGridProps, {}> {
 
   private _id: string;
@@ -22,8 +28,11 @@ export class Grid extends BaseComponent<IGridProps, {}> {
       columnCount,
       onRenderItem,
       positionInSet,
-      setSize
+      setSize,
     } = this.props;
+
+    let getStyles = this.props.getStyles || getBaseStyles;
+    const classNames = getClassNames(getStyles!, { theme: this.props.theme! });
 
     // Array to store the cells in the correct row index
     let rowsOfItems: any[][] = toMatrix(items, columnCount);
@@ -34,7 +43,7 @@ export class Grid extends BaseComponent<IGridProps, {}> {
         role={ 'grid' }
         aria-posinset={ positionInSet }
         aria-setsize={ setSize }
-        style={ { padding: '2px', outline: 'none' } }
+        className={ classNames.root }
       >
         <tbody>
           {
@@ -49,7 +58,7 @@ export class Grid extends BaseComponent<IGridProps, {}> {
                       <td
                         role={ 'presentation' }
                         key={ this._id + '-' + cellIndex + '-cell' }
-                        style={ { padding: '0px' } }
+                        className={ classNames.tableCell }
                       >
                         { onRenderItem(cell, cellIndex) }
                       </td>
@@ -60,7 +69,7 @@ export class Grid extends BaseComponent<IGridProps, {}> {
             })
           }
         </tbody>
-      </table>
+      </table >
     );
 
     // Create the table/grid
@@ -68,7 +77,7 @@ export class Grid extends BaseComponent<IGridProps, {}> {
       this.props.doNotContainWithinFocusZone ? content : (
         <FocusZone
           isCircularNavigation={ this.props.shouldFocusCircularNavigate }
-          className={ this.props.containerClassName }
+          className={ classNames.focusedContainer }
           onBlur={ this.props.onBlur }
         >
           { content }

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
@@ -7,13 +7,13 @@ import {
   classNamesFunction
 } from '../../Utilities';
 import { FocusZone } from '../../FocusZone';
-import { IGridProps, IGridStyleProps, IGridStyles } from './Grid.types';
+import { IGrid, IGridProps, IGridStyleProps, IGridStyles } from './Grid.types';
 import { getStyles as getBaseStyles } from './Grid.styles';
 
 const getClassNames = classNamesFunction<IGridStyleProps, IGridStyles>();
 
 @customizable('Grid', ['theme'])
-export class Grid extends BaseComponent<IGridProps, {}> {
+export class Grid extends BaseComponent<IGridProps, {}> implements IGrid {
 
   private _id: string;
 

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
@@ -12,7 +12,6 @@ import { getStyles as getBaseStyles } from './Grid.styles';
 
 const getClassNames = classNamesFunction<IGridStyleProps, IGridStyles>();
 
-@customizable('Grid', ['theme'])
 export class Grid extends BaseComponent<IGridProps, {}> implements IGrid {
 
   private _id: string;

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -74,7 +74,6 @@ export interface IGridStyleProps { }
  * Styles for the Grid Component.
  */
 export interface IGridStyles {
-
   /**
    * Style for the table container of a grid.
    */

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -39,6 +39,8 @@ export interface IGridProps extends React.Props<Grid> {
 
   /**
    * Optional, class name for the FocusZone container for the grid
+   * @deprecated Use getStyles and IGridStyles to define a styling for the focus zone container with
+   * focusedContainer property.
    */
   containerClassName?: string;
 
@@ -58,22 +60,12 @@ export interface IGridProps extends React.Props<Grid> {
   setSize?: number;
 
   /**
- * Theme to apply to the component.
- */
-  theme?: ITheme;
-
-  /**
  * Optional styles for the component.
  */
   getStyles?: IStyleFunction<IGridStyleProps, IGridStyles>;
 }
 
-export interface IGridStyleProps {
-  /**
-   * Theme to apply to the container
-   */
-  theme: ITheme;
-}
+export interface IGridStyleProps { }
 
 export interface IGridStyles {
   root: IStyle;

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -65,10 +65,28 @@ export interface IGridProps extends React.Props<Grid> {
   getStyles?: IStyleFunction<IGridStyleProps, IGridStyles>;
 }
 
+/**
+ * Properties required to build the styles for the grid component.
+ */
 export interface IGridStyleProps { }
 
+/**
+ * Styles for the Grid Component.
+ */
 export interface IGridStyles {
+
+  /**
+   * Style for the table container of a grid.
+   */
   root: IStyle;
+
+  /**
+   * Style for the table cells of the grid.
+   */
   tableCell: IStyle;
+
+  /**
+   * Optional, style for the FocusZone container for the grid
+   */
   focusedContainer?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -1,11 +1,14 @@
 import { IStyle, ITheme } from '../../Styling';
 import { IStyleFunction } from '../../Utilities';
+import { Grid } from './Grid';
 
-export interface IGridProps {
+export interface IGrid { }
+
+export interface IGridProps extends React.Props<Grid> {
   /**
    * Gets the component ref.
    */
-  componentRef?: () => void;
+  componentRef?: (componentRef?: IGrid) => void;
 
   /**
    * The items to turn into a grid

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -1,3 +1,6 @@
+import { IStyle, ITheme } from '../../Styling';
+import { IStyleFunction } from '../../Utilities';
+
 export interface IGridProps {
   /**
    * Gets the component ref.
@@ -50,4 +53,27 @@ export interface IGridProps {
    * The optional size of the parent set (size of parent menu, for example)
    */
   setSize?: number;
+
+  /**
+ * Theme to apply to the component.
+ */
+  theme?: ITheme;
+
+  /**
+ * Optional styles for the component.
+ */
+  getStyles?: IStyleFunction<IGridStyleProps, IGridStyles>;
+}
+
+export interface IGridStyleProps {
+  /**
+   * Theme to apply to the container
+   */
+  theme: ITheme;
+}
+
+export interface IGridStyles {
+  root: IStyle;
+  tableCell: IStyle;
+  focusedContainer?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -1,10 +1,9 @@
 import { IStyle, ITheme } from '../../Styling';
 import { IStyleFunction } from '../../Utilities';
-import { Grid } from './Grid';
 
 export interface IGrid { }
 
-export interface IGridProps extends React.Props<Grid> {
+export interface IGridProps {
   /**
    * Gets the component ref.
    */

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -59,6 +59,11 @@ export interface IGridProps {
   setSize?: number;
 
   /**
+   * Theme to apply to the component.
+   */
+  theme?: ITheme;
+
+  /**
  * Optional styles for the component.
  */
   getStyles?: IStyleFunction<IGridStyleProps, IGridStyles>;
@@ -67,7 +72,12 @@ export interface IGridProps {
 /**
  * Properties required to build the styles for the grid component.
  */
-export interface IGridStyleProps { }
+export interface IGridStyleProps {
+  /**
+  * Theme to apply to the grid
+  */
+  theme: ITheme;
+}
 
 /**
  * Styles for the Grid Component.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

These changes is converting the grid component to getStyles, to enable customization of grid styling.
