### PR TITLE
ChoiceGroup: Fix the hidden input on the image and icon variant

### DIFF
--- a/common/changes/office-ui-fabric-react/Choice-group--Narrator-focus-boundary-is-improper-on-the-ChoiceGroup-option--2131_2018-01-19-00-10.json
+++ b/common/changes/office-ui-fabric-react/Choice-group--Narrator-focus-boundary-is-improper-on-the-ChoiceGroup-option--2131_2018-01-19-00-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add classNames and style the hidden input inside the ChoiceGroup image and icon variants so the Narrator highlights it correctly. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -315,7 +315,7 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
   }
 
   // Hidden input for icon and image
-  .inputIsImage, .inputIsIcon {
+  .inputHasImage, .inputHasIcon {
     top: 0;
     right: 0;
     opacity: 0;

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -64,7 +64,7 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
 .input {
   position: absolute;
   opacity: 0;
-  top: 8px
+  top: 8px;
 }
 
 // The circle
@@ -194,9 +194,10 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
   @include ms-padding-left(0px);
   @include ms-bgColor-neutralLighter;
 
+  $radioButtonSpacing: 3px;
+  $radioButtonInnerSize: 5px;
+
   .fieldIsImage, .fieldIsIcon {
-    $radioButtonSpacing: 3px;
-    $radioButtonInnerSize: 5px;
 
     display: inline-block;
     box-sizing: border-box;
@@ -311,6 +312,16 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
         }
       }
     }
+  }
+
+  // Hidden input for icon and image
+  .inputIsImage, .inputIsIcon {
+    top: 0;
+    right: 0;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -106,8 +106,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                     ref={ this._resolveRef('_inputElement') }
                     id={ option.id }
                     className={ css('ms-ChoiceField-input', styles.input, {
-                      ['ms-ChoiceField--image ' + styles.inputIsImage]: !!option.imageSrc,
-                      ['ms-ChoiceField--icon ' + styles.inputIsIcon]: !!option.iconProps
+                      ['ms-ChoiceField--image ' + styles.inputHasImage]: !!option.imageSrc,
+                      ['ms-ChoiceField--icon ' + styles.inputHasIcon]: !!option.iconProps
                     }) }
                     type='radio'
                     name={ this.props.name || this._id }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -105,7 +105,10 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                   <input
                     ref={ this._resolveRef('_inputElement') }
                     id={ option.id }
-                    className={ css('ms-ChoiceField-input', styles.input) }
+                    className={ css('ms-ChoiceField-input', styles.input, {
+                      ['ms-ChoiceField--image ' + styles.inputIsImage]: !!option.imageSrc,
+                      ['ms-ChoiceField--icon ' + styles.inputIsIcon]: !!option.iconProps
+                    }) }
                     type='radio'
                     name={ this.props.name || this._id }
                     disabled={ option.disabled || this.props.disabled }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2131
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Give the ChoiceGroup hidden input classNames for the image and icon variant, and styled those classes so the Narrator highlights them correctly.

#### Focus areas to test

Test if the ChoiceGroup still functions as expected and the windows Narrator works as expected.
