### PR TITLE
ContextualMenu: Added styling for disabled icons

### DIFF
--- a/common/changes/office-ui-fabric-react/magellan-disabledContextMenuIcon_2018-01-03-19-17.json
+++ b/common/changes/office-ui-fabric-react/magellan-disabledContextMenuIcon_2018-01-03-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Added styling for disabled icon\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -183,6 +183,10 @@ export const getItemClassNames = memoizeFunction((
       knownIcon && 'ms-ContextualMenu-iconColor ' && styles.iconColor,
       styles.icon,
       iconClassName,
+      disabled && [
+        'is-disabled',
+        styles.iconDisabled
+      ]
     ],
     checkmarkIcon: [
       'ms-ContextualMenu-checkmarkIcon',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -133,6 +133,9 @@ export const getMenuItemStyles = memoizeFunction((
         }
       }
     },
+    iconDisabled: {
+      color: semanticColors.disabledBodyText,
+    },
     checkmarkIcon: {
       color: semanticColors.bodySubtext,
       selectors: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

This may also be useful for representing the disabled state for an icon-only command.
![disable icon](https://user-images.githubusercontent.com/6496608/34535821-077c8004-f078-11e7-9afc-5ec13c6fc137.png)

