### PR TITLE
 Add a measured context value to ResizeGroup

### DIFF
--- a/common/changes/@uifabric/utilities/brwatt-measured-context_2018-01-13-22-47.json
+++ b/common/changes/@uifabric/utilities/brwatt-measured-context_2018-01-13-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Adding a helper component to inject context values",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "brwatt@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/brwatt-measured-context_2018-01-13-22-47.json
+++ b/common/changes/office-ui-fabric-react/brwatt-measured-context_2018-01-13-22-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add a context value under ResizeGroup to allow child components to detect whether they are being used only for measurement.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "brwatt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {
   css,
-  BaseComponent,
-  provideContext
+  BaseComponent
 } from '../../Utilities';
+import { provideContext } from '@uifabric/utilities/lib/Context';
 import { IResizeGroupProps } from './ResizeGroup.types';
 import * as styles from './ResizeGroup.scss';
 

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
@@ -274,6 +274,8 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
   };
 };
 
+// Provides a context property that (if true) tells any child components that
+// they are only being used for measurement purposes and will not be visible.
 const MeasuredContext = provideContext({
   isMeasured: PropTypes.bool
 }, () => {

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import {
   css,
-  BaseComponent
+  BaseComponent,
+  provideContext
 } from '../../Utilities';
 import { IResizeGroupProps } from './ResizeGroup.types';
 import * as styles from './ResizeGroup.scss';
@@ -272,6 +274,12 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
   };
 };
 
+const MeasuredContext = provideContext({
+  isMeasured: PropTypes.bool
+}, () => {
+  return { isMeasured: true };
+});
+
 export class ResizeGroup extends BaseComponent<IResizeGroupProps, IResizeGroupState> {
   private _nextResizeGroupStateProvider = getNextResizeGroupStateProvider();
   private _root: HTMLElement;
@@ -294,7 +302,7 @@ export class ResizeGroup extends BaseComponent<IResizeGroupProps, IResizeGroupSt
       <div className={ css('ms-ResizeGroup', className) } ref={ this._resolveRef('_root') }>
         { this._nextResizeGroupStateProvider.shouldRenderDataToMeasureInHiddenDiv(dataToMeasure) && (
           <div className={ css(styles.measured) } ref={ this._resolveRef('_measured') }>
-            { onRenderData(dataToMeasure) }
+            <MeasuredContext>{ onRenderData(dataToMeasure) }</MeasuredContext>
           </div>
         ) }
 

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroupPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroupPage.tsx
@@ -63,6 +63,9 @@ export class ResizeGroupPage extends React.Component<IComponentDemoPageProps, an
                 skipped for that data object. In the controls with an overflow example, the cacheKey is simply the concatenation of the
                 keys of the controls that appear in the top level.
               </p>
+              <p>
+                There is a boolean context property (isMeasured) added to let child components know if they are only being used for measurement purposes. When isMeasured is true, it will signify that the component is not the instance visible to the user. This will not be needed for most scenarios. It is intended to be used to to skip unwanted side effects of mounting a child component more than once. This includes cases where the the component makes API requests, requests focus to one of its elements, expensive computations, and/or renders markup unrelated to its size. Be careful not to use this property to change the components rendered output in a way that effects it size in any way.
+              </p>
             </span>
           </div>
         }

--- a/packages/utilities/src/Context.test.tsx
+++ b/packages/utilities/src/Context.test.tsx
@@ -11,19 +11,19 @@ const TestContext = provideContext({
   return { isTest: props.isTest };
 });
 
