### PR TITLE
ResizeGroup: Add the ability for ResizeGroup to take divProps

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-AddAraiPropsToResizeGroup_2018-01-23-20-18.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-AddAraiPropsToResizeGroup_2018-01-23-20-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ResizeGroup: Add the ability for ResizeGroup to get divProps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {
+  BaseComponent,
   css,
-  BaseComponent
+  divProperties,
+  getNativeProps
 } from '../../Utilities';
 import { provideContext } from '@uifabric/utilities/lib/Context';
 import { IResizeGroupProps } from './ResizeGroup.types';
@@ -299,9 +301,10 @@ export class ResizeGroup extends BaseComponent<IResizeGroupProps, IResizeGroupSt
   public render() {
     const { onRenderData, className } = this.props;
     const { dataToMeasure, renderedData } = this.state;
+    const divProps = getNativeProps(this.props, divProperties, ['data']);
 
     return (
-      <div className={ css('ms-ResizeGroup', className) } ref={ this._resolveRef('_root') }>
+      <div {...divProps} className={ css('ms-ResizeGroup', className) } ref={ this._resolveRef('_root') }>
         { this._nextResizeGroupStateProvider.shouldRenderDataToMeasureInHiddenDiv(dataToMeasure) && (
           <div className={ css(styles.measured) } ref={ this._resolveRef('_measured') }>
             <MeasuredContext>{ onRenderData(dataToMeasure) }</MeasuredContext>

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
@@ -75,6 +75,8 @@ export class ResizeGroupOverflowSetExample extends BaseComponent<{}, IResizeGrou
     return (
       <div className={ short ? styles.resizeIsShort : 'notResized' }>
         <ResizeGroup
+          role='tabpanel'
+          aria-label='Resize Group with an Overflow Set'
           data={ dataToRender }
           onReduceData={ this._onReduceData }
           onGrowData={ onGrowDataEnabled ? this._onGrowData : undefined }


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Before this PR a ResizeGroup could not take in generic divProps (including aria markup), so this change is adding that functionality

#### Focus areas to test

Verified that the divProps get applied as expected and we are excluding the overloaded data prop that is also defined (in another sense) on the ResizeGroup
