### PR TITLE
Adding check to DatePicker componentWillReceiveProps to prevent unnecessary validation failures

### DIFF
--- a/common/changes/office-ui-fabric-react/jolore-datePickerValidationFix_2018-01-30-23-50.json
+++ b/common/changes/office-ui-fabric-react/jolore-datePickerValidationFix_2018-01-30-23-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "updating willReceiveProps of date picker to not run validation unless the props actually changed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -142,7 +142,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   }
 
   public componentWillReceiveProps(nextProps: IDatePickerProps) {
-    if (JSON.stringify(this.props) == JSON.stringify(nextProps)) {
+    if (JSON.stringify(this.props) === JSON.stringify(nextProps)) {
       // if the props haven't changed, don't run validation
       return;
     }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -142,6 +142,11 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   }
 
   public componentWillReceiveProps(nextProps: IDatePickerProps) {
+    if (JSON.stringify(this.props) == JSON.stringify(nextProps)) {
+      // if the props haven't changed, don't run validation
+      return;
+    }
+
     let { formatDate, isRequired, strings, value, minDate, maxDate } = nextProps;
     let errorMessage = (isRequired && !value) ? (strings!.isRequiredErrorMessage || '*') : undefined;
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -142,12 +142,17 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   }
 
   public componentWillReceiveProps(nextProps: IDatePickerProps) {
-    if (JSON.stringify(this.props) === JSON.stringify(nextProps)) {
-      // if the props haven't changed, don't run validation
+    let { formatDate, isRequired, strings, value, minDate, maxDate } = nextProps;
+
+    if (compareDates(this.props.minDate!, nextProps.minDate!) &&
+      compareDates(this.props.maxDate!, nextProps.maxDate!) &&
+      this.props.isRequired === nextProps.isRequired &&
+      compareDates(this.state.selectedDate!, value!) &&
+      this.props.formatDate === formatDate) {
+      // if the props we care about haven't changed, don't run validation or updates
       return;
     }
 
-    let { formatDate, isRequired, strings, value, minDate, maxDate } = nextProps;
     let errorMessage = (isRequired && !value) ? (strings!.isRequiredErrorMessage || '*') : undefined;
 
     if (!errorMessage && value) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #822
- [x] Include a change request file using `$ npm run change`

#### Description of changes

DatePicker allows the consumer to pass a prop for the value, and a prop for isRequired. If a consumer changes the properties, it's possible that the required validation step might no longer be passing, so DatePicker was running validation during WillReceiveProps. However, it ran this regardless of whether the props actually changed, so the parent rerendering was causing validation to fail even without ever focusing the component. Here we add a quick check to make sure the serializable props actually changed before running that validation.

#### Focus areas to test

(optional)
