### PR TITLE
Address Issue #1026 ChoiceGroup: Support image alt text

### DIFF
--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -173,7 +173,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                   }) }
               >
                 <Image
-                  src={ option.imageSrc }
+                  src={ option.imageSrc ? option.imageSrc : '' }
+                  alt={ option.imageAlt }
                   width={ option.imageSize ? option.imageSize.width : undefined }
                   height={ option.imageSize ? option.imageSize.height : undefined }
                 />
@@ -187,7 +188,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                   }) }
               >
                 <Image
-                  src={ option.selectedImageSrc }
+                  src={ option.imageSrc ? option.imageSrc : '' }
+                  alt={ option.selectedImageAlt ? option.selectedImageAlt : option.imageAlt }
                   width={ option.imageSize ? option.imageSize.width : undefined }
                   height={ option.imageSize ? option.imageSize.height : undefined }
                 />

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -188,8 +188,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                   }) }
               >
                 <Image
-                  src={ option.imageSrc }
-                  alt={ option.selectedImageAlt ? option.selectedImageAlt : '' }
+                  src={ option.selectedImageSrc }
+                  alt={ option.imageAlt ? option.imageAlt : '' }
                   width={ option.imageSize ? option.imageSize.width : undefined }
                   height={ option.imageSize ? option.imageSize.height : undefined }
                 />

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -173,8 +173,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                   }) }
               >
                 <Image
-                  src={ option.imageSrc ? option.imageSrc : '' }
-                  alt={ option.imageAlt }
+                  src={ option.imageSrc }
+                  alt={ option.imageAlt ? option.imageAlt : '' }
                   width={ option.imageSize ? option.imageSize.width : undefined }
                   height={ option.imageSize ? option.imageSize.height : undefined }
                 />
@@ -188,8 +188,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                   }) }
               >
                 <Image
-                  src={ option.imageSrc ? option.imageSrc : '' }
-                  alt={ option.selectedImageAlt ? option.selectedImageAlt : option.imageAlt }
+                  src={ option.imageSrc }
+                  alt={ option.selectedImageAlt ? option.selectedImageAlt : '' }
                   width={ option.imageSize ? option.imageSize.width : undefined }
                   height={ option.imageSize ? option.imageSize.height : undefined }
                 />

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -78,9 +78,20 @@ export interface IChoiceGroupOption extends React.HTMLAttributes<HTMLElement | H
   imageSrc?: string;
 
   /**
+   * The alt of image for choice field. Defaults to '' if not set.
+   */
+  imageAlt?: string;
+
+
+  /**
    * The src of image for choice field which is selected.
    */
   selectedImageSrc?: string;
+
+  /**
+   * The alt of image for choice field which is selected. Defaults to imageAlt if not set.
+   */
+  selectedImageAlt?: string;
 
   /**
    * The width and height of the image in px for choice field.

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -82,16 +82,10 @@ export interface IChoiceGroupOption extends React.HTMLAttributes<HTMLElement | H
    */
   imageAlt?: string;
 
-
   /**
    * The src of image for choice field which is selected.
    */
   selectedImageSrc?: string;
-
-  /**
-   * The alt of image for choice field which is selected. Defaults to imageAlt if not set.
-   */
-  selectedImageAlt?: string;
 
   /**
    * The width and height of the image in px for choice field.

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
@@ -32,13 +32,16 @@ export class ChoiceGroupImageExample extends React.Component<{}, IChoiceGroupIma
             {
               key: 'bar',
               imageSrc: TestImages.choiceGroupBarUnselected,
+              imageAlt: 'Bar chart icon',
               selectedImageSrc: TestImages.choiceGroupBarSelected,
+              selectedImageAlt: 'Selected bar chart icon',
               imageSize: { width: 32, height: 32 },
               text: 'Bar chart'
             },
             {
               key: 'pie',
               imageSrc: TestImages.choiceGroupBarUnselected,
+              imageAlt: '',
               selectedImageSrc: TestImages.choiceGroupBarSelected,
               imageSize: { width: 32, height: 32 },
               text: 'Pie chart'

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
@@ -34,14 +34,12 @@ export class ChoiceGroupImageExample extends React.Component<{}, IChoiceGroupIma
               imageSrc: TestImages.choiceGroupBarUnselected,
               imageAlt: 'Bar chart icon',
               selectedImageSrc: TestImages.choiceGroupBarSelected,
-              selectedImageAlt: 'Selected bar chart icon',
               imageSize: { width: 32, height: 32 },
               text: 'Bar chart'
             },
             {
               key: 'pie',
               imageSrc: TestImages.choiceGroupBarUnselected,
-              imageAlt: '',
               selectedImageSrc: TestImages.choiceGroupBarSelected,
               imageSize: { width: 32, height: 32 },
               text: 'Pie chart'


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #1026
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Added imageAlt and selectedImageAlt props to ChoiceGroup. 

imageAlt falls back to empty ('') by default giving the decorative images an empty alt tag (alt='') if text is not set. 

#### Focus areas to test

Test the ChoiceGroup in general.
