### PR TITLE
Update CODEOWNERS with new packages and owner assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,10 @@
 
 #### Packages
 # packages/example-app-base/
-# packages/example-component/
+packages/file-type-icons/  @KatherineThayerMicrosoft @jahnp
+# packages/icons/
+# packages/jest-serializer-merge-styles/
+# packages/merge-styles/
 # packages/office-ui-fabric-react-tslint/
 packages/styling/  @dzearing
 packages/styling/src/interfaces/ @phkuo
@@ -46,18 +49,18 @@ dateValues/   @johannao76 lorejoh12@gmail.com jolore@microsoft.com
 # Breadcrumb/
 # Button/
 Calendar/   @johannao76 lorejoh12@gmail.com jolore@microsoft.com
-# Callout/
+Callout/  @joschect
 # Check/
 # Checkbox/
 # ChoiceGroup/
 # ColorPicker/
 # ComboBox/
 CommandBar/   @micahgodbolt
-# ContextualMenu/
+ContextualMenu/  @joschect
 DatePicker/   @johannao76 lorejoh12@gmail.com jolore@microsoft.com
 # DetailsList/
 # Dialog/
-# DocumentCard/
+DocumentCard/ @yiminwu @mikewheaton
 # Dropdown/
 # Fabric/
 # FacePile/
@@ -68,7 +71,7 @@ HoverCard/   @atneik @Jahnp
 # Icon/
 # Image/
 # Label/
-# Layer/
+Layer/  @ThomasMichon
 # Link/
 List/  @cschleiden
 # MarqueeSelection/
@@ -81,7 +84,7 @@ OverflowSet/  @micahgodbolt
 # Persona/
 Persona/PersonaCoin.tsx @mtennoe @jakob101
 Persona/PersonaConsts.tsx @mtennoe @jakob101
-# pickers/
+pickers/  @joschect
 # Pivot/
 # Popup/
 # ProgressIndicator/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@ packages/styling/  @dzearing
 packages/styling/src/interfaces/ @phkuo
 packages/styling/src/styles/ @phkuo
 # packages/utilities/
+packages/utilities/positioning/ @joschect
 
 ### Fabric
 # common/


### PR DESCRIPTION
This PR adds several new packages that weren't being tracked, and updates several component paths with new code owners. Thanks so much @KatherineThayerMicrosoft, @joschect, @yiminwu, @mikewheaton, and @ThomasMichon! As a reminder, please see the [contributing guidelines](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/CONTRIBUTING.md), [best practices](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/ghdocs/BESTPRACTICES.md), and other [ghdocs](https://github.com/OfficeDev/office-ui-fabric-react/tree/master/ghdocs) when reviewing pull requests into your areas.

# New packages or paths
| Package or path        | Owner |
|:------------- |:--------------|
| `packages/file-type-icons/` | @KatherineThayerMicrosoft |
| `packages/icons/` | **No codeowner** |
| `packages/merge-styles/` | **No codeowner** |
| `packages/jest-serializer-merge-styles/` | **No codeowner** |
| `packages/utilities/positioning/` | @joschect |

# New codeowners
| Package or path        | Owner |
|:------------- |:--------------|
| `Callout/` | @joschect |
| `ContextualMenu/` | @joschect |
| `DocumentCard/` | @yiminwu @mikewheaton |
| `Layer/` | @ThomasMichon |
| `pickers/` | @joschect |