### PR TITLE
Minor README.md update for styling

### DIFF
--- a/packages/styling/README.md
+++ b/packages/styling/README.md
@@ -94,7 +94,7 @@ The default palette of colors matches the default Fabric core styling convention
 ```tsx
 import {
   loadTheme({
-    colors: {
+    palette: {
       themePrimary: 'red',
       themeSeconary: 'blue'
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3305

#### Description of changes
Fixes a minor docs bug with the `@uifabric/styling` README. `colors` should instead be `palette`. See the value of the object returned from `createTheme` [here](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/styling/src/styles/theme.ts#L107) for an example of what I mean.
