### PR TITLE
Contextual Menu: Added after Sub Menu Dismiss Callback

### DIFF
--- a/common/changes/office-ui-fabric-react/menuSubItem_2018-02-27-18-27.json
+++ b/common/changes/office-ui-fabric-react/menuSubItem_2018-02-27-18-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Contextual Menu: Added after sub menu dismiss callback",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -884,7 +884,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       };
 
       if (item.subMenuProps) {
-        assign(submenuProps, item.subMenuProps); // TODO get rid of, this prevents us from closing our submenu
+        assign(submenuProps, item.subMenuProps); // TODO get rid of onDismiss as this prevents us from closing our submenu
       }
     }
     return submenuProps;
@@ -915,6 +915,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   @autobind
   private _onSubMenuDismiss(ev?: any, dismissAll?: boolean) {
+    let item: IContextualMenuItem | undefined;
+    if (this.state.expandedMenuItemKey) {
+      item = this._findItemByKey(this.state.expandedMenuItemKey);
+    }
+
     if (dismissAll) {
       this.dismiss(ev, dismissAll);
     } else {
@@ -923,11 +928,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         expandedMenuItemKey: undefined,
         submenuTarget: undefined
       });
-    }
-
-    let item: IContextualMenuItem | undefined;
-    if (this.state.expandedMenuItemKey) {
-      item = this._findItemByKey(this.state.expandedMenuItemKey);
     }
 
     if (item && item.subMenuProps && item.subMenuProps.onAfterSubMenuDismiss) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -884,7 +884,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       };
 
       if (item.subMenuProps) {
-        assign(submenuProps, item.subMenuProps, { onDismiss: (ev: any, dismissAll: boolean) => this._onSubMenuDismiss(ev, dismissAll, item) });
+        assign(submenuProps, item.subMenuProps, { onDismiss: this._getDismissSubmenu(item) });
       }
     }
     return submenuProps;
@@ -893,6 +893,16 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   private _findItemByKey(key: string): IContextualMenuItem | undefined {
     const { items } = this.props;
     return this._findItemByKeyFromItems(key, items);
+  }
+
+  /**
+   * Returns the callback that should be used when we dismiss a sub menu
+   * this way we can dismiss the submenu UI and call the onDismiss provided by the item
+   * @param item - the item that contains a onDismiss callback that we want to use
+   * @returns A callback that will remove the submenu UI and call the onDismiss callback of item
+   */
+  private _getDismissSubmenu(item?: IContextualMenuItem) {
+    return (ev: any, dismissAll: boolean) => this._onSubMenuDismiss(ev, dismissAll, item);
   }
 
   /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -884,7 +884,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       };
 
       if (item.subMenuProps) {
-        assign(submenuProps, item.subMenuProps); // TODO get rid of onDismiss as this prevents us from closing our submenu
+        assign(submenuProps, item.subMenuProps, { onDismiss: (ev: any, dismissAll: boolean) => this._onSubMenuDismiss(ev, dismissAll, item) });
       }
     }
     return submenuProps;
@@ -914,12 +914,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   }
 
   @autobind
-  private _onSubMenuDismiss(ev?: any, dismissAll?: boolean) {
-    let item: IContextualMenuItem | undefined;
-    if (this.state.expandedMenuItemKey) {
-      item = this._findItemByKey(this.state.expandedMenuItemKey);
-    }
-
+  private _onSubMenuDismiss(ev?: any, dismissAll?: boolean, item?: IContextualMenuItem) {
     if (dismissAll) {
       this.dismiss(ev, dismissAll);
     } else {
@@ -930,8 +925,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       });
     }
 
-    if (item && item.subMenuProps && item.subMenuProps.onAfterSubMenuDismiss) {
-      item.subMenuProps.onAfterSubMenuDismiss();
+    if (item && item.subMenuProps && item.subMenuProps.onDismiss) {
+      item.subMenuProps.onDismiss();
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -884,7 +884,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       };
 
       if (item.subMenuProps) {
-        assign(submenuProps, item.subMenuProps);
+        assign(submenuProps, item.subMenuProps); // TODO get rid of, this prevents us from closing our submenu
       }
     }
     return submenuProps;
@@ -923,6 +923,15 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         expandedMenuItemKey: undefined,
         submenuTarget: undefined
       });
