### PR TITLE
Add overflow menu props to command bar

### DIFF
--- a/common/changes/@uifabric/experiments/addOverflowMenuPropsToCommandBar_2018-01-26-21-02.json
+++ b/common/changes/@uifabric/experiments/addOverflowMenuPropsToCommandBar_2018-01-26-21-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add overflowMenuProps to Experiments CommandBar",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "staylo@microsoft.com"
+}

--- a/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
@@ -67,6 +67,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       farItems,
       elipisisAriaLabel,
       elipisisIconProps,
+      overflowMenuProps,
       buttonStyles,
       getStyles,
       theme,
@@ -111,7 +112,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
                       styles: { ...buttonStyles, menuIcon: { fontSize: '17px' } },
                       ariaLabel: elipisisAriaLabel,
                       className: css('ms-CommandBar-overflowButton'),
-                      menuProps: { items: renderedOverflowItems },
+                      menuProps: { ...overflowMenuProps, items: renderedOverflowItems },
                       menuIconProps: elipisisIconProps,
                     })
                   );

--- a/packages/experiments/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/experiments/src/components/CommandBar/CommandBar.types.ts
@@ -1,6 +1,6 @@
 
 import * as React from 'react';
-import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { IContextualMenuItem, IContextualMenuProps } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { IIconProps } from 'office-ui-fabric-react/lib/Icon';
 import { ICommandBarData } from './CommandBar.base';
@@ -50,6 +50,11 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   * Icon props to be passed to overflow elipsis
   */
   elipisisIconProps?: IIconProps;
+
+  /**
+  * Menu props to be passed to overflow elipsis
+  */
+  overflowMenuProps?: Partial<IContextualMenuProps>;
 
   /**
   * If endAligned, all icons will be aligned to the far side of the commandbar, and overflow items


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change

#### Description of changes

- Add optional prop 'overflowMenuProps' to Experiments/CommandBar .
- 'overflowMenuProps' is a partial IContexutalMenuProps because overflowItems are already included in CommandBar props.

#### Focus areas to test

