### PR TITLE
Persona: Increased heights to account for double diacriticals and prevent textoverflow

### DIFF
--- a/common/changes/office-ui-fabric-react/people-picker-height_2018-01-25-18-32.json
+++ b/common/changes/office-ui-fabric-react/people-picker-height_2018-01-25-18-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Persona: Changed text and root heights for size24 when secondary text is shown.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.scss
@@ -360,12 +360,12 @@ $ms-Persona-presenceBorder: 2px;
   }
 
   &.showSecondaryText {
-    height: 32px;
+    height: 36px;
 
     .primaryText,
     .secondaryText {
       display: block;
-      height: 16px;
+      height: 18px;
       line-height: 16px;
       overflow-x: hidden;
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3717 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- PeoplePicker is a use case where we were showing secondary text on a size24 Persona. The text heights were causing text descenders to be cut off, which triggers a tooltip to show on hover. 
- Also had to increase the root height to account for double diacriticals.

This is after - I pasted a double diacritcal A in for testing:
![image](https://user-images.githubusercontent.com/16619843/35405907-507b01b8-01bc-11e8-90e3-ec147bf877d7.png)

#### Focus areas to test

(optional)
