### PR TITLE
Searchable dropdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,7 +43,7 @@
   "tslint.rulesDirectory": "./common/temp/node_modules/tslint-microsoft-contrib",
   // Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": true,
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "typescript.tsdk": "./common/temp/node_modules/typescript/lib",
   "tslint.autoFixOnSave": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,7 +43,7 @@
   "tslint.rulesDirectory": "./common/temp/node_modules/tslint-microsoft-contrib",
   // Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": true,
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "typescript.tsdk": "./common/temp/node_modules/typescript/lib",
   "tslint.autoFixOnSave": false
 }

--- a/common/changes/office-ui-fabric-react/wygoodin-dropdown_search_2018-02-23-18-36.json
+++ b/common/changes/office-ui-fabric-react/wygoodin-dropdown_search_2018-02-23-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Added option for searchable dropdowns.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "wygoodin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -348,16 +348,16 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       return (
         <TextField
           borderless
-          cellPadding={'0'}
-          style={{ padding: '0 0' }}
-          placeholder={this.props.placeHolder}
+          cellPadding={ '0' }
+          style={ { padding: '0 0' } }
+          placeholder={ this.props.placeHolder }
           value={ displayText }
-          disabled={this.props.disabled}
-          onChanged={this._onSearchChanged}
-          onClick={this._onClickSearchInput}
-          onFocus={this._onSearchFocus}
-          onKeyDown={this._onSearchKeyDown}
-          onKeyUp={this._onSearchKeyUp}
+          disabled={ this.props.disabled }
+          onChanged={ this._onSearchChanged }
+          onClick={ this._onClickSearchInput }
+          onFocus={ this._onSearchFocus }
+          onKeyDown={ this._onSearchKeyDown }
+          onKeyUp={ this._onSearchKeyUp }
         />
       );
     } else {
@@ -372,16 +372,16 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       return (
         <TextField
           borderless
-          cellPadding={'0'}
-          style={{ padding: '0 0' }}
-          placeholder={this.props.placeHolder}
-          value={this.state.searchText || ''}
-          disabled={this.props.disabled}
-          onClick={this._onClickSearchInput}
-          onChanged={this._onSearchChanged}
-          onFocus={this._onSearchFocus}
-          onKeyDown={this._onSearchKeyDown}
-          onKeyUp={this._onSearchKeyUp}
+          cellPadding={ '0' }
+          style={ { padding: '0 0' } }
+          placeholder={ this.props.placeHolder }
+          value={ this.state.searchText || '' }
+          disabled={ this.props.disabled }
+          onClick={ this._onClickSearchInput }
+          onChanged={ this._onSearchChanged }
+          onFocus={ this._onSearchFocus }
+          onKeyDown={ this._onSearchKeyDown }
+          onKeyUp={ this._onSearchKeyUp }
         />
       );
     } else {
@@ -439,8 +439,11 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
     }
   }
 
+  /**
+   * Creates a case insensitive regex for the given search string.
+   */
   private _filterRegex(text: string) {
-      return new RegExp(text.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), 'i');
+    return new RegExp(text.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), 'i');
   }
 
   @autobind
