### PR TITLE
ContextualMenu - Added support for custom component lengths and fixed aria-posinset value

### DIFF
--- a/common/changes/office-ui-fabric-react/menusize_2018-02-16-18-26.json
+++ b/common/changes/office-ui-fabric-react/menusize_2018-02-16-18-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updated contextual menu to pass the correct number",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -317,7 +317,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                     let menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
                     if (item.itemType !== ContextualMenuItemType.Divider &&
                       item.itemType !== ContextualMenuItemType.Header) {
-                      const indexIncrease = item.customOnRenderListLength ? item.customOnRenderListLength : 1;
+                      const indexIncrease = item.customOnRenderListLength ? item.customOnRenderListLength + 1 : 1; // +1 move to the next elemnt
                       indexCorrection += indexIncrease;
                     }
                     return menuItem;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -444,7 +444,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderNormalItem(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {
     if (item.onRender) {
-      return [item.onRender({ 'aria-posinset': focusableElementIndex, 'aria-setsize': totalItemCount, ...item }, this.dismiss)];
+      return [item.onRender({ 'aria-posinset': focusableElementIndex + 1, 'aria-setsize': totalItemCount, ...item }, this.dismiss)];
     }
     if (item.href) {
       return this._renderAnchorMenuItem(item, classNames, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -317,7 +317,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                     let menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
                     if (item.itemType !== ContextualMenuItemType.Divider &&
                       item.itemType !== ContextualMenuItemType.Header) {
-                      const indexIncrease = item.customOnRenderListLength ? item.customOnRenderListLength + 1 : 1; // +1 move to the next elemnt
+                      const indexIncrease = item.customOnRenderListLength ? item.customOnRenderListLength : 1;
                       indexCorrection += indexIncrease;
                     }
                     return menuItem;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -267,11 +267,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       for (let item of items) {
         if (item.itemType !== ContextualMenuItemType.Divider &&
           item.itemType !== ContextualMenuItemType.Header) {
-          if (item.customOnRenderListLength) {
-            totalItemCount += item.customOnRenderListLength;
-          } else {
-            totalItemCount++;
-          }
+          let itemCount = item.customOnRenderListLength ? item.customOnRenderListLength : 1;
+          totalItemCount += itemCount;
         }
       }
       return (

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -267,7 +267,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       for (let item of items) {
         if (item.itemType !== ContextualMenuItemType.Divider &&
           item.itemType !== ContextualMenuItemType.Header) {
-          totalItemCount++;
+          if (item.customOnRenderListLength) {
+            totalItemCount += item.customOnRenderListLength;
+          } else {
+            totalItemCount++;
+          }
         }
       }
       return (
@@ -313,11 +317,13 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                   onKeyDown={ this._onKeyDown }
                 >
                   { items.map((item, index) => {
-                    if (item.itemType === ContextualMenuItemType.Divider ||
-                      item.itemType === ContextualMenuItemType.Header) {
-                      indexCorrection++;
+                    let menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
+                    if (item.itemType !== ContextualMenuItemType.Divider &&
+                      item.itemType !== ContextualMenuItemType.Header) {
+                      const indexIncrease = item.customOnRenderListLength ? item.customOnRenderListLength : 1;
+                      indexCorrection += indexIncrease;
                     }
-                    return this._renderMenuItem(item, index, index - indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
+                    return menuItem;
                   }) }
                 </ul>
               </FocusZone>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -267,7 +267,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       for (let item of items) {
         if (item.itemType !== ContextualMenuItemType.Divider &&
           item.itemType !== ContextualMenuItemType.Header) {
-          let itemCount = item.customOnRenderListLength ? item.customOnRenderListLength : 1;
+          const itemCount = item.customOnRenderListLength ? item.customOnRenderListLength : 1;
           totalItemCount += itemCount;
         }
       }
@@ -314,7 +314,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                   onKeyDown={ this._onKeyDown }
                 >
                   { items.map((item, index) => {
-                    let menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
+                    const menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);
                     if (item.itemType !== ContextualMenuItemType.Divider &&
                       item.itemType !== ContextualMenuItemType.Header) {
                       const indexIncrease = item.customOnRenderListLength ? item.customOnRenderListLength : 1;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -407,6 +407,13 @@ export interface IContextualMenuItem {
   role?: string;
 
   /**
+   * When rendering a custom component that is passed in, the component might also be a list of
+   * elements. We want to keep track of the correct index our menu is using based off of
+   * the length of the custom list.
+   */
+  customOnRenderListLength?: number;
+
+  /**
    * Any additional properties to use when custom rendering menu items.
    */
   [propertyName: string]: any;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -409,7 +409,7 @@ export interface IContextualMenuItem {
   /**
    * When rendering a custom component that is passed in, the component might also be a list of
    * elements. We want to keep track of the correct index our menu is using based off of
-   * the length of the custom list.
+   * the length of the custom list. It is up to the user to increment the count for their list.
    */
   customOnRenderListLength?: number;
 


### PR DESCRIPTION
**Problem:**
In the Contextual Menu if we have to rely on the custom onRender() of a passed in ContextualItem we would pass in the index of our element so that the user can use it for aria-posinset for accessibility reasons.

However, in the event that the contextual item is a list and has items in it. The contextual menu would have no way of knowing.  

Also, posinset starts at index 1 and not 0. We currently pass in our index starting at the value of 0, so I'm also doing a side fix for that for the custom onRender()

**Solution:**
To help detect that we might have a custom component that has their own list of items, I introduced a new prop that allows the users to add in the length of their component that we'll consider when calculating the index and total set size of the elements in our list.

I also added 1 to the value that we're sending out to help adjust for the fact that aria-posinset is 1-based index and not 0 based-index.

**Validation:**
I tested the changes locally by using my changes with my own custom component with a list and validated that the numbers are all correct.