### PR TITLE
DatePicker: order of callbacks for onSelectDate and onAfterMenuDismiss

### DIFF
--- a/common/changes/office-ui-fabric-react/dbrough-datePickerCallbackOrderFix_2018-02-25-00-39.json
+++ b/common/changes/office-ui-fabric-react/dbrough-datePickerCallbackOrderFix_2018-02-25-00-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker calls onDateSelected then AfterMenuDismissed to follow the same pattern as BaseButton",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dbrough@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -290,14 +290,21 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   private _onSelectDate(date: Date) {
     const { formatDate, onSelectDate } = this.props;
 
+    if (this.props.calendarProps && this.props.calendarProps.onSelectDate) {
+      this.props.calendarProps.onSelectDate(date);
+    }
+
     this.setState({
       selectedDate: date,
-      isDatePickerShown: false,
       formattedDate: formatDate && date ? formatDate(date) : '',
-    }, () => {
-      if (onSelectDate) {
-        onSelectDate(date);
-      }
+    });
+
+    if (onSelectDate) {
+      onSelectDate(date);
+    }
+
+    this.setState({
+      isDatePickerShown: false,
     });
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

We recently added an "onAfterMenuDismiss" to datePicker, however the order in which it was getting called relative to the onSelectDate was opposite of the pattern established in BaseButton when a menu is used.  DatePicker was using the callback from setting the state to hide the menu to do the selection callback.
With this change, we'll set the component state with the new date, call the onSelectDate callbacks, then set the state to dismiss the Calendar menu.
The component was also over-writing the onSelectDate option that was available via the calendarProps prop, so we'll call that immediately should the caller provide it, then deal with local state and callbacks.
