### PR TITLE
ChevronDown was too dark when CommandBar component was disabled

### DIFF
--- a/common/changes/office-ui-fabric-react/disabledChevronCSS_2018-02-06-22-19.json
+++ b/common/changes/office-ui-fabric-react/disabledChevronCSS_2018-02-06-22-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix issue where CommandBar chevron doesn't change color with rest of control when disabled",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "darylc@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
@@ -114,7 +114,8 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
     color: $ms-color-neutralTertiaryAlt;
     cursor: default;
     pointer-events: none;
-    .itemIcon {
+    .itemIcon,
+    .itemChevronDown {
       color: $ms-color-neutralTertiaryAlt;
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3900
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The existing rule causes CommandBar icons to "ghost" or turn lighter when the CommandBar is disabled. The new rule just applies the same styling change to the chevron.

![image](https://user-images.githubusercontent.com/945384/35923638-ccc9e180-0bee-11e8-95fb-bdb04fbd0a6f.png)