### PR TITLE
File type icons: support size 64 icons

### DIFF
--- a/common/changes/@uifabric/experiments/kathayer-add64_2018-01-11-00-29.json
+++ b/common/changes/@uifabric/experiments/kathayer-add64_2018-01-11-00-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add demo of size 64 file type icons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kathayer@microsoft.com"
+}

--- a/common/changes/@uifabric/file-type-icons/kathayer-add64_2018-01-11-00-29.json
+++ b/common/changes/@uifabric/file-type-icons/kathayer-add64_2018-01-11-00-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Support size 64 file type icons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "kathayer@microsoft.com"
+}

--- a/packages/experiments/src/components/FileTypeIcon/examples/FileTypeIcon.Basic.Example.tsx
+++ b/packages/experiments/src/components/FileTypeIcon/examples/FileTypeIcon.Basic.Example.tsx
@@ -17,6 +17,8 @@ export class FileTypeIconBasicExample extends React.Component<{}, {}> {
         <Icon {...getFileTypeIconProps({ extension: '.cpp', size: 40, imageFileType: 'png' }) } />
         <h3>Size 48 csv icon as .png</h3>
         <Icon {...getFileTypeIconProps({ extension: 'csv', size: 48, imageFileType: 'png' }) } />
+        <h3>Size 64 model icon as .png</h3>
+        <Icon {...getFileTypeIconProps({ extension: 'blend', size: 64, imageFileType: 'png' }) } />
         <h3>Size 96 docx icon as .png</h3>
         <Icon {...getFileTypeIconProps({ extension: 'docx', size: 96, imageFileType: 'png' }) } />
         <h3>Size 16 dotx icon as .svg</h3>
@@ -29,6 +31,8 @@ export class FileTypeIconBasicExample extends React.Component<{}, {}> {
         <Icon {...getFileTypeIconProps({ extension: '.woff', size: 40 }) } />
         <h3>Size 48 html icon as .svg</h3>
         <Icon {...getFileTypeIconProps({ extension: 'html', size: 48 }) } />
+        <h3>Size 64 mpp icon as .svg</h3>
+        <Icon {...getFileTypeIconProps({ extension: 'mpp', size: 64 }) } />
         <h3>Size 96 link icon as .svg</h3>
         <Icon {...getFileTypeIconProps({ extension: 'url', size: 96 }) } />
         <h3>Size 16 docset icon as .png</h3>
@@ -39,8 +43,8 @@ export class FileTypeIconBasicExample extends React.Component<{}, {}> {
         <Icon {...getFileTypeIconProps({ size: 40, imageFileType: 'png' }) } />
         <h3>Size 48 listitem icon as .svg</h3>
         <Icon {...getFileTypeIconProps({ type: FileIconType.listItem, size: 48, imageFileType: 'svg' }) } />
-        <h3>Size 96 sharedfolder icon as .png</h3>
-        <Icon {...getFileTypeIconProps({ type: FileIconType.sharedFolder, size: 96, imageFileType: 'png' }) } />
+        <h3>Size 64 sharedfolder icon as .png</h3>
+        <Icon {...getFileTypeIconProps({ type: FileIconType.sharedFolder, size: 64, imageFileType: 'png' }) } />
       </div>
     );
   }

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -10,7 +10,7 @@ const DOCSET_FOLDER = 'docset';
 const LIST_ITEM = 'listitem';
 const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 
-export type FileTypeIconSize = 16 | 20 | 32 | 40 | 48 | 96;
+export type FileTypeIconSize = 16 | 20 | 32 | 40 | 48 | 64 | 96;
 export type ImageFileType = 'svg' | 'png';
 
 export interface IFileTypeIconOptions {
@@ -105,24 +105,36 @@ function _getFileTypeIconSuffix(size: FileTypeIconSize, imageFileType: ImageFile
   let devicePixelRatio: number = window.devicePixelRatio;
   let devicePixelRatioSuffix = ''; // Default is 1x
 
-  // SVGs scale well, so you can generally use the default image.
-  // 1.5x is a special case where SVGs need a different image.
-  if (imageFileType === 'svg' && 1 < devicePixelRatio && devicePixelRatio <= 1.5) {
-    // Currently missing 1.5x SVGs at sizes 20 and 40, snap to 1x for now
-    if (size !== 20 && size !== 40) {
-      devicePixelRatioSuffix = '_1.5x';
+  if (size !== 64) {
+    // SVGs scale well, so you can generally use the default image.
+    // 1.5x is a special case where SVGs need a different image.
+    if (imageFileType === 'svg' && 1 < devicePixelRatio && devicePixelRatio <= 1.5) {
+      // Currently missing 1.5x SVGs at sizes 20 and 40, snap to 1x for now
+      if (size !== 20 && size !== 40) {
+        devicePixelRatioSuffix = '_1.5x';
+      }
+    } else if (imageFileType === 'png') {
+      // To look good, PNGs should use a different image for higher device pixel ratios
+      if (1 < devicePixelRatio && devicePixelRatio <= 1.5) {
+        // Currently missing 1.5x icons for size 20, snap to 2x for now
+        devicePixelRatioSuffix = (size === 20) ? '_2x' : '_1.5x';
+      } else if (1.5 < devicePixelRatio && devicePixelRatio <= 2) {
+        devicePixelRatioSuffix = '_2x';
+      } else if (2 < devicePixelRatio && devicePixelRatio <= 3) {
+        devicePixelRatioSuffix = '_3x';
+      } else if (3 < devicePixelRatio) {
+        devicePixelRatioSuffix = '_4x';
+      }
     }
-  } else if (imageFileType === 'png') {
-    // To look good, PNGs should use a different image for higher device pixel ratios
-    if (1 < devicePixelRatio && devicePixelRatio <= 1.5) {
-      // Currently missing 1.5x icons for size 20, snap to 2x for now
-      devicePixelRatioSuffix = (size === 20) ? '_2x' : '_1.5x';
-    } else if (1.5 < devicePixelRatio && devicePixelRatio <= 2) {
-      devicePixelRatioSuffix = '_2x';
-    } else if (2 < devicePixelRatio && devicePixelRatio <= 3) {
-      devicePixelRatioSuffix = '_3x';
-    } else if (3 < devicePixelRatio) {
-      devicePixelRatioSuffix = '_4x';
+  } else {
+    // Currently we have a more limited set of image files for size 64.
+    // For SVGs, we only have the default 1x. For PNGs, we have 1x, 1.5x, and 2x.
+    if (imageFileType === 'png') {
+      if (1 < devicePixelRatio && devicePixelRatio <= 1.5) {
+        devicePixelRatioSuffix = '_1.5x';
+      } else if (1.5 < devicePixelRatio) {
+        devicePixelRatioSuffix = '_2x';
+      }
     }
   }
 

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -12,6 +12,9 @@ export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, opti
   ICON_SIZES.forEach((size: number) => {
     _initializeIcons(baseUrl, size, options);
   });
+  // Currently we have a more limited set of image files for size 64.
+  // When we have the full set, add 64 to ICON_SIZES and remove _initializeSize64Icons.
+  _initializeSize64Icons(baseUrl, options);
 }
 
 function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIconOptions>): void {
@@ -47,6 +50,36 @@ function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIcon
     );
     fileTypeIcons[type + size + '_4x' + PNG_SUFFIX] = (
       <img src={ baseUrl + size + '_4x/' + type + '.png' } height='100%' width='100%' />
+    );
+  });
+
+  registerIcons({
+    fontFace: {},
+    style: {
+      width: size,
+      height: size,
+      overflow: 'hidden'
+    },
+    icons: fileTypeIcons
+  }, options);
+}
+
+function _initializeSize64Icons(baseUrl: string, options?: Partial<IIconOptions>): void {
+  const iconTypes: string[] = Object.keys(FileTypeIconMap);
+  const fileTypeIcons: { [key: string]: JSX.Element } = {};
+  const size = 64;
+
+  iconTypes.forEach((type: string) => {
+    fileTypeIcons[type + size + PNG_SUFFIX] = <img src={ baseUrl + size + '/' + type + '.png' } />;
+    fileTypeIcons[type + size + SVG_SUFFIX] = <img src={ baseUrl + size + '/' + type + '.svg' } />;
+
+    // For high resolution screens, register additional versions.
+    // Size 64 only has PNGs for 1.5x and 2x.
+    fileTypeIcons[type + size + '_1.5x' + PNG_SUFFIX] = (
+      <img src={ baseUrl + size + '_1.5x/' + type + '.png' } height='100%' width='100%' />
+    );
+    fileTypeIcons[type + size + '_2x' + PNG_SUFFIX] = (
+      <img src={ baseUrl + size + '_2x/' + type + '.png' } height='100%' width='100%' />
     );
   });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Originally, we did not support size 64 file type icons because we do not currently have image files for every screen resolution at that size. However, some people would like to use size 64 file type icons, so I added logic to register the icons we do have and transparently snap to the closest available resolution.

#### Focus areas to test

(optional)
