### PR TITLE
Fixed controlled TextField with multiline and autoAdjustHeight does not adjust when setting value via state

### DIFF
--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -116,7 +116,10 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
       this.setState({
         value: newProps.value,
         errorMessage: ''
-      } as ITextFieldState);
+      } as ITextFieldState,
+        () => {
+          this._adjustInputHeight();
+        });
 
       this._delayedValidate(newProps.value);
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3941
- [ ] Include a change request file using `$ npm run change` (reports No change file is needed)

#### Description of changes

Updated TextField component so that _adjustInputHeight is called when value is changed via prop update. This ensures the height is adjusted when value updates for a controlled TextField (with multiline and autoAdjustHeight true).

#### Focus areas to test

(optional)
