### PR TITLE
Addressing issue #3793 - Can't set ComboBox's button to aria-hidden="false"

### DIFF
--- a/common/changes/office-ui-fabric-react/combobox-ariabtn-3793_2018-01-29-19-47.json
+++ b/common/changes/office-ui-fabric-react/combobox-ariabtn-3793_2018-01-29-19-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added prop to ComboBox to control its button's aria-hidden attribute",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -271,6 +271,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       allowFreeform,
       autoComplete,
       buttonIconProps,
+      buttonAriaHidden = true,
       styles: customStyles,
       theme,
       title
@@ -337,7 +338,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             className={ 'ms-ComboBox-CaretDown-button' }
             styles={ this._getCaretButtonStyles() }
             role='presentation'
-            aria-hidden='true'
+            aria-hidden={ buttonAriaHidden }
             tabIndex={ -1 }
             onClick={ this._onComboBoxClick }
             iconProps={ buttonIconProps }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -271,7 +271,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       allowFreeform,
       autoComplete,
       buttonIconProps,
-      buttonAriaHidden = true,
+      isButtonAriaHidden = true,
       styles: customStyles,
       theme,
       title
@@ -338,7 +338,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             className={ 'ms-ComboBox-CaretDown-button' }
             styles={ this._getCaretButtonStyles() }
             role='presentation'
-            aria-hidden={ buttonAriaHidden }
+            aria-hidden={ isButtonAriaHidden }
             tabIndex={ -1 }
             onClick={ this._onComboBoxClick }
             iconProps={ buttonIconProps }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -137,7 +137,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * Sets the 'aria-hidden' attribute on the ComboBox's button element instructing screen readers how to handle the element. This element is hidden by default because all functionality is handled by the input element and the arrow button is only meant to be decorative.
    * @default true
    */
-  buttonAriaHidden?: boolean;
+  isButtonAriaHidden?: boolean;
 }
 
 export interface IComboBoxStyles {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -132,6 +132,12 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * Whether to use the ComboBoxes width as the menu's width
    */
   useComboBoxAsMenuWidth?: boolean;
+
+  /**
+   * Sets the 'aria-hidden' attribute on the ComboBox's button element instructing screen readers how to handle the element. This element is hidden by default because all functionality is handled by the input element and the arrow button is only meant to be decorative.
+   * @default true
+   */
+  buttonAriaHidden?: boolean;
 }
 
 export interface IComboBoxStyles {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
     />
     <button
       aria-describedby={null}
-      aria-hidden="true"
+      aria-hidden={true}
       aria-label={undefined}
       aria-labelledby={null}
       aria-pressed={false}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #3793
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Added prop to ComboBox to control its button's aria-hidden attribute

#### Focus areas to test

N/A
