### PR TITLE
Filetype icon registration options

### DIFF
--- a/common/changes/@uifabric/file-type-icons/filetype-icon-registration-options_2018-01-02-11-57.json
+++ b/common/changes/@uifabric/file-type-icons/filetype-icon-registration-options_2018-01-02-11-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Adds possibility to pass options for icon registration when initializing file type icons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { registerIcons } from '@uifabric/styling/lib/index';
+import { registerIcons, IIconOptions } from '@uifabric/styling/lib/index';
 import { FileTypeIconMap } from './FileTypeIconMap';
 
 const PNG_SUFFIX = '_png';
@@ -8,13 +8,13 @@ const SVG_SUFFIX = '_svg';
 const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/';
 const ICON_SIZES: number[] = [16, 20, 32, 40, 48, 96];
 
-export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL): void {
+export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {
   ICON_SIZES.forEach((size: number) => {
-    _initializeIcons(baseUrl, size);
+    _initializeIcons(baseUrl, size, options);
   });
 }
 
-function _initializeIcons(baseUrl: string, size: number): void {
+function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIconOptions>): void {
   const iconTypes: string[] = Object.keys(FileTypeIconMap);
   const fileTypeIcons: { [key: string]: JSX.Element } = {};
 
@@ -58,5 +58,5 @@ function _initializeIcons(baseUrl: string, size: number): void {
       overflow: 'hidden'
     },
     icons: fileTypeIcons
-  });
+  }, options);
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 (no existing issue)
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds support for passing the icon registration options when registering the file type icons. This makes it consistent with the regular icons (See https://github.com/OfficeDev/office-ui-fabric-react/pull/3477)

#### Focus areas to test

(optional)
