### PR TITLE
Fix toggle colors

### DIFF
--- a/common/changes/office-ui-fabric-react/fixToggleColors_2018-02-27-19-09.json
+++ b/common/changes/office-ui-fabric-react/fixToggleColors_2018-02-27-19-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle color fixes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.classNames.ts
@@ -27,15 +27,15 @@ export const getClassNames = memoizeFunction((
   const pillUncheckedBackground = semanticColors.bodyBackground;
   const pillCheckedBackground = semanticColors.inputBackgroundChecked;
   const pillCheckedHoveredBackground = semanticColors.inputBackgroundCheckedHovered;
-  const pillCheckedDisabledBackground = semanticColors.disabledText;
+  const pillCheckedDisabledBackground = semanticColors.disabledBodyText;
   const thumbBackground = semanticColors.inputBorderHovered;
   const thumbCheckedBackground = semanticColors.inputForegroundChecked;
-  const thumbDisabledBackground = semanticColors.disabledText;
+  const thumbDisabledBackground = semanticColors.disabledBodyText;
   const thumbCheckedDisabledBackground = semanticColors.disabledBackground;
   const pillBorderColor = semanticColors.smallInputBorder;
   const pillBorderHoveredColor = semanticColors.inputBorderHovered;
-  const pillBorderDisabledColor = semanticColors.disabledText;
-  const textDisabledColor = semanticColors.disabledBodyText;
+  const pillBorderDisabledColor = semanticColors.disabledBodyText;
+  const textDisabledColor = semanticColors.disabledText;
 
   styles = styles || {};
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3290 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Labels for disabled toggle are neutralTertiary, background color for "on" is neutralTertiaryAlt, and thumb and border color for "off" is neutralTertiaryAlt

