### PR TITLE
Dialog: modal props now mixed correctly

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-dialog-props_2018-02-21-03-49.json
+++ b/common/changes/office-ui-fabric-react/fix-dialog-props_2018-02-21-03-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dialog: default modal props now respective (Modal rendered with light background.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
@@ -5,28 +5,30 @@ import {
   getId
 } from '../../Utilities';
 import { IDialogProps } from './Dialog.types';
-import { DialogType } from './DialogContent.types';
-import { Modal } from '../../Modal';
+import { DialogType, IDialogContentProps } from './DialogContent.types';
+import { Modal, IModalProps } from '../../Modal';
 import { withResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 import * as stylesImport from './Dialog.scss';
 const styles: any = stylesImport;
 
 import { DialogContent } from './DialogContent';
 
+const DefaultModalProps: IModalProps = {
+  isDarkOverlay: false,
+  isBlocking: false,
+  className: '',
+  containerClassName: ''
+};
+
+const DefaultDialogContentProps: IDialogContentProps = {
+  type: DialogType.normal,
+  className: '',
+  topButtonsProps: [],
+};
+
 @withResponsiveMode
 export class DialogBase extends BaseComponent<IDialogProps, {}> {
   public static defaultProps: IDialogProps = {
-    modalProps: {
-      isDarkOverlay: true,
-      isBlocking: false,
-      className: '',
-      containerClassName: ''
-    },
-    dialogContentProps: {
-      type: DialogType.normal,
-      className: '',
-      topButtonsProps: [],
-    },
     hidden: true,
   };
 
@@ -78,11 +80,19 @@ export class DialogBase extends BaseComponent<IDialogProps, {}> {
       type,
       contentClassName,
       topButtonsProps,
-      dialogContentProps,
-      modalProps,
       containerClassName,
       hidden
     } = this.props;
+
+    const modalProps = {
+      ...DefaultModalProps,
+      ...this.props.modalProps
+    };
+
+    const dialogContentProps: IDialogContentProps = {
+      ...DefaultDialogContentProps,
+      ...this.props.dialogContentProps
+    };
 
     return (
       <Modal


### PR DESCRIPTION
There was a bug in Dialog where "defaults" would be easily overwritten for `modalProps` and `dialogContentProps`.

This change now mixes the user provided values in with defaults. This means we respect the default white overlay for Modal.
