### PR TITLE
Fix peoplepicker coin

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-peoplepicker-coin_2018-01-26-19-16.json
+++ b/common/changes/office-ui-fabric-react/fix-peoplepicker-coin_2018-01-26-19-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "setting people picker default size back to 28 from 24",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -48,7 +48,7 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
         <Persona
           { ...item }
           presence={ item.presence !== undefined ? item.presence : PersonaPresence.none }
-          size={ PersonaSize.size24 }
+          size={ PersonaSize.size28 }
         />
       </div>
       <IconButton


### PR DESCRIPTION
#### Description of changes

Setting people picker coin default size back to 28 from 24

#### Focus areas to test

N/A
