### PR TITLE
SplitButton: Fix SPACE/ENTER so that it executes the primary button

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-SplitButtonFixClick_2018-02-27-23-14.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-SplitButtonFixClick_2018-02-27-23-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SplitButton: ENTER/SPACE should execute the primary button when focus is on the whole splitButton",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -419,7 +419,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       styles = {},
       disabled,
       checked,
-      getSplitButtonClassNames
+      getSplitButtonClassNames,
+      primaryDisabled
     } = this.props;
 
     const classNames = getSplitButtonClassNames ? getSplitButtonClassNames(
@@ -444,7 +445,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         onKeyDown={ this._onMenuKeyDown }
         ref={ this._resolveRef('_splitButtonContainer') }
         data-is-focusable={ true }
-        onClick={ buttonProps.onClick }
+        onClick={ !disabled && !primaryDisabled ? buttonProps.onClick : undefined }
       >
         <span
           style={ { 'display': 'flex' } }

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -451,7 +451,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         <span
           style={ { 'display': 'flex' } }
         >
-          { this._onRenderContent(tag, { ...buttonProps, onClick: undefined, 'data-is-focusable': false } as any) }
+          { this._onRenderContent(tag, { ...buttonProps, onClick: undefined } as any) }
           { this._onRenderSplitButtonMenuButton(classNames) }
           { this._onRenderSplitButtonDivider(classNames) }
         </span>
@@ -490,8 +490,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'iconProps': menuIconProps,
       'ariaLabel': splitButtonAriaLabel,
       'aria-haspopup': true,
-      'aria-expanded': this._isExpanded,
-      'data-is-focusable': false
+      'aria-expanded': this._isExpanded
     };
 
     return <BaseButton { ...splitButtonProps } onMouseDown={ this._onMouseDown } />;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -420,6 +420,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       disabled,
       checked,
       getSplitButtonClassNames,
+      onClick,
       primaryDisabled
     } = this.props;
 
@@ -445,7 +446,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         onKeyDown={ this._onMenuKeyDown }
         ref={ this._resolveRef('_splitButtonContainer') }
         data-is-focusable={ true }
-        onClick={ !disabled && !primaryDisabled ? buttonProps.onClick : undefined }
+        onClick={ !disabled && !primaryDisabled ? onClick : undefined }
       >
         <span
           style={ { 'display': 'flex' } }

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -88,7 +88,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       variantClassName,
       theme,
       getClassNames
-         } = this.props;
+    } = this.props;
 
     const { menuProps } = this.state;
     // Button is disabled if the whole button (in case of splitbutton is disabled) or if the primary action is disabled
@@ -223,7 +223,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     } = props;
 
     const Content = (
-      <Tag {...buttonProps }>
+      <Tag { ...buttonProps }>
         <div className={ this._classNames.flexContainer } >
           { onRenderIcon(props, this._onRenderIcon) }
           { this._onRenderTextContents() }
@@ -251,12 +251,12 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   private _onRenderIcon(buttonProps?: IButtonProps, defaultRender?: IRenderFunction<IButtonProps>): JSX.Element | null {
     const {
       iconProps
-       } = this.props;
+    } = this.props;
 
     if (iconProps) {
       return (
         <Icon
-          {...iconProps}
+          { ...iconProps }
           className={ this._classNames.icon }
         />
       );
@@ -335,7 +335,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   @autobind
   private _onRenderDescription(props: IButtonProps) {
     const {
-    description
+      description
     } = this.props;
 
     // ms-Button-description is only shown when the button type is compound.
@@ -393,7 +393,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       <ContextualMenu
         id={ this._labelId + '-menu' }
         directionalHint={ DirectionalHint.bottomLeftEdge }
-        {...menuProps}
+        { ...menuProps }
         className={ 'ms-BaseButton-menuhost ' + menuProps.className }
         target={ this._isSplitButton ? this._splitButtonContainer : this._buttonElement }
         labelElementId={ this._labelId }
@@ -443,11 +443,13 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         className={ classNames && classNames.splitButtonContainer }
         onKeyDown={ this._onMenuKeyDown }
         ref={ this._resolveRef('_splitButtonContainer') }
+        data-is-focusable={ true }
+        onClick={ buttonProps.onClick }
       >
         <span
           style={ { 'display': 'flex' } }
         >
-          { this._onRenderContent(tag, buttonProps) }
+          { this._onRenderContent(tag, { ...buttonProps, onClick: undefined, 'data-is-focusable': false } as any) }
           { this._onRenderSplitButtonMenuButton(classNames) }
           { this._onRenderSplitButtonDivider(classNames) }
         </span>
@@ -486,10 +488,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'iconProps': menuIconProps,
       'ariaLabel': splitButtonAriaLabel,
       'aria-haspopup': true,
-      'aria-expanded': this._isExpanded
+      'aria-expanded': this._isExpanded,
+      'data-is-focusable': false
     };
 
-    return <BaseButton {...splitButtonProps} onMouseDown={ this._onMouseDown } />;
+    return <BaseButton { ...splitButtonProps } onMouseDown={ this._onMouseDown } />;
 
   }
 

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -433,6 +433,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         !!this.state.menuProps,
         !!checked);
 
