### PR TITLE
mergeStyles: Fill opacity is now unitless.

### DIFF
--- a/common/changes/@uifabric/merge-styles/fill-opacity_2018-02-15-22-38.json
+++ b/common/changes/@uifabric/merge-styles/fill-opacity_2018-02-15-22-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "mergeStyles: setting `fill-opacity` as unitless.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/transforms/provideUnits.ts
+++ b/packages/merge-styles/src/transforms/provideUnits.ts
@@ -5,6 +5,7 @@ const NON_PIXEL_NUMBER_PROPS = [
   'flex',
   'flex-grow',
   'flex-shrink',
+  'fill-opacity',
   'opacity',
   'order',
   'z-index',


### PR DESCRIPTION
Providing fillOpacity: 1 no longer appends "px" in the output.

Addresses issue: #3983 