### PR TITLE
Allowing iconProps in nav link

### DIFF
--- a/common/changes/office-ui-fabric-react/jdrush89-Allow-Icon-Props-In-Nav-Link_2018-02-27-22-44.json
+++ b/common/changes/office-ui-fabric-react/jdrush89-Allow-Icon-Props-In-Nav-Link_2018-02-27-22-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allowing Nav Links to specify iconProps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jdrush89@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -158,7 +158,7 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
         className={ classNames.link }
         styles={ buttonStyles }
         href={ link.url || (link.forceAnchor ? 'javascript:' : undefined) }
-        iconProps={ { iconName: link.icon || '' } }
+        iconProps={ link.iconProps || { iconName: link.icon || '' } }
         description={ link.title || link.name }
         onClick={ link.onClick ? this._onNavButtonLinkClicked.bind(this, link) : this._onNavAnchorLinkClicked.bind(this, link) }
         title={ link.title || link.name }

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { NavBase } from './Nav.base';
 import { IStyle, ITheme } from '../../Styling';
 import { IRenderFunction, IStyleFunction } from '../../Utilities';
+import { IIconProps } from '../Icon/Icon.types';
 
 export interface INav {
   /**
@@ -158,6 +159,11 @@ export interface INavLink {
    * Classname to apply to the icon link.
    */
   iconClassName?: string;
+
+  /**
+   * button icon props if applied
+   */
+  iconProps?: IIconProps;
 
   /**
    * Deprecated at v0.68.1 and will be removed at >= v1.0.0.

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx
@@ -42,6 +42,13 @@ export class NavBasicExample extends React.Component<any, any> {
                     onClick: this._onClickHandler2,
                     icon: 'Edit',
                     key: 'key8'
+                  },
+                  {
+                    name: 'Delete',
+                    url: 'http://cnn.com',
+                    onClick: this._onClickHandler2,
+                    iconProps: { iconName: 'Delete' },
+                    key: 'key9'
                   }
                 ]
               }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4120
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Allowing IconProps to be specified on a Nav link.  Before, only the iconName could be specified and this was being used to create iconProps.

#### Focus areas to test
Verified that Nav links with iconName still render correctly, as well as links using the new iconProps.
