### PR TITLE
[SearchBox] onChange and flex layout fix for IE

### DIFF
--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -36,8 +36,10 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
   public constructor(props: ISearchBoxProps) {
     super(props);
 
+    this._latestValue = props.value || '';
+
     this.state = {
-      value: props.value || '',
+      value: this._latestValue,
       hasFocus: false,
       id: getId('SearchBox')
     };

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -133,9 +133,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         fontSize: 'inherit',
         color: palette.neutralPrimary,
         backgroundColor: 'transparent',
-        flexBasis: 0,
-        flexGrow: 1,
-        flexShrink: 1,
+        flex: '1 1 0px',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         // This padding forces the text placement to round up.

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -133,7 +133,9 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         fontSize: 'inherit',
         color: palette.neutralPrimary,
         backgroundColor: 'transparent',
-        flex: '1 1 0',
+        flexBasis: 0,
+        flexGrow: 1,
+        flexShrink: 1,
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         // This padding forces the text placement to round up.

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -78,7 +78,9 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
           box-shadow: none;
           box-sizing: border-box;
           color: #333333;
-          flex: 1 1 0;
+          flex-basis: 0;
+          flex-grow: 1;
+          flex-shrink: 1;
           font-family: inherit;
           font-size: inherit;
           font-weight: inherit;

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -78,9 +78,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
           box-shadow: none;
           box-sizing: border-box;
           color: #333333;
-          flex-basis: 0;
-          flex-grow: 1;
-          flex-shrink: 1;
+          flex: 1 1 0px;
           font-family: inherit;
           font-size: inherit;
           font-weight: inherit;

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.FullSize.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.FullSize.Example.tsx
@@ -8,6 +8,7 @@ export class SearchBoxFullSizeExample extends React.Component<any, any> {
         // tslint:disable:jsx-no-lambda
         onFocus={ () => console.log('onFocus called') }
         onBlur={ () => console.log('onBlur called') }
+        onChange={ () => console.log('onChange called') }
       />
     );
   }


### PR DESCRIPTION
#### Description of changes

Fixes two things for the SearchBox when running on IE:

- Layout issue causing the flex layout to break (the clear button was not right aligned)
- Focusing on the SearchBox caused onChange to be called, which is inconsistent with Chrome.