### PR TITLE
[examplecard] no focus

### DIFF
--- a/common/changes/@uifabric/example-app-base/magellan-examplecard_no_focus_2017-12-22-23-46.json
+++ b/common/changes/@uifabric/example-app-base/magellan-examplecard_no_focus_2017-12-22-23-46.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/example-app-base",
-      "comment": "Disabled focus on the examplecard",
+      "comment": "ExampleCard: Disabled focus on the container.",
       "type": "patch"
     }
   ],

--- a/common/changes/@uifabric/example-app-base/magellan-examplecard_no_focus_2017-12-22-23-46.json
+++ b/common/changes/@uifabric/example-app-base/magellan-examplecard_no_focus_2017-12-22-23-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Disabled focus on the examplecard",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "law@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -69,6 +69,7 @@ export class ExampleCard extends React.Component<IExampleCardProps, IExampleCard
             isRightAligned && ' is-right-aligned'
           ) }
           data-is-scrollable='true'
+          tabIndex={ -1 }
         >
           { children }
         </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3626
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Setting the tabindex to -1 of the `ExampleCard-example` div makes it unfocusable in Firefox only.
Other browsers are unaffected.
