### PR TITLE
Add fillHorizontal stretch mode to TilesList

### DIFF
--- a/common/changes/@uifabric/experiments/tiles-mobile_2018-02-01-14-12.json
+++ b/common/changes/@uifabric/experiments/tiles-mobile_2018-02-01-14-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Added a fillHorizontal mode to TilesList",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -148,9 +148,13 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
         className={ css(TilesListStyles.cell) }
         // tslint:disable-next-line:jsx-ban-props
         style={
-          {
-            paddingTop: `${(100 * itemHeightOverWidth).toFixed(2)}%`
-          }
+          item.grid.mode === TilesGridMode.fillHorizontal ?
+            {
+              height: `${item.grid.minRowHeight}px`
+            } :
+            {
+              paddingTop: `${(100 * itemHeightOverWidth).toFixed(2)}%`
+            }
         }
       >
         <div
@@ -214,12 +218,17 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
             scaleFactor
           } = currentRow;
 
-          if (grid.mode === TilesGridMode.fill && (!currentRow.isLastRow || scaleFactor <= grid.maxScaleFactor)) {
+          if ((grid.mode === TilesGridMode.fill ||
+            grid.mode === TilesGridMode.fillHorizontal) &&
+            (!currentRow.isLastRow ||
+              scaleFactor <= grid.maxScaleFactor)) {
             const finalScaleFactor = Math.min(grid.maxScaleFactor, scaleFactor);
 
             finalSize = {
               width: finalSize.width * finalScaleFactor,
-              height: finalSize.height * finalScaleFactor
+              height: grid.mode === TilesGridMode.fill ?
+                finalSize.height * finalScaleFactor :
+                grid.minRowHeight
             };
           }
         }
@@ -390,7 +399,10 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
         currentRow.scaleFactor = (boundsWidth - totalMargin) / (rowWidth - totalMargin);
       }
 
-      if (!isAtGridEnd && currentRow.scaleFactor > (grid.mode === TilesGridMode.fill ? grid.maxScaleFactor : 1)) {
+      if (!isAtGridEnd && currentRow.scaleFactor > (
+        grid.mode === TilesGridMode.fill || grid.mode === TilesGridMode.fillHorizontal ?
+          grid.maxScaleFactor :
+          1)) {
         // If the last computed row is not the end of the grid, and the content cannot scale to fit the width,
         // declare these cells as 'extra' and let them be pushed into the next page.
         extraCells = cells.slice(rowStart, i);
@@ -442,7 +454,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
 
     const itemWidthOverHeight = item.aspectRatio || 1;
     const margin = grid.spacing / 2;
-    const isFill = gridMode === TilesGridMode.fill;
+    const isFill = gridMode === TilesGridMode.fill || gridMode === TilesGridMode.fillHorizontal;
     const width = itemWidthOverHeight * grid.minRowHeight;
 
     return {

--- a/packages/experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/experiments/src/components/TilesList/TilesList.types.ts
@@ -36,9 +36,13 @@ export const enum TilesGridMode {
    */
   stack,
   /**
-   * Items in the row are stretched if necessary to fill the row.
+   * Items in the row are stretched proportionally if necessary to fill the row.
    */
-  fill
+  fill,
+  /**
+   * Items in the row are stretched horizontally only if necessary to fill the row.
+   */
+  fillHorizontal
 }
 
 export interface ITilesGridSegment<TItem> {

--- a/packages/experiments/src/components/TilesList/examples/ExampleHelpers.tsx
+++ b/packages/experiments/src/components/TilesList/examples/ExampleHelpers.tsx
@@ -78,10 +78,12 @@ export function createGroup(items: IExampleItem[], type: 'document' | 'media', i
 
 export function getTileCells(groups: IExampleGroup[], {
   onRenderCell,
-  onRenderHeader
+  onRenderHeader,
+  size = 'large'
 }: {
     onRenderHeader: (item: IExampleItem) => JSX.Element;
     onRenderCell: (item: IExampleItem, finalSize?: ITileSize) => JSX.Element;
+    size?: 'large' | 'small'
   }): (ITilesGridSegment<IExampleItem> | ITilesGridItem<IExampleItem>)[] {
   const items: (ITilesGridSegment<IExampleItem> | ITilesGridItem<IExampleItem>)[] = [];
 
@@ -89,9 +91,9 @@ export function getTileCells(groups: IExampleGroup[], {
     const header: ITilesGridItem<IExampleItem> = {
       key: `header-${group.key}`,
       content: {
-        key: '',
+        key: group.key,
         aspectRatio: 1,
-        name: lorem(6),
+        name: group.name,
         index: group.index
       },
       onRender: onRenderHeader
@@ -118,7 +120,9 @@ export function getTileCells(groups: IExampleGroup[], {
       marginBottom: 40,
       minRowHeight: 171,
       mode: group.type === 'document' ?
-        TilesGridMode.stack :
+        size === 'small' ?
+          TilesGridMode.fillHorizontal :
+          TilesGridMode.stack :
         TilesGridMode.fill,
       key: group.key
     });


### PR DESCRIPTION
# Overview

This change adds a new `fillHorizontal` grid stretch mode to `TilesList`. This can be used to make a grid section stretch tiles only horizontally, as opposed to proportionally.