### PR TITLE
ContextualMenu: Update hover behavior around submenus

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ContextualMenuFixSubmenuHover_2018-02-27-20-46.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ContextualMenuFixSubmenuHover_2018-02-27-20-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Update Hover/Focus Behavior around expanding/collapsing Submenus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -797,13 +797,13 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
     const menuExpanded = this.state.expandedMenuItemKey !== undefined;
 
-    //If the menu isn't expanded we can update focus without any delay
+    // If the menu is not expanded we can update focus without any delay
     if (!menuExpanded) {
       targetElement.focus();
     }
 
     // Delay updating expanding/dismissing the submenu
-    // and only set focus if we haven't already done so
+    // and only set focus if we have not already done so
     if (hasSubmenu(item)) {
       this._enterTimerId = this._async.setTimeout(() => {
         menuExpanded && targetElement.focus();

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -745,14 +745,19 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     const targetElement = ev.currentTarget as HTMLElement;
 
     if (item.key !== this.state.expandedMenuItemKey) {
+      if (this._enterTimerId !== undefined) {
+        this._async.clearTimeout(this._enterTimerId);
+        this._enterTimerId = undefined;
+      }
+
       if (hasSubmenu(item)) {
         this._enterTimerId = this._async.setTimeout(() => this._onItemSubMenuExpand(item, targetElement), 500);
       } else {
         this._enterTimerId = this._async.setTimeout(() => this._onSubMenuDismiss(ev), 500);
       }
+    } else {
+      targetElement.focus();
     }
-
-    targetElement.focus();
   }
 
   private _onItemMouseMove(item: any, ev: React.MouseEvent<HTMLElement>) {
@@ -764,14 +769,19 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     }
 
     if (item.key !== this.state.expandedMenuItemKey) {
+      if (this._enterTimerId !== undefined) {
+        this._async.clearTimeout(this._enterTimerId);
+        this._enterTimerId = undefined;
+      }
+
       if (hasSubmenu(item)) {
         this._enterTimerId = this._async.setTimeout(() => this._onItemSubMenuExpand(item, targetElement), 500);
       } else {
         this._enterTimerId = this._async.setTimeout(() => this._onSubMenuDismiss(ev), 500);
       }
+    } else {
+      targetElement.focus();
     }
-
-    targetElement.focus();
   }
 
   @autobind
@@ -785,7 +795,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       this._enterTimerId = undefined;
     }
 
-    if (item.key === this.state.expandedMenuItemKey && hasSubmenu(item)) {
+    if (this.state.expandedMenuItemKey !== undefined) {
       return;
     }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -800,10 +800,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       this._enterTimerId = undefined;
     }
 
-    const menuExpanded = this.state.expandedMenuItemKey !== undefined;
-
     // If the menu is not expanded we can update focus without any delay
-    if (!menuExpanded) {
+    if (this.state.expandedMenuItemKey === undefined) {
       targetElement.focus();
     }
 
@@ -811,13 +809,13 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     // and only set focus if we have not already done so
     if (hasSubmenu(item)) {
       this._enterTimerId = this._async.setTimeout(() => {
-        menuExpanded && targetElement.focus();
+        targetElement.focus();
         this._onItemSubMenuExpand(item, targetElement);
       }, this._navigationIdleDelay);
     } else {
       this._enterTimerId = this._async.setTimeout(() => {
         this._onSubMenuDismiss(ev);
-        menuExpanded && targetElement.focus();
+        targetElement.focus();
       }, this._navigationIdleDelay);
     }
   }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -784,7 +784,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   }
 
   /**
-   * Hnadles updating focus when mouseEnter or mouseMove fire.
+   * Handles updating focus when mouseEnter or mouseMove fire.
    * As part of updating focus, This function will also update
    * the expand/collapse state accordingly.
    */

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -783,6 +783,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     }
   }
 
+  /**
+   * Hnadles updating focus when mouseEnter or mouseMove fire.
+   * As part of updating focus, This function will also update
+   * the expand/collapse state accordingly.
+   */
   private _updateFocusOnMouseEvent(item: any, ev: React.MouseEvent<HTMLElement>) {
     const targetElement = ev.currentTarget as HTMLElement;
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -786,25 +786,34 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   private _updateFocusOnMouseEvent(item: any, ev: React.MouseEvent<HTMLElement>) {
     const targetElement = ev.currentTarget as HTMLElement;
 
-    if (item.key !== this.state.expandedMenuItemKey) {
-      if (this._enterTimerId !== undefined) {
-        this._async.clearTimeout(this._enterTimerId);
-        this._enterTimerId = undefined;
-      }
+    if (item.key === this.state.expandedMenuItemKey) {
+      return;
+    }
 
-      if (hasSubmenu(item)) {
-        this._enterTimerId = this._async.setTimeout(() => {
-          this._onItemSubMenuExpand(item, targetElement);
-          targetElement.focus();
-        }, this._navigationIdleDelay);
-      } else {
-        this._enterTimerId = this._async.setTimeout(() => {
-          this._onSubMenuDismiss(ev);
-          targetElement.focus();
-        }, this._navigationIdleDelay);
-      }
-    } else {
+    if (this._enterTimerId !== undefined) {
+      this._async.clearTimeout(this._enterTimerId);
+      this._enterTimerId = undefined;
+    }
+
+    const menuExpanded = this.state.expandedMenuItemKey !== undefined;
+
+    //If the menu isn't expanded we can update focus without any delay
+    if (!menuExpanded) {
       targetElement.focus();
+    }
+
+    // Delay updating expanding/dismissing the submenu
+    // and only set focus if we haven't already done so
+    if (hasSubmenu(item)) {
+      this._enterTimerId = this._async.setTimeout(() => {
+        menuExpanded && targetElement.focus();
+        this._onItemSubMenuExpand(item, targetElement);
+      }, this._navigationIdleDelay);
+    } else {
+      this._enterTimerId = this._async.setTimeout(() => {
+        this._onSubMenuDismiss(ev);
+        menuExpanded && targetElement.focus();
+      }, this._navigationIdleDelay);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
When moving the mouse from a parent menu to a submenu if the user moused into another menu item from the parent menu, the submenu would instantly be dismissed.

The fix is to add setting the focus to timeout that we have to allow for users to move over other menu items on the way to the submenu without instantly collapsing the submenu. This also aligns the timeout so they consistent across all navigation idle timeouts.

Before:
![updatefocusonhoverbefore](https://user-images.githubusercontent.com/7033561/36754500-087c4dba-1bbe-11e8-9e5d-8b1a9f11442a.gif)

After:
![updatefocusonhoverafter](https://user-images.githubusercontent.com/7033561/36755142-182d1756-1bc0-11e8-934a-2adf58a7d262.gif)


#### Focus areas to test
Verified that Focus still updates correctly across items the same level, a submenu does not collapse instantly when an outer menu item is moused into, a submenu can be collapsed if the user exceeds the timeout when a submenu is open, and updating focus of menu items when a submenu is not present does not have to wait for the timeout before setting focus.
