### PR TITLE
Combo box escape key behavior

### DIFF
--- a/common/changes/office-ui-fabric-react/vecooper-comboBoxEscFix_2018-01-10-22-28.json
+++ b/common/changes/office-ui-fabric-react/vecooper-comboBoxEscFix_2018-01-10-22-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Escape key shouldn't propogate in combo box if it isn't open",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "vecooper@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/vecooper-comboBoxEscFix_2018-01-10-22-28.json
+++ b/common/changes/office-ui-fabric-react/vecooper-comboBoxEscFix_2018-01-10-22-28.json
@@ -1,8 +1,8 @@
-{
+
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Escape key shouldn't propogate in combo box if it isn't open",
+      "comment": "Escape key shouldn't propagate in combo box if it isn't open",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1313,6 +1313,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           this.setState({
             isOpen: false
           });
+        } else {
+          return;
         }
         break;
 
@@ -1515,7 +1517,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     if (this.props.allowFreeform) {
       this.focus(true);
     } else {
-       this._onComboBoxClick();
+      this._onComboBoxClick();
     }
   }
 


### PR DESCRIPTION
Escape key shouldn't propagate in combo box if it isn't open. Right now because it does forms cannot get the ESC key to perform correctly on their forms if the focus is in a combo box.