### PR TITLE
BasePicker: call onBlur callback if it is defined in inputProps

### DIFF
--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -441,6 +441,9 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   @autobind
   protected onInputBlur(ev: React.FocusEvent<HTMLInputElement | Autofill>) {
     this.setState({ isFocused: false });
+    if (this.props.inputProps && this.props.inputProps.onBlur) {
+      this.props.inputProps.onBlur(ev as React.FocusEvent<HTMLInputElement>);
+    }
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4000 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

The onBlur callback will be called if it is defined in the inputProps of the BasePicker. Before it was not the case.