### PR TITLE
Respect "forceintofirstchild" parameter of FocusZone.focus()

### DIFF
--- a/common/changes/office-ui-fabric-react/issues-3960-focuszone-forceintofirstchild_2018-02-13-16-29.json
+++ b/common/changes/office-ui-fabric-react/issues-3960-focuszone-forceintofirstchild_2018-02-13-16-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone.Focus now respects forceIntoFirstChild parameter and  IFocusZone.ts has been updated to reflect this",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cohoov@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -139,6 +139,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
   /**
    * Sets focus to the first tabbable item in the zone.
+   * @param {boolean} forceIntoFirstElement If true, focus will be forced into the first element, even if focus is already in the focus zone.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   public focus(forceIntoFirstElement: boolean = false): boolean {
@@ -153,7 +154,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         }
 
         return false;
-      } else if (this._activeElement && elementContains(this._root, this._activeElement)
+      } else if (!forceIntoFirstElement && this._activeElement && elementContains(this._root, this._activeElement)
         && isElementTabbable(this._activeElement)) {
         this._activeElement.focus();
         return true;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
@@ -7,9 +7,10 @@ import { FocusZone } from './FocusZone';
 export interface IFocusZone {
   /**
    * Sets focus to the first tabbable item in the zone.
+   * @param {boolean} forceIntoFirstElement If true, focus will be forced into the first element, even if focus is already in the focus zone.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  focus(): boolean;
+  focus(forceIntoFirstElement?: boolean): boolean;
 
   /**
    * Sets focus to a specific child element within the zone. This can be used in conjunction with


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3960
- [X] Include a change request file using `$ npm run change`

#### Description of changes

FocusZone.Focus now respects `forceIntoFirstChild` parameter and  `IFocusZone.ts` has been updated to reflect this
