### PR TITLE
DatePicker: Prevent calendar from opening if disabled

### DIFF
--- a/common/changes/office-ui-fabric-react/datepicker-disabled_2017-12-22-22-07.json
+++ b/common/changes/office-ui-fabric-react/datepicker-disabled_2017-12-22-22-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Datepicker: Fix so calendar doesn't open when clicking icon when DatePicker is disabled",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.scss
@@ -34,9 +34,12 @@
 // Insert a calendar icon over the date field.
 .eventWithLabel {
   @include ms-DatePicker-event();
-  pointer-events: initial;
-  cursor: pointer;
   bottom:5px;
+
+  &:not(.ms-DatePicker-disabled) {
+    pointer-events: initial;
+    cursor: pointer;
+  }
 }
 
 .eventWithoutLabel {

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.scss
@@ -36,7 +36,7 @@
   @include ms-DatePicker-event();
   bottom:5px;
 
-  &:not(.ms-DatePicker-disabled) {
+  &:not(.msDatePickerDisabled) {
     pointer-events: initial;
     cursor: pointer;
   }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -14,6 +14,19 @@ describe('DatePicker', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should not open DatePicker when disabled, no label', () => {
+    let wrapper = mount(<DatePicker disabled />);
+    wrapper.find('i').simulate('click');
+
+    expect(wrapper.state('isDatePickerShown')).toBe(false);
+  });
+
+  it('should not open DatePicker when disabled, with label', () => {
+    let wrapper = mount(<DatePicker disabled label='label' />);
+    wrapper.find('i').simulate('click');
+    expect(wrapper.state('isDatePickerShown')).toBe(false);
+  });
+
   describe('when Calendar properties are not specified', () => {
     const datePicker = shallow(<DatePicker />);
     datePicker.setState({ isDatePickerShown: true });

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -210,7 +210,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
               iconName: 'Calendar',
               onClick: this._onIconClick,
               className: css(
-                disabled && styles['ms-DatePicker-disabled'],
+                disabled && styles.msDatePickerDisabled,
                 label ? 'ms-DatePicker-event--with-label' : 'ms-DatePicker-event--without-label',
                 label ? styles.eventWithLabel : styles.eventWithoutLabel
               )

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -210,6 +210,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
               iconName: 'Calendar',
               onClick: this._onIconClick,
               className: css(
+                disabled && styles['ms-DatePicker-disabled'],
                 label ? 'ms-DatePicker-event--with-label' : 'ms-DatePicker-event--without-label',
                 label ? styles.eventWithLabel : styles.eventWithoutLabel
               )
@@ -342,7 +343,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
 
   @autobind
   private _onTextFieldClick(ev: React.MouseEvent<HTMLElement>) {
-    if (!this.state.isDatePickerShown) {
+    if (!this.state.isDatePickerShown && !this.props.disabled) {
       this._showDatePickerPopup();
     } else {
       if (this.props.allowTextInput) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3611
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixed DatePicker so the calendar doesn't open when clicking the icon if `disabled={true}`. Previously, if the DatePicker had a label, the calendar would open even when disabled. [Repro](https://codepen.io/erichdev/pen/ZvpPrP)

Note: I approached the fix in two ways: 1) check for `this.props.disabled` in the onClick handler, and 2) apply the property `pointer-events: initial` _only_ if the DatePicker is not disabled. The latter was the root cause of the bug.

I'm not sure what the original intent was for adding the `pointer-events` property -- quick testing shows DatePicker still works without it -- but I didn't want to remove it in case there were edge cases I was missing. I also still added the `this.props.disabled` check to make this more testable.  

