### PR TITLE
Positioning/Callout: Fix positioning for HTMLImg elements when used as target

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-positioningfor-imgtargets_2018-01-09-02-14.json
+++ b/common/changes/office-ui-fabric-react/fix-positioningfor-imgtargets_2018-01-09-02-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout/Positioning: Fix a bug where callouts would position incorrectly if the target was  an HTMLImg element",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -394,6 +394,7 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
         let targetElement: HTMLElement = target as HTMLElement;
         this._targetWindow = getWindow(targetElement)!;
         this._target = target;
+        // HTMLImgElements can have x and y values. The check for it being a point must go last.
       } else {
         this._targetWindow = getWindow()!;
         this._target = target;

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -390,12 +390,12 @@ export class CalloutContent extends BaseComponent<ICalloutProps, ICalloutState> 
       } else if ((target as MouseEvent).stopPropagation) {
         this._targetWindow = getWindow((target as MouseEvent).toElement as HTMLElement)!;
         this._target = target;
-      } else if ((target as IPoint).x !== undefined && (target as IPoint).y !== undefined) {
-        this._targetWindow = getWindow()!;
-        this._target = target;
-      } else {
+      } else if ((target as HTMLElement).getBoundingClientRect) {
         let targetElement: HTMLElement = target as HTMLElement;
         this._targetWindow = getWindow(targetElement)!;
+        this._target = target;
+      } else {
+        this._targetWindow = getWindow()!;
         this._target = target;
       }
     } else {

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -581,6 +581,7 @@ export module positioningFunctions {
         targetRectangle = new Rectangle(ev.clientX, ev.clientX, ev.clientY, ev.clientY);
       } else if ((target as HTMLElement).getBoundingClientRect) {
         targetRectangle = _getRectangleFromHTMLElement(target as HTMLElement);
+        // HTMLImgElements can have x and y values. The check for it being a point must go last.
       } else {
         let point: IPoint = target as IPoint;
         targetRectangle = new Rectangle(point.x, point.x, point.y, point.y);

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -579,11 +579,11 @@ export module positioningFunctions {
       if ((target as MouseEvent).preventDefault) {
         let ev: MouseEvent = target as MouseEvent;
         targetRectangle = new Rectangle(ev.clientX, ev.clientX, ev.clientY, ev.clientY);
-      } else if ((target as IPoint).x !== undefined) {
+      } else if ((target as HTMLElement).getBoundingClientRect) {
+        targetRectangle = _getRectangleFromHTMLElement(target as HTMLElement);
+      } else {
         let point: IPoint = target as IPoint;
         targetRectangle = new Rectangle(point.x, point.x, point.y, point.y);
-      } else {
-        targetRectangle = _getRectangleFromHTMLElement(target as HTMLElement);
       }
 
       if (!_isRectangleWithinBounds(targetRectangle, bounds)) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

HTMLImgElements have x and y as attributes available to them. This causes positioning to treat the target as a point, rather than an element. This causes the callout to be positioned improperly since it returns "a long representing the vertical offset from the nearest layer." (taken from the link below.

See https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement for more.

#### Focus areas to test

(optional)
