### PR TITLE
Fixed persona import paths

### DIFF
--- a/common/changes/office-ui-fabric-react/law-fix_amdgraph_2017-12-21-00-00.json
+++ b/common/changes/office-ui-fabric-react/law-fix_amdgraph_2017-12-21-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed persona import paths",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.tsx
@@ -7,7 +7,7 @@ import { IActivityItemProps, IActivityItemStyles } from './ActivityItem.types';
 import { mergeStyles } from '../../Styling';
 import { IActivityItemClassNames, getClassNames } from './ActivityItem.classNames';
 import { getStyles } from './ActivityItem.styles';
-import { PersonaSize, PersonaCoin, IPersonaProps} from '../Persona';
+import { PersonaSize, PersonaCoin, IPersonaProps } from '../../Persona';
 
 export class ActivityItem extends BaseComponent<IActivityItemProps, {}> {
   private _classNames: IActivityItemClassNames;

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IStyle } from '../../Styling';
 import { IRenderFunction } from '../../Utilities';
-import { IPersonaProps } from '../Persona';
+import { IPersonaProps } from '../../Persona';
 
 // Please keep alphabetized
 export interface IActivityItemProps extends React.AllHTMLAttributes<HTMLElement> {

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
@@ -7,7 +7,7 @@ import { mount, shallow, ReactWrapper } from 'enzyme';
 import { setRTL } from '../../Utilities';
 import { Facepile } from './Facepile';
 import { IFacepilePersona, OverflowButtonType } from './Facepile.types';
-import { PersonaSize } from '../Persona';
+import { PersonaSize } from '../../Persona';
 import { PersonaCoin } from '../../PersonaCoin';
 import { TestImages } from '../../common/TestImages';
 import { findNodes, expectOne, expectMissing } from '../../common/testUtilities';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Was getting AMDGraph errors when trying to import a directory path as my build tooling was unable to retrieve the index file of a directory.
