### PR TITLE
Dropdown, ComboBox, TextField: Improved high contrast in focus state

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-hc_2018-02-02-02-15.json
+++ b/common/changes/office-ui-fabric-react/dropdown-hc_2018-02-02-02-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox, Dropdown, TextField: Improved high contrast in focus state. Layout changes for ComboBox to allow for border-box sizing.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -225,7 +225,7 @@ export const getStyles = memoizeFunction((
         top: '-2px'
       }
     }
-  }
+  };
 
   const styles: IComboBoxStyles = {
     container: {},

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -149,6 +149,9 @@ export const getCaretDownButtonStyles = memoizeFunction((
       color: caretButtonTextColor,
       fontSize: FontSizes.small,
       position: 'absolute',
+      // The negative positioning accounts for the 1px root border now that box-sizing is border-box
+      top: '-1px',
+      right: '-1px',
       height: ComboBoxHeight,
       lineHeight: ComboBoxLineHeight,
       width: ComboxBoxCaretDownWidth,
@@ -204,6 +207,25 @@ export const getStyles = memoizeFunction((
   const ComboBoxCalloutBorderColor = palette.neutralLight;
   const ComboBoxOptionHeaderTextColor = semanticColors.menuHeader;
   const ComboBoxOptionDividerBorderColor = semanticColors.bodyDivider;
+  const ComboBoxRootHighContrastFocused = {
+    color: 'HighlightText',
+    borderColor: 'Highlight',
+    backgroundColor: 'Window',
+    borderWidth: '2px',
+    MsHighContrastAdjust: 'none',
+    paddingLeft: '11px',
+    selectors: {
+      '.ms-ComboBox-Input': {
+        // ComboBoxHeight is 32, 28 accounts for the 2px borders
+        height: '28px'
+      },
+      '.ms-ComboBox-CaretDown-button': {
+        // Negative positioning to account for the 2px border
+        right: '-2px',
+        top: '-2px'
+      }
+    }
+  }
 
   const styles: IComboBoxStyles = {
     container: {},
@@ -230,11 +252,10 @@ export const getStyles = memoizeFunction((
         cursor: 'text',
         display: 'block',
         height: ComboBoxHeight,
-        lineHeight: ComboBoxLineHeight,
         overflow: 'hidden',
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
-        boxSizing: 'content-box',
+        boxSizing: 'border-box', // Border-box matches Dropdown and TextField
         selectors: {
           '.ms-Label': {
             display: 'inline-block',
@@ -248,7 +269,10 @@ export const getStyles = memoizeFunction((
             }
           },
           '&.is-open': {
-            borderColor: ComboBoxRootBorderColorFocused
+            borderColor: ComboBoxRootBorderColorFocused,
+            selectors: {
+              [HighContrastSelector]: ComboBoxRootHighContrastFocused
+            },
           }
         }
       }
@@ -260,23 +284,23 @@ export const getStyles = memoizeFunction((
         [HighContrastSelector]: {
           color: 'HighlightText',
           borderColor: 'Highlight',
+          backgroundColor: 'Window',
           MsHighContrastAdjust: 'none'
         }
       },
     },
 
     rootPressed: {
-      borderColor: ComboBoxRootBorderColorFocused
+      borderColor: ComboBoxRootBorderColorFocused,
+      selectors: {
+        [HighContrastSelector]: ComboBoxRootHighContrastFocused
+      }
     },
 
     rootFocused: {
       borderColor: ComboBoxRootBorderColorFocused,
       selectors: {
-        [HighContrastSelector]: {
-          color: 'HighlightText',
-          borderColor: 'Highlight',
-          MsHighContrastAdjust: 'none'
-        }
+        [HighContrastSelector]: ComboBoxRootHighContrastFocused
       },
     },
 
@@ -298,7 +322,6 @@ export const getStyles = memoizeFunction((
       font: 'inherit',
       textOverflow: 'ellipsis',
       padding: '0',
-      margin: '1px 0px'
     },
 
     inputDisabled: getDisabledStyles(theme),

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
           border-style: solid;
           border-width: 1px;
           box-shadow: none;
-          box-sizing: content-box;
+          box-sizing: border-box;
           color: #333333;
           cursor: text;
           display: block;
@@ -24,7 +24,6 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
           font-size: 14px;
           font-weight: 400;
           height: 32px;
-          line-height: 30px;
           margin-bottom: 10px;
           margin-left: 0;
           outline: 0;
@@ -48,24 +47,65 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
         &.is-open {
           border-color: #0078d7;
         }
+        @media screen and (-ms-high-contrast: active){&.is-open {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          border-color: Highlight;
+          border-width: 2px;
+          color: HighlightText;
+          padding-left: 11px;
+        }
+        @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-Input {
+          height: 28px;
+        }
+        @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+          right: -2px;
+          top: -2px;
+        }
         &:hover {
           border-color: #212121;
         }
         @media screen and (-ms-high-contrast: active){&:hover {
           -ms-high-contrast-adjust: none;
+          background-color: Window;
           border-color: Highlight;
           color: HighlightText;
         }
         &:active {
           border-color: #0078d7;
         }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: Window;
+          border-color: Highlight;
+          border-width: 2px;
+          color: HighlightText;
+          padding-left: 11px;
+        }
+        @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-Input {
+          height: 28px;
+        }
+        @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+          right: -2px;
+          top: -2px;
+        }
         &:focus {
           border-color: #0078d7;
         }
         @media screen and (-ms-high-contrast: active){&:focus {
           -ms-high-contrast-adjust: none;
+          background-color: Window;
           border-color: Highlight;
+          border-width: 2px;
           color: HighlightText;
+          padding-left: 11px;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-Input {
+          height: 28px;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+          right: -2px;
+          top: -2px;
         }
     id="ComboBox0wrapper"
   >
@@ -88,10 +128,6 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
             box-sizing: border-box;
             font: inherit;
             height: 30px;
-            margin-bottom: 1px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 1px;
             outline: none;
             padding-bottom: 0;
             padding-left: 0;
@@ -150,8 +186,10 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
             padding-right: 4px;
             padding-top: 0;
             position: absolute;
+            right: -1px;
             text-align: center;
             text-decoration: none;
+            top: -1px;
             user-select: none;
             vertical-align: top;
             width: 32px;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -12,8 +12,8 @@ $Dropdown-selectedItem-hover-bg: $ms-color-neutralLighter;
 $DropDown-height: 32px;
 $DropDown-item-height: 32px;
 
-// Mixin for high contrast mode link states
-@mixin highContrastListItemState {
+// Mixin for high contrast mode states
+@mixin highContrastItemAndTitleState {
   @include high-contrast {
     background-color: Highlight;
     border-color: Highlight;
@@ -21,6 +21,12 @@ $DropDown-item-height: 32px;
   }
 
   @include highContrastAdjust();
+}
+
+@mixin highContrastBorderState {
+  @include high-contrast {
+    border-color: Highlight;
+  }
 }
 
 .root {
@@ -38,11 +44,6 @@ $DropDown-item-height: 32px;
     .title,
     .caretDown {
       color: $ms-color-neutralDark;
-
-      @include high-contrast {
-        // Using Highlight for text here specifically to match the border color that indicates focus on dropdown root elements.
-        color: Highlight;
-      }
     }
 
     .titleIsPlaceHolder {
@@ -53,6 +54,7 @@ $DropDown-item-height: 32px;
   &:hover {
     .title {
       border-color: $ms-color-neutralDark;
+      @include highContrastBorderState();
     }
     .titleIsError {
       border-color: $ms-color-error;
@@ -62,6 +64,7 @@ $DropDown-item-height: 32px;
   &:active {
     .title {
       border-color: $ms-color-themeDark;
+      @include highContrastBorderState();
     }
     .titleIsError {
       border-color: $ms-color-error;
@@ -71,6 +74,10 @@ $DropDown-item-height: 32px;
   &:focus {
     .title {
       border-color: $ms-color-themePrimary;
+      @include highContrastItemAndTitleState();
+    }
+    .caretDown {
+      @include highContrastAdjust();
     }
     .titleIsError {
       border-color: $ms-color-error;
@@ -207,7 +214,7 @@ $DropDown-item-height: 32px;
 
   &:focus {
     background-color: $ms-color-neutralLighter;
-    @include highContrastListItemState;
+    @include highContrastItemAndTitleState;
   }
 
   &:active {
@@ -229,7 +236,7 @@ $DropDown-item-height: 32px;
   background-color: $Dropdown-selectedItem-bg;
   color: $ms-color-black;
 
-  @include highContrastListItemState;
+  @include highContrastItemAndTitleState;
 
   &.itemIsDisabled {
     color: $ms-color-neutralTertiary;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -28,6 +28,14 @@ $field-placeholder-disabled-color: $disabledTextColor;
 $field-description-color: $bodySubtextColor;
 $field-error-color: $errorTextColor;
 
+// Mixin for focus border, including high contrast
+@mixin fieldFocusBorder {
+  border-color: $field-border-focus-color;
+  @include high-contrast {
+    border-width: 2px;
+  }
+}
+
 // the box containing the label and input field
 .root {
   @include ms-normalize;
@@ -54,7 +62,7 @@ $field-error-color: $errorTextColor;
   }
 
   &.fieldGroupIsFocused {
-    border-color: $field-border-focus-color;
+    @include fieldFocusBorder();
   }
 
   &.fieldGroupIsFocused {
@@ -163,7 +171,7 @@ $field-error-color: $errorTextColor;
 
 //= State: An active textfield
 .root.rootIsActive {
-  border-color: $field-border-focus-color;
+  @include fieldFocusBorder();
 }
 
 .icon {
@@ -241,7 +249,7 @@ $field-error-color: $errorTextColor;
   }
 
   &.rootIsActive {
-    border-color: $field-border-focus-color;
+    @include fieldFocusBorder();
   }
 
   &:hover:not(.rootIsDisabled),

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -33,6 +33,9 @@ $field-error-color: $errorTextColor;
   border-color: $field-border-focus-color;
   @include high-contrast {
     border-width: 2px;
+    .field {
+      @include ms-padding(0, 11px, 0, 11px);
+    }
   }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3846 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Dropdown did not have the expected focus state in high contrast mode (see issue). Adjusted Dropdown per the issue.

For ComboBox and TextField, we are increasing the border thickness on focus. To allow for this, I gave ComboBox box-sizing: border-box like the other two components have, which required adjusting the layout a bit more.

Dropdown Before:
![dropdown-hc-focus-before](https://user-images.githubusercontent.com/16619843/35713840-61ba14a6-077e-11e8-8040-49f07f157d78.png)

Dropdown After:
![dropdown-hc-focus-after](https://user-images.githubusercontent.com/16619843/35713838-5efc5850-077e-11e8-8c41-7cb7fd973cd0.png)

TextField Before:
![textfield-hc-focus-before](https://user-images.githubusercontent.com/16619843/35713835-5bdd27d0-077e-11e8-9264-2aab4731731b.png)

TextField After:
![textfield-hc-focus-after](https://user-images.githubusercontent.com/16619843/35713831-5607e8a4-077e-11e8-99f0-ccda0d22e166.png)

ComboBox Before:
![combobox-hc-focus-before](https://user-images.githubusercontent.com/16619843/35713827-526b5870-077e-11e8-9bd0-ac84247f9b3f.png)

ComboBox After:
![combobox-hc-focus-after](https://user-images.githubusercontent.com/16619843/35713825-4ff1095a-077e-11e8-869a-e93387ee45c3.png)


#### Focus areas to test

(optional)
