### PR TITLE
[Spinner] Use rotateZ to stop the spinner from wiggling in IE

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-spinner-ie-wiggle_2018-02-06-17-13.json
+++ b/common/changes/office-ui-fabric-react/fix-spinner-ie-wiggle_2018-02-06-17-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "[Spinner] Use rotateZ to stop the spinner from wiggling in IE",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "hlynur.tryggvason@officeatwork.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.scss
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.scss
@@ -12,10 +12,10 @@ $borderSize: 1.5px;
 
 @keyframes spinAnimation {
   0% {
-    transform: rotate(0deg);
+    transform: rotateZ(0deg);
   }
   100% {
-    transform: rotate(360deg);
+    transform: rotateZ(360deg);
   }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The change uses rotationZ() instead of rotation() to limit roatation calculation to the Z-axis.

#### Focus areas to test

The effect is very noticeable when using the spinner with a label:
https://developer.microsoft.com/en-us/fabric#/components/spinner
