### PR TITLE
ChoiceGroup: More flexible field sizing, especially for images

### DIFF
--- a/apps/vr-tests/src/stories/ChoiceGroup.stories.tsx
+++ b/apps/vr-tests/src/stories/ChoiceGroup.stories.tsx
@@ -77,7 +77,7 @@ storiesOf('ChoiceGroup', module)
       ] }
     />
   ))
-  .add('With images', () => (
+  .add('With default size images', () => (
     <ChoiceGroup
       label='Pick one image'
       defaultSelectedKey='bar'
@@ -86,14 +86,34 @@ storiesOf('ChoiceGroup', module)
           key: 'bar',
           imageSrc: TestImages.choiceGroupBarUnselected,
           selectedImageSrc: TestImages.choiceGroupBarSelected,
-          imageSize: { width: 32, height: 32 },
           text: 'Clustered bar chart'
         },
         {
           key: 'pie',
           imageSrc: TestImages.choiceGroupBarUnselected,
           selectedImageSrc: TestImages.choiceGroupBarSelected,
-          imageSize: { width: 32, height: 32 },
+          text: 'Pie chart'
+        }
+      ] }
+    />
+  ))
+  .add('With large size images', () => (
+    <ChoiceGroup
+      label='Pick one image'
+      defaultSelectedKey='bar'
+      options={ [
+        {
+          key: 'bar2',
+          imageSrc: TestImages.choiceGroupBarUnselected,
+          selectedImageSrc: TestImages.choiceGroupBarSelected,
+          imageSize: { width: 120, height: 120 },
+          text: 'Clustered bar chart'
+        },
+        {
+          key: 'pie2',
+          imageSrc: TestImages.choiceGroupBarUnselected,
+          selectedImageSrc: TestImages.choiceGroupBarSelected,
+          imageSize: { width: 120, height: 120 },
           text: 'Pie chart'
         }
       ] }

--- a/common/changes/office-ui-fabric-react/choicegroup-size-refactor_2018-02-08-22-52.json
+++ b/common/changes/office-ui-fabric-react/choicegroup-size-refactor_2018-02-08-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: More flexible image field sizing, default image size, large image class.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -228,8 +228,8 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
 
     &.imageIsLarge {
       .innerField {
-        padding-left: 20px;
-        padding-right: 20px;
+        padding-left: 24px;
+        padding-right: 24px;
       }
     }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -30,7 +30,6 @@ $radioButton-border-disabled-color: $radioButton-background-unselected-disabled-
 
 $ms-choiceField-field-size: 20px;
 $ms-choiceField-image-size: 32px;
-$ms-choiceField-text-height: 32px;
 $ms-choiceField-iconField-size: 96px;
 $ms-choiceField-transition-duration: 200ms;
 $ms-choiceField-transition-duration-inner: 150ms;
@@ -199,22 +198,20 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
   $radioButtonSpacing: 3px;
   $radioButtonInnerSize: 5px;
 
-  height: $ms-choiceField-iconField-size;
-  width: $ms-choiceField-iconField-size;
-
   .fieldIsImage, .fieldIsIcon {
 
     display: inline-block;
     box-sizing: border-box;
-    min-width: $ms-choiceField-iconField-size;
     cursor: pointer;
     padding-top: 22px;
     margin: 0;
     text-align: center;
     transition: all $ms-choiceField-transition-duration ease;
     border: 2px solid transparent;
-    height: $ms-choiceField-iconField-size;
-    width: $ms-choiceField-iconField-size;
+    justify-content: center;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
 
     &.fieldIsDisabled {
       cursor: default;
@@ -229,11 +226,18 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
       }
     }
 
+    &.imageIsLarge {
+      .innerField {
+        padding-left: 20px;
+        padding-right: 20px;
+      }
+    }
+
     .innerField {
       position: relative;
-      padding: 0 28px;
-      height: $ms-choiceField-image-size;
-      width: $ms-choiceField-image-size;
+      display: inline-block;
+      padding-left: 30px;
+      padding-right: 30px;
 
       .imageWrapper {
         padding-bottom: 2px;
@@ -260,8 +264,8 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
       $lineHeight: 15px;
       display: block;
       position: relative;
-      margin: 4px 0 2px 0;
-      height: $ms-choiceField-text-height;
+      margin: 4px 8px;
+      height: $lineHeight*2;
       line-height: $lineHeight;
       overflow: hidden;
       white-space: pre-wrap;

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -153,6 +153,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
   private _onRenderField(option: IChoiceGroupOption) {
 
     let { onRenderLabel } = option;
+    let imageSize = option.imageSize ? option.imageSize : { width: 32, height: 32 };
+    let imageIsLarge: boolean = imageSize.width > 71 || imageSize.height > 71;
 
     return (
       <label
@@ -161,12 +163,16 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
           ['ms-ChoiceField-field--image ' + styles.fieldIsImage]: !!option.imageSrc,
           ['ms-ChoiceField--icon ' + styles.fieldIsIcon]: !!option.iconProps,
           ['is-checked ' + styles.fieldIsChecked]: option.checked,
-          ['is-disabled ' + styles.fieldIsDisabled]: option.disabled
+          ['is-disabled ' + styles.fieldIsDisabled]: option.disabled,
+          ['is-largeImage ' + styles.imageIsLarge]: !!option.imageSrc && imageIsLarge
         }) }
       >
         {
           option.imageSrc && (
-            <div className={ css('ms-ChoiceField-innerField', styles.innerField) }>
+            <div
+              className={ css('ms-ChoiceField-innerField', styles.innerField) }
+              style={ { height: imageSize.height, width: imageSize.width } }
+            >
               <div
                 className={ css(
                   'ms-ChoiceField-imageWrapper',
@@ -178,8 +184,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                 <Image
                   src={ option.imageSrc }
                   alt={ option.imageAlt ? option.imageAlt : '' }
-                  width={ option.imageSize ? option.imageSize.width : undefined }
-                  height={ option.imageSize ? option.imageSize.height : undefined }
+                  width={ imageSize.width }
+                  height={ imageSize.height }
                 />
               </div>
               <div
@@ -193,8 +199,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                 <Image
                   src={ option.selectedImageSrc }
                   alt={ option.imageAlt ? option.imageAlt : '' }
-                  width={ option.imageSize ? option.imageSize.width : undefined }
-                  height={ option.imageSize ? option.imageSize.height : undefined }
+                  width={ imageSize.width }
+                  height={ imageSize.height }
                 />
               </div>
             </div>
@@ -212,7 +218,9 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
         {
           option.imageSrc || option.iconProps
             ? (
-              <div className={ css('ms-ChoiceField-labelWrapper', styles.labelWrapper) }>
+              <div className={ css('ms-ChoiceField-labelWrapper', styles.labelWrapper) }
+                style={ { maxWidth: imageSize.width * 2 } }
+              >
                 { onRenderLabel!(option) }
               </div>
             ) : onRenderLabel!(option)

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -218,7 +218,8 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
         {
           option.imageSrc || option.iconProps
             ? (
-              <div className={ css('ms-ChoiceField-labelWrapper', styles.labelWrapper) }
+              <div
+                className={ css('ms-ChoiceField-labelWrapper', styles.labelWrapper) }
                 style={ { maxWidth: imageSize.width * 2 } }
               >
                 { onRenderLabel!(option) }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -89,6 +89,7 @@ export interface IChoiceGroupOption extends React.HTMLAttributes<HTMLElement | H
 
   /**
    * The width and height of the image in px for choice field.
+   * @default { width: 32, height: 32 }
    */
   imageSize?: { width: number, height: number };
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3924 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- ChoiceGroup will be able to support a wider range of sizes
- Instead of specific wrapper sizes for each field, we are using padding to create a sizing pattern that is more flexible
- Larger images get smaller padding
- Images with no specific imageSize set will be given a default height and width of 32px
- Label text wraps when it is > 2x the image size
- Changes to the layout will be slight for default image and icon fields, but they will compatible with more sizes

![image](https://user-images.githubusercontent.com/16619843/36002788-431ab9e4-0ce0-11e8-8625-11ba769e2731.png)

#### Focus areas to test

(optional)
