### PR TITLE
Spin Button - Removing aria-hidden and adding aria-labels for up/down buttons

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-accSpinBtn_2018-01-23-22-21.json
+++ b/common/changes/office-ui-fabric-react/chiechan-accSpinBtn_2018-01-23-22-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "spin button - add aria label for decrement and increment buttons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -197,7 +197,6 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
               checked={ keyboardSpinDirection === KeyboardSpinDirection.up }
               disabled={ disabled }
               iconProps={ incrementButtonIcon }
-              aria-hidden='true'
               onMouseDown={ this._onIncrementMouseDown }
               onMouseLeave={ this._stop }
               onMouseUp={ this._stop }
@@ -209,7 +208,6 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
               checked={ keyboardSpinDirection === KeyboardSpinDirection.down }
               disabled={ disabled }
               iconProps={ decrementButtonIcon }
-              aria-hidden='true'
               onMouseDown={ this._onDecrementMouseDown }
               onMouseLeave={ this._stop }
               onMouseUp={ this._stop }

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -126,7 +126,9 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
       labelPosition,
       iconProps,
       incrementButtonIcon,
+      incrementButtonAriaLabel,
       decrementButtonIcon,
+      decrementButtonAriaLabel,
       title,
       ariaLabel,
       styles: customStyles,
@@ -201,6 +203,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
               onMouseLeave={ this._stop }
               onMouseUp={ this._stop }
               tabIndex={ -1 }
+              ariaLabel={ incrementButtonAriaLabel }
             />
             <IconButton
               styles={ getArrowButtonStyles(theme!, false, customDownArrowButtonStyles) }
@@ -212,6 +215,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
               onMouseLeave={ this._stop }
               onMouseUp={ this._stop }
               tabIndex={ -1 }
+              ariaLabel={ decrementButtonAriaLabel }
             />
           </span>
         </div>

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -155,6 +155,16 @@ export interface ISpinButtonProps {
    * Theme provided by HOC.
    */
   theme?: ITheme;
+
+  /**
+   * Accessibility label text for the increment button for the benefit of the screen reader.
+   */
+  incrementButtonAriaLabel?: string;
+
+  /**
+   * Accessibility label text for the decrement button for the benefit of the screen reader.
+   */
+  decrementButtonAriaLabel?: string;
 }
 
 export interface ISpinButtonStyles {

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -146,7 +146,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
     >
       <button
         aria-describedby={null}
-        aria-hidden="true"
         aria-label={undefined}
         aria-labelledby={null}
         aria-pressed={false}
@@ -253,7 +252,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
       </button>
       <button
         aria-describedby={null}
-        aria-hidden="true"
         aria-label={undefined}
         aria-labelledby={null}
         aria-pressed={false}


### PR DESCRIPTION
#### Description of changes

To comply with the standards set by screen readers for a spin button, an input must have 2 controls, which in the case of the spin button, is the up and down buttons. We have to remove the aria-hidden on these 2 buttons so screen readers can detect them.

Alongside of that, we should also be able to add an accessible name to the up/down buttons in the spinner.

#### Focus areas to test

Spin Button page in the component, specifically to see that the aria-hidden value is gone.