### PR TITLE
Spinbutton value check

### DIFF
--- a/common/changes/office-ui-fabric-react/spinbutton-value-check_2017-12-22-01-39.json
+++ b/common/changes/office-ui-fabric-react/spinbutton-value-check_2017-12-22-01-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SpinButton: Fix falsey check for value so custom handlers work even if value is 0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -645,4 +645,3 @@ describe('SpinButton', () => {
     expect(onIncrement).toBeCalled();
   });
 });
-

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -617,4 +617,32 @@ describe('SpinButton', () => {
     let newCurrentValue = inputDOM.value;
     expect(currentValue).toEqual(newCurrentValue);
   });
+
+  it('should fire custom handlers even when value prop is 0', () => {
+    const val: string = 0 as any;
+    const onIncrement: jest.Mock = jest.fn();
+
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <SpinButton
+        label='label'
+        value={ val }
+        onIncrement={ onIncrement }
+      />
+    );
+
+    // Assert on the input element.
+    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-UpButton')[0];
+
+    ReactTestUtils.Simulate.mouseDown(buttonDOM,
+      {
+        type: 'mousedown',
+        clientX: 0,
+        clientY: 0
+      }
+    );
+
+    expect(onIncrement).toBeCalled();
+  });
 });
+

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -91,7 +91,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
     this._inputId = getId('input');
     this._spinningByMouse = false;
 
-    if (!props.defaultValue && props.value) {
+    if (!props.defaultValue && props.value !== undefined) {
       this._onValidate = props.onValidate;
       this._onIncrement = props.onIncrement;
       this._onDecrement = props.onDecrement;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3340
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Change falsey check of `props.value` to check for `undefined` so that when value of `0` is passed in, custom handlers work instead of using default handlers.