### PR TITLE
Addressing Issue #3776 - Sticky component loops forever if background-color is not set for page

### DIFF
--- a/common/changes/office-ui-fabric-react/stick-bgc-3776_2018-01-29-23-43.json
+++ b/common/changes/office-ui-fabric-react/stick-bgc-3776_2018-01-29-23-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "added return default when reaching the html tag in while loop inside _getBackground() inside Sticky component.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
@@ -33,7 +33,8 @@ export class ScrollablePanePage extends React.Component<IComponentDemoPageProps,
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts'),
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Sticky/Sticky.types.ts')
             ] }
           />
         }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
@@ -31,17 +31,16 @@ export class ScrollablePaneDefaultExample extends React.Component {
   }
 
   private _createContentArea(index: number) {
-    const style = {
-      backgroundColor: this._getRandomColor()
-    };
+    const style = this._getRandomColor();
 
     return (
       <div key={ index }>
         <Sticky
           stickyPosition={ StickyPositionType.Both }
           stickyClassName='largeFont'
+          stickyBackgroundColor={ style }
         >
-          <div className='sticky' style={ style }>
+          <div className='sticky'>
             Sticky Component #{ index + 1 }
           </div>
         </Sticky>

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -64,7 +64,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     const { scrollablePane } = this.context;
     scrollablePane.subscribe(this._onScrollEvent);
     this.content = document.createElement('div');
-    this.content.style.background = this._getBackground() || 'rgba(244, 244, 244, 1)';
+    this.content.style.background = this.props.stickyBackgroundColor || this._getBackground();
     ReactDOM.render(<div>{ this.props.children }</div>, this.content);
     this.refs.root.appendChild(this.content);
     this.context.scrollablePane.notifySubscribers(true);

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -64,7 +64,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     const { scrollablePane } = this.context;
     scrollablePane.subscribe(this._onScrollEvent);
     this.content = document.createElement('div');
-    this.content.style.background = this._getBackground();
+    this.content.style.background = this._getBackground() || 'rgba(244, 244, 244, 1)';
     ReactDOM.render(<div>{ this.props.children }</div>, this.content);
     this.refs.root.appendChild(this.content);
     this.context.scrollablePane.notifySubscribers(true);
@@ -172,13 +172,13 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
   }
 
   // Gets background of nearest parent element that has a declared background-color attribute
-  private _getBackground(): string {
+  private _getBackground(): string | null {
     let curr = this.refs.root;
     while (window.getComputedStyle(curr).getPropertyValue('background-color') === 'rgba(0, 0, 0, 0)' ||
       window.getComputedStyle(curr).getPropertyValue('background-color') === 'transparent') {
       if (curr.tagName === 'HTML') {
         // Fallback color if no element has a declared background-color attribute
-        return 'rgba(244, 244, 244, 1)';
+        return null;
       }
       if (curr.parentElement) {
         curr = curr.parentElement;

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -176,6 +176,10 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     let curr = this.refs.root;
     while (window.getComputedStyle(curr).getPropertyValue('background-color') === 'rgba(0, 0, 0, 0)' ||
       window.getComputedStyle(curr).getPropertyValue('background-color') === 'transparent') {
+      if (curr.tagName === 'HTML') {
+        // Fallback color if no element has a declared background-color attribute
+        return 'rgba(244, 244, 244, 1)';
+      }
       if (curr.parentElement) {
         curr = curr.parentElement;
       }

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.types.ts
@@ -13,7 +13,13 @@ export interface IStickyProps extends React.Props<Sticky> {
   stickyClassName?: string;
 
   /**
-   * Region to render sticky component in.  Defaults to Both.
+   * color to apply as 'background-color' style for sticky element.
+  */
+  stickyBackgroundColor?: string;
+
+  /**
+   * Region to render sticky component in.
+   * @default Both
    */
   stickyPosition?: StickyPositionType;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #3776
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

added return default when reaching the html tag in while loop inside _getBackground() inside Sticky component

#### Focus areas to test

N/A
