### PR TITLE
Fix DatePicker prev and next arrows in RTL

### DIFF
--- a/common/changes/office-ui-fabric-react/srk-RTL-FixDatePickerPrevAndNextArrows_2018-01-25-09-39.json
+++ b/common/changes/office-ui-fabric-react/srk-RTL-FixDatePickerPrevAndNextArrows_2018-01-25-09-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing the up and down arrows position and behavior according to RTL expected behavior",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "srkandu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -142,7 +142,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
               role='button'
               tabIndex={ 0 }
             >
-              <Icon iconName={ getRTL() ? rightNavigationIcon : leftNavigationIcon } />
+              <Icon iconName={ leftNavigationIcon } />
             </button >
             <button
               className={ css('ms-DatePicker-nextMonth js-nextMonth', styles.nextMonth,
@@ -156,7 +156,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
               role='button'
               tabIndex={ 0 }
             >
-              <Icon iconName={ getRTL() ? leftNavigationIcon : rightNavigationIcon } />
+              <Icon iconName={ rightNavigationIcon } />
             </button >
           </div >
         </div >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3821 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

1. Modified the behavior of the up and down buttons to be consistent with the expected behavior in RTL. i.e., up button -> prev month/year and down button -> next month/year
2. Changed the position of the buttons relative to each other in RTL view i.e., up arrow will be on the right side of the down arrow. See the picture below
![image](https://user-images.githubusercontent.com/6827024/35483488-b93c4ece-0468-11e8-9744-19778d30d033.png)





