### PR TITLE
Adding indeterminate ProgressIndicator variation

### DIFF
--- a/common/changes/office-ui-fabric-react/v-krbrow-indeterminate-progress_2018-01-08-22-52.json
+++ b/common/changes/office-ui-fabric-react/v-krbrow-indeterminate-progress_2018-01-08-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ProgressIndicator: Adding indeterminate progress variant.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-krbrow@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
@@ -11,7 +11,6 @@
 $ProgressIndicatorMarginBetweenText: 8px;
 $ProgressIndicatorButtonsWidth: 218px;
 $ProgressIndicatorTextHeight: 18px;
-$ProgressIndicatorTransparentThemePrimary: rgba(0, 120, 215, 0);
 
 .root {
   font-weight: $ms-font-weight-regular;

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
@@ -55,7 +55,6 @@ $ProgressIndicatorTextHeight: 18px;
   transition: width .3s ease;
   width: 0;
 
-
   &.indeterminate {
     position: absolute;
     min-width: 33%;
@@ -66,10 +65,11 @@ $ProgressIndicatorTextHeight: 18px;
   @include high-contrast {
     background-color: WindowText;
   }
-}
-[dir='rtl'] .progressBar {
-  &.indeterminate {
-    animation: indeterminateProgressRTL 3s infinite;
+
+  @include RTL {
+    &.indeterminate {
+      animation: indeterminateProgressRTL 3s infinite;
+    }
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
@@ -67,6 +67,11 @@ $ProgressIndicatorTextHeight: 18px;
     background-color: WindowText;
   }
 }
+[dir='rtl'] .progressBar {
+  &.indeterminate {
+    animation: indeterminateProgressRTL 3s infinite;
+  }
+}
 
 .smoothTransition {
   transition-property: width;
@@ -80,5 +85,14 @@ $ProgressIndicatorTextHeight: 18px;
   }
   100% {
     left: 100%;
+  }
+}
+
+@keyframes indeterminateProgressRTL {
+  0% {
+    right: -30%;
+  }
+  100% {
+    right: 100%;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
@@ -77,7 +77,7 @@ $ProgressIndicatorTransparentThemePrimary: rgba(0, 120, 215, 0);
 
 @keyframes indeterminateProgress {
   0% {
-    left: -33%;
+    left: -30%;
   }
   100% {
     left: 100%;

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
@@ -11,6 +11,7 @@
 $ProgressIndicatorMarginBetweenText: 8px;
 $ProgressIndicatorButtonsWidth: 218px;
 $ProgressIndicatorTextHeight: 18px;
+$ProgressIndicatorTransparentThemePrimary: rgba(0, 120, 215, 0);
 
 .root {
   font-weight: $ms-font-weight-regular;
@@ -55,6 +56,14 @@ $ProgressIndicatorTextHeight: 18px;
   transition: width .3s ease;
   width: 0;
 
+
+  &.indeterminate {
+    position: absolute;
+    min-width: 33%;
+    background: linear-gradient(to right, transparent 0%, $ms-color-themePrimary 50%, transparent 100%);
+    animation: indeterminateProgress 3s infinite;
+  }
+
   @include high-contrast {
     background-color: WindowText;
   }
@@ -64,4 +73,13 @@ $ProgressIndicatorTextHeight: 18px;
   transition-property: width;
   transition-timing-function: linear;
   transition-duration: 150ms;
+}
+
+@keyframes indeterminateProgress {
+  0% {
+    left: -33%;
+  }
+  100% {
+    left: 100%;
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -6,13 +6,13 @@ import { ProgressIndicator } from './ProgressIndicator';
 describe('ProgressIndicator', () => {
   it('renders ProgressIndicator correctly', () => {
     const component = renderer.create(<ProgressIndicator percentComplete={ 0.75 } />);
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('renders indeterminate ProgressIndicator correctly', () => {
     const component = renderer.create(<ProgressIndicator />);
-    let tree = component.toJSON();
+    const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -5,6 +5,12 @@ import { ProgressIndicator } from './ProgressIndicator';
 
 describe('ProgressIndicator', () => {
   it('renders ProgressIndicator correctly', () => {
+    const component = renderer.create(<ProgressIndicator percentComplete={ 0.75 } />);
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders indeterminate ProgressIndicator correctly', () => {
     const component = renderer.create(<ProgressIndicator />);
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -38,7 +38,9 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
       label = title;
     }
 
-    this.props.percentComplete !== undefined ? percentComplete = Math.min(100, Math.max(0, percentComplete! * 100)) : percentComplete = 0;
+    if (this.props.percentComplete !== undefined) {
+      percentComplete = Math.min(100, Math.max(0, percentComplete! * 100));
+    }
 
     return (
       <div className={ css('ms-ProgressIndicator', styles.root, className) }>
@@ -49,14 +51,14 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
             className={ css(
               'ms-ProgressIndicator-progressBar',
               styles.progressBar,
-              percentComplete > ZERO_THRESHOLD && 'smoothTransition',
-              !percentComplete && styles.indeterminate
+              percentComplete && percentComplete > ZERO_THRESHOLD && 'smoothTransition',
+              percentComplete === undefined && styles.indeterminate
             ) }
-            style={ percentComplete ? { width: percentComplete + '%' } : undefined }
+            style={ percentComplete !== undefined ? { width: percentComplete + '%' } : undefined }
             role='progressbar'
             aria-valuemin='0'
             aria-valuemax='100'
-            aria-valuenow={ percentComplete.toFixed().toString() }
+            aria-valuenow={ percentComplete && percentComplete.toFixed().toString() }
             aria-valuetext={ ariaValueText }
           />
         </div>

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -53,7 +53,7 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
               percentComplete > ZERO_THRESHOLD && 'smoothTransition',
               !percentComplete && styles.indeterminate
             ) }
-            style={ percentComplete ? { width: percentComplete + '%' } : {} }
+            style={ percentComplete ? { width: percentComplete + '%' } : undefined }
             role='progressbar'
             aria-valuemin='0'
             aria-valuemax='100'

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -18,7 +18,6 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
   public static defaultProps = {
     label: '',
     description: '',
-    percentComplete: 0,
     width: 180
   };
 
@@ -39,7 +38,7 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
       label = title;
     }
 
-    this.props.percentComplete ? percentComplete = Math.min(100, Math.max(0, percentComplete! * 100)) : percentComplete = 0;
+    this.props.percentComplete !== undefined ? percentComplete = Math.min(100, Math.max(0, percentComplete! * 100)) : percentComplete = 0;
 
     return (
       <div className={ css('ms-ProgressIndicator', styles.root, className) }>

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -39,7 +39,7 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
       label = title;
     }
 
-    percentComplete = Math.min(100, Math.max(0, percentComplete! * 100));
+    this.props.percentComplete ? percentComplete = Math.min(100, Math.max(0, percentComplete! * 100)) : percentComplete = 0;
 
     return (
       <div className={ css('ms-ProgressIndicator', styles.root, className) }>
@@ -50,9 +50,10 @@ export class ProgressIndicator extends BaseComponent<IProgressIndicatorProps, {}
             className={ css(
               'ms-ProgressIndicator-progressBar',
               styles.progressBar,
-              percentComplete > ZERO_THRESHOLD && 'smoothTransition'
+              percentComplete > ZERO_THRESHOLD && 'smoothTransition',
+              !percentComplete && styles.indeterminate
             ) }
-            style={ { width: percentComplete + '%' } }
+            style={ percentComplete ? { width: percentComplete + '%' } : {} }
             role='progressbar'
             aria-valuemin='0'
             aria-valuemax='100'

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
@@ -25,7 +25,7 @@ export interface IProgressIndicatorProps {
   description?: string;
 
   /**
-   * Percentage of the operation's completeness.
+   * Percentage of the operation's completeness. If this is not set, the indeterminate progress animation will be shown instead.
    */
   percentComplete?: number;
 

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicatorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicatorPage.tsx
@@ -6,10 +6,12 @@ import {
   PropertiesTableSet
 } from '@uifabric/example-app-base';
 import { ProgressIndicatorBasicExample } from './examples/ProgressIndicator.Basic.Example';
+import { ProgressIndicatorIndeterminateExample } from './examples/ProgressIndicator.Indeterminate.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { ProgressIndicatorStatus } from './ProgressIndicator.checklist';
 
 const ProgressIndicatorBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ProgressIndicator/examples/ProgressIndicator.Basic.Example.tsx') as string;
+const ProgressIndicatorIndeterminateExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ProgressIndicator/examples/ProgressIndicator.Indeterminate.Example.tsx') as string;
 
 export class ProgressIndicatorPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -18,9 +20,14 @@ export class ProgressIndicatorPage extends React.Component<IComponentDemoPagePro
         title='ProgressIndicator'
         componentName='ProgressIndicatorExample'
         exampleCards={
-          <ExampleCard title='Default ProgressIndicator' code={ ProgressIndicatorBasicExampleCode }>
-            <ProgressIndicatorBasicExample />
-          </ExampleCard>
+          <div>
+            <ExampleCard title='Default ProgressIndicator' code={ ProgressIndicatorBasicExampleCode }>
+              <ProgressIndicatorBasicExample />
+            </ExampleCard>
+            <ExampleCard title='Indeterminate ProgressIndicator' code={ ProgressIndicatorIndeterminateExampleCode }>
+              <ProgressIndicatorIndeterminateExample />
+            </ExampleCard>
+          </div>
         }
         propertiesTables={
           <PropertiesTableSet

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
   <div
     className="ms-ProgressIndicator-itemName"
   >
-
+    
   </div>
   <div
     className="ms-ProgressIndicator-itemProgress"
@@ -32,7 +32,7 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
   <div
     className="ms-ProgressIndicator-itemDescription"
   >
-
+    
   </div>
 </div>
 `;
@@ -44,7 +44,7 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
   <div
     className="ms-ProgressIndicator-itemName"
   >
-
+    
   </div>
   <div
     className="ms-ProgressIndicator-itemProgress"
@@ -65,7 +65,7 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
   <div
     className="ms-ProgressIndicator-itemDescription"
   >
-
+    
   </div>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -22,11 +22,7 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
       aria-valuetext={undefined}
       className="ms-ProgressIndicator-progressBar"
       role="progressbar"
-      style={
-        Object {
-          "width": "0%",
-        }
-      }
+      style={undefined}
     />
   </div>
   <div

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -7,7 +7,44 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
   <div
     className="ms-ProgressIndicator-itemName"
   >
-    
+
+  </div>
+  <div
+    className="ms-ProgressIndicator-itemProgress"
+  >
+    <div
+      className="ms-ProgressIndicator-progressTrack"
+    />
+    <div
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="75"
+      aria-valuetext={undefined}
+      className="ms-ProgressIndicator-progressBar smoothTransition"
+      role="progressbar"
+      style={
+        Object {
+          "width": "75%",
+        }
+      }
+    />
+  </div>
+  <div
+    className="ms-ProgressIndicator-itemDescription"
+  >
+
+  </div>
+</div>
+`;
+
+exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`] = `
+<div
+  className="ms-ProgressIndicator"
+>
+  <div
+    className="ms-ProgressIndicator-itemName"
+  >
+
   </div>
   <div
     className="ms-ProgressIndicator-itemProgress"
@@ -28,7 +65,7 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
   <div
     className="ms-ProgressIndicator-itemDescription"
   >
-    
+
   </div>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
     <div
       aria-valuemax="100"
       aria-valuemin="0"
-      aria-valuenow="0"
+      aria-valuenow={undefined}
       aria-valuetext={undefined}
       className="ms-ProgressIndicator-progressBar"
       role="progressbar"

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/examples/ProgressIndicator.Indeterminate.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/examples/ProgressIndicator.Indeterminate.Example.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import {
+  ProgressIndicator
+} from 'office-ui-fabric-react/lib/ProgressIndicator';
+import { Async } from 'office-ui-fabric-react/lib/Utilities';
+
+export class ProgressIndicatorIndeterminateExample extends React.Component<{}, {}> {
+  constructor(props: {}) {
+    super(props);
+  }
+
+  public render() {
+    return (
+      <ProgressIndicator
+        label='Example title'
+        description='Example description'
+      />
+    );
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds a ProgressIndicator variant to indicate indeterminate or unknown progress. If no value is passed for the percentComplete prop, the indeterminate variant will be shown instead of the normal percentage variant.

Low quality .gif preview: 
![recording 1](https://user-images.githubusercontent.com/12915480/34694638-b4074f72-f47c-11e7-9cf8-c1ee3b8c71a9.gif)