### PR TITLE
DatePicker: Add an initial picker date property

### DIFF
--- a/common/changes/office-ui-fabric-react/alebet-initialPickerDate_2017-12-28-21-56.json
+++ b/common/changes/office-ui-fabric-react/alebet-initialPickerDate_2017-12-28-21-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker: Add an initialPickerDate property",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "alexbettadapur@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -107,6 +107,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       return null;
     },
     firstDayOfWeek: DayOfWeek.Sunday,
+    initialPickerDate: new Date(),
     isRequired: false,
     isMonthPickerVisible: true,
     showMonthPickerAsOverlay: false,
@@ -173,6 +174,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       firstDayOfWeek,
       strings,
       label,
+      initialPickerDate,
       isRequired,
       disabled,
       ariaLabel,
@@ -240,7 +242,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
               isMonthPickerVisible={ this.props.isMonthPickerVisible }
               showMonthPickerAsOverlay={ this.props.showMonthPickerAsOverlay }
               today={ this.props.today }
-              value={ selectedDate }
+              value={ selectedDate || initialPickerDate }
               firstDayOfWeek={ firstDayOfWeek }
               strings={ strings! }
               highlightCurrentMonth={ this.props.highlightCurrentMonth }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -164,6 +164,11 @@ export interface IDatePickerProps extends React.Props<DatePicker> {
    * The maximum allowable date.
    */
   maxDate?: Date;
+
+  /**
+   * The initially highlighted date in the calendar picker
+   */
+  initialPickerDate?: Date;
 }
 
 export interface IDatePickerStrings {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3644 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add an initialPickerDate property, which sets the Calendar to show the provided date as the selected date.

This is distinct from the selectedDate state in the DatePicker, which will take precedence over this property.

Open to other suggestions on the property name

