### PR TITLE
DatePicker: Fix datePicker overlap with week numbers for RTL

### DIFF
--- a/common/changes/office-ui-fabric-react/srk-CalendarDayRTLFix_2018-01-23-12-33.json
+++ b/common/changes/office-ui-fabric-react/srk-CalendarDayRTLFix_2018-01-23-12-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix CalendarDay RTL view",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "srkandu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -223,6 +223,32 @@ $Calendar-dayPicker-margin: 10px;
   }
 }
 
+// week numbers style in right-to-left view
+.showWeekNumbersRTL {
+  .weekNumbers {
+    position: absolute;
+    margin-top: $Calendar-day;
+    border-left: 1px solid $ms-color-neutralLight;
+    box-sizing: border-box;
+    width: 30px;
+    .day {
+      color: $ms-color-neutralSecondary;
+      &.weekIsHighlighted {
+        color: $ms-color-black;
+      }
+    }
+  }
+  .table {
+    &:not(.weekNumbers) {
+      margin-right: 30px;
+    }
+    .day,
+    .weekday {
+      width: 30px;
+    }
+  }
+}
+
 // Month and year previous/next components.
 .monthComponents,
 .yearComponents,
@@ -434,6 +460,22 @@ $Calendar-dayPicker-margin: 10px;
     .table {
       &:not(.weekNumbers) {
         margin-left: 19px;
+      }
+      .day,
+      .weekday {
+        width: 26px;
+      }
+    }
+  } // week numbers style in right-to-left view
+  .showWeekNumbersRTL {
+    .weekNumbers {
+      margin-top: $Calendar-day;
+      width: 26px;
+      margin-right: -7px;
+    }
+    .table {
+      &:not(.weekNumbers) {
+        margin-right: 19px;
       }
       .day,
       .weekday {

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -123,7 +123,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       <div
         className={ css('ms-DatePicker-dayPicker',
           styles.dayPicker,
-          showWeekNumbers && 'ms-DatePicker-showWeekNumbers' && styles.showWeekNumbers
+          showWeekNumbers && 'ms-DatePicker-showWeekNumbers' && (getRTL() ? styles.showWeekNumbersRTL : styles.showWeekNumbers)
         ) }
         id={ dayPickerId }
       >


### PR DESCRIPTION
#### Pull request checklist

- [ x ] Addresses an existing issue: Fixes #3771 
- [ x ] Include a change request file using `$ npm run change`

#### Description of changes

1. Added new style showWeekNumbersRTL in Calendar.scss, which just modifies the existing showWeekNumbers such that the borders and margins on the left and right are swapped. 
2. Modified the CalendarDay render method to choose the new style or the old one based on RTL setting.

#### Before the fix
![image](https://user-images.githubusercontent.com/6827024/35279817-36432292-0074-11e8-87ec-55a2ff1f510e.png)

#### After the fix
![image](https://user-images.githubusercontent.com/6827024/35280282-b53459f8-0075-11e8-8f22-83a5156e6307.png)


