### PR TITLE
[ExpandingCard] fix for null content ref

### DIFF
--- a/common/changes/office-ui-fabric-react/magellan-fix_hovercard_2017-12-22-19-38.json
+++ b/common/changes/office-ui-fabric-react/magellan-fix_hovercard_2017-12-22-19-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Hovercard: Check for null content ref",
+      "comment": "Hovercard: Changed content keydown listener to element event binding",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/magellan-fix_hovercard_2017-12-22-19-38.json
+++ b/common/changes/office-ui-fabric-react/magellan-fix_hovercard_2017-12-22-19-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fix hovercard ref error",
+      "comment": "Hovercard: Check for null content ref",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/magellan-fix_hovercard_2017-12-22-19-38.json
+++ b/common/changes/office-ui-fabric-react/magellan-fix_hovercard_2017-12-22-19-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix hovercard ref error",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.tsx
@@ -31,8 +31,6 @@ export class ExpandingCard extends BaseComponent<IExpandingCardProps, IExpanding
     gapSpace: 0
   };
 
-  private _expandingCard: HTMLElement;
-
   private _styles: IExpandingCardStyles;
   // tslint:disable-next-line:no-unused-variable
   private _callout: ICallout;
@@ -49,10 +47,6 @@ export class ExpandingCard extends BaseComponent<IExpandingCardProps, IExpanding
 
   public componentDidMount() {
     this._checkNeedsScroll();
-
-    if (this.props.trapFocus) {
-      this._events.on(this._expandingCard, 'keydown', this._onDismiss);
-    }
   }
 
   public componentWillUnmount() {
@@ -73,9 +67,9 @@ export class ExpandingCard extends BaseComponent<IExpandingCardProps, IExpanding
 
     const content = (
       <div
-        ref={ this._resolveRef('_expandingCard') }
         onMouseEnter={ this.props.onEnter }
         onMouseLeave={ this.props.onLeave }
+        onKeyDown={ this._onKeyDown }
       >
         { this._onRenderCompactCard() }
         { this._onRenderExpandedCard() }
@@ -110,12 +104,15 @@ export class ExpandingCard extends BaseComponent<IExpandingCardProps, IExpanding
   }
 
   @autobind
-  private _onDismiss(ev: MouseEvent): void {
-    if (ev.type === 'keydown' && (ev.which !== KeyCodes.escape)) {
-      return;
-    } else {
+  private _onKeyDown(ev: React.KeyboardEvent<HTMLElement>): void {
+    if (ev.which === KeyCodes.escape) {
       this.props.onLeave && this.props.onLeave(ev);
     }
+  }
+
+  @autobind
+  private _onDismiss(ev: MouseEvent): void {
+    this.props.onLeave && this.props.onLeave(ev);
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3604
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The `_expandingCard` ref was being passed null and the ExpandingCard was unable to bind to the `keydown` event of a null element. The keydown handler was moved to a component event handler.

#### Focus areas to test

Needs to make sure that this actually works and didn't cause an accessibility regression.
