### PR TITLE
Button - Added support for aria-posinset and aria-setsize

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-accButtonPos_2018-01-23-01-28.json
+++ b/common/changes/office-ui-fabric-react/chiechan-accButtonPos_2018-01-23-01-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button - add support for aria-posinset and aria-setsize",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`CommandBar renders commands correctly 1`] = `
             aria-describedby={null}
             aria-label={undefined}
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--commandBar
@@ -146,7 +148,9 @@ exports[`CommandBar renders commands correctly 1`] = `
             aria-describedby={null}
             aria-label={undefined}
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--commandBar

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -183,7 +183,9 @@ exports[`Breadcrumb renders breadcumb correctly 2`] = `
               aria-label={undefined}
               aria-labelledby={null}
               aria-owns={null}
+              aria-posinset={undefined}
               aria-pressed={undefined}
+              aria-setsize={undefined}
               className=
                   ms-Button
                   ms-Button--icon

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -87,7 +87,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       checked,
       variantClassName,
       theme,
-      getClassNames
+      getClassNames,
+      ariaPosInSet,
+      ariaSetSize
          } = this.props;
 
     let { menuProps } = this.state;
@@ -164,7 +166,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         'aria-labelledby': ariaLabelledBy,
         'aria-describedby': ariaDescribedBy,
         'data-is-focusable': ((this.props as any)['data-is-focusable'] === false || disabled) ? false : true,
-        'aria-pressed': checked
+        'aria-pressed': checked,
+        'aria-posinset': ariaPosInSet,
+        'aria-setsize': ariaSetSize
       }
     );
 
@@ -429,12 +433,16 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     return (
       <div
+        // TODO: ROLE SHOULD BE SET BASED OFF OF ARIAHIDDEN
+        role={ 'button' }
         aria-labelledby={ buttonProps.ariaLabel }
         aria-disabled={ disabled }
         aria-haspopup={ true }
         aria-expanded={ this._isExpanded }
         aria-pressed={ this.props.checked }
         aria-describedby={ buttonProps.ariaDescription }
+        aria-posinset={ buttonProps.ariaPosInSet }
+        aria-setsize={ buttonProps.ariaSetSize }
         className={ classNames && classNames.splitButtonContainer }
         onKeyDown={ this._onMenuKeyDown }
         ref={ this._resolveRef('_splitButtonContainer') }
@@ -478,7 +486,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'onClick': this._onMenuClick,
       'menuProps': undefined,
       'iconProps': menuIconProps,
-      'ariaLabel': splitButtonAriaLabel
+      'ariaLabel': splitButtonAriaLabel,
+      'aria-haspopup': true,
+      'aria-expanded': this._isExpanded
     };
 
     return <BaseButton {...splitButtonProps} />;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -433,8 +433,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     return (
       <div
-        // TODO: ROLE SHOULD BE SET BASED OFF OF ARIAHIDDEN
-        role={ 'button' }
         aria-labelledby={ buttonProps.ariaLabel }
         aria-disabled={ disabled }
         aria-haspopup={ true }
@@ -486,9 +484,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'onClick': this._onMenuClick,
       'menuProps': undefined,
       'iconProps': menuIconProps,
-      'ariaLabel': splitButtonAriaLabel,
-      'aria-haspopup': true,
-      'aria-expanded': this._isExpanded
+      'ariaLabel': splitButtonAriaLabel
     };
 
     return <BaseButton {...splitButtonProps} />;

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -224,8 +224,14 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
     expanded: boolean,
     checked: boolean) => ISplitButtonClassNames;
 
+  /**
+   * The position of the button in a set for the benefit of screen readers.
+   */
   ariaPosInSet?: number;
 
+  /**
+   * The total number of items in a set of html elements for the benefit of screen readers.
+   */
   ariaSetSize?: number;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -223,6 +223,10 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
   getSplitButtonClassNames?: (disabled: boolean,
     expanded: boolean,
     checked: boolean) => ISplitButtonClassNames;