+    buttonProps = { ...buttonProps, onClick: undefined };
+
     return (
       <div
         role={ 'button' }
@@ -451,7 +453,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         <span
           style={ { 'display': 'flex' } }
         >
-          { this._onRenderContent(tag, { ...buttonProps, onClick: undefined } as any) }
+          { this._onRenderContent(tag, buttonProps) }
           { this._onRenderSplitButtonMenuButton(classNames) }
           { this._onRenderSplitButtonDivider(classNames) }
         </span>

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -8,7 +8,6 @@ import {
 import { DefaultButton, IconButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { getCustomSplitButtonStyles } from './Button.Split.Example.styles';
-import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 
 const alertClicked = (): void => {
   alert('Clicked: ');
@@ -23,94 +22,90 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
     const classNames = getClassNames(getStyles);
 
     return (
-      <FocusZone
-        direction={ FocusZoneDirection.horizontal } >
-        <div className={ css(classNames.twoup) }>
-          <div>
-            <Label>Standard</Label>
-            <DefaultButton
-              data-automation-id='test'
-              disabled={ disabled }
-              checked={ checked }
-              text='Create account'
-              onClick={ alertClicked }
-              // onMenuClick={ () => alert('OnMenuClick') }
-              split={ true }
-              splitButtonAriaLabel={ 'See 2 sample options' }
-              style={ { height: '35px' } }
-              menuProps={ {
-                items: [
-                  {
-                    key: 'emailMessage',
-                    name: 'Email message',
-                    icon: 'Mail'
-                  },
-                  {
-                    key: 'calendarEvent',
-                    name: 'Calendar event',
-                    icon: 'Calendar'
-                  }
-                ]
-              } }
-            />
-          </div>
-          <div>
-            <Label>Primary</Label>
-            <DefaultButton
-              primary
-              data-automation-id='test'
-              disabled={ disabled }
-              checked={ checked }
-              text='Create account'
-              onClick={ alertClicked }
-              split={ true }
-              style={ { height: '35px' } }
-              menuProps={ {
-                items: [
-                  {
-                    key: 'emailMessage',
-                    name: 'Email message',
-                    icon: 'Mail'
-                  },
-                  {
-                    key: 'calendarEvent',
-                    name: 'Calendar event',
-                    icon: 'Calendar'
-                  }
-                ]
-              } }
-            />
-          </div>
-          <div>
-            <Label>Primary Action Disabled</Label>
-            <DefaultButton
-              primary
-              data-automation-id='test'
-              disabled={ disabled }
-              primaryDisabled={ true }
-              checked={ checked }
-              text='Create account'
-              onClick={ alertClicked }
-              split={ true }
-              style={ { height: '35px' } }
-              menuProps={ {
-                items: [
-                  {
-                    key: 'emailMessage',
-                    name: 'Email message',
-                    icon: 'Mail'
-                  },
-                  {
-                    key: 'calendarEvent',
-                    name: 'Calendar event',
-                    icon: 'Calendar'
-                  }
-                ]
-              } }
-            />
-          </div>
+      <div className={ css(classNames.twoup) }>
+        <div>
+          <Label>Standard</Label>
+          <DefaultButton
+            data-automation-id='test'
+            disabled={ disabled }
+            checked={ checked }
+            text='Create account'
+            onClick={ alertClicked }
+            split={ true }
+            splitButtonAriaLabel={ 'See 2 sample options' }
+            style={ { height: '35px' } }
+            menuProps={ {
+              items: [
+                {
+                  key: 'emailMessage',
+                  name: 'Email message',
+                  icon: 'Mail'
+                },
+                {
+                  key: 'calendarEvent',
+                  name: 'Calendar event',
+                  icon: 'Calendar'
+                }
+              ]
+            } }
+          />
         </div>
-      </FocusZone>
+        <div>
+          <Label>Primary</Label>
+          <DefaultButton
+            primary
+            data-automation-id='test'
+            disabled={ disabled }
+            checked={ checked }
+            text='Create account'
+            onClick={ alertClicked }
+            split={ true }
+            style={ { height: '35px' } }
+            menuProps={ {
+              items: [
+                {
+                  key: 'emailMessage',
+                  name: 'Email message',
+                  icon: 'Mail'
+                },
+                {
+                  key: 'calendarEvent',
+                  name: 'Calendar event',
+                  icon: 'Calendar'
+                }
+              ]
+            } }
+          />
+        </div>
+        <div>
+          <Label>Primary Action Disabled</Label>
+          <DefaultButton
+            primary
+            data-automation-id='test'
+            disabled={ disabled }
+            primaryDisabled={ true }
+            checked={ checked }
+            text='Create account'
+            onClick={ alertClicked }
+            split={ true }
+            style={ { height: '35px' } }
+            menuProps={ {
+              items: [
+                {
+                  key: 'emailMessage',
+                  name: 'Email message',
+                  icon: 'Mail'
+                },
+                {
+                  key: 'calendarEvent',
+                  name: 'Calendar event',
+                  icon: 'Calendar'
+                }
+              ]
+            } }
+          />
+        </div>
+      </div>
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -10,7 +10,7 @@ import { Label } from 'office-ui-fabric-react/lib/Label';
 import { getCustomSplitButtonStyles } from './Button.Split.Example.styles';
 
 const alertClicked = (): void => {
-  alert('Clicked: ');
+  alert('Clicked');
 };
 
 export class ButtonSplitExample extends React.Component<IButtonProps> {

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -8,9 +8,10 @@ import {
 import { DefaultButton, IconButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { getCustomSplitButtonStyles } from './Button.Split.Example.styles';
+import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 
 const alertClicked = (): void => {
-  alert('Clicked');
+  alert('Clicked: ');
 };
 
 export class ButtonSplitExample extends React.Component<IButtonProps> {
@@ -22,90 +23,94 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
     const classNames = getClassNames(getStyles);
 
     return (
-      <div className={ css(classNames.twoup) }>
-        <div>
-          <Label>Standard</Label>
-          <DefaultButton
-            data-automation-id='test'
-            disabled={ disabled }
-            checked={ checked }
-            text='Create account'
-            onClick={ alertClicked }
-            split={ true }
-            splitButtonAriaLabel={ 'See 2 sample options' }
-            style={ { height: '35px' } }
-            menuProps={ {
-              items: [
-                {
-                  key: 'emailMessage',
-                  name: 'Email message',
-                  icon: 'Mail'
-                },
-                {
-                  key: 'calendarEvent',
-                  name: 'Calendar event',
-                  icon: 'Calendar'
-                }
-              ]
-            } }
-          />
+      <FocusZone
+        direction={ FocusZoneDirection.horizontal } >
+        <div className={ css(classNames.twoup) }>
+          <div>
+            <Label>Standard</Label>
+            <DefaultButton
+              data-automation-id='test'
+              disabled={ disabled }
+              checked={ checked }
+              text='Create account'
+              onClick={ alertClicked }
+              // onMenuClick={ () => alert('OnMenuClick') }
+              split={ true }
+              splitButtonAriaLabel={ 'See 2 sample options' }
+              style={ { height: '35px' } }
+              menuProps={ {
+                items: [
+                  {
+                    key: 'emailMessage',
+                    name: 'Email message',
+                    icon: 'Mail'
+                  },
+                  {
+                    key: 'calendarEvent',
+                    name: 'Calendar event',
+                    icon: 'Calendar'
+                  }
+                ]
+              } }
+            />
+          </div>
+          <div>
+            <Label>Primary</Label>
+            <DefaultButton
+              primary
+              data-automation-id='test'
+              disabled={ disabled }
+              checked={ checked }
+              text='Create account'
+              onClick={ alertClicked }
+              split={ true }
+              style={ { height: '35px' } }
+              menuProps={ {
+                items: [
+                  {
+                    key: 'emailMessage',
+                    name: 'Email message',
+                    icon: 'Mail'
+                  },
+                  {
+                    key: 'calendarEvent',
+                    name: 'Calendar event',
+                    icon: 'Calendar'
+                  }
+                ]
+              } }
+            />
+          </div>
+          <div>
+            <Label>Primary Action Disabled</Label>
+            <DefaultButton
+              primary
+              data-automation-id='test'
+              disabled={ disabled }
+              primaryDisabled={ true }
+              checked={ checked }
+              text='Create account'
+              onClick={ alertClicked }
+              split={ true }
+              style={ { height: '35px' } }
+              menuProps={ {
+                items: [
+                  {
+                    key: 'emailMessage',
+                    name: 'Email message',
+                    icon: 'Mail'
+                  },
+                  {
+                    key: 'calendarEvent',
+                    name: 'Calendar event',
+                    icon: 'Calendar'
+                  }
+                ]
+              } }
+            />
+          </div>
         </div>
-        <div>
-          <Label>Primary</Label>
-          <DefaultButton
-            primary
-            data-automation-id='test'
-            disabled={ disabled }
-            checked={ checked }
-            text='Create account'
-            onClick={ alertClicked }
-            split={ true }
-            style={ { height: '35px' } }
-            menuProps={ {
-              items: [
-                {
-                  key: 'emailMessage',
-                  name: 'Email message',
-                  icon: 'Mail'
-                },
-                {
-                  key: 'calendarEvent',
-                  name: 'Calendar event',
-                  icon: 'Calendar'
-                }
-              ]
-            } }
-          />
-        </div>
-        <div>
-          <Label>Primary Action Disabled</Label>
-          <DefaultButton
-            primary
-            data-automation-id='test'
-            disabled={ disabled }
-            primaryDisabled={ true }
-            checked={ checked }
-            text='Create account'
-            onClick={ alertClicked }
-            split={ true }
-            style={ { height: '35px' } }
-            menuProps={ {
-              items: [
-                {
-                  key: 'emailMessage',
-                  name: 'Email message',
-                  icon: 'Mail'
-                },
-                {
-                  key: 'calendarEvent',
-                  name: 'Calendar event',
-                  icon: 'Calendar'
-                }
-              ]
-            } }
-          />
-        </div>
-      </div>
+      </FocusZone>
     );
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

When the whole splitButton has focus, ENTER/SPACE no longer executes the primary button as expected. This change makes that behavior work again.

#### Focus areas to test
Verified that SPACE and ENTER work as expected for all three pieces (the whole control, the primary button, and the secondary button) of a splitButton

There's another conversation about updating the splitButton to be one stabstop but is out of scope for this PR