### PR TITLE
feat(pkg): add sideEffects false field

### DIFF
--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/OfficeDev/office-ui-fabric-react"
   },
+  "sideEffects": false,
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/build.js",


### PR DESCRIPTION
Update package.json to add `"sideEffects": false` key value pair.

#### Pull request checklist
~- [ ] Include a change request file using `$ npm run change`~ *Submitted this change from GitHub UI. If this is really needed for the scope of this change, I can generate it.* 

#### Description of changes
Update package.json to add sideEffects: false feature (which is for webpack v4 support of deep pruning of unused reexported modules). [Read blog post on webpack v4 and sideEffects for more info](https://medium.com/webpack/webpack-4-beta-try-it-today-6b1d27d7d7e2)

Given this component library (after skimming through) doesn't appear to have side effects in any of the module reexports, it would look like setting this value wouldn't break any user running webpack 4. And given webpack 3 doesn't detect this field, there is no concern of backwards compat issue. 

**Why?** This can reduce bundle sizes in a considerable amount for those leveraging webpack 4. 

#### Focus areas to test
None.

