### PR TITLE
Minor visual alignment for FolderCover

### DIFF
--- a/common/changes/@uifabric/experiments/folder-cover_2017-12-27-21-49.json
+++ b/common/changes/@uifabric/experiments/folder-cover_2017-12-27-21-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Minor visual alignment for FolderCover text",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -85,19 +85,12 @@
   &,
   &.isSmall {
     font-size: $ms-font-size-s;
+    margin-bottom: 3px;
   }
 
   .isLarge & {
     font-size: $ms-font-size-m;
-  }
-
-  &,
-  &.isDefault {
-    margin-bottom: 8px;
-  }
-
-  .isMedia & {
-    margin-bottom: 4px;
+    margin-bottom: 3px;
   }
 }
 
@@ -111,19 +104,11 @@
   &,
   &.isSmall {
     font-size: $ms-font-size-l;
+    margin-bottom: 3px;
   }
 
   .isLarge & {
     font-size: $ms-font-size-xl;
-  }
-
-
-  &,
-  &.isDefault {
-    margin-bottom: 8px;
-  }
-
-  .isMedia & {
-    margin-bottom: 4px;
+    margin-bottom: 3px;
   }
 }

--- a/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
+++ b/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
@@ -4,7 +4,6 @@ import { FolderCover, getFolderCoverLayout, renderFolderCoverWithLayout } from '
 import { IFolderCoverProps } from '../FolderCover.types';
 import { ISize, fitContentToBounds } from '../../../Utilities';
 import { SharedSignal } from '../../signals/Signals';
-import { lorem } from '@uifabric/example-app-base';
 
 interface IFolderCoverWithImageProps extends IFolderCoverProps {
   originalImageSize: ISize;
@@ -76,7 +75,8 @@ export class FolderCoverBasicExample extends React.Component<{}, {}> {
           }
           folderCoverSize='large'
           folderCoverType='media'
-          metadata={ lorem(5) }
+          metadata={ 20 }
+          signal={ <SharedSignal /> }
         />
         <h3>Small Media Cover</h3>
         <FolderCoverWithImage


### PR DESCRIPTION
### Overview

This change brings `FolderCover` more inline with the design specification. The alignment of the metadata text displayed on a `FolderCover` has been adjusted for clarity.