### PR TITLE
Remove duplicate export from button index

### DIFF
--- a/common/changes/office-ui-fabric-react/chrisgo-duplicate-export_2018-02-06-21-59.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-duplicate-export_2018-02-06-21-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove duplicate export of command button from the button index",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/index.ts
@@ -6,7 +6,6 @@ export * from './CommandBarButton/CommandBarButton';
 export * from './CommandButton/CommandButton';
 export * from './CompoundButton/CompoundButton';
 export * from './DefaultButton/DefaultButton';
-export * from './CommandButton/CommandButton';
 export * from './MessageBarButton/MessageBarButton';
 export * from './PrimaryButton/PrimaryButton';
 export * from './IconButton/IconButton';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
We're starting to use the es-2015 module version of fabric. Jest didn't like the fact that we export command bar button twice from the button index. 

#### Focus areas to test

