### PR TITLE
ExpandingCard: Fix callout opacity

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-calloutopacity-inedge_2017-12-21-00-33.json
+++ b/common/changes/office-ui-fabric-react/fix-calloutopacity-inedge_2017-12-21-00-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout: Fix opacity when class name has animation that involves opacity",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -30,7 +30,10 @@ import { AnimationClassNames, mergeStyles } from '../../Styling';
 const styles: any = stylesImport;
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
-const OFF_SCREEN_STYLE = { opacity: 0 };
+// Microsoft Edge will overwrite inline styles if there is an animation pertaining to that style.
+// To help ensure that edge will respect the offscreen style opacity
+// filter needs to be added as an additional way to set opacity.
+const OFF_SCREEN_STYLE = { opacity: 0, filter: 'opacity(0)' };
 const BORDER_WIDTH: number = 1;
 const SLIDE_ANIMATIONS: { [key: number]: string; } = {
   [RectangleEdge.top]: 'slideUpIn20',

--- a/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Callout renders Callout correctly 1`] = `
     className="ms-Callout"
     style={
       Object {
+        "filter": "opacity(0)",
         "opacity": 0,
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Edge overwrites inline styles with keyframe/animation styles, to get around this problem I've added another opacity 0 to ensure that the callout will not have opacity, even when there is an animation that has opacity.

#### Focus areas to test

(optional)
