### PR TITLE
Moves label outside of DatePicker hit target

### DIFF
--- a/common/changes/office-ui-fabric-react/joem-fix-datepicker-hit-target_2018-01-29-21-52.json
+++ b/common/changes/office-ui-fabric-react/joem-fix-datepicker-hit-target_2018-01-29-21-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Moves DatePicker label outside of hit target",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joem@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -11,6 +11,7 @@ import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { Callout } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { TextField } from '../../TextField';
+import { Label } from "../../Label";
 import {
   autobind,
   BaseComponent,
@@ -189,6 +190,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
 
     return (
       <div className={ css('ms-DatePicker', styles.root, className) } ref={ this._resolveRef('_root') }>
+        <Label required={ isRequired }>{ label }</Label>
         <div ref={ this._resolveRef('_datepicker') }>
           <TextField
             className={ styles.textField }
@@ -203,7 +205,6 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
             onClick={ this._onTextFieldClick }
             onChanged={ this._onTextFieldChanged }
             errorMessage={ errorMessage }
-            label={ label }
             placeholder={ placeholder }
             borderless={ borderless }
             iconProps={ {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3829 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Moves label outside of hit target so that user can click outside the `TextField` and dismiss the `DatePicker`. This is particularly useful in cases where the `DatePicker` is rendered in a small area and there's not much space around it for the user to click out and dismiss it.
