### PR TITLE
Contextual Menu empty submenu changes

### DIFF
--- a/common/changes/office-ui-fabric-react/keyou-empty-submenu-changes_2018-01-05-19-17.json
+++ b/common/changes/office-ui-fabric-react/keyou-empty-submenu-changes_2018-01-05-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Contextual Menu submenus that have no items will have chevron icon and call onMenuOpened",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.test.tsx
@@ -263,4 +263,57 @@ describe('CommandBar', () => {
       document.body.removeChild(renderContainer);
     }
   });
+
+  it('Command bar item shows chevron even if submenu has no items', () => {
+    const menuWithNoSubmenu: IContextualMenuItem[] = [
+      {
+        name: 'TestText 1',
+        key: 'TestKey1',
+        subMenuProps: {
+          items: []
+        }
+      },
+    ];
+
+    let renderedContent = ReactTestUtils.renderIntoDocument<CommandBar>(
+      <CommandBar
+        items={ menuWithNoSubmenu }
+      />
+    ) as React.Component<CommandBar, {}>;
+    let menuItem = (ReactDOM.findDOMNode(renderedContent) as HTMLElement).querySelector('button') as HTMLButtonElement;
+
+    expect(menuItem.querySelector('.ms-CommandBarItem-chevronDown')).not.toEqual(null);
+  });
+
+  it('Command bar item onMenuOpened is called even if submenu has no items', () => {
+    let subMenuOpened = false;
+
+    const onSubMenuOpened = (): void => {
+      subMenuOpened = true;
+    };
+
+    const menuWithEmptySubMenu: IContextualMenuItem[] = [
+      {
+        name: 'TestText 1',
+        key: 'TestKey1',
+        subMenuProps: {
+          items: [],
+          onMenuOpened: onSubMenuOpened
+        }
+      }
+    ];
+
+    let renderedContent = ReactTestUtils.renderIntoDocument<CommandBar>(
+      <CommandBar
+        items={ menuWithEmptySubMenu }
+      />
+    ) as React.Component<CommandBar, {}>;
+
+    let menuItem = (ReactDOM.findDOMNode(renderedContent) as HTMLElement).querySelector('button') as HTMLButtonElement;
+
+    ReactTestUtils.Simulate.click(menuItem);
+
+    expect(subMenuOpened).toEqual(true);
+  });
+
 });

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../Utilities';
 import { ICommandBar, ICommandBarProps, ICommandBarItemProps } from './CommandBar.types';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
-import { ContextualMenu, IContextualMenuProps, IContextualMenuItem, hasSubmenuItems } from '../../ContextualMenu';
+import { ContextualMenu, IContextualMenuProps, IContextualMenuItem, hasSubmenu } from '../../ContextualMenu';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import {
   Icon,
@@ -173,7 +173,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     }
 
     const itemKey = item.key || String(index);
-    const isLink = item.onClick || hasSubmenuItems(item);
+    const isLink = item.onClick || hasSubmenu(item);
     const className = css(
       isLink ? ('ms-CommandBarItem-link ' + styles.itemLink) : ('ms-CommandBarItem-text ' + styles.itemText),
       !item.name && ('ms-CommandBarItem--noName ' + styles.itemLinkIsNoName),
@@ -192,8 +192,8 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
           className={ className }
           onClick={ this._onItemClick(item) }
           data-command-key={ itemKey }
-          aria-haspopup={ hasSubmenuItems(item) }
-          aria-expanded={ hasSubmenuItems(item) ? expandedMenuItemKey === item.key : undefined }
+          aria-haspopup={ hasSubmenu(item) }
+          aria-expanded={ hasSubmenu(item) ? expandedMenuItemKey === item.key : undefined }
           role='menuitem'
           aria-label={ ariaLabel }
         >
@@ -205,7 +205,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
               { item.name }
             </span>
           ) }
