### PR TITLE
[ContextualMenu] Fixes useTargetWidth property

### DIFF
--- a/common/changes/office-ui-fabric-react/joem-fix-callout-targetwidth_2018-02-11-00-32.json
+++ b/common/changes/office-ui-fabric-react/joem-fix-callout-targetwidth_2018-02-11-00-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes useTargetWidth prop for ContextualMenu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joem@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -45,6 +45,7 @@ export interface IContextualMenuState {
   slideDirectionalClassName?: string;
   subMenuId?: string;
   submenuDirection?: DirectionalHint;
+  targetWidth?: number;
 }
 
 export function hasSubmenu(item: IContextualMenuItem) {
@@ -153,6 +154,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     if (newProps.target !== this.props.target) {
       let newTarget = newProps.target;
       this._setTargetWindowAndElement(newTarget!);
+      this._setTargetWidthAsync();
     }
   }
 
@@ -160,6 +162,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   public componentWillMount() {
     let target = this.props.target;
     this._setTargetWindowAndElement(target!);
+    this._setTargetWidthAsync();
     this._previousActiveElement = this._targetWindow ? this._targetWindow.document.activeElement as HTMLElement : null;
   }
 
@@ -246,17 +249,14 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
      */
     let contextMenuStyle;
     let targetAsHtmlElement = this._target as HTMLElement;
-    if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement && targetAsHtmlElement.offsetWidth) {
-      const targetBoundingRect = targetAsHtmlElement.getBoundingClientRect();
-      const targetWidth = targetBoundingRect.width;
-
+    if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement) {
       if (useTargetWidth) {
         contextMenuStyle = {
-          width: targetWidth
+          width: this.state.targetWidth
         };
       } else if (useTargetAsMinWidth) {
         contextMenuStyle = {
-          minWidth: targetWidth
+          minWidth: this.state.targetWidth
         };
       }
     }
@@ -330,6 +330,23 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     } else {
       return null;
     }
+  }
+
+  private _setTargetWidthAsync() {
+    const targetAsHtmlElement = this._target as HTMLElement;
+
+    // If component doesn't care about target's width, then this is a no-op.
+    if ((!this.props.useTargetWidth && !this.props.useTargetAsMinWidth) || !targetAsHtmlElement) {
+      return;
+    }
+
+    this._async.requestAnimationFrame(() => {
+      const targetBoundingRect = targetAsHtmlElement.getBoundingClientRect();
+
+      this.setState({
+        targetWidth: targetBoundingRect.width - 2 /* Need to account for border width */
+      });
+    });
   }
 
   private _onRenderSubMenu(subMenuProps: IContextualMenuProps) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -45,7 +45,6 @@ export interface IContextualMenuState {
   slideDirectionalClassName?: string;
   subMenuId?: string;
   submenuDirection?: DirectionalHint;
-  targetWidth?: number;
 }
 
 export function hasSubmenu(item: IContextualMenuItem) {
@@ -154,7 +153,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     if (newProps.target !== this.props.target) {
       let newTarget = newProps.target;
       this._setTargetWindowAndElement(newTarget!);
-      this._setTargetWidthAsync();
     }
   }
 
@@ -162,7 +160,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   public componentWillMount() {
     let target = this.props.target;
     this._setTargetWindowAndElement(target!);
-    this._setTargetWidthAsync();
     this._previousActiveElement = this._targetWindow ? this._targetWindow.document.activeElement as HTMLElement : null;
   }
 
@@ -249,14 +246,17 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
      */
     let contextMenuStyle;
     let targetAsHtmlElement = this._target as HTMLElement;
-    if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement) {
+    if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement && targetAsHtmlElement.offsetWidth) {
+      const targetBoundingRect = targetAsHtmlElement.getBoundingClientRect();
+      const targetWidth = targetBoundingRect.width;
+
       if (useTargetWidth) {
         contextMenuStyle = {
-          width: this.state.targetWidth
+          width: targetWidth
         };
       } else if (useTargetAsMinWidth) {
         contextMenuStyle = {
-          minWidth: this.state.targetWidth
+          minWidth: targetWidth
         };
       }
     }
@@ -330,23 +330,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     } else {
       return null;
     }
-  }
-
-  private _setTargetWidthAsync() {
-    const targetAsHtmlElement = this._target as HTMLElement;
-
-    // If component doesn't care about target's width, then this is a no-op.
-    if ((!this.props.useTargetWidth && !this.props.useTargetAsMinWidth) || !targetAsHtmlElement) {
-      return;
-    }
-
-    this._async.requestAnimationFrame(() => {
-      const targetBoundingRect = targetAsHtmlElement.getBoundingClientRect();
-
-      this.setState({
-        targetWidth: targetBoundingRect.width - 2 /* Need to account for border width */
-      });
-    });
   }
 
   private _onRenderSubMenu(subMenuProps: IContextualMenuProps) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -248,7 +248,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     let targetAsHtmlElement = this._target as HTMLElement;
     if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement && targetAsHtmlElement.offsetWidth) {
       const targetBoundingRect = targetAsHtmlElement.getBoundingClientRect();
-      const targetWidth = targetBoundingRect.width;
+      const targetWidth = targetBoundingRect.width - 2 /* Accounts for 1px border */;
 
       if (useTargetWidth) {
         contextMenuStyle = {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -247,7 +247,9 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     let contextMenuStyle;
     let targetAsHtmlElement = this._target as HTMLElement;
     if ((useTargetWidth || useTargetAsMinWidth) && targetAsHtmlElement && targetAsHtmlElement.offsetWidth) {
-      let targetWidth = targetAsHtmlElement.offsetWidth;
+      const targetBoundingRect = targetAsHtmlElement.getBoundingClientRect();
+      const targetWidth = targetBoundingRect.width;
+
       if (useTargetWidth) {
         contextMenuStyle = {
           width: targetWidth
@@ -271,7 +273,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       }
       return (
         <Callout
-          {...calloutProps}
+          { ...calloutProps }
           target={ useTargetPoint ? targetPoint : target }
           isBeakVisible={ isBeakVisible }
           beakWidth={ beakWidth }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3433
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Instead of using `offsetWidth`, which rounds the actual width value to the nearest integer, I changed the behavior to get the target element's bounding rect and use that element's actual `width` property. So instead of rendering a `ContextualMenu` that is slightly wider than the target, it'll now render with the proper width.