### PR TITLE
Fix issues in scrollable pane

### DIFF
--- a/common/changes/office-ui-fabric-react/maxlus-stickyContainer_2018-02-21-19-45.json
+++ b/common/changes/office-ui-fabric-react/maxlus-stickyContainer_2018-02-21-19-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix infinite recursion in scrollable pane",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "maxlus@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -63,14 +63,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
   public componentDidMount() {
     this._events.on(this.root, 'scroll', this.notifySubscribers);
     this._events.on(window, 'resize', this._onWindowResize);
-    this._async.setTimeout(() => {
-      this._resizeContainer();
-      if (this.stickyContainer.parentElement && this.root.parentElement) {
-        this.stickyContainer.parentElement.removeChild(this.stickyContainer);
-        this.root.parentElement.insertBefore(this.stickyContainer, this.root.nextSibling);
-        this.notifySubscribers();
-      }
-    }, 500);
   }
 
   public componentWillUnmount() {
@@ -95,13 +87,12 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
         { ...getNativeProps(this.props, divProperties) }
         ref={ this._resolveRef('root') }
         className={ classNames.root }
-        data-is-scrollable={ true }
       >
-        <div ref={ this._resolveRef('stickyContainer') } className={ classNames.stickyContainer }>
-          <div ref={ this._resolveRef('stickyAbove') } className={ classNames.stickyAbove } />
-          <div ref={ this._resolveRef('stickyBelow') } className={ classNames.stickyBelow } />
+        <div ref={ this._resolveRef('stickyAbove') } className={ styles.stickyAbove } />
+        <div ref={ this._resolveRef('stickyBelow') } className={ styles.stickyBelow } />
+        <div data-is-scrollable={ true }>
+          { this.props.children }
         </div>
-        { this.props.children }
       </div>
     );
   }
@@ -185,24 +176,10 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
 
   private _onWindowResize() {
     this._async.setTimeout(() => {
-      this._resizeContainer();
       this.notifySubscribers();
       this._setPlaceholderHeights(this._stickyAbove);
       this._setPlaceholderHeights(this._stickyBelow);
     }, 5);
-  }
-
-  private _resizeContainer() {
-    const { stickyContainer, root } = this;
-    const { borderTopWidth, borderLeftWidth } = getComputedStyle(root);
-    stickyContainer.style.height = root.clientHeight + 'px';
-    stickyContainer.style.width = root.clientWidth + 'px';
-    if (borderTopWidth) {
-      stickyContainer.style.top = root.offsetTop + parseInt(borderTopWidth, 10) + 'px';
-    }
-    if (borderLeftWidth) {
-      stickyContainer.style.left = root.offsetLeft + parseInt(borderLeftWidth, 10) + 'px';
-    }
   }
 
   @autobind

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -32,7 +32,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
   };
 
   public root: HTMLElement;
-  public stickyContainer: HTMLElement;
   public stickyAbove: HTMLElement;
   public stickyBelow: HTMLElement;
   private _subscribers: Set<Function>;
@@ -85,8 +84,8 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
         ref={ this._resolveRef('root') }
         className={ classNames.root }
       >
-        <div ref={ this._resolveRef('stickyAbove') } className={ styles.stickyAbove } />
-        <div ref={ this._resolveRef('stickyBelow') } className={ styles.stickyBelow } />
+        <div ref={ this._resolveRef('stickyAbove') } className={ classNames.stickyAbove } />
+        <div ref={ this._resolveRef('stickyBelow') } className={ classNames.stickyBelow } />
         <div data-is-scrollable={ true }>
           { this.props.children }
         </div>

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -68,9 +68,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
   public componentWillUnmount() {
     this._events.off(this.root);
     this._events.off(window);
-    if (this.stickyContainer.parentElement) {
-      this.stickyContainer.parentElement.removeChild(this.stickyContainer);
-    }
   }
 
   public render() {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -171,7 +171,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
           }
         }, 1);
       }
-      this.notifySubscribers();
       this._setPlaceholderHeights(stickyList);
     }
   }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.scss
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.scss
@@ -1,0 +1,32 @@
+@import '../../common/common';
+
+.root {
+  overflow-y: auto;
+  max-height: inherit;
+  height: inherit;
+  -webkit-overflow-scrolling: touch;
+}
+
+.stickyAbove,
+.stickyBelow {
+  position: absolute;
+  pointer-events: auto;
+  width: 100%;
+  z-index: 1;
+}
+
+.stickyAbove {
+  top: 0;
+
+  @include high-contrast {
+    border-bottom: 1px solid WindowText;
+  }
+}
+
+.stickyBelow {
+  bottom: 0;
+
+  @include high-contrast {
+    border-top: 1px solid WindowText;
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
@@ -33,14 +33,6 @@ export const getStyles = (
       },
       className
     ],
-    stickyContainer: [
-      {
-        overflow: 'hidden',
-        position: 'absolute',
-        pointerEvents: 'none',
-
-      }
-    ],
     stickyAbove: [
       {
         top: 0,

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -54,10 +54,6 @@ export interface IScrollablePaneStyles {
    */
   root: IStyle;
   /**
-   * Style set for the stickyContainer element.
-   */
-  stickyContainer: IStyle;
-  /**
    * Style set for the stickyAbove element.
    */
   stickyAbove: IStyle;

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -145,8 +145,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     const canStickyFooter = stickyPosition === StickyPositionType.Both || stickyPosition === StickyPositionType.Footer;
 
     this.setState({
-      isStickyTop: canStickyHeader && ((!isStickyTop && top <= headerBound.bottom) || (isStickyTop && bottom < headerBound.bottom)),
-      isStickyBottom: canStickyFooter && ((!isStickyBottom && bottom >= footerBound.top) || (isStickyBottom && top > footerBound.top))
+      isStickyTop: canStickyHeader && ((top <= headerBound.bottom) || (isStickyTop && bottom < headerBound.bottom)),
+      isStickyBottom: canStickyFooter && ((bottom >= footerBound.top) || (isStickyBottom && top > footerBound.top))
     });
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

It's possible to enter an infinite recursion in scrollable pane. notifySubscribers is called from _onWindowResize, which is called from forceLayoutUpdate (callable from the parent item). This calls Sticky::_onScrollEvent, which updates the Sticky's state. Sticky::componentDidUpdate can call scrollablePane.addStickyHeader, which calls _addSticky, which then calls notifySubscribers, infinitely recursing. The solution to this was to update Sticky::_onScrollEvent to not check the current of conditions of isStickyTop and isStickyBottom, since it was causing them to constantly flip, causing setState to constantly get called.

This, however, unfurled a different bug in ScrollablePane which the infinite loop had masked: the top sticky header wouldn't properly be placed in stickyAbove on creation of the ScrollablePane, but the constant changing of isStickyTop and isStickyBottom eventually caused it to snap in place. By getting rid of stickyContainer and moving stickyAbove and stickyBelow to siblings of the children of the pane, this is fixed (it also removed the need for resizeContainer).

#### Focus areas to test

Scrollable Pane
