### PR TITLE
[provideUnits] Ignore line-height units

### DIFF
--- a/common/changes/@uifabric/merge-styles/law-ignoreLineHeightUnits_2018-02-06-01-03.json
+++ b/common/changes/@uifabric/merge-styles/law-ignoreLineHeightUnits_2018-02-06-01-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "[provideUnits] Add line-height to ignore",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "law@microsoft.com"
+}

--- a/packages/merge-styles/src/transforms/provideUnits.test.ts
+++ b/packages/merge-styles/src/transforms/provideUnits.test.ts
@@ -58,4 +58,14 @@ describe('provideUnits', () => {
     expect(testSet).toEqual(['opacity', '0']);
   });
 
+  it('ignores line-height', () => {
+    const testSet = [
+      'line-height',
+      1
+    ];
+
+    provideUnits(testSet, 0);
+
+    expect(testSet).toEqual(['line-height', '1']);
+  });
 });

--- a/packages/merge-styles/src/transforms/provideUnits.ts
+++ b/packages/merge-styles/src/transforms/provideUnits.ts
@@ -5,6 +5,7 @@ const NON_PIXEL_NUMBER_PROPS = [
   'flex',
   'flex-grow',
   'flex-shrink',
+  'line-height',
   'opacity',
   'order',
   'z-index',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3879
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Don't provide units for line-height css property.