### PR TITLE
Prevent default to avoid setting focus on SplitButton menu button

### DIFF
--- a/common/changes/office-ui-fabric-react/PreventDefault_OnMouseDown_SplitButton_2018-01-23-21-51.json
+++ b/common/changes/office-ui-fabric-react/PreventDefault_OnMouseDown_SplitButton_2018-01-23-21-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Prevent default to avoid setting focus on SplitButton menu button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "madosal@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -481,7 +481,17 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'ariaLabel': splitButtonAriaLabel
     };
 
-    return <BaseButton {...splitButtonProps} />;
+    return <BaseButton {...splitButtonProps} onMouseDown={ this._onMouseDown } />;
+
+  }
+
+  @autobind
+  private _onMouseDown(ev: React.MouseEvent<BaseButton>) {
+    if (this.props.onMouseDown) {
+      this.props.onMouseDown(ev);
+    }
+
+    ev.preventDefault();
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [x ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

1.Click on SplitButton menu button.
2.Press Esc.
Actual: Focus stays in split button
Expected: Focus should go to previous focused element.

#### Focus areas to test

Tested that focus is set properly.
Made sure that we are able to execute primary action and secondary action of SplitButtons.