### PR TITLE
Prefix suffix whitespace

### DIFF
--- a/common/changes/office-ui-fabric-react/prefix-suffix-whitespace_2018-01-30-21-56.json
+++ b/common/changes/office-ui-fabric-react/prefix-suffix-whitespace_2018-01-30-21-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "fix whitespace wrapping with prefix/suffix",
+      "comment": "TextField: fixed whitespace wrapping with prefix/suffix.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/prefix-suffix-whitespace_2018-01-30-21-56.json
+++ b/common/changes/office-ui-fabric-react/prefix-suffix-whitespace_2018-01-30-21-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fix whitespace wrapping with prefix/suffix",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "sbalentine88@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -99,12 +99,13 @@ $field-error-color: $errorTextColor;
 }
 
 .fieldPrefixSuffix {
+  align-items: center;
   background: $ms-color-neutralLighter;
   color: $ms-color-neutralSecondary;
   display: flex;
-  align-items: center;
-  padding: 0 10px;
   line-height: 1;
+  padding: 0 10px;
+  white-space: nowrap;
 }
 
 .field {


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

If there is whitespace in the prefix or suffix of the TextField component, the text was wrapping. This CSS change fixes that.
