### PR TITLE
FloatingPicker: Throttle search

### DIFF
--- a/common/changes/@uifabric/experiments/throttleSearch_2018-01-02-21-14.json
+++ b/common/changes/@uifabric/experiments/throttleSearch_2018-01-02-21-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add search throttle to floating picker",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "amyngu@microsoft.com"
+}

--- a/packages/experiments/src/components/ExtendedPicker/BaseExtendedPicker.scss
+++ b/packages/experiments/src/components/ExtendedPicker/BaseExtendedPicker.scss
@@ -21,4 +21,8 @@
   outline: none;
   padding: 0 6px 0px;
   margin: 1px;
+
+  &::-ms-clear {
+    display: none;
+  }
 }

--- a/packages/experiments/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
+++ b/packages/experiments/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
@@ -29,7 +29,8 @@ const suggestionProps: IBasePickerSuggestionsProps = {
   loadingText: 'Loading',
   showRemoveButtons: true,
   suggestionsAvailableAlertText: 'People Picker Suggestions available',
-  suggestionsContainerAriaLabel: 'Suggested contacts'
+  suggestionsContainerAriaLabel: 'Suggested contacts',
+  searchForMoreText: 'Search more',
 };
 
 // tslint:disable-next-line:no-any

--- a/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -39,7 +39,6 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
   protected loadingTimer: number | undefined;
   // tslint:disable-next-line:no-any
   protected currentPromise: PromiseLike<any>;
-  protected timer: number | undefined;
 
   constructor(basePickerProps: P) {
     super(basePickerProps);
@@ -97,6 +96,8 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
 
   public componentDidMount(): void {
     this._bindToInputElement();
+
+    this._onResolveSuggestions = this._async.debounce(this._onResolveSuggestions, this.props.resolveDelay)
   }
 
   public componentDidUpdate(): void {
@@ -203,19 +204,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
       (this.props.onInputChanged as (filter: string) => void)(updatedValue);
     }
 
-    if (this.props.resolveDelay) {
-      // If there is a resolve delay, clear the timer, if it is not null
-      if (this.timer) {
-        this._async.clearTimeout(this.timer);
-        this.timer = undefined;
-      }
-
-      // Set a timeout action to resolve the suggestions after the resolve delay time
-      this.timer = this._async.setTimeout(() => this._onResolveSuggestions(updatedValue), this.props.resolveDelay as number);
-    } else {
-      // If there is no resolve delay, resolve the suggestions immediately
-      this._onResolveSuggestions(updatedValue);
-    }
+    this._onResolveSuggestions(updatedValue);
   }
 
   protected updateSuggestionWithZeroState(): void {

--- a/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -97,7 +97,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
   public componentDidMount(): void {
     this._bindToInputElement();
 
-    this._onResolveSuggestions = this._async.debounce(this._onResolveSuggestions, this.props.resolveDelay)
+    this._onResolveSuggestions = this._async.debounce(this._onResolveSuggestions, this.props.resolveDelay);
   }
 
   public componentDidUpdate(): void {

--- a/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -200,7 +200,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
   protected updateValue(updatedValue: string): void {
     // Call onInputChanged
     if (this.props.onInputChanged) {
-      (this.props.onInputChanged as any)(updatedValue);
+      (this.props.onInputChanged as (filter: string) => void)(updatedValue);
     }
 
     if (this.props.resolveDelay) {

--- a/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.types.ts
+++ b/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.types.ts
@@ -44,8 +44,21 @@ export interface IBaseFloatingPickerProps<T> extends React.Props<any> {
   /**
    * A callback for what should happen when a person types text into the input.
    * Returns the already selected items so the resolver can filter them out.
+   * If used in conjunction with resolveDelay this will ony kick off after the delay throttle.
    */
   onResolveSuggestions: (filter: string, selectedItems?: T[]) => T[] | PromiseLike<T[]>;
+
+  /**
+   * A callback for when the input has been changed
+   */
+  onInputChanged?: (filtier: string) => void;
+
+  /**
+   * The delay time in ms before resolving suggestions, which is kicked off when input has been cahnged.
+   * e.g. If a second input change happens within the resolveDelay time, the timer will start over.
+   * Only until after the timer completes will onResolveSuggestions be called.
+   */
+  resolveDelay?: number;
 
   /**
    * A callback for when a suggestion is clicked

--- a/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.types.ts
+++ b/packages/experiments/src/components/FloatingPicker/BaseFloatingPicker.types.ts
@@ -51,7 +51,7 @@ export interface IBaseFloatingPickerProps<T> extends React.Props<any> {
   /**
    * A callback for when the input has been changed
    */
-  onInputChanged?: (filtier: string) => void;
+  onInputChanged?: (filter: string) => void;
 
   /**
    * The delay time in ms before resolving suggestions, which is kicked off when input has been cahnged.

--- a/packages/experiments/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
+++ b/packages/experiments/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
@@ -12,7 +12,7 @@ export const SuggestionItemNormal: (persona: IPersonaProps, suggestionProps?: IB
       <div className={ css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent) }>
         <Persona
           presence={ personaProps.presence !== undefined ? personaProps.presence : PersonaPresence.none }
-          size={ PersonaSize.small }
+          size={ PersonaSize.size40 }
           className={ css('ms-PeoplePicker-Persona', stylesImport.peoplePickerPersona) }
           showSecondaryText={ true }
           { ...personaProps }

--- a/packages/experiments/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
+++ b/packages/experiments/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
@@ -12,7 +12,7 @@ export const SuggestionItemNormal: (persona: IPersonaProps, suggestionProps?: IB
       <div className={ css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent) }>
         <Persona
           presence={ personaProps.presence !== undefined ? personaProps.presence : PersonaPresence.none }
-          size={ PersonaSize.size24 }
+          size={ PersonaSize.small }
           className={ css('ms-PeoplePicker-Persona', stylesImport.peoplePickerPersona) }
           showSecondaryText={ true }
           { ...personaProps }

--- a/packages/experiments/src/components/FloatingPicker/PeoplePicker/examples/FloatingPeoplePicker.Basic.Example.tsx
+++ b/packages/experiments/src/components/FloatingPicker/PeoplePicker/examples/FloatingPeoplePicker.Basic.Example.tsx
@@ -83,6 +83,7 @@ export class FloatingPeoplePickerTypesExample extends BaseComponent<{}, IPeopleP
         componentRef={ this._setComponentRef }
         onChange={ this._onPickerChange }
         inputElement={ this._inputElement }
+        resolveDelay={ 300 }
       />
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add mechanism to throttle searching for floating picker
- Add resolveDelay to allow consumer to add a delay on calling resolveSuggestions (to not burden services and not waste cycles on throw away searches)
