### PR TITLE
ComboBox button should have data-is-focusable="false"

### DIFF
--- a/common/changes/office-ui-fabric-react/ComboBoxButtonDataIsFocusable_2018-02-22-18-29.json
+++ b/common/changes/office-ui-fabric-react/ComboBoxButtonDataIsFocusable_2018-02-22-18-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Added property to set ComboBox's button's data-is-focusable attribute.",
+      "comment": "ComboBox: Added property to set ComboBox's button's data-is-focusable attribute.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/ComboBoxButtonDataIsFocusable_2018-02-22-18-29.json
+++ b/common/changes/office-ui-fabric-react/ComboBoxButtonDataIsFocusable_2018-02-22-18-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added property to set ComboBox's button's data-is-focusable attribute.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mipatera@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -270,7 +270,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       autoComplete,
       buttonIconProps,
       isButtonAriaHidden = true,
-      isButtonDataFocusable = true,
       styles: customStyles,
       theme,
       title
@@ -348,7 +347,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             styles={ this._getCaretButtonStyles() }
             role='presentation'
             aria-hidden={ isButtonAriaHidden }
-            data-is-focusable={ isButtonDataFocusable }
+            data-is-focusable={false}
             tabIndex={ -1 }
             onClick={ this._onComboBoxClick }
             iconProps={ buttonIconProps }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -270,6 +270,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       autoComplete,
       buttonIconProps,
       isButtonAriaHidden = true,
+      isButtonDataFocusable = true,
       styles: customStyles,
       theme,
       title
@@ -347,6 +348,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             styles={ this._getCaretButtonStyles() }
             role='presentation'
             aria-hidden={ isButtonAriaHidden }
+            data-is-focusable={ isButtonDataFocusable }
             tabIndex={ -1 }
             onClick={ this._onComboBoxClick }
             iconProps={ buttonIconProps }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -154,6 +154,12 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * @default true
    */
   isButtonAriaHidden?: boolean;
+
+  /**
+   * Sets the 'data-is-focusable' attribute on the ComboBox's button element. Setting this to false while the ComboBox is wrapped in a
+   * FocusZone will allow keyboard navigation to skip the button (as it is redundant within that context).
+   */
+  isButtonDataFocusable?: boolean;
 }
 
 export interface IComboBoxStyles {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -154,12 +154,6 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * @default true
    */
   isButtonAriaHidden?: boolean;
-
-  /**
-   * Sets the 'data-is-focusable' attribute on the ComboBox's button element. Setting this to false while the ComboBox is wrapped in a
-   * FocusZone will allow keyboard navigation to skip the button (as it is redundant within that context).
-   */
-  isButtonDataFocusable?: boolean;
 }
 
 export interface IComboBoxStyles {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -223,7 +223,7 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
             background-color: #eaeaea;
             color: #212121;
           }
-      data-is-focusable={true}
+      data-is-focusable={false}
       disabled={undefined}
       onClick={[Function]}
       role="presentation"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4051
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added a property to ComboBox to specify the value for its button's data-is-focusable attribute. This is useful when the ComboBox is part of a FocusZone, as setting the value to false allows the button to be skipped with keyboard navigation.

I defaulted it to true, to avoid making a silent, subtle change for existing users. However, I believe the most frequent use case would be to set it to false, as that button doesn't make much sense in a keyboard navigation context. Any advice on what the appropriate default setting should be would be appreciated.