### PR TITLE
mergeStyles: Global selector support

### DIFF
--- a/common/changes/@uifabric/merge-styles/global-support-merge-styles_2018-02-13-19-06.json
+++ b/common/changes/@uifabric/merge-styles/global-support-merge-styles_2018-02-13-19-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "mergeStyles: Adding support to register selectors globally. Use `:global(rule)` as the selector to ensure that the unique className is not prepended in the output. See merge-styles README.md for more details.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -195,6 +195,21 @@ This would register the rules:
 .css-0 .child { background: green; }
 ```
 
+### Global selectors
+
+While we suggest avoiding global selectors, there are some cases which make sense to register things globally. Keep in mind that global selectors can't be guaranteed unique and may suffer from specificity problems and versioning issues in the case that two different versions of your library get rendered on the page.
+
+To register a selector globally, wrap it in a `:global()` wrapper:
+
+```tsx
+{
+  selectors: {
+    ':global(button): {
+      overflow: 'visible'
+    }
+  }
+}
+
 ### Media queries
 
 Media queries can be applied via selectors. For example, this style will produce a class which has a red background when above 600px, and green when at or below 600px:

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -97,7 +97,7 @@ describe('styleToClassName', () => {
   });
 
   it('does not emit a rule which has an undefined value', () => {
-    expect(styleToClassName({fontFamily: undefined})).toEqual('');
+    expect(styleToClassName({ fontFamily: undefined })).toEqual('');
     expect(_stylesheet.getRules()).toEqual('');
   });
 
@@ -144,6 +144,17 @@ describe('styleToClassName', () => {
 
     expect(newClassName).toEqual('css-1');
     expect(_stylesheet.getRules()).toEqual('.css-0{background:red;}.css-1 > *{background:red;}');
+  });
+
+  it('can register global selectors', () => {
+    const className = styleToClassName({
+      selectors: {
+        ':global(button)': { background: 'red' }
+      },
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('button{background:red;}');
   });
 
   it('can expand an array of rules', () => {

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -58,7 +58,9 @@ function extractRules(
             if (selectors.hasOwnProperty(newSelector)) {
               const selectorValue = selectors[newSelector];
 
-              if (newSelector.indexOf('@media') === 0) {
+              if (newSelector.indexOf(':global(') === 0) {
+                newSelector = newSelector.replace(/:global\(|\)$/g, '');
+              } else if (newSelector.indexOf('@media') === 0) {
                 newSelector = newSelector + '{' + currentSelector;
               } else if (newSelector.indexOf(':') === 0) {
                 newSelector = currentSelector + newSelector;


### PR DESCRIPTION
Adding a feature to mergeStyles, which allows you to wrap your selector in a `:global()` wrapper, akin toe the SCSS modules approach.

Example:

```tsx
mergeStyles({
  selectors: {
    ':global(button)': {
      overflow: 'visible'
    }
  }
});
```
