### PR TITLE
Checkbox styles to match XD styling docs

### DIFF
--- a/common/changes/office-ui-fabric-react/checkbox-styles_2018-02-20-23-22.json
+++ b/common/changes/office-ui-fabric-react/checkbox-styles_2018-02-20-23-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Update styles to conform to XD design docs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -47,7 +47,9 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         !checked && {
           selectors: {
             ':hover .ms-Checkbox-checkbox': { borderColor: checkboxBorderHoveredColor },
-            ':focus .ms-Checkbox-checkbox': { borderColor: checkboxBorderHoveredColor }
+            ':focus .ms-Checkbox-checkbox': { borderColor: checkboxBorderHoveredColor },
+            ':hover .ms-Checkbox-checkmark': { color: checkboxBorderColor, opacity: '0.5' },
+            ':focus .ms-Checkbox-checkmark': { color: checkboxBorderColor, opacity: '0.5' },
           }
         },
         checked && {
@@ -121,10 +123,13 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         borderColor: checkboxBorderColorDisabled
       }
     ],
-    checkmark: {
-      opacity: checked ? '1' : '0',
-      color: checked && disabled ? checkmarkFontColorCheckedDisabled : checkmarkFontColor
-    },
+    checkmark: [
+      'ms-Checkbox-checkmark',
+      {
+        opacity: checked ? '1' : '0',
+        color: checked && disabled ? checkmarkFontColorCheckedDisabled : checkmarkFontColor,
+      }
+    ],
     text: [
       'ms-Checkbox-text',
       {

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -48,8 +48,8 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
           selectors: {
             ':hover .ms-Checkbox-checkbox': { borderColor: checkboxBorderHoveredColor },
             ':focus .ms-Checkbox-checkbox': { borderColor: checkboxBorderHoveredColor },
-            ':hover .ms-Checkbox-checkmark': { color: checkboxBorderColor, opacity: '0.5' },
-            ':focus .ms-Checkbox-checkmark': { color: checkboxBorderColor, opacity: '0.5' },
+            ':hover .ms-Checkbox-checkmark': { color: checkboxBorderHoveredColor, opacity: '0.5' },
+            ':focus .ms-Checkbox-checkmark': { color: checkboxBorderHoveredColor, opacity: '0.5' },
           }
         },
         checked && {

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -14,6 +14,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
   const { className, theme, reversed, checked, disabled } = props;
   const { semanticColors, palette } = theme;
   const checkmarkFontColor = semanticColors.inputForegroundChecked;
+  const checkmartFontColorHovered = semanticColors.inputBorder;
   const checkmarkFontColorCheckedDisabled = semanticColors.disabledBackground;
   const checkboxBorderColor = semanticColors.inputBorder;
   const checkboxBorderColorChecked = semanticColors.inputBackgroundChecked;
@@ -48,8 +49,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
           selectors: {
             ':hover .ms-Checkbox-checkbox': { borderColor: checkboxBorderHoveredColor },
             ':focus .ms-Checkbox-checkbox': { borderColor: checkboxBorderHoveredColor },
-            ':hover .ms-Checkbox-checkmark': { color: checkboxBorderHoveredColor, opacity: '0.5' },
-            ':focus .ms-Checkbox-checkmark': { color: checkboxBorderHoveredColor, opacity: '0.5' },
+            ':hover .ms-Checkbox-checkmark': { color: checkmartFontColorHovered, opacity: '1' },
           }
         },
         checked && {
@@ -127,7 +127,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
       'ms-Checkbox-checkmark',
       {
         opacity: checked ? '1' : '0',
-        color: checked && disabled ? checkmarkFontColorCheckedDisabled : checkmarkFontColor,
+        color: checked && disabled ? checkmarkFontColorCheckedDisabled : checkmarkFontColor
       }
     ],
     text: [

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -46,6 +46,14 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
       &:focus .ms-Checkbox-checkbox {
         border-color: #212121;
       }
+      &:hover .ms-Checkbox-checkmark {
+        color: #212121;
+        opacity: 0.5;
+      }
+      &:focus .ms-Checkbox-checkmark {
+        color: #212121;
+        opacity: 0.5;
+      }
       &:hover .ms-Checkbox-text {
         color: #000000;
       }
@@ -107,6 +115,7 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
         aria-label={undefined}
         className=
             ms-Icon
+            ms-Checkbox-checkmark
             {
               color: #ffffff;
               display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -47,12 +47,8 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
         border-color: #212121;
       }
       &:hover .ms-Checkbox-checkmark {
-        color: #212121;
-        opacity: 0.5;
-      }
-      &:focus .ms-Checkbox-checkmark {
-        color: #212121;
-        opacity: 0.5;
+        color: #a6a6a6;
+        opacity: 1;
       }
       &:hover .ms-Checkbox-text {
         color: #000000;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adjust styles on the checkbox so they match the document (specifically :hover styles). I'm targeting the 6.0 branch to avoid merge conflicts on the existing mergeStyles conversion.

XD Document:
![image](https://user-images.githubusercontent.com/7110658/36457472-04ab5276-165f-11e8-9b9e-f496e3359e69.png)

Rendered Before:
![image](https://user-images.githubusercontent.com/7110658/36457491-1dcf5702-165f-11e8-969f-9db38c22f072.png)

Rendered After:
![image](https://user-images.githubusercontent.com/7110658/36458152-4420299c-1662-11e8-986a-503732085dfd.png)