-class Parent extends React.Component {
-  public render() {
-    return <Child />;
-  }
-}
-
 class Child extends React.Component {
-  public static contextTypes = {
+  public static contextTypes: PropTypes.ValidationMap<{ isTest: boolean }> = {
     isTest: PropTypes.bool
   };
 
-  public render() {
+  public render(): JSX.Element {
     return <div>{ `${this.context.isTest || false}` }</div>;
+  }
+}
+
+class Parent extends React.Component {
+  public render(): JSX.Element {
+    return <Child />;
   }
 }
 
@@ -31,5 +31,5 @@ describe('Context', () => {
   it('can provide context for child components', () => {
     expect(ReactDOM.renderToStaticMarkup(<Parent />)).toEqual('<div>false</div>');
     expect(ReactDOM.renderToStaticMarkup(<TestContext isTest={ true }><Parent /></TestContext>)).toEqual('<div>true</div>');
-  })
+  });
 });

--- a/packages/utilities/src/Context.test.tsx
+++ b/packages/utilities/src/Context.test.tsx
@@ -1,0 +1,35 @@
+
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+
+import * as ReactDOM from 'react-dom/server';
+import { provideContext } from './Context';
+
+const TestContext = provideContext({
+  isTest: PropTypes.bool
+}, (props: { isTest: boolean }) => {
+  return { isTest: props.isTest };
+});
+
+class Parent extends React.Component {
+  public render() {
+    return <Child />;
+  }
+}
+
+class Child extends React.Component {
+  public static contextTypes = {
+    isTest: PropTypes.bool
+  };
+
+  public render() {
+    return <div>{ `${this.context.isTest || false}` }</div>;
+  }
+}
+
+describe('Context', () => {
+  it('can provide context for child components', () => {
+    expect(ReactDOM.renderToStaticMarkup(<Parent />)).toEqual('<div>false</div>');
+    expect(ReactDOM.renderToStaticMarkup(<TestContext isTest={ true }><Parent /></TestContext>)).toEqual('<div>true</div>');
+  })
+});

--- a/packages/utilities/src/Context.tsx
+++ b/packages/utilities/src/Context.tsx
@@ -1,0 +1,22 @@
+
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+
+export function provideContext<TContext, TProps>(
+  contextTypes: PropTypes.ValidationMap<TContext>,
+  mapPropsToContext: (props: TProps) => TContext
+): React.ComponentType<TProps & React.Props<{}>> {
+  class Provider extends React.PureComponent<TProps> {
+    public static readonly childContextTypes: PropTypes.ValidationMap<TContext> = contextTypes;
+
+    public getChildContext(): TContext {
+      return mapPropsToContext(this.props);
+    }
+
+    public render(): JSX.Element | null {
+      return React.Children.only(this.props.children);
+    }
+  }
+
+  return Provider;
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Async';
 export * from './AutoScroll';
 export * from './BaseComponent';
+export * from './Context';
 export * from './Customizations';
 export * from './Customizer';
 export * from './DelayedRender';

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,7 +1,6 @@
 export * from './Async';
 export * from './AutoScroll';
 export * from './BaseComponent';
-export * from './Context';
 export * from './Customizations';
 export * from './Customizer';
 export * from './DelayedRender';

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -49,7 +49,7 @@
   "bundlesize": [
     {
       "path": "../apps/test-bundle-button/dist/main.min.js",
-      "maxSize": "42.6 kB"
+      "maxSize": "42.8 kB"
     }
   ]
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -49,7 +49,7 @@
   "bundlesize": [
     {
       "path": "../apps/test-bundle-button/dist/main.min.js",
-      "maxSize": "42.5 kB"
+      "maxSize": "42.6 kB"
     }
   ]
 }


### PR DESCRIPTION
#### Pull request checklist

- [x ] Include a change request file using `$ npm run change`

#### Description of changes

This change adds a context value (`isMeasured: true`) under the `ResizeGroup` sub-tree that is used only for size measurements in the DOM. This can be used by any child component to potentially alter its rendered output accordingly.

I am adding this specifically to be used with `CommandBar`. I have several commands with custom render functions. One of these commands renders a `Callout` along with it as well as makes an API request. The `Callout` is obviously not needed for sizing information for the `CommandBar` and the API requests should not be made either. Adding this context property will allow me to fix this scenario.