### PR TITLE
Grid - Adding accessibility support to allow screen readers to read the name of a Grid

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-accGridLabel_2018-01-23-02-44.json
+++ b/common/changes/office-ui-fabric-react/chiechan-accGridLabel_2018-01-23-02-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Grid - added aria-label and aria-labelledby for screen readers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -20,6 +20,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
   role="presentation"
 >
   <table
+    aria-label={undefined}
+    aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
     className=

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -26,7 +26,9 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
       onRenderItem,
       positionInSet,
       setSize,
-      getStyles
+      getStyles,
+      ariaLabelledBy,
+      ariaLabel
     } = this.props;
 
     const classNames = getClassNames(getStyles!, { theme: this.props.theme! });
@@ -41,6 +43,8 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
         aria-posinset={ positionInSet }
         aria-setsize={ setSize }
         className={ classNames.root }
+        aria-label={ !ariaLabelledBy && ariaLabel }
+        aria-labelledby={ ariaLabelledBy }
       >
         <tbody>
           {

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -64,9 +64,19 @@ export interface IGridProps {
   theme?: ITheme;
 
   /**
- * Optional styles for the component.
- */
+   * Optional styles for the component.
+   */
   getStyles?: IStyleFunction<IGridStyleProps, IGridStyles>;
+
+  /**
+   * The optional id of an label to be read for the benefit of screen readers.
+   */
+  ariaLabelledBy?: string;
+
+  /**
+   * The optional label to be read for the benefit of screen readers.
+   */
+  ariaLabel?: string;
 }
 
 /**


### PR DESCRIPTION
#### Description of changes

Currently Grids don't have an accessible name that we can attach to it for ScreenReaders to more easily read the components.

I'm adding support for aria-label and aria-labelledby, where labelledby would take precedence over label for the Grid component.

#### Focus areas to test

(optional)
