### PR TITLE
Icon component: remove ms-Icon to avoid collisions with fabric-core css.

### DIFF
--- a/common/changes/office-ui-fabric-react/remove-icon-classname_2018-01-14-21-43.json
+++ b/common/changes/office-ui-fabric-react/remove-icon-classname_2018-01-14-21-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Icon: the `ms-Icon` class name, despite being unused, is causing conflicts with fabric-core usage inadvertently. There isn't a great way to deal with this other than to avoid re-using the `ms-Icon` class name.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -175,7 +175,7 @@ exports[`ActivityItem renders compact with an icon correctly 1`] = `
       aria-hidden={true}
       aria-label={undefined}
       className=
-          ms-Icon
+
           {
             display: inline-block;
           }
@@ -596,7 +596,7 @@ exports[`ActivityItem renders with an icon correctly 1`] = `
       aria-hidden={true}
       aria-label={undefined}
       className=
-          ms-Icon
+
           {
             display: inline-block;
           }

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -46,7 +46,6 @@ exports[`Breadcrumb renders breadcumb correctly 1`] = `
               aria-hidden={true}
               aria-label={undefined}
               className=
-                  ms-Icon
                   ms-Breadcrumb-chevron
                   {
                     display: inline-block;
@@ -76,7 +75,6 @@ exports[`Breadcrumb renders breadcumb correctly 1`] = `
               aria-hidden={true}
               aria-label={undefined}
               className=
-                  ms-Icon
                   ms-Breadcrumb-chevron
                   {
                     display: inline-block;
@@ -106,7 +104,6 @@ exports[`Breadcrumb renders breadcumb correctly 1`] = `
               aria-hidden={true}
               aria-label={undefined}
               className=
-                  ms-Icon
                   ms-Breadcrumb-chevron
                   {
                     display: inline-block;
@@ -136,7 +133,6 @@ exports[`Breadcrumb renders breadcumb correctly 1`] = `
               aria-hidden={true}
               aria-label={undefined}
               className=
-                  ms-Icon
                   ms-Breadcrumb-chevron
                   {
                     display: inline-block;
@@ -259,7 +255,6 @@ exports[`Breadcrumb renders breadcumb correctly 2`] = `
                   aria-hidden={true}
                   aria-label={undefined}
                   className=
-                      ms-Icon
                       ms-Button-icon
                       {
                         display: inline-block;
@@ -285,7 +280,6 @@ exports[`Breadcrumb renders breadcumb correctly 2`] = `
               aria-hidden={true}
               aria-label={undefined}
               className=
-                  ms-Icon
                   ms-Breadcrumb-chevron
                   {
                     display: inline-block;
@@ -315,7 +309,6 @@ exports[`Breadcrumb renders breadcumb correctly 2`] = `
               aria-hidden={true}
               aria-label={undefined}
               className=
-                  ms-Icon
                   ms-Breadcrumb-chevron
                   {
                     display: inline-block;
@@ -345,7 +338,6 @@ exports[`Breadcrumb renders breadcumb correctly 2`] = `
               aria-hidden={true}
               aria-label={undefined}
               className=
-                  ms-Icon
                   ms-Breadcrumb-chevron
                   {
                     display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -182,7 +182,6 @@ exports[`Button renders CommandBarButton correctly 1`] = `
       aria-hidden={true}
       aria-label={undefined}
       className=
-          ms-Icon
           ms-Button-icon
           {
             display: inline-block;
@@ -230,7 +229,6 @@ exports[`Button renders CommandBarButton correctly 1`] = `
       aria-hidden={true}
       aria-label={undefined}
       className=
-          ms-Icon
           ms-Button-menuIcon
           {
             display: inline-block;
@@ -557,7 +555,6 @@ exports[`Button renders IconButton correctly 1`] = `
       aria-hidden={true}
       aria-label={undefined}
       className=
-          ms-Icon
           ms-Button-icon
           {
             display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     aria-hidden={true}
                     aria-label={undefined}
                     className=
-                        ms-Icon
+
                         {
                           display: inline-block;
                         }
@@ -62,7 +62,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     aria-hidden={true}
                     aria-label={undefined}
                     className=
-                        ms-Icon
+
                         {
                           display: inline-block;
                         }
@@ -918,7 +918,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     aria-hidden={true}
                     aria-label={undefined}
                     className=
-                        ms-Icon
+
                         {
                           display: inline-block;
                         }
@@ -938,7 +938,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     aria-hidden={true}
                     aria-label={undefined}
                     className=
-                        ms-Icon
+
                         {
                           display: inline-block;
                         }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
         aria-hidden={true}
         aria-label={undefined}
         className=
-            ms-Icon
+
             {
               display: inline-block;
             }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -160,11 +160,11 @@ export const getCaretDownButtonStyles = memoizeFunction((
           borderColor: 'ButtonText',
           color: 'ButtonText',
           MsHighContrastAdjust: 'none'
-        },
-        '.ms-Icon': {
-          fontSize: FontSizes.small
         }
       }
+    },
+    icon: {
+      fontSize: FontSizes.small
     },
     rootHovered: {
       backgroundColor: caretButtonBackgroundHovered,
@@ -195,7 +195,6 @@ export const getStyles = memoizeFunction((
 ): Partial<IComboBoxStyles> => {
 
   const { semanticColors, fonts, palette } = theme;
-
   const ComboBoxRootBackground = semanticColors.bodyBackground;
   const ComboBoxRootTextColor = semanticColors.bodyText;
   const ComboBoxRootBorderColor = semanticColors.inputBorder;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -207,7 +207,6 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-Button-icon
               {
                 display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -173,9 +173,6 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
             border-color: ButtonText;
             color: ButtonText;
           }
-          & .ms-Icon {
-            font-size: 12px;
-          }
           &:hover {
             background-color: #f4f4f4;
             color: #212121;
@@ -213,7 +210,7 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
               }
               {
                 flex-shrink: 0;
-                font-size: 16px;
+                font-size: 12px;
                 height: 16px;
                 line-height: 16px;
                 margin-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`CommandBar renders CommandBar correctly 1`] = `
             aria-hidden={true}
             aria-label={undefined}
             className=
-                ms-Icon
                 ms-CommandBarItem-chevronDown
                 {
                   display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
             aria-hidden={true}
             aria-label={undefined}
             className=
-                ms-Icon
                 ms-DatePicker-event--without-label
                 {
                   display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
                 aria-hidden={true}
                 aria-label={undefined}
                 className=
-                    ms-Icon
+
                     {
                       display: inline-block;
                     }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -37,7 +37,6 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
         aria-hidden={true}
         aria-label={undefined}
         className=
-            ms-Icon
             ms-Dropdown-caretDown
             {
               display: inline-block;
@@ -87,7 +86,6 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
         aria-hidden={true}
         aria-label={undefined}
         className=
-            ms-Icon
             ms-Dropdown-caretDown
             {
               display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -24,7 +24,6 @@ export const Icon = (props: IIconProps): JSX.Element => {
 
   if (props.iconType === IconType.image || props.iconType === IconType.Image) {
     let containerClassName = css(
-      'ms-Icon',
       'ms-Icon-imageContainer',
       classNames.root,
       classNames.imageContainer,
@@ -53,7 +52,7 @@ export const Icon = (props: IIconProps): JSX.Element => {
         { ...getNativeProps(props, htmlElementProperties) }
         className={
           css(
-            'ms-Icon ms-Icon-placeHolder',
+            'ms-Icon-placeHolder',
             classNames.rootHasPlaceHolder,
             props.className
           ) }
@@ -78,7 +77,6 @@ export const Icon = (props: IIconProps): JSX.Element => {
         { ...getNativeProps(props, htmlElementProperties) }
         className={
           css(
-            'ms-Icon', // dangerous?
             iconDefinition.subset.className,
             classNames.root,
             props.className

--- a/packages/office-ui-fabric-react/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Icon renders Icon correctly 1`] = `
   aria-hidden={true}
   aria-label={undefined}
   className=
-      ms-Icon
+
       {
         display: inline-block;
       }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
         aria-hidden={true}
         aria-label={undefined}
         className=
-            ms-Icon
+
             {
               display: inline-block;
             }

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -124,7 +124,6 @@ exports[`Nav renders Nav correctly 1`] = `
                     aria-hidden={true}
                     aria-label={undefined}
                     className=
-                        ms-Icon
                         ms-Icon-placeHolder
                         ms-Button-icon
                         {

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -107,7 +107,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-back
               {
                 display: inline-block;
@@ -123,7 +122,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-front
               {
                 display: inline-block;
@@ -233,7 +231,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-back
               {
                 display: inline-block;
@@ -249,7 +246,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-front
               {
                 display: inline-block;
@@ -359,7 +355,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-back
               {
                 display: inline-block;
@@ -375,7 +370,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-front
               {
                 display: inline-block;
@@ -485,7 +479,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-back
               {
                 display: inline-block;
@@ -501,7 +494,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-front
               {
                 display: inline-block;
@@ -611,7 +603,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-back
               {
                 display: inline-block;
@@ -627,7 +618,6 @@ exports[`Rating Renders Rating correctly 1`] = `
           aria-hidden={true}
           aria-label={undefined}
           className=
-              ms-Icon
               ms-RatingStar-front
               {
                 display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -56,7 +56,6 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
       aria-hidden={true}
       aria-label={undefined}
       className=
-          ms-Icon
           ms-SearchBox-icon
           {
             display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -230,7 +230,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
             aria-hidden={true}
             aria-label={undefined}
             className=
-                ms-Icon
                 ms-Button-icon
                 {
                   display: inline-block;
@@ -338,7 +337,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
             aria-hidden={true}
             aria-label={undefined}
             className=
-                ms-Icon
                 ms-Button-icon
                 {
                   display: inline-block;


### PR DESCRIPTION
When fabric-core css is loaded on the page, it defines the class name `ms-Icon` which defines the font-family to use MDL2Icons, which has a font-face pointing at an 88k woff.

However, the icons rendered from Fabric React do not use this or require this, and instead refer to the partitioned icon files, reducing download size.

But because the `Icon` component includes the `ms-Icon` classname, which it does not rely on but is there for legacy purposes, the Fabric core css styling can override the css definitions made by the `@uifabric/styling` icon helpers depending on load order.

I can only see 2 solutions here. Removing the class completely, or alternatively, using !important on the font-family defined in `@uifabric/styling`.

Fixes #3240 