### PR TITLE
ContextualMenu: Remove the list inside the menu and move aria labeling to the correct element

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ContextualMenuRemoveListness_2018-01-30-18-06.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ContextualMenuRemoveListness_2018-01-30-18-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Remove the list in the menu and move the aria-label/labelledby to the correct element",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -289,6 +289,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         >
           <div
             role='menu'
+            aria-label={ ariaLabel }
+            aria-labelledby={ labelElementId }
             style={ contextMenuStyle }
             ref={ (host: HTMLDivElement) => this._host = host }
             id={ id }
@@ -305,8 +307,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                 allowTabKey={ true }
               >
                 <ul
-                  aria-label={ ariaLabel }
-                  aria-labelledby={ labelElementId }
+                  role='presentation'
                   className={ this._classNames.list }
                   onKeyDown={ this._onKeyDown }
                 >


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

The child of the menu was incorrectly showing up in the UIA tree as a list. Upon investigating, the list items of the list had already been changed to role=presentation, but the ul list element had not yet been updated.

This change marks role=presentation on the list (ul) element and moves the aria-label/labelledby to the correct role=menu element

#### Focus areas to test
Verified that the menu is no longer reporting as a list and the labelling is hooked up to the correct element
