### PR TITLE
Add aria label prop for clear button in Searchbox

### DIFF
--- a/common/changes/office-ui-fabric-react/searchBoxClearButton_2018-02-08-23-08.json
+++ b/common/changes/office-ui-fabric-react/searchBoxClearButton_2018-02-08-23-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add aria label prop for clear button in searchbox",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-hudole@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -89,11 +89,11 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
         />
         { value!.length > 0 &&
           <div className={ classNames.clearButton }>
-            <IconButton 
-              styles={ { root: { height: 'auto' }, icon: { fontSize: '12px' } } } 
-              onClick={ this._onClearClick } 
-              iconProps={ { iconName: 'Clear' } } 
-              ariaLabel={ this.props.clearButtonAriaLabel } 
+            <IconButton
+              styles={ { root: { height: 'auto' }, icon: { fontSize: '12px' } } }
+              onClick={ this._onClearClick }
+              iconProps={ { iconName: 'Clear' } }
+              ariaLabel={ this.props.clearButtonAriaLabel }
             />
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -89,7 +89,7 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
         />
         { value!.length > 0 &&
           <div className={ classNames.clearButton }>
-            <IconButton styles={ { root: { height: 'auto' }, icon: { fontSize: '12px' } } } onClick={ this._onClearClick } iconProps={ { iconName: 'Clear' } } />
+            <IconButton styles={ { root: { height: 'auto' }, icon: { fontSize: '12px' } } } onClick={ this._onClearClick } iconProps={ { iconName: 'Clear' } } ariaLabel={ this.props.clearButtonAriaLabel } />
           </div>
         }
       </div>

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -89,7 +89,12 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
         />
         { value!.length > 0 &&
           <div className={ classNames.clearButton }>
-            <IconButton styles={ { root: { height: 'auto' }, icon: { fontSize: '12px' } } } onClick={ this._onClearClick } iconProps={ { iconName: 'Clear' } } ariaLabel={ this.props.clearButtonAriaLabel } />
+            <IconButton 
+              styles={ { root: { height: 'auto' }, icon: { fontSize: '12px' } } } 
+              onClick={ this._onClearClick } 
+              iconProps={ { iconName: 'Clear' } } 
+              ariaLabel={ this.props.clearButtonAriaLabel } 
+            />
           </div>
         }
       </div>

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -65,6 +65,11 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
   ariaLabel?: string;
 
   /**
+  * The aria label of the clear button for the benefit of screen readers.
+  */
+  clearButtonAriaLabel?: string;
+
+  /**
    * Whether or not the SearchBox is underlined.
    * @default false
    */

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
@@ -10,6 +10,7 @@ export class SearchBoxSmallExample extends React.Component<any, any> {
     return (
       <div className='ms-SearchBoxSmallExample'>
         <SearchBox
+          clearButtonAriaLabel="Clear searchbox"
           onEscape={ (ev) => {
             console.log('Custom onEscape Called');
           } }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
@@ -10,7 +10,7 @@ export class SearchBoxSmallExample extends React.Component<any, any> {
     return (
       <div className='ms-SearchBoxSmallExample'>
         <SearchBox
-          clearButtonAriaLabel="Clear searchbox"
+          clearButtonAriaLabel='Clear Searchbox'
           onEscape={ (ev) => {
             console.log('Custom onEscape Called');
           } }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ x] Include a change request file using `$ npm run change`

#### Description of changes
Added a prop to Searchbocx called clearButtonAriaLabel to add an aria-label to the clear search box button.

#### Focus areas to test
Added clearButtonAriaLabel to SearchBox.Small.Example for testing.
