### PR TITLE
Dropdown: Align error message style to TextField and ComboBox

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-errormessage_2018-01-22-18-50.json
+++ b/common/changes/office-ui-fabric-react/dropdown-errormessage_2018-01-22-18-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Align error message styling to TextField.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/dropdown-errormessage_2018-01-22-18-50.json
+++ b/common/changes/office-ui-fabric-react/dropdown-errormessage_2018-01-22-18-50.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Dropdown: Align error message styling to TextField.",
+      "comment": "Dropdown: Align error message styling to TextField. TextField & ComboBox: Updated invalid input border color to be red in all states.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.classNames.ts
@@ -44,17 +44,16 @@ export const getClassNames = memoizeFunction((
     ),
     root: mergeStyles(
       'ms-ComboBox',
-      isOpen && 'is-open',
+      hasErrorMessage ? styles.rootError : isOpen && 'is-open',
       required && 'is-required',
       styles.root,
       !allowFreeForm && styles.rootDisallowFreeForm,
-      hasErrorMessage && styles.rootError,
-      !disabled && focused && styles.rootFocused,
+      hasErrorMessage ? styles.rootError : !disabled && focused && styles.rootFocused,
       !disabled && {
         selectors: {
-          ':hover': !isOpen && !focused && styles.rootHovered,
-          ':active': styles.rootPressed,
-          ':focus': styles.rootFocused
+          ':hover': hasErrorMessage ? styles.rootError : !isOpen && !focused && styles.rootHovered,
+          ':active': hasErrorMessage ? styles.rootError : styles.rootPressed,
+          ':focus': hasErrorMessage ? styles.rootError : styles.rootFocused
         }
       },
       disabled && [

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -160,10 +160,9 @@ $DropDown-item-height: 32px;
 }
 
 .errorMessage{
-    color: $ms-color-error;
-  &::before {
-    content: '* ';
-  }
+  color: $ms-color-error;
+  @include ms-font-s;
+  padding-top: 5px;
 }
 
 .items {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -54,11 +54,17 @@ $DropDown-item-height: 32px;
     .title {
       border-color: $ms-color-neutralDark;
     }
+    .titleIsError {
+      border-color: $ms-color-error;
+    }
   }
 
   &:active {
     .title {
       border-color: $ms-color-themeDark;
+    }
+    .titleIsError {
+      border-color: $ms-color-error;
     }
   }
 
@@ -66,6 +72,13 @@ $DropDown-item-height: 32px;
     .title {
       border-color: $ms-color-themePrimary;
     }
+    .titleIsError {
+      border-color: $ms-color-error;
+    }
+  }
+
+  .titleIsError {
+    border-color: $ms-color-error;
   }
 
   :global(.ms-Label) {
@@ -135,9 +148,6 @@ $DropDown-item-height: 32px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  &.titleIsError {
-    border-color: $ms-color-error;
-  }
   &.titleIsPlaceHolder {
     color: $ms-color-neutralSecondary;
   }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/DropdownPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/DropdownPage.tsx
@@ -7,11 +7,13 @@ import {
 } from '@uifabric/example-app-base';
 import { DropdownBasicExample } from './examples/Dropdown.Basic.Example';
 import { DropdownCustomExample } from './examples/Dropdown.Custom.Example';
+import { DropdownErrorExample } from './examples/Dropdown.Error.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { DropdownStatus } from './Dropdown.checklist';
 
 const DropdownBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx') as string;
 const DropdownCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx') as string;
+const DropdownErrorExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx') as string;
 
 export class DropdownPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -21,14 +23,25 @@ export class DropdownPage extends React.Component<IComponentDemoPageProps, {}> {
         componentName='DropdownExample'
         exampleCards={
           <div>
-            <ExampleCard title='Dropdown' code={ DropdownBasicExampleCode }>
+            <ExampleCard
+              title='Dropdown'
+              code={ DropdownBasicExampleCode }
+            >
               <DropdownBasicExample />
             </ExampleCard>
 
-            <ExampleCard title='Customized Dropdown' code={ DropdownCustomExampleCode }>
+            <ExampleCard
+              title='Customized Dropdown'
+              code={ DropdownCustomExampleCode }
+            >
               <DropdownCustomExample />
             </ExampleCard>
-
+            <ExampleCard
+              title='Dropdown with Error Message'
+              code={ DropdownErrorExampleCode }
+            >
+              <DropdownErrorExample />
+            </ExampleCard>
           </div>
 
         }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.scss
@@ -1,8 +1,8 @@
 :global {
-  .DropdownBasicExample {
+  .docs-DropdownExample {
     max-width: 300px;
-  }
-  .Dropdown-example {
-    margin-bottom: 10px;
+    .ms-Dropdown-container {
+      margin-bottom: 10px;
+    }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -22,9 +22,8 @@ export class DropdownBasicExample extends BaseComponent<{}, {
     let { selectedItem, selectedItems } = this.state;
 
     return (
-      <div className='DropdownBasicExample'>
+      <div className='docs-DropdownExample'>
         <Dropdown
-          className='Dropdown-example'
           placeHolder='Select an Option'
           label='Basic uncontrolled example:'
           id='Basicdrop1'
@@ -55,7 +54,6 @@ export class DropdownBasicExample extends BaseComponent<{}, {
           onClick={ this._onSetFocusButtonClicked }
         />
         <Dropdown
-          className='Dropdown-example'
           label='Disabled uncontrolled example with defaultSelectedKey:'
           defaultSelectedKey='D'
           options={
@@ -75,7 +73,6 @@ export class DropdownBasicExample extends BaseComponent<{}, {
         />
 
         <Dropdown
-          className='Dropdown-example'
           label='Controlled example:'
           selectedKey={ (selectedItem ? selectedItem.key : undefined) }
           onChanged={ this.changeState }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
@@ -15,7 +15,7 @@ export class DropdownCustomExample extends React.Component {
 
   public render() {
     return (
-      <div className='dropdownExample'>
+      <div className='docs-DropdownExample'>
 
         <Dropdown
           placeHolder='Select an Option'

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { Dropdown, IDropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { autobind, BaseComponent } from '../../../Utilities';
+import './Dropdown.Basic.Example.scss';
+
+export class DropdownErrorExample extends BaseComponent<{}, {}> {
+  private _basicDropdown: IDropdown;
+
+  constructor(props: {}) {
+    super(props);
+  }
+
+  public render() {
+    return (
+      <div className='docs-DropdownExample'>
+        <Dropdown
+          placeHolder='Select an Option'
+          label='Error message example:'
+          id='Errormessagedrop1'
+          ariaLabel='Error message dropdown example'
+          options={
+            [
+              { key: 'A', text: 'Option a' },
+              { key: 'B', text: 'Option b' },
+              { key: 'C', text: 'Option c' },
+              { key: 'D', text: 'Option d' },
+              { key: 'E', text: 'Option e' },
+            ]
+          }
+          componentRef={ this._resolveRef('_basicDropdown') }
+          errorMessage='Error message'
+        />
+      </div>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -56,6 +56,12 @@ $field-error-color: $errorTextColor;
     border-color: $field-border-focus-color;
   }
 
+  &.fieldGroupIsFocused {
+    &.invalid {
+      border-color: $field-border-error-color;
+    }
+  }
+
   .rootIsDisabled & {
     background-color: $field-background-disabled-color;
     border-color: $field-border-disabled-color;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3748 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Error message text styling now aligns with TextField's
- New example for documentation so we can see this functionality
- Fixed border color states when there is an error
- Also fixed border color states for ComboBox and TextField to be consistent, not all states were red, they should be
- Tweaked some example scss to match patterns we're using with other examples

![image](https://user-images.githubusercontent.com/16619843/35238322-f6cd6644-ff61-11e7-88d1-697176bb509b.png)

#### Focus areas to test

(optional)