-          { hasSubmenuItems(item) ? (
+          { hasSubmenu(item) ? (
             <Icon className={ css('ms-CommandBarItem-chevronDown', styles.itemChevronDown) } iconName='ChevronDown' />
           ) : (null) }
         </button>
@@ -218,7 +218,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
           className={ className }
           href={ item.href }
           data-command-key={ itemKey }
-          aria-haspopup={ hasSubmenuItems(item) }
+          aria-haspopup={ hasSubmenu(item) }
           role='menuitem'
           aria-label={ ariaLabel }
         >
@@ -239,7 +239,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
           id={ this._id + item.key }
           className={ className }
           data-command-key={ itemKey }
-          aria-haspopup={ hasSubmenuItems(item) }
+          aria-haspopup={ hasSubmenu(item) }
           aria-label={ ariaLabel }
         >
           { (hasIcon) ? this._renderIcon(item) : (null) }
@@ -371,7 +371,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
 
   private _onItemClick(item: IContextualMenuItem): (ev: React.MouseEvent<HTMLButtonElement>) => void {
     return (ev: React.MouseEvent<HTMLButtonElement>): void => {
-      if (item.key === this.state.expandedMenuItemKey || !hasSubmenuItems(item)) {
+      if (item.key === this.state.expandedMenuItemKey || !hasSubmenu(item)) {
         this._onContextMenuDismiss();
       } else {
         this.setState({

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -508,6 +508,59 @@ describe('ContextualMenu', () => {
     expect(menuMountedFirst).toEqual(false);
   });
 
+  it('Contextual Menu submenu has chrevron icon even if submenu has no items', () => {
+    const menuWithEmptySubMenu: IContextualMenuItem[] = [
+      {
+        name: 'TestText 1',
+        key: 'TestKey1',
+        subMenuProps: {
+          items: []
+        }
+      }
+    ];
+
+    ReactTestUtils.renderIntoDocument<ContextualMenu>(
+      <ContextualMenu
+        items={ menuWithEmptySubMenu }
+      />
+    );
+
+    let menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
+
+    expect(menuItem.querySelector('.ms-ContextualMenu-submenuIcon')).not.toEqual(null);
+  });
+
+  it('Contextual Menu submenu calls onMenuOpened on click even if submenu has no items', () => {
+    let subMenuOpened = false;
+
+    const onSubMenuOpened = (): void => {
+      subMenuOpened = true;
+    };
+
+    const menuWithEmptySubMenu: IContextualMenuItem[] = [
+      {
+        name: 'TestText 1',
+        key: 'TestKey1',
+        subMenuProps: {
+          items: [],
+          onMenuOpened: onSubMenuOpened
+        }
+      }
+    ];
+
+    ReactTestUtils.renderIntoDocument<ContextualMenu>(
+      <ContextualMenu
+        items={ menuWithEmptySubMenu }
+      />
+    );
+
+    let menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
+
+    ReactTestUtils.Simulate.click(menuItem);
+
+    expect(subMenuOpened).toEqual(true);
+  });
+
   describe('canAnyMenuItemsCheck', () => {
     it('returns false when there are no checkable menu items', () => {
       const items: IContextualMenuItem[] = [

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -48,7 +48,7 @@ export interface IContextualMenuState {
 }
 
 export function hasSubmenu(item: IContextualMenuItem) {
-  return item.subMenuProps ? !!item.subMenuProps : !!item.items;
+  return !!(item.subMenuProps || item.items);
 }
 
 export function getSubmenuItems(item: IContextualMenuItem) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -47,10 +47,8 @@ export interface IContextualMenuState {
   submenuDirection?: DirectionalHint;
 }
 
-export function hasSubmenuItems(item: IContextualMenuItem) {
-  let submenuItems = getSubmenuItems(item);
-
-  return !!(submenuItems && submenuItems.length);
+export function hasSubmenu(item: IContextualMenuItem) {
+  return item.subMenuProps ? !!item.subMenuProps : !!item.items;
 }
 
 export function getSubmenuItems(item: IContextualMenuItem) {
@@ -450,7 +448,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       return this._renderAnchorMenuItem(item, classNames, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);
     }
 
-    if (item.split && hasSubmenuItems(item)) {
+    if (item.split && hasSubmenu(item)) {
       return this._renderSplitButton(item, classNames, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);
     }
 
@@ -508,7 +506,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     const itemButtonProperties = {
       className: classNames.root,
       onClick: this._onItemClick.bind(this, item),
-      onKeyDown: hasSubmenuItems(item) ? this._onItemKeyDown.bind(this, item) : null,
+      onKeyDown: hasSubmenu(item) ? this._onItemKeyDown.bind(this, item) : null,
       onMouseEnter: this._onItemMouseEnter.bind(this, item),
       onMouseLeave: this._onMouseItemLeave.bind(this, item),
       onMouseDown: (ev: any) => this._onItemMouseDown(item, ev),
@@ -517,9 +515,9 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       href: item.href,
       title: item.title,
       'aria-label': ariaLabel,
-      'aria-haspopup': hasSubmenuItems(item) || null,
+      'aria-haspopup': hasSubmenu(item) || null,
       'aria-owns': item.key === expandedMenuItemKey ? subMenuId : null,
-      'aria-expanded': hasSubmenuItems(item) ? item.key === expandedMenuItemKey : null,
+      'aria-expanded': hasSubmenu(item) ? item.key === expandedMenuItemKey : null,
       'aria-checked': isChecked,
       'aria-posinset': focusableElementIndex + 1,
       'aria-setsize': totalItemCount,
@@ -634,7 +632,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
           <span className={ classNames.label }>{ item.name }</span>
         ) : null
         }
-        { hasSubmenuItems(item) ? (
+        { hasSubmenu(item) ? (
           <Icon
             iconName={ getRTL() ? 'ChevronLeft' : 'ChevronRight' }
             { ...item.submenuIconProps }
@@ -724,7 +722,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     let targetElement = ev.currentTarget as HTMLElement;
 
     if (item.key !== this.state.expandedMenuItemKey) {
-      if (hasSubmenuItems(item)) {
+      if (hasSubmenu(item)) {
         this._enterTimerId = this._async.setTimeout(() => this._onItemSubMenuExpand(item, targetElement), 500);
       } else {
         this._enterTimerId = this._async.setTimeout(() => this._onSubMenuDismiss(ev), 500);
@@ -743,7 +741,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     }
 
     if (item.key !== this.state.expandedMenuItemKey) {
-      if (hasSubmenuItems(item)) {
+      if (hasSubmenu(item)) {
         this._enterTimerId = this._async.setTimeout(() => this._onItemSubMenuExpand(item, targetElement), 500);
       } else {
         this._enterTimerId = this._async.setTimeout(() => this._onSubMenuDismiss(ev), 500);
@@ -764,7 +762,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       this._enterTimerId = undefined;
     }
 
-    if (item.key === this.state.expandedMenuItemKey && hasSubmenuItems(item)) {
+    if (item.key === this.state.expandedMenuItemKey && hasSubmenu(item)) {
       return;
     }
 
@@ -789,7 +787,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   private _onItemClick(item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>) {
     let items = getSubmenuItems(item);
 
-    if (!items || !items.length) { // This is an item without a menu. Click it.
+    if (!hasSubmenu(item) && (!items || !items.length)) { // This is an item without a menu. Click it.
       this._executeItemClick(item, ev);
     } else {
       if (item.key === this.state.expandedMenuItemKey) { // This has an expanded sub menu. collapse it.


### PR DESCRIPTION
Contextual Menu submenus that have no items will have the chevron icon and call onMenuOpened

- Check only for the existence of a submenu, not that it has items
- Apply changes to CommandBar
- Add tests for icon check and onMenuOpened on click

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ x] Include a change request file using `$ npm run change`

#### Description of changes

Previously, an empty submenu in a Contextual Menu would be treated as a normal button. However, we need an empty submenu to behave like one that has items to allow for dynamically loading menus (populated on an onMenuOpened call). We now only check that a submenu has been defined ('subMenuProps' is defined, or the soon to be deprecated 'items' property is defined) to render the chevron icon and have the submenu call onMenuOpened

#### Focus areas to test

Added tests for Contextual Menu and Command Bar, which creates Contextual Menu items
