### PR TITLE
[Picker] Fixed border clipping in high contrast mode

### DIFF
--- a/common/changes/office-ui-fabric-react/magellan-tag_picker_border_fix_2018-01-10-01-43.json
+++ b/common/changes/office-ui-fabric-react/magellan-tag_picker_border_fix_2018-01-10-01-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pickers: Fixed border clipping of tag item in high-contrast mode",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.scss
@@ -2,6 +2,7 @@
 
 .root {
   @include focus-border();
+  box-sizing: content-box;
   flex-shrink: 1;
   background: $ms-color-neutralLighter;
   margin: 1px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3687
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The cancel icon was clipping the border of TagItems when in high contrast mode. This fixes it.
