### PR TITLE
Contextual Menu Item - Passing Extra Information For MenuItem OnRender

### DIFF
--- a/common/changes/office-ui-fabric-react/accContextualMenu_2018-02-03-00-25.json
+++ b/common/changes/office-ui-fabric-react/accContextualMenu_2018-02-03-00-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Contextual Menu - adding support for aria-setsize and aria-posinset for rendering menu items that relies on the menu item's own rendering",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -442,7 +442,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderNormalItem(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {
     if (item.onRender) {
-      return [item.onRender({ posInSet: focusableElementIndex, setSize: totalItemCount, ...item }, this.dismiss)];
+      return [item.onRender({ positionInSet: focusableElementIndex, setSize: totalItemCount, ...item }, this.dismiss)];
     }
     if (item.href) {
       return this._renderAnchorMenuItem(item, classNames, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -442,7 +442,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderNormalItem(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {
     if (item.onRender) {
-      return [item.onRender({ 'aria-posinset': focusableElementIndex, ['aria-setsize']: totalItemCount, ...item }, this.dismiss)];
+      return [item.onRender({ 'aria-posinset': focusableElementIndex, 'aria-setsize': totalItemCount, ...item }, this.dismiss)];
     }
     if (item.href) {
       return this._renderAnchorMenuItem(item, classNames, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -442,7 +442,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderNormalItem(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {
     if (item.onRender) {
-      return [item.onRender({ positionInSet: focusableElementIndex, setSize: totalItemCount, ...item }, this.dismiss)];
+      return [item.onRender({ 'aria-posinset': focusableElementIndex, ['aria-setsize']: totalItemCount, ...item }, this.dismiss)];
     }
     if (item.href) {
       return this._renderAnchorMenuItem(item, classNames, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -442,6 +442,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderNormalItem(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {
     if (item.onRender) {
+      item.positionInSet = focusableElementIndex;
+      item.setSize = totalItemCount;
       return [item.onRender(item, this.dismiss)];
     }
     if (item.href) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -444,6 +444,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     if (item.onRender) {
       item.positionInSet = focusableElementIndex;
       item.setSize = totalItemCount;
+      item.hasCheckMarks = hasCheckmarks;
+      item.hasIcon = hasIcons;
       return [item.onRender(item, this.dismiss)];
     }
     if (item.href) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -442,11 +442,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderNormalItem(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {
     if (item.onRender) {
-      item.positionInSet = focusableElementIndex;
-      item.setSize = totalItemCount;
-      item.hasCheckMarks = hasCheckmarks;
-      item.hasIcon = hasIcons;
-      return [item.onRender(item, this.dismiss)];
+      return [item.onRender({ posInSet: focusableElementIndex, setSize: totalItemCount, ...item }, this.dismiss)];
     }
     if (item.href) {
       return this._renderAnchorMenuItem(item, classNames, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -407,16 +407,6 @@ export interface IContextualMenuItem {
   role?: string;
 
   /**
-   * (Optional) Accessible value of a list item's position in the list (aria-posinset) attribute that will be stamped on to the element.
-   */
-  positionInSet?: number;
-
-  /**
-   * (Optional) Accessible value for total size of a list (aria-setsize) that will be stamped on to the element.
-   */
-  setSize?: number;
-
-  /**
    * Any additional properties to use when custom rendering menu items.
    */
   [propertyName: string]: any;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -407,24 +407,14 @@ export interface IContextualMenuItem {
   role?: string;
 
   /**
-   * Optional accessibility a list item's position in the list (aria-posinset) attribute that will be stamped on to the element.
+   * (Optional) Accessible value of a list item's position in the list (aria-posinset) attribute that will be stamped on to the element.
    */
   positionInSet?: number;
 
   /**
-   * Optional accessibility for total size of a list (aria-setsize) attribute that will be stamped on to the element.
+   * (Optional) Accessible value for total size of a list (aria-setsize) that will be stamped on to the element.
    */
   setSize?: number;
-
-  /**
-   * True if a list of menu items can contain a checkbox. False/undefined otherwise.
-   */
-  hasCheckMark?: boolean;
-
-  /**
-   * True if a menu items can contain a icon. False/undefined otherwise.
-   */
-  hasIcons?: boolean;
 
   /**
    * Any additional properties to use when custom rendering menu items.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -407,6 +407,16 @@ export interface IContextualMenuItem {
   role?: string;
 
   /**
+   * Optional accessibility a list item's position in the list (aria-posinset) attribute that will be stamped on to the element.
+   */
+  positionInSet?: number;
+
+  /**
+   * Optional accessibility for total size of a list (aria-setsize) attribute that will be stamped on to the element.
+   */
+  setSize?: number;
+
+  /**
    * Any additional properties to use when custom rendering menu items.
    */
   [propertyName: string]: any;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -417,6 +417,16 @@ export interface IContextualMenuItem {
   setSize?: number;
 
   /**
+   * True if a list of menu items can contain a checkbox. False/undefined otherwise.
+   */
+  hasCheckMark?: boolean;
+
+  /**
+   * True if a menu items can contain a icon. False/undefined otherwise.
+   */
+  hasIcons?: boolean;
+
+  /**
    * Any additional properties to use when custom rendering menu items.
    */
   [propertyName: string]: any;


### PR DESCRIPTION
#### Description of changes

When we're rendering other types of menu item in our ContextualMenu we expose certain information like the current index or the total number of items in a contextual menu.

We currently don't expose these values to our Menu Items when we let them use their own custom onRender(). As a result we miss information that we might need. 

The specific scenario for this is when we need to set the aria-setsize and aria-posinset for custom onRender() for the swatchcolorpicker and fullgallery menu items in the contextual menu but we don't have the information to set these values correctly.
