### PR TITLE
Adding onPendingValueSet callback

### DIFF
--- a/common/changes/office-ui-fabric-react/ComboBox_Add_onPendingValueSet_Callback_2018-02-27-01-11.json
+++ b/common/changes/office-ui-fabric-react/ComboBox_Add_onPendingValueSet_Callback_2018-02-27-01-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox adding onPendingValueSet callback prop to run when pending value is changed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "madosal@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -192,13 +192,17 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       allowFreeform,
       value,
       onMenuOpen,
-      onMenuDismissed
+      onMenuDismissed,
+      onPendingValueSet
     } = this.props;
     const {
       isOpen,
       focused,
+      currentOptions,
       selectedIndex,
-      currentPendingValueValidIndex
+      currentPendingValue,
+      currentPendingValueValidIndex,
+      currentPendingValueValidIndexOnHover
     } = this.state;
 
     // If we are newly open or are open and the pending valid index changed,
@@ -242,6 +246,16 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     if (!isOpen && prevState.isOpen && onMenuDismissed) {
       onMenuDismissed();
+    }
+
+    if (onPendingValueSet) {
+      if (currentPendingValue !== prevState.currentPendingValue) {
+        onPendingValueSet(undefined, undefined, currentPendingValue);
+      } else if (currentPendingValueValidIndexOnHover !== prevState.currentPendingValueValidIndexOnHover) {
+        onPendingValueSet(currentOptions[currentPendingValueValidIndexOnHover], currentPendingValueValidIndexOnHover, undefined);
+      } else if (currentPendingValueValidIndex !== prevState.currentPendingValueValidIndex) {
+        onPendingValueSet(currentOptions[currentPendingValueValidIndex], currentPendingValueValidIndex, undefined);
+      }
     }
   }
 
@@ -347,7 +361,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             styles={ this._getCaretButtonStyles() }
             role='presentation'
             aria-hidden={ isButtonAriaHidden }
-            data-is-focusable={false}
+            data-is-focusable={ false }
             tabIndex={ -1 }
             onClick={ this._onComboBoxClick }
             iconProps={ buttonIconProps }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -49,6 +49,12 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   onChanged?: (option?: IComboBoxOption, index?: number, value?: string) => void;
 
   /**
+   * Callback issued when the user changes the pending value in ComboBox
+   * If now value is set, we send undefined parameters
+   */
+  onPendingValueSet?: (option?: IComboBoxOption, index?: number, value?: string) => void;
+
+  /**
    * Function that gets invoked when the ComboBox menu is launched
    */
   onMenuOpen?: () => void;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -20,20 +20,20 @@ export class ComboBoxBasicExample extends React.Component<{}, {
   value?: string;
 }> {
   private _testOptions =
-    [{ key: 'Header', text: 'Theme Fonts', itemType: SelectableOptionMenuItemType.Header },
-    { key: 'A', text: 'Arial Black' },
-    { key: 'B', text: 'Times New Roman' },
-    { key: 'C', text: 'Comic Sans MS' },
-    { key: 'divider_2', text: '-', itemType: SelectableOptionMenuItemType.Divider },
-    { key: 'Header1', text: 'Other Options', itemType: SelectableOptionMenuItemType.Header },
-    { key: 'D', text: 'Option d' },
-    { key: 'E', text: 'Option e' },
-    { key: 'F', text: 'Option f' },
-    { key: 'G', text: 'Option g' },
-    { key: 'H', text: 'Option h' },
-    { key: 'I', text: 'Option i' },
-    { key: 'J', text: 'Option j', disabled: true },
-    ];
+  [{ key: 'Header', text: 'Theme Fonts', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'A', text: 'Arial Black' },
+  { key: 'B', text: 'Times New Roman' },
+  { key: 'C', text: 'Comic Sans MS' },
+  { key: 'divider_2', text: '-', itemType: SelectableOptionMenuItemType.Divider },
+  { key: 'Header1', text: 'Other Options', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'D', text: 'Option d' },
+  { key: 'E', text: 'Option e' },
+  { key: 'F', text: 'Option f' },
+  { key: 'G', text: 'Option g' },
+  { key: 'H', text: 'Option h' },
+  { key: 'I', text: 'Option i' },
+  { key: 'J', text: 'Option j', disabled: true },
+  ];
 
   private _fontMapping: { [key: string]: string } = {
     ['Arial Black']: '"Arial Black", "Arial Black_MSFontService", sans-serif',
@@ -81,7 +81,8 @@ export class ComboBoxBasicExample extends React.Component<{}, {
           onFocus={ () => console.log('onFocus called') }
           onBlur={ () => console.log('onBlur called') }
           onMenuOpen={ () => console.log('ComboBox menu opened') }
-          // tslint:enable:jsx-no-lambda
+          onPendingValueSet={ (option, pendingIndex, pendingValue) => console.log('Pending value was changed. Pending index: ' + pendingIndex + '. Pending value: ' + pendingValue) }
+        // tslint:enable:jsx-no-lambda
         />
 
         <PrimaryButton


### PR DESCRIPTION
#### Pull request checklist

- [] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

ComboBox: adding onPendingValueSet callback prop to run when pending value is changed.

#### Focus areas to test

Tested that hovering and using arrows through menu items runs the callback.