### PR TITLE
[TextField] onChange fix for IE when using multiline with placeholder

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-02-22-16-54.json
+++ b/common/changes/office-ui-fabric-react/master_2018-02-22-16-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "[TextField] onChange fix for IE when using multiline with placeholder",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "hlynur.tryggvason@officeatwork.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -425,6 +425,24 @@ describe('TextField', () => {
     expect(callCount).toEqual(2);
   });
 
+  it('should not call onChanged when initial value is undefined and input change is an empty string', () => {
+    let callCount = 0;
+    const onChangedSpy = (value: string) => { callCount++; };
+
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <TextField
+        onChanged={ onChangedSpy }
+      />
+    );
+
+    expect(callCount).toEqual(0);
+    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent(''));
+    ReactTestUtils.Simulate.change(inputDOM, mockEvent(''));
+    expect(callCount).toEqual(0);
+  });
+
   it('should select a range of text', () => {
     let textField: TextField | undefined;
     const initialValue = 'initial value';

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -73,8 +73,10 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     this._id = getId('TextField');
     this._descriptionId = getId('TextFieldDescription');
 
+    this._latestValue = props.value || props.defaultValue || '';
+
     this.state = {
-      value: props.value || props.defaultValue || '',
+      value: this._latestValue,
       isFocused: false,
       errorMessage: ''
     };


### PR DESCRIPTION
#### Description of changes

Initialize _latestValue in constructor so it matches the state.

#### Focus areas to test

IE only: TextField with multiline and placeholder calls onChanged when initialized like this:

```
<TextField
          label='Standard'
          multiline
          rows={ 4 }
          placeholder='A placeholder'
          onChanged={ () => console.log('changed') }
        />
```
