### PR TITLE
Add post reduce grow callbacks

### DIFF
--- a/common/changes/@uifabric/experiments/AddPostReduceGrowCallbacks_2018-01-19-23-48.json
+++ b/common/changes/@uifabric/experiments/AddPostReduceGrowCallbacks_2018-01-19-23-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add callbacks for onDataReduced and onDataGrown",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "staylo@microsoft.com"
+}

--- a/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
@@ -155,7 +155,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   @autobind
   private _onReduceData(data: ICommandBarData): ICommandBarData | undefined {
-    const { endAligned } = this.props;
+    const { endAligned, onDataReduced } = this.props;
     let { primaryItems, overflowItems, cacheKey, farItems } = data;
 
     // Use first item if endAligned, otherwise use last item
@@ -168,6 +168,10 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       primaryItems = endAligned ? primaryItems.slice(1) : primaryItems.slice(0, -1);
       cacheKey = this._computeCacheKey(primaryItems, farItems!, !!overflowItems.length);
 
+      if (onDataReduced) {
+        onDataReduced(movedItem);
+      }
+
       return { ...data, primaryItems, overflowItems, cacheKey };
     }
 
@@ -176,7 +180,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   @autobind
   private _onGrowData(data: ICommandBarData): ICommandBarData | undefined {
-    const { endAligned } = this.props;
+    const { endAligned, onDataGrown } = this.props;
     let { primaryItems, overflowItems, cacheKey, minimumOverflowItems, farItems } = data;
     const movedItem = overflowItems[0];
 
@@ -188,6 +192,10 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       // if endAligned, movedItem goes first, otherwise, last.
       primaryItems = endAligned ? [movedItem, ...primaryItems] : [...primaryItems, movedItem];
       cacheKey = this._computeCacheKey(primaryItems, farItems!, !!overflowItems.length);
+
+      if (onDataGrown) {
+        onDataGrown(movedItem);
+      }
 
       return { ...data, primaryItems, overflowItems, cacheKey };
     }

--- a/packages/experiments/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/experiments/src/components/CommandBar/CommandBar.types.ts
@@ -90,6 +90,16 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   onGrowData?: (data: ICommandBarData) => ICommandBarData;
 
   /**
+   * Function callback invoked when data has been reduced.
+   */
+  onDataReduced?: (movedItem: ICommandBarItemProps) => void;
+
+  /**
+   * Function callback invoked when data has been grown.
+   */
+  onDataGrown?: (movedItem: ICommandBarItemProps) => void;
+
+  /**
    * Additional css class to apply to the command bar
    * @defaultvalue undefined
    */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Add callbacks onDataReduced and onDataGrown to the experiments CommandBar. These will be called with the movedItem in the event that an item is moved.

#### Focus areas to test