@@ -451,13 +454,13 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
 
     if (this.props.searchItemsBy) {
       if (!this._filteredOptionsCache ||
-          this._filteredOptionsCache.filter !== filter ||
-          this._filteredOptionsCache.original !== options) {
+        this._filteredOptionsCache.filter !== filter ||
+        this._filteredOptionsCache.original !== options) {
         this._filteredOptionsCache = {
           filter,
           original: options,
           result: !filter ? options : options.filter((x: any) =>
-            !x.disabled&&
+            !x.disabled &&
             (
               x.itemType === SelectableOptionMenuItemType.Header ||
               x.itemType === SelectableOptionMenuItemType.Divider ||
@@ -507,6 +510,9 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
     ev.stopPropagation();
   }
 
+  /**
+   * Gets the first selectable item that matches the given or current filter.
+   */
   private _matchingIndex(filter: string | undefined | null, options: any) {
     const regex = this._filterRegex(filter || '');
     return options.findIndex((x: any) =>
@@ -586,7 +592,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
         onKeyDown={ this._onZoneKeyDown }
         ref={ this._resolveRef('_host') }
         tabIndex={ 0 }
-        { ...{ 'aria-live': 'polite', 'aria-atomic': true, 'aria-relevant': 'all' }}
+        { ...{ 'aria-live': 'polite', 'aria-atomic': true, 'aria-relevant': 'all' } }
       >
         <FocusZone
           ref={ this._resolveRef('_focusZone') }
@@ -737,7 +743,9 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   private _onItemClick(item: IDropdownOption): () => void {
     return (): void => {
       if (!item.disabled) {
-        const common = this._toSetSelectedIndex(this.props.options.findIndex((x: IDropdownOption) => x.key === item.key));
+        const common = {
+          selectedIndices: [this.props.options.findIndex((x: IDropdownOption) => x.key === item.key)],
+        };
 
         // only close the callout when it's in single-select mode
         if (!this.props.multiSelect) {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -736,7 +736,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
   private _onItemClick(item: IDropdownOption): () => void {
     return (): void => {
       if (!item.disabled) {
-        const common = this._toSetSelectedIndex(item.index!);
+        const common = this._toSetSelectedIndex(this.props.options.findIndex((x: IDropdownOption) => x.key === item.key));
 
         // only close the callout when it's in single-select mode
         if (!this.props.multiSelect) {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -73,6 +73,13 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<HTMLDivEle
   multiSelectDelimiter?: string;
 
   /**
+   * Allows the user to search the dropdown items with a text input, like a
+   * combobox. If an item does not have the property specified, it will not be
+   * searchable.
+   */
+  searchItemsBy?: string;
+
+  /**
    * Deprecated at v0.52.0, use 'disabled' instead.
    * @deprecated
    */

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -160,9 +160,9 @@ export class DropdownBasicExample extends BaseComponent<{}, {
         />
         <Dropdown
           placeHolder='Select an Option'
-          label='Text search allowed example:'
+          label='Text search example:'
           id='Basicdrop1'
-          ariaLabel='Text search allowed example'
+          ariaLabel='Text search example'
           searchItemsBy='text'
           options={
             [

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -158,6 +158,32 @@ export class DropdownBasicExample extends BaseComponent<{}, {
           onFocus={ this._log('onFocus called') }
           onBlur={ this._log('onBlur called') }
         />
+        <Dropdown
+          placeHolder='Select an Option'
+          label='Text search allowed example:'
+          id='Basicdrop1'
+          ariaLabel='Text search allowed example'
+          searchItemsBy='text'
+          options={
+            [
+              { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
+              { key: 'A', text: 'Create' },
+              { key: 'B', text: 'Delete' },
+              { key: 'C', text: 'Modify', disabled: true },
+              { key: 'D', text: 'Duplicate' },
+              { key: 'E', text: 'Save' },
+              { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
+              { key: 'Header2', text: 'Compare', itemType: DropdownMenuItemType.Header },
+              { key: 'F', text: 'Apples' },
+              { key: 'G', text: 'Oranges' },
+              { key: 'H', text: 'Cats' },
+              { key: 'I', text: 'Dogs' },
+            ]
+          }
+          onFocus={ this._log('onFocus called') }
+          onBlur={ this._log('onBlur called') }
+          componentRef={ this._resolveRef('_basicDropdown') }
+        />
       </div>
 
     );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The dropdown can be set to include a text field to search through the dropdown's items. While searching, the first result is automatically selected, and the user can search and then click on an item in the filtered dropdown. As the dropdown is searched, a screen reader announces "{Selected item} selected, 1 of N items". The user may also use the arrow keys to navigate down the list after having searched. This experience is similar to that of a combobox, but with more accessibility and a more dropdown oriented interaction mode.

![dropdownsearch](https://user-images.githubusercontent.com/30271291/36611230-9bbb683e-1887-11e8-8018-ac554dfaa69c.gif)

#### Focus areas to test

There are lots of edge cases around selecting items with the mouse or keyboard while there is a search active. I believe I have checked all of them, but there are a lot of state interactions to test.
