### PR TITLE
List: Add a _notifyPageChanges function 

### DIFF
--- a/common/changes/office-ui-fabric-react/alebet-onPageAdded_2018-02-15-21-11.json
+++ b/common/changes/office-ui-fabric-react/alebet-onPageAdded_2018-02-15-21-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add notifyPageChange function to List",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "alebet@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -570,15 +570,15 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     }
 
     let newListState = this._buildPages(props);
-    let oldListPages = this.state.pages;
+    let oldListPages = this.state.pages!;
 
-    this._notifyPageChanges(oldListPages as IPage[], newListState.pages as IPage[]);
+    this._notifyPageChanges(oldListPages, newListState.pages!);
 
     this.setState(newListState, () => {
       // If we weren't provided with the page height, measure the pages
       if (!props.getPageHeight) {
         // If measured version is invalid since we've updated the DOM
-        const heightsChanged = this._updatePageMeasurements(newListState.pages as IPage[]);
+        const heightsChanged = this._updatePageMeasurements(newListState.pages!);
 
         // On first render, we should re-measure so that we don't get a visual glitch.
         if (heightsChanged) {
@@ -604,6 +604,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
    * Notify consumers that the rendered pages have changed
    * @param oldPages The old pages
    * @param newPages The new pages
+   * @param props The props to use
    */
   private _notifyPageChanges(oldPages: IPage[], newPages: IPage[], props: IListProps = this.props) {
     const {
@@ -616,17 +617,13 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
         [index: number]: IPage;
       } = {};
 
-      for (let i = 0; i < oldPages.length; i++) {
-        let page = oldPages[i];
-
+      for (const page of oldPages) {
         if (page.items) {
           renderedIndexes[page.startIndex] = page;
         }
       }
 
-      for (let i = 0; i < newPages.length; i++) {
-        let page = newPages[i];
-
+      for (const page of newPages) {
         if (page.items) {
           if (!renderedIndexes[page.startIndex]) {
             this._onPageAdded(page);

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -435,7 +435,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     const {
       page: {
         items,
-      startIndex
+        startIndex
       },
       ...divProps
     } = pageProps;
@@ -572,11 +572,13 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     let newListState = this._buildPages(props);
     let oldListPages = this.state.pages;
 
+    this._notifyPageChanges(oldListPages, newListState.pages as IPage[]);
+
     this.setState(newListState, () => {
       // If we weren't provided with the page height, measure the pages
       if (!props.getPageHeight) {
         // If measured version is invalid since we've updated the DOM
-        const heightsChanged = this._updatePageMeasurements(oldListPages as IPage[], newListState.pages as IPage[]);
+        const heightsChanged = this._updatePageMeasurements(newListState.pages as IPage[]);
 
         // On first render, we should re-measure so that we don't get a visual glitch.
         if (heightsChanged) {
@@ -598,7 +600,51 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     });
   }
 
-  private _updatePageMeasurements(oldPages: IPage[], newPages: IPage[]) {
+  /**
+   * Notify consumers that the rendered pages have changed
+   * @param oldPages The old pages
+   * @param newPages The new pages
+   */
+  private _notifyPageChanges(oldPages: IPage[], newPages: IPage[], props: IListProps = this.props) {
+    const {
+      onPageAdded,
+      onPageRemoved
+    } = props;
+
+    if (onPageAdded || onPageRemoved) {
+      const renderedIndexes: {
+        [index: number]: IPage;
+      } = {};
+
+      for (let i = 0; i < oldPages.length; i++) {
+        let page = oldPages[i];
+
+        if (page.items) {
+          renderedIndexes[page.startIndex] = page;
+        }
+      }
+
+      for (let i = 0; i < newPages.length; i++) {
+        let page = newPages[i];
+
+        if (page.items) {
+          if (!renderedIndexes[page.startIndex]) {
+            this._onPageAdded(page);
+          } else {
+            delete renderedIndexes[page.startIndex];
+          }
+        }
+      }
+
+      for (let index in renderedIndexes) {
+        if (renderedIndexes.hasOwnProperty(index)) {
+          this._onPageRemoved(renderedIndexes[index]);
+        }
+      }
+    }
+  }
+
+  private _updatePageMeasurements(pages: IPage[]) {
     const renderedIndexes: {
       [index: number]: IPage;
     } = {};
@@ -610,31 +656,11 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
       return heightChanged;
     }
 
-    for (let i = 0; i < oldPages.length; i++) {
-      let page = oldPages[i];
-
-      if (page.items) {
-        renderedIndexes[page.startIndex] = page;
-      }
-    }
-
-    for (let i = 0; i < newPages.length; i++) {
-      let page = newPages[i];
+    for (let i = 0; i < pages.length; i++) {
+      let page = pages[i];
 
       if (page.items) {
         heightChanged = this._measurePage(page) || heightChanged;
-
-        if (!renderedIndexes[page.startIndex]) {
-          this._onPageAdded(page);
-        } else {
-          delete renderedIndexes[page.startIndex];
-        }
-      }
-    }
-
-    for (let index in renderedIndexes) {
-      if (renderedIndexes.hasOwnProperty(index)) {
-        this._onPageRemoved(renderedIndexes[index]);
       }
     }
 

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -572,7 +572,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     let newListState = this._buildPages(props);
     let oldListPages = this.state.pages;
 
-    this._notifyPageChanges(oldListPages, newListState.pages as IPage[]);
+    this._notifyPageChanges(oldListPages as IPage[], newListState.pages as IPage[]);
 
     this.setState(newListState, () => {
       // If we weren't provided with the page height, measure the pages


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3989 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

If the `getPageHeight` property is provided to List, the `onPageAdded` and `onPageRemoved` callbacks are never called.

This is because these callbacks are called within the `updatePageMeasurements` function, which does not need to be called if `getPageHeight` is provided.

The fix is to separate this logic into its own function, `_notifyPageChanges`, which is called in the `_updatePages` function

