### PR TITLE
CalloutContent: Remove CalloutWidth from calloutMain div

### DIFF
--- a/common/changes/office-ui-fabric-react/malozano-CalloutBorderWidth_2018-02-13-23-13.json
+++ b/common/changes/office-ui-fabric-react/malozano-CalloutBorderWidth_2018-02-13-23-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CalloutContent: Remove calloutWidth from calloutMain ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "malozano@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
@@ -113,7 +113,6 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
         position: 'relative',
         maxHeight: contentMaxHeight
       },
-      !!calloutWidth && { width: calloutWidth },
       overflowYHidden && {
         overflowY: 'hidden'
       },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When converting component to getStyles, calloutWidth was added by mistake to calloutmain div. It should only be part of the css of the root element.

This issue was causing the border to be hidden from the callout content main div.
