### PR TITLE
ComboBox: Fix auto expand for allowFreeform

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxAutoExpandFix_2018-01-26-19-35.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxAutoExpandFix_2018-01-26-19-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: ComboBoxes were changed to always expand which is incorrect behavior, fixing to align with the correct design",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1517,7 +1517,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   @autobind
   private _onBaseAutofillClick() {
     if (this.props.allowFreeform) {
-      this.focus(true);
+      this.focus(this.state.isOpen);
     } else {
       this._onComboBoxClick();
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes
ComboBoxes should not auto expand on click if it allowFreeform is true

#### Focus areas to test

verified that the comboBox no longer autoexpands when it gets focus if allow freeform is true, but will stay expanded if it was already open (so that the IP can be placed/moved/ or a selection can be made)
