### PR TITLE
[SpinButton] Fix floating point rounding issues and implemented precision

### DIFF
--- a/common/changes/@uifabric/utilities/magellan-spinbutton_precision_2018-02-02-18-16.json
+++ b/common/changes/@uifabric/utilities/magellan-spinbutton_precision_2018-02-02-18-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "[Math] implemented precision rounding functions",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "law@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/magellan-spinbutton_precision_2018-02-02-00-02.json
+++ b/common/changes/office-ui-fabric-react/magellan-spinbutton_precision_2018-02-02-00-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "[SpinButton] Implemented precision",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
-import { SpinButton, precisionRound, calculatePrecision } from './SpinButton';
+import { SpinButton } from './SpinButton';
 import { KeyCodes } from '../../Utilities';
 
 describe('SpinButton', () => {
@@ -643,43 +643,5 @@ describe('SpinButton', () => {
     );
 
     expect(onIncrement).toBeCalled();
-  });
-
-  it('caluclatePrecision should work as intended', () => {
-    expect(calculatePrecision(0)).toEqual(0);
-    expect(calculatePrecision(1)).toEqual(0);
-    expect(calculatePrecision('1')).toEqual(0);
-
-    expect(calculatePrecision(200)).toEqual(-2);
-    expect(calculatePrecision(32100012300000)).toEqual(-5);
-
-    expect(calculatePrecision(231.00)).toEqual(0);
-    expect(calculatePrecision('231.00')).toEqual(2);
-    expect(calculatePrecision(321.00002)).toEqual(5);
-    expect(calculatePrecision('321.00002')).toEqual(5);
-
-    expect(calculatePrecision(.002)).toEqual(3);
-    expect(calculatePrecision('.002')).toEqual(3);
-  });
-
-  it('precisionRound should work as intended', () => {
-    expect(precisionRound(1234, 0)).toEqual(1234);
-    expect(precisionRound(1234, -1)).toEqual(1230);
-    expect(precisionRound(1234, -3)).toEqual(1000);
-
-    expect(precisionRound(1234.5678, 0)).toEqual(1235);
-    expect(precisionRound(1234.5678, 1)).toEqual(1234.6);
-    expect(precisionRound(1234.5678, 5)).toEqual(1234.5678);
-
-    expect(precisionRound(1234.555, 2)).toEqual(1234.56);
-    expect(precisionRound(1234.554, 2)).toEqual(1234.55);
-    expect(precisionRound(1250, -2)).toEqual(1300);
-    expect(precisionRound(1249, -2)).toEqual(1200);
-
-    // Different bases
-    expect(precisionRound(1234.5, -2, 2)).toEqual(1236);
-    expect(precisionRound(1234.5, -2, 16)).toEqual(1280);
-    expect(precisionRound(1234.5, -2, 8)).toEqual(1216);
-    expect(precisionRound(1234.5, -2, 7)).toEqual(1225);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
-import { SpinButton } from './SpinButton';
+import { SpinButton, precisionRound, calculatePrecision } from './SpinButton';
 import { KeyCodes } from '../../Utilities';
 
 describe('SpinButton', () => {
@@ -643,5 +643,43 @@ describe('SpinButton', () => {
     );
 
     expect(onIncrement).toBeCalled();
+  });
+
+  it('caluclatePrecision should work as intended', () => {
+    expect(calculatePrecision(0)).toEqual(0);
+    expect(calculatePrecision(1)).toEqual(0);
+    expect(calculatePrecision('1')).toEqual(0);
+
+    expect(calculatePrecision(200)).toEqual(-2);
+    expect(calculatePrecision(32100012300000)).toEqual(-5);
+
+    expect(calculatePrecision(231.00)).toEqual(0);
+    expect(calculatePrecision('231.00')).toEqual(2);
+    expect(calculatePrecision(321.00002)).toEqual(5);
+    expect(calculatePrecision('321.00002')).toEqual(5);
+
+    expect(calculatePrecision(.002)).toEqual(3);
+    expect(calculatePrecision('.002')).toEqual(3);
+  });
+
+  it('precisionRound should work as intended', () => {
+    expect(precisionRound(1234, 0)).toEqual(1234);
+    expect(precisionRound(1234, -1)).toEqual(1230);
+    expect(precisionRound(1234, -3)).toEqual(1000);
+
+    expect(precisionRound(1234.5678, 0)).toEqual(1235);
+    expect(precisionRound(1234.5678, 1)).toEqual(1234.6);
+    expect(precisionRound(1234.5678, 5)).toEqual(1234.5678);
+
+    expect(precisionRound(1234.555, 2)).toEqual(1234.56);
+    expect(precisionRound(1234.554, 2)).toEqual(1234.55);
+    expect(precisionRound(1250, -2)).toEqual(1300);
+    expect(precisionRound(1249, -2)).toEqual(1200);
+
+    // Different bases
+    expect(precisionRound(1234.5, -2, 2)).toEqual(1236);
+    expect(precisionRound(1234.5, -2, 16)).toEqual(1280);
+    expect(precisionRound(1234.5, -2, 8)).toEqual(1216);
+    expect(precisionRound(1234.5, -2, 7)).toEqual(1225);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -88,7 +88,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
     this._lastValidValue = value;
 
     // Ensure that the autocalculated precision is not negative.
-    const precision = props.precision || Math.max(calculatePrecision(props.step || SpinButton.defaultProps.step!), 0);
+    const precision = props.precision || Math.max(calculatePrecision(props.step!), 0);
 
     this.state = {
       isFocused: false,

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -51,9 +51,11 @@ export interface ISpinButtonProps {
 
   /**
    * The difference between the two adjacent values of the SpinButton.
+   * A string can be entered to force precision to consider trailing zeros after a decimal
+   * For example, 2.00 gives a precision of 0 while the string literal "2.00" gives a precision of 2.
    * @default 1
    */
-  step?: number;
+  step?: number | string;
 
   /**
    * A description of the SpinButton for the benefit of screen readers.
@@ -165,6 +167,13 @@ export interface ISpinButtonProps {
    * Accessibility label text for the decrement button for the benefit of the screen reader.
    */
   decrementButtonAriaLabel?: string;
+
+  /**
+   * To how many decimal places the value should be rounded to.
+   * The default value is calculated based on the precision of step.
+   * IE: if step = 1, precision = 0. step = 0.0089, precision = 4. step = 300, precision = 2. step = 23.00, precision = 2.
+   */
+  precision?: number;
 }
 
 export interface ISpinButtonStyles {

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -51,11 +51,12 @@ export interface ISpinButtonProps {
 
   /**
    * The difference between the two adjacent values of the SpinButton.
-   * A string can be entered to force precision to consider trailing zeros after a decimal
-   * For example, 2.00 gives a precision of 0 while the string literal "2.00" gives a precision of 2.
+   * This value is sued to calculate the precision of the input if no
+   * precision is given. The precision calculated this way will always
+   * be >= 0.
    * @default 1
    */
-  step?: number | string;
+  step?: number;
 
   /**
    * A description of the SpinButton for the benefit of screen readers.

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx
@@ -15,6 +15,15 @@ export class SpinButtonBasicExample extends React.Component<any, any> {
           onFocus={ () => console.log('onFocus called') }
           onBlur={ () => console.log('onBlur called') }
         />
+        <SpinButton
+          defaultValue='0'
+          label={ 'Decimal SpinButton:' }
+          min={ 0 }
+          max={ 10 }
+          step={ 0.1 }
+          onFocus={ () => console.log('onFocus called') }
+          onBlur={ () => console.log('onBlur called') }
+        />
       </div>
     );
   }

--- a/packages/utilities/src/math.test.ts
+++ b/packages/utilities/src/math.test.ts
@@ -1,4 +1,8 @@
-import { fitContentToBounds } from './math';
+import {
+  fitContentToBounds,
+  calculatePrecision,
+  precisionRound
+} from './math';
 
 describe('math', () => {
   describe('#fitContentToBounds', () => {
@@ -142,6 +146,48 @@ describe('math', () => {
           height: 200
         });
       });
+    });
+  });
+
+  describe('#calculatePrecision', () => {
+    it('caluclatePrecision should work as intended', () => {
+      expect(calculatePrecision(0)).toEqual(0);
+      expect(calculatePrecision(1)).toEqual(0);
+      expect(calculatePrecision('1')).toEqual(0);
+
+      expect(calculatePrecision(200)).toEqual(-2);
+      expect(calculatePrecision(32100012300000)).toEqual(-5);
+
+      expect(calculatePrecision(231.00)).toEqual(0);
+      expect(calculatePrecision('231.00')).toEqual(2);
+      expect(calculatePrecision(321.00002)).toEqual(5);
+      expect(calculatePrecision('321.00002')).toEqual(5);
+
+      expect(calculatePrecision(.002)).toEqual(3);
+      expect(calculatePrecision('.002')).toEqual(3);
+    });
+  });
+
+  describe('#precisionRound', () => {
+    it('precisionRound should work as intended', () => {
+      expect(precisionRound(1234, 0)).toEqual(1234);
+      expect(precisionRound(1234, -1)).toEqual(1230);
+      expect(precisionRound(1234, -3)).toEqual(1000);
+
+      expect(precisionRound(1234.5678, 0)).toEqual(1235);
+      expect(precisionRound(1234.5678, 1)).toEqual(1234.6);
+      expect(precisionRound(1234.5678, 5)).toEqual(1234.5678);
+
+      expect(precisionRound(1234.555, 2)).toEqual(1234.56);
+      expect(precisionRound(1234.554, 2)).toEqual(1234.55);
+      expect(precisionRound(1250, -2)).toEqual(1300);
+      expect(precisionRound(1249, -2)).toEqual(1200);
+
+      // Different bases
+      expect(precisionRound(1234.5, -2, 2)).toEqual(1236);
+      expect(precisionRound(1234.5, -2, 16)).toEqual(1280);
+      expect(precisionRound(1234.5, -2, 8)).toEqual(1216);
+      expect(precisionRound(1234.5, -2, 7)).toEqual(1225);
     });
   });
 });

--- a/packages/utilities/src/math.ts
+++ b/packages/utilities/src/math.ts
@@ -93,3 +93,40 @@ export function fitContentToBounds(options: IFitContentToBoundsOptions): ISize {
     height: contentSize.height * finalScale
   };
 }
+
+/**
+ * Calculates a number's precision based on the number of trailing
+ * zeros if the number does not have a decimal indicated by a negative
+ * precision. Otherwise, it calculates the number of digits after
+ * the decimal point indicated by a positive precision.
+ * @param value
+ */
+export function calculatePrecision(value: number | string): number {
+  /**
+   * Group 1:
+   * [1-9]([0]+$) matches trailing zeros
+   * Group 2:
+   * \.([0-9]*) matches all digits after a decimal point.
+   */
+  const groups = /[1-9]([0]+$)|\.([0-9]*)/.exec(String(value));
+  if (!groups) {
+    return 0;
+  }
+  if (groups[1]) {
+    return -groups[1].length;
+  }
+  if (groups[2]) {
+    return groups[2].length;
+  }
+  return 0;
+}
+
+/**
+ * Rounds a number to a certain level of precision. Accepts negative precision.
+ * @param value The value that is being rounded.
+ * @param precision The number of decimal places to round the number to
+ */
+export function precisionRound(value: number, precision: number, base: number = 10): number {
+  const exp = Math.pow(base, precision);
+  return Math.round(value * exp) / exp;
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3339
- [x] Include a change request file using `$ npm run change`

#### Description of changes

SpinButton will now round with a degree of precision calculated based on the input step value or a user-defined value.
