### PR TITLE
Added contextMenuClassName and onContextMenuDismiss to ICommandBarProps

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2017-12-23-04-49.json
+++ b/common/changes/office-ui-fabric-react/master_2017-12-23-04-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added contextMenuClassName and onContextMenuDismiss to ICommandBarProps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "adtran@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -403,8 +403,8 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
 
   @autobind
   private _onContextMenuDismiss(ev?: any) {
-    const { onContextMenuDismiss  } = this.props;
-    
+    const { onContextMenuDismiss } = this.props;
+
     if (!ev || !ev.relatedTarget || !this.refs.commandSurface.contains(ev.relatedTarget as HTMLElement)) {
       const { contextualMenuProps } = this.state;
 

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -82,7 +82,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
   }
 
   public render() {
-    const { isSearchBoxVisible, searchPlaceholderText, className } = this.props;
+    const { isSearchBoxVisible, searchPlaceholderText, className, contextMenuClassName } = this.props;
     const { renderedItems, contextualMenuProps, expandedMenuItemKey, expandedMenuId, renderedOverflowItems, contextualMenuTarget, renderedFarItems } = this.state;
     let searchBox;
 
@@ -146,7 +146,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
         </FocusZone>
         { (contextualMenuProps) ?
           (<ContextualMenu
-            className={ css('ms-CommandBar-menuHost') }
+            className={ css('ms-CommandBar-menuHost', contextMenuClassName) }
             directionalHint={ DirectionalHint.bottomAutoEdge }
             { ...contextualMenuProps }
             target={ contextualMenuTarget }
@@ -372,7 +372,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
   private _onItemClick(item: IContextualMenuItem): (ev: React.MouseEvent<HTMLButtonElement>) => void {
     return (ev: React.MouseEvent<HTMLButtonElement>): void => {
       if (item.key === this.state.expandedMenuItemKey || !hasSubmenuItems(item)) {
-        this._onContextMenuDismiss();
+        this._onContextMenuDismiss(ev);
       } else {
         this.setState({
           expandedMenuId: ev.currentTarget.id,
@@ -390,7 +390,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
   @autobind
   private _onOverflowClick(ev: React.MouseEvent<HTMLButtonElement>) {
     if (this.state.expandedMenuItemKey === OVERFLOW_KEY) {
-      this._onContextMenuDismiss();
+      this._onContextMenuDismiss(ev);
     } else {
       this.setState({
         expandedMenuId: ev.currentTarget.id,
@@ -404,10 +404,14 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
   @autobind
   private _onContextMenuDismiss(ev?: any) {
     if (!ev || !ev.relatedTarget || !this.refs.commandSurface.contains(ev.relatedTarget as HTMLElement)) {
-      let { contextualMenuProps } = this.state;
+      const { contextualMenuProps } = this.state;
+      const { onContextMenuDismiss  } = this.props;
 
       if (contextualMenuProps && contextualMenuProps.onDismiss) {
         this.state.contextualMenuProps!.onDismiss!(ev);
+      }
+      if (onContextMenuDismiss) {
+        onContextMenuDismiss(ev);
       }
 
       this.setState({

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -403,15 +403,13 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
 
   @autobind
   private _onContextMenuDismiss(ev?: any) {
+    const { onContextMenuDismiss  } = this.props;
+    
     if (!ev || !ev.relatedTarget || !this.refs.commandSurface.contains(ev.relatedTarget as HTMLElement)) {
       const { contextualMenuProps } = this.state;
-      const { onContextMenuDismiss  } = this.props;
 
       if (contextualMenuProps && contextualMenuProps.onDismiss) {
         this.state.contextualMenuProps!.onDismiss!(ev);
-      }
-      if (onContextMenuDismiss) {
-        onContextMenuDismiss(ev);
       }
 
       this.setState({
@@ -422,6 +420,10 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     } else {
       ev.stopPropagation();
       ev.preventDefault();
+    }
+
+    if (onContextMenuDismiss) {
+      onContextMenuDismiss(ev);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -42,6 +42,16 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   elipisisAriaLabel?: string;
 
   /**
+   * Additional css class to apply to the command bar's context menu
+   */
+  contextMenuClassName?: string;
+
+  /**
+   * Optional callback when the ContextualMenu tries to close
+   */
+  onContextMenuDismiss?: (ev?: any) => void;
+
+  /**
    * Items to render on the right side (or left, in RTL).
    */
   farItems?: IContextualMenuItem[];


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3630
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Allow custom class name for the CommandBar's context menu and an optional callback for its onDismiss event

