### PR TITLE
Split Button - Adding aria support for all buttons including the overall container.

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-accSplitButtons_2018-01-23-00-13.json
+++ b/common/changes/office-ui-fabric-react/chiechan-accSplitButtons_2018-01-23-00-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SplitButton - added aria support for button in split buttons and the whole container",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -429,7 +429,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     return (
       <div
-        role={ this.props.ariaHidden ? 'button' : undefined }
+        // TODO: THIS SHOULD BE SET BASED OFF OF ARIAHIDDEN
+        role={ 'button' }
         aria-labelledby={ buttonProps.ariaLabel }
         aria-disabled={ disabled }
         aria-haspopup={ true }

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -429,6 +429,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     return (
       <div
+        role={ this.props.ariaHidden ? 'button' : undefined }
         aria-labelledby={ buttonProps.ariaLabel }
         aria-disabled={ disabled }
         aria-haspopup={ true }
@@ -478,7 +479,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'onClick': this._onMenuClick,
       'menuProps': undefined,
       'iconProps': menuIconProps,
-      'ariaLabel': splitButtonAriaLabel
+      'ariaLabel': splitButtonAriaLabel,
+      'aria-haspopup': true,
+      'aria-expanded': this._isExpanded
     };
 
     return <BaseButton {...splitButtonProps} />;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -429,7 +429,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     return (
       <div
-        // TODO: THIS SHOULD BE SET BASED OFF OF ARIAHIDDEN
         role={ 'button' }
         aria-labelledby={ buttonProps.ariaLabel }
         aria-disabled={ disabled }
@@ -442,8 +441,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         ref={ this._resolveRef('_splitButtonContainer') }
       >
         <span
-          aria-hidden={ true }
-          // TODO: THIS SHOULD BE REMOVED!
           style={ { 'display': 'flex' } }
         >
           { this._onRenderContent(tag, buttonProps) }


### PR DESCRIPTION
#### Description of changes

In our current Split button, the only button that has aria attributes is the primary button. However, according to changes desired in the accessibility community, we want to add aria-attributes to both the primary button, the split button, and the button containers.

With the changes here, I gave the button container a role of a button and added aria attributes to the split button.

#### Focus areas to test

Split container page.