+    }
+
+    let item: IContextualMenuItem | undefined;
+    if (this.state.expandedMenuItemKey) {
+      item = this._findItemByKey(this.state.expandedMenuItemKey);
+    }
+
+    if (item && item.subMenuProps && item.subMenuProps.onAfterSubMenuDismiss) {
+      item.subMenuProps.onAfterSubMenuDismiss();
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -237,16 +237,6 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * @default {direction: FocusZoneDirection.vertical}
    */
   focusZoneProps?: IFocusZoneProps;
-
-  /**
-   * Callback to run after a sub menu gets dismissed.
-   * Note: This is only used for when we rendered sub menu's from ContextualMenuItem
-   * that has a subMenuProp after we dismissed it.
-   * Note: if we were to define our own onMenuDismissed than this callback will never
-   * get called, because we only use the callback in _onSubMenuDismiss() which can get
-   * overrided with onMenuDissmissed.
-   */
-  onAfterSubMenuDismiss?: () => void;
 }
 
 export interface IContextualMenuItem {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -227,8 +227,8 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * @default ContextualMenuItem
    */
   contextualMenuItemAs?:
-  React.ComponentClass<IContextualMenuItemProps> |
-  React.StatelessComponent<IContextualMenuItemProps>;
+    React.ComponentClass<IContextualMenuItemProps> |
+    React.StatelessComponent<IContextualMenuItemProps>;
 
   /**
    * Props to pass down to the FocusZone.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -227,8 +227,8 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * @default ContextualMenuItem
    */
   contextualMenuItemAs?:
-    React.ComponentClass<IContextualMenuItemProps> |
-    React.StatelessComponent<IContextualMenuItemProps>;
+  React.ComponentClass<IContextualMenuItemProps> |
+  React.StatelessComponent<IContextualMenuItemProps>;
 
   /**
    * Props to pass down to the FocusZone.
@@ -237,6 +237,16 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * @default {direction: FocusZoneDirection.vertical}
    */
   focusZoneProps?: IFocusZoneProps;
+
+  /**
+   * Callback to run after a sub menu gets dismissed.
+   * Note: This is only used for when we rendered sub menu's from ContextualMenuItem
+   * that has a subMenuProp after we dismissed it.
+   * Note: if we were to define our own onMenuDismissed than this callback will never
+   * get called, because we only use the callback in _onSubMenuDismiss() which can get
+   * overrided with onMenuDissmissed.
+   */
+  onAfterSubMenuDismiss?: () => void;
 }
 
 export interface IContextualMenuItem {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -64,6 +64,25 @@ export class ContextualMenuSubmenuExample extends React.Component<any, any> {
                   ],
                 },
                 name: 'Share'
+              },
+              {
+                key: 'subMenuDismiss',
+                name: "Dismiss Sub Menu Example",
+                subMenuProps: {
+                  onAfterSubMenuDismiss: () => { alert("Sub Menu Dismissed!") },
+                  items: [
+                    {
+                      key: 'dismissSubMenuExample1',
+                      name: 'Dismiss Sub Menu Example Item 1',
+                      title: 'Dismiss Sub Menu Example Item 1'
+                    },
+                    {
+                      key: 'dismissSubMenuExample2',
+                      name: 'Dismiss Sub Menu Example Item 2',
+                      title: 'Dismiss Sub Menu Example Item 2',
+                    }
+                  ]
+                }
               }
             ]
           }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -69,7 +69,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, any> {
                 key: 'subMenuDismiss',
                 name: "Dismiss Sub Menu Example",
                 subMenuProps: {
-                  onAfterSubMenuDismiss: () => { alert("Sub Menu Dismissed!") },
+                  onDismiss: () => { alert("Sub Menu Dismissed!") },
                   items: [
                     {
                       key: 'dismissSubMenuExample1',


### PR DESCRIPTION
**Problem:**
Currently if we have a contextual menu item that that has a submenu and that we want to pass in a OnDismiss callback we would override the _onSubMenuDismiss() which is needed to close the sub menu. So we can either: call our custom callback when the sub menu closes and not be able to close it or reversed.

**Solution:**
OnDismiss is needed for the main contextual menu, however it shouldn't be used for sub-menus.

Instead of using onDismiss for the sub menu, I created a new prop onAfterSubMenuDismiss that would specifically be triggered after we dismiss our submenu in _onSubMenuDismiss(). 

**Validation:**
I was able to create a project that had a sub menu items and was able to validate that the onAfterSubMenuDismiss prop was getting called and that functionality of sub menu remained the same.

I also added an example in the contextual menu sub menu example page to show it.

**Questions to be discussed:**
1. Do we want to call onAfterSubMenuDismiss if we were to dismiss everything? Or should that be something we let something else handle?