### PR TITLE
[TextField] input "size" attribute

### DIFF
--- a/common/changes/office-ui-fabric-react/law-textfieldMinSize_2018-02-21-21-44.json
+++ b/common/changes/office-ui-fabric-react/law-textfieldMinSize_2018-02-21-21-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "[TextField] Set input size to 1",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -128,6 +128,12 @@ $field-error-color: $errorTextColor;
   color: $field-text-color;
   @include ms-padding(0, 12px, 0, 12px);
   width: 100%;
+  /**
+   * min-width is set to 1 in order to tell the browser to ignore the
+   * default value calculated from the size attribute and respect the
+   * width set on parent elements.
+   */
+  min-width: 0;
   text-overflow: ellipsis;
   outline: 0;
   &:active,

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -294,7 +294,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     const {
       label,
       componentId
-     } = props;
+    } = props;
     if (label) {
       return (<Label htmlFor={ componentId }>{ label }</Label>);
     }
@@ -370,6 +370,11 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
   private _renderInput(): React.ReactElement<React.HTMLAttributes<HTMLInputElement>> {
     const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
 
+    /**
+     * Size is set to 1 for the input element in order to force the browser to
+     * respect the width set on parent elements.
+     * See: https://html.spec.whatwg.org/multipage/input.html#the-size-attribute
+     */
     return (
       <input
         type={ 'text' }
@@ -385,6 +390,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         aria-invalid={ !!this.state.errorMessage }
         onFocus={ this._onFocus }
         onBlur={ this._onBlur }
+        size={ 1 }
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -370,11 +370,6 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
   private _renderInput(): React.ReactElement<React.HTMLAttributes<HTMLInputElement>> {
     const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
 
-    /**
-     * Size is set to 1 for the input element in order to force the browser to
-     * respect the width set on parent elements.
-     * See: https://html.spec.whatwg.org/multipage/input.html#the-size-attribute
-     */
     return (
       <input
         type={ 'text' }
@@ -390,7 +385,6 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         aria-invalid={ !!this.state.errorMessage }
         onFocus={ this._onFocus }
         onBlur={ this._onBlur }
-        size={ 1 }
       />
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Size is set to 1 for the input element in order to force the browser to respect the width set on parent elements. When size is set, it tells the browser it must show at least that number of characters in the textfield. Size defaults to 20 which forces the field to have a minimum width that may be larger than the intended size of the textfield.

See: https://html.spec.whatwg.org/multipage/input.html#the-size-attribute

![default size input text](https://user-images.githubusercontent.com/6496608/36507141-a5915858-170d-11e8-8878-ade9e9494fed.png)
