### PR TITLE
Cancel should set timeoutId to null

### DIFF
--- a/common/changes/@uifabric/utilities/debounceCancel_2018-01-23-23-50.json
+++ b/common/changes/@uifabric/utilities/debounceCancel_2018-01-23-23-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Set timeout ids to null for cancel and flush functions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "alexbettadapur@gmail.com"
+}

--- a/packages/utilities/src/Async.ts
+++ b/packages/utilities/src/Async.ts
@@ -403,12 +403,14 @@ export class Async {
     let cancel = (): void => {
       if (timeoutId) {
         this.clearTimeout(timeoutId);
+        timeoutId = null;
       }
     };
 
     let flush = (): T => {
       if (timeoutId) {
         this.clearTimeout(timeoutId);
+        timeoutId = null;
         invokeFunction(new Date().getTime());
       }
 

--- a/packages/utilities/src/Async.ts
+++ b/packages/utilities/src/Async.ts
@@ -360,12 +360,16 @@ export class Async {
     }
 
     let invokeFunction = (time: number) => {
+      markExecuted(time);
+      lastResult = func.apply(this._parent, lastArgs);
+    };
+
+    let markExecuted = (time: number) => {
       if (timeoutId) {
         this.clearTimeout(timeoutId);
         timeoutId = null;
       }
       lastExecuteTime = time;
-      lastResult = func.apply(this._parent, lastArgs);
     };
 
     let callback = (userCall?: boolean) => {
@@ -401,16 +405,14 @@ export class Async {
     };
 
     let cancel = (): void => {
-      if (timeoutId) {
-        this.clearTimeout(timeoutId);
-        timeoutId = null;
+      if (pending()) {
+        // Mark the debounced function as having executed
+        markExecuted(new Date().getTime());
       }
     };
 
     let flush = (): T => {
-      if (timeoutId) {
-        this.clearTimeout(timeoutId);
-        timeoutId = null;
+      if (pending()) {
         invokeFunction(new Date().getTime());
       }
 

--- a/packages/utilities/src/Async.ts
+++ b/packages/utilities/src/Async.ts
@@ -359,17 +359,17 @@ export class Async {
       maxWait = options.maxWait;
     }
 
-    let invokeFunction = (time: number) => {
-      markExecuted(time);
-      lastResult = func.apply(this._parent, lastArgs);
-    };
-
     let markExecuted = (time: number) => {
       if (timeoutId) {
         this.clearTimeout(timeoutId);
         timeoutId = null;
       }
       lastExecuteTime = time;
+    };
+
+    let invokeFunction = (time: number) => {
+      markExecuted(time);
+      lastResult = func.apply(this._parent, lastArgs);
     };
 
     let callback = (userCall?: boolean) => {
@@ -404,6 +404,10 @@ export class Async {
       return lastResult;
     };
 
+    let pending = (): boolean => {
+      return !!timeoutId;
+    };
+
     let cancel = (): void => {
       if (pending()) {
         // Mark the debounced function as having executed
@@ -417,10 +421,6 @@ export class Async {
       }
 
       return lastResult;
-    };
-
-    let pending = (): boolean => {
-      return !!timeoutId;
     };
 
     // tslint:disable-next-line:no-any


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3781 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
* Create a markExecuted function, which clears timeout and sets timeoutId to null
* Cancel, flush, and invoke now call this markExecuted function