+
+  ariaPosInSet?: number;
+
+  ariaSetSize?: number;
 }
 
 export enum ElementType {

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -5,7 +5,9 @@ exports[`Button renders ActionButton correctly 1`] = `
   aria-describedby={null}
   aria-label={undefined}
   aria-labelledby={null}
+  aria-posinset={undefined}
   aria-pressed={undefined}
+  aria-setsize={undefined}
   className=
       ms-Button
       ms-Button--action
@@ -110,7 +112,9 @@ exports[`Button renders CommandBarButton correctly 1`] = `
   aria-label={undefined}
   aria-labelledby={null}
   aria-owns={null}
+  aria-posinset={undefined}
   aria-pressed={undefined}
+  aria-setsize={undefined}
   className=
       ms-Button
       ms-Button--commandBar
@@ -258,7 +262,9 @@ exports[`Button renders CompoundButton correctly 1`] = `
   aria-describedby="id__10"
   aria-label={undefined}
   aria-labelledby={null}
+  aria-posinset={undefined}
   aria-pressed={undefined}
+  aria-setsize={undefined}
   className=
       ms-Button
       ms-Button--compound
@@ -387,7 +393,9 @@ exports[`Button renders DefaultButton correctly 1`] = `
   aria-describedby={null}
   aria-label={undefined}
   aria-labelledby={null}
+  aria-posinset={undefined}
   aria-pressed={undefined}
+  aria-setsize={undefined}
   className=
       ms-Button
       ms-Button--default
@@ -486,7 +494,9 @@ exports[`Button renders IconButton correctly 1`] = `
   aria-describedby={null}
   aria-label="Emoji"
   aria-labelledby={null}
+  aria-posinset={undefined}
   aria-pressed={undefined}
+  aria-setsize={undefined}
   className=
       ms-Button
       ms-Button--icon

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -120,7 +120,9 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
       aria-hidden="true"
       aria-label={undefined}
       aria-labelledby={null}
+      aria-posinset={undefined}
       aria-pressed={false}
+      aria-setsize={undefined}
       checked={false}
       className=
           ms-Button

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -97,7 +97,9 @@ exports[`Facepile renders Facepile correctly 1`] = `
         aria-describedby={null}
         aria-label={undefined}
         aria-labelledby={null}
+        aria-posinset={undefined}
         aria-pressed={undefined}
+        aria-setsize={undefined}
         className=
             ms-Button
             ms-Facepile-itemButton

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`Nav renders Nav correctly 1`] = `
                 aria-describedby={null}
                 aria-label={undefined}
                 aria-labelledby={null}
+                aria-posinset={undefined}
                 aria-pressed={undefined}
+                aria-setsize={undefined}
                 className=
                     ms-Button
                     ms-Button--action

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -20,8 +20,10 @@ exports[`Pivot renders Pivot correctly 1`] = `
         aria-describedby={null}
         aria-label={undefined}
         aria-labelledby={null}
+        aria-posinset={undefined}
         aria-pressed={undefined}
         aria-selected={true}
+        aria-setsize={undefined}
         className=
             ms-Button
             ms-Button--action
@@ -115,8 +117,10 @@ exports[`Pivot renders Pivot correctly 1`] = `
         aria-describedby={null}
         aria-label={undefined}
         aria-labelledby={null}
+        aria-posinset={undefined}
         aria-pressed={undefined}
         aria-selected={false}
+        aria-setsize={undefined}
         className=
             ms-Button
             ms-Button--action

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -149,7 +149,9 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
         aria-hidden="true"
         aria-label={undefined}
         aria-labelledby={null}
+        aria-posinset={undefined}
         aria-pressed={false}
+        aria-setsize={undefined}
         checked={false}
         className=
             ms-Button
@@ -256,7 +258,9 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
         aria-hidden="true"
         aria-label={undefined}
         aria-labelledby={null}
+        aria-posinset={undefined}
         aria-pressed={false}
+        aria-setsize={undefined}
         checked={false}
         className=
             ms-Button

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -53,8 +53,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="green"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -237,8 +239,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="orange"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -421,8 +425,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="blue"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -605,8 +611,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="red"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -793,8 +801,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="green"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -977,8 +987,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="orange"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -1161,8 +1173,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="blue"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -1345,8 +1359,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="red"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -1533,8 +1549,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="black"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -1717,8 +1735,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="grey"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -1901,8 +1921,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="purple"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action
@@ -2085,8 +2107,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
             aria-describedby={null}
             aria-label="yellow"
             aria-labelledby={null}
+            aria-posinset={undefined}
             aria-pressed={undefined}
             aria-selected={false}
+            aria-setsize={undefined}
             className=
                 ms-Button
                 ms-Button--action


### PR DESCRIPTION
#### Description of changes

Currently our button model does not have the ability to indicate to screen readers that it is an item that's a part of a list.

Adding in aria-posinset to help screen readers understand which number in a set of items our button is and aria-setsize to help screen readers identify how many items in a set of buttons.
