### PR TITLE
[DetailsList] Header box-sizing

### DIFF
--- a/common/changes/office-ui-fabric-react/magellan-detailsList_header_box_sizing_2018-02-02-17-58.json
+++ b/common/changes/office-ui-fabric-react/magellan-detailsList_header_box_sizing_2018-02-02-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "[DetailsHeader] Set box-sizing to content-box",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/magellan-detailsList_header_box_sizing_2018-02-02-17-58.json
+++ b/common/changes/office-ui-fabric-react/magellan-detailsList_header_box_sizing_2018-02-02-17-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "[DetailsHeader] Set box-sizing to content-box",
+      "comment": "DetailsList: fix disappearing line when hovering on column header",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -18,6 +18,7 @@ $isPaddedMargin: 24px;
   height: $rowHeight;
   line-height: $rowHeight;
   white-space: nowrap;
+  box-sizing: content-box;
   padding-bottom: 1px;
   border-bottom: 1px solid $bodyDividerColor;
   cursor: default;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3299
- [x] Include a change request file using `$ npm run change`

#### Description of changes

On some pages, the DetailsHeader inherits box-sizing: border-box which causes the underline to disappear when hovered. This change sets box-sizing to be explicitly content-box.
