### PR TITLE
Fixing direct reference to @uifabric/utilities/lib

### DIFF
--- a/common/changes/@uifabric/utilities/master_2018-02-06-09-33.json
+++ b/common/changes/@uifabric/utilities/master_2018-02-06-09-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Fixing direct reference to @uifabric/utilities/lib from ResizeGroup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "serkani@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/master_2018-02-06-09-33.json
+++ b/common/changes/office-ui-fabric-react/master_2018-02-06-09-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing direct reference to @uifabric/utilities/lib from ResizeGroup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "serkani@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.tsx
@@ -4,9 +4,9 @@ import {
   BaseComponent,
   css,
   divProperties,
-  getNativeProps
+  getNativeProps,
+  provideContext
 } from '../../Utilities';
-import { provideContext } from '@uifabric/utilities/lib/Context';
 import { IResizeGroupProps } from './ResizeGroup.types';
 import * as styles from './ResizeGroup.scss';
 

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Async';
 export * from './AutoScroll';
 export * from './BaseComponent';
+export * from './Context';
 export * from './Customizations';
 export * from './Customizer';
 export * from './DelayedRender';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Getting rid of direct reference to @uifabric/utilities/lib from ResizeGroup component which is causing issue for consumers using AMD.

#### Focus areas to test

None
