### PR TITLE
Add audo expand on focus for Combobox

### DIFF
--- a/common/changes/office-ui-fabric-react/expand_2018-01-08-11-10.json
+++ b/common/changes/office-ui-fabric-react/expand_2018-01-08-11-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add auto expand on focus for Combobox",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "stanleyy@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -312,7 +312,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             onBlur={ this._onBlur }
             onKeyDown={ this._onInputKeyDown }
             onKeyUp={ this._onInputKeyUp }
-            onClick={ allowFreeform ? this.focus : this._onComboBoxClick }
+            onClick={ () => { allowFreeform ? this.focus(true) : this._onComboBoxClick() } }
             onInputValueChange={ this._onInputChange }
             aria-expanded={ isOpen }
             aria-autocomplete={ (!disabled && autoComplete === 'on') }
@@ -370,9 +370,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * Set focus on the input
    */
   @autobind
-  public focus() {
+  public focus(shouldOpenOnFocus?: boolean) {
     if (this._comboBox) {
       this._comboBox.focus();
+      if (shouldOpenOnFocus) {
+        this.setState({
+          isOpen: true
+        });
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -312,7 +312,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             onBlur={ this._onBlur }
             onKeyDown={ this._onInputKeyDown }
             onKeyUp={ this._onInputKeyUp }
-            onClick={ () => { allowFreeform ? this.focus(true) : this._onComboBoxClick() } }
+            onClick={ this._onBaseAutofillClick }
             onInputValueChange={ this._onInputChange }
             aria-expanded={ isOpen }
             aria-autocomplete={ (!disabled && autoComplete === 'on') }
@@ -1504,6 +1504,18 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     if (!disabled) {
       this._setOpenStateAndFocusOnClose(!isOpen, false /* focusInputAfterClose */);
+    }
+  }
+
+  /**
+   * Click handler for the autofill.
+   */
+  @autobind
+  private _onBaseAutofillClick() {
+    if (this.props.allowFreeform) {
+      this.focus(true);
+    } else {
+       this._onComboBoxClick();
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -15,7 +15,7 @@ export interface IComboBox {
    * Sets focus to the input in the comboBox
    * @returns True if focus could be set, false if no operation was taken.
    */
-  focus(): boolean;
+  focus(shouldOpenOnFocus?: boolean): boolean;
 }
 
 export interface IComboBoxOption extends ISelectableOption {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -319,7 +319,7 @@ export class ComboBoxBasicExample extends React.Component<{}, {
   }
 
   @autobind
-  private _basicComboBoxComponentRef(component: IComboBox): {
+  private _basicComboBoxComponentRef(component: IComboBox) {
     this._basicCombobox = component;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -86,7 +86,7 @@ export class ComboBoxBasicExample extends React.Component<{}, {
 
         <PrimaryButton
           text='Set focus'
-          onClick={ () => this._basicCombobox.focus(true) } />
+          onClick={ this._basicComboBoxOnClick } />
 
         <ComboBox
           defaultSelectedKey='C'
@@ -310,5 +310,10 @@ export class ComboBoxBasicExample extends React.Component<{}, {
         value: undefined
       });
     }
+  }
+
+  @autobind
+  private _basicComboBoxOnClick(): void {
+    this._basicCombobox.focus(true);
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -11,6 +11,8 @@ import {
   autobind
 } from 'office-ui-fabric-react/lib/Utilities';
 import { SelectableOptionMenuItemType } from 'office-ui-fabric-react/lib/utilities/selectableOption/SelectableOption.types';
+import { IComboBox } from '../ComboBox.types';
+import { PrimaryButton } from '../../../Button';
 
 export class ComboBoxBasicExample extends React.Component<{}, {
   options: IComboBoxOption[];
@@ -41,6 +43,7 @@ export class ComboBoxBasicExample extends React.Component<{}, {
   };
 
   private scaleOptions: IComboBoxOption[] = [];
+  private _basicCombobox: IComboBox;
 
   constructor(props: {}) {
     super(props);
@@ -73,12 +76,17 @@ export class ComboBoxBasicExample extends React.Component<{}, {
           autoComplete='on'
           options={ this._testOptions }
           onRenderOption={ this._onRenderFontOption }
+          componentRef={ (component: IComboBox) => this._basicCombobox = component }
           // tslint:disable:jsx-no-lambda
           onFocus={ () => console.log('onFocus called') }
           onBlur={ () => console.log('onBlur called') }
           onMenuOpen={ () => console.log('ComboBox menu opened') }
-        // tslint:enable:jsx-no-lambda
+          // tslint:enable:jsx-no-lambda
         />
+
+        <PrimaryButton
+          text='Set focus'
+          onClick={ () => this._basicCombobox.focus(true) } />
 
         <ComboBox
           defaultSelectedKey='C'

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -76,7 +76,7 @@ export class ComboBoxBasicExample extends React.Component<{}, {
           autoComplete='on'
           options={ this._testOptions }
           onRenderOption={ this._onRenderFontOption }
-          componentRef={ (component: IComboBox) => this._basicCombobox = component }
+          componentRef={ this._basicComboBoxComponentRef }
           // tslint:disable:jsx-no-lambda
           onFocus={ () => console.log('onFocus called') }
           onBlur={ () => console.log('onBlur called') }
@@ -86,7 +86,8 @@ export class ComboBoxBasicExample extends React.Component<{}, {
 
         <PrimaryButton
           text='Set focus'
-          onClick={ this._basicComboBoxOnClick } />
+          onClick={ this._basicComboBoxOnClick }
+        />
 
         <ComboBox
           defaultSelectedKey='C'
@@ -315,5 +316,10 @@ export class ComboBoxBasicExample extends React.Component<{}, {
   @autobind
   private _basicComboBoxOnClick(): void {
     this._basicCombobox.focus(true);
+  }
+
+  @autobind
+  private _basicComboBoxComponentRef(component: IComboBox): {
+    this._basicCombobox = component;
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3675
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add an optional argument to IComboBox.focus(shouldOpenOnFocus). So when shouldOpenOnFocus is provided and the value is true, upon getting the focus, it will auto expand/open.

#### Focus areas to test

Added test case in the example page. When clicking on a button, it will call focus(true).  The ComboBox will focus and also expand.
  