### PR TITLE
Fix issue in modal Selection handling

### DIFF
--- a/common/changes/office-ui-fabric-react/selection-modal_2018-01-30-15-24.json
+++ b/common/changes/office-ui-fabric-react/selection-modal_2018-01-30-15-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix bug in modal selection handling",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -82,6 +82,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   private _activeRows: { [key: string]: DetailsRow };
   private _dragDropHelper: DragDropHelper | null;
   private _initialFocusedIndex: number | undefined;
+  private _pendingForceUpdate: boolean;
 
   private _columnOverrides: {
     [key: string]: IColumn;
@@ -213,6 +214,12 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     }
 
     if (shouldForceUpdates) {
+      this._pendingForceUpdate = true;
+    }
+  }
+
+  public componentWillUpdate(): void {
+    if (this._pendingForceUpdate) {
       this._forceListUpdates();
     }
   }
@@ -556,6 +563,8 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   }
 
   private _forceListUpdates() {
+    this._pendingForceUpdate = false;
+
     if (this._groupedList) {
       this._groupedList.forceUpdate();
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -7,6 +7,7 @@ import {
   DetailsList,
   DetailsListLayoutMode,
   Selection,
+  SelectionMode,
   IColumn
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { autobind } from 'office-ui-fabric-react/lib/Utilities';
@@ -231,6 +232,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
             items={ items }
             compact={ isCompactMode }
             columns={ columns }
+            selectionMode={ this.state.isModalSelection ? SelectionMode.multiple : SelectionMode.none }
             setKey='set'
             layoutMode={ DetailsListLayoutMode.justified }
             isHeaderVisible={ true }

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -33,8 +33,6 @@ exports[`Pickers BasePicker renders BasePicker correctly 1`] = `
       onKeyDownCapture={[Function]}
       onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
-      onTouchEndCapture={[Function]}
-      onTouchStartCapture={[Function]}
       role="presentation"
     >
       <div
@@ -101,8 +99,6 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
       onKeyDownCapture={[Function]}
       onMouseDown={[Function]}
       onMouseDownCapture={[Function]}
-      onTouchEndCapture={[Function]}
-      onTouchStartCapture={[Function]}
       role="presentation"
     >
       <div

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -86,7 +86,7 @@ export class Selection implements ISelection {
 
   public setModal(isModal: boolean): void {
     if (this._isModal !== isModal) {
-      this.setChangeEvents(true);
+      this.setChangeEvents(false);
 
       this._isModal = isModal;
 
@@ -96,7 +96,7 @@ export class Selection implements ISelection {
 
       this._change();
 
-      this.setChangeEvents(false);
+      this.setChangeEvents(true);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -79,6 +79,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     // Track the latest modifier keys globally.
     this._events.on(win, 'keydown, keyup', this._updateModifiers, true);
     this._events.on(scrollElement, 'click', this._tryClearOnEmptyClick);
+    this._events.on(document.body, 'touchstart', this._onTouchStartCapture, true);
+    this._events.on(document.body, 'touchend', this._onTouchStartCapture, true);
   }
 
   public render() {
@@ -89,8 +91,6 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         onKeyDown={ this._onKeyDown }
         onMouseDown={ this._onMouseDown }
         onKeyDownCapture={ this._onKeyDownCapture }
-        onTouchStartCapture={ this._onTouchStartCapture }
-        onTouchEndCapture={ this._onTouchStartCapture }
         onClick={ this._onClick }
         role='presentation'
 


### PR DESCRIPTION
# Overview

This change fixes in issue where use of `_setChangeEvents` in `Selection` was incorrectly flipped when handling the modal selection state. This causes change notifications to fail in downstream UX.
This change also fixed an issue where touch events were not properly triggering the modal selection state in some edge cases.