### PR TITLE
Import Unstyled Component for Layer, Nav, Image, ScrollablePane, ResizeGroup,  and Rating

### DIFF
--- a/common/changes/office-ui-fabric-react/import-componentbases_2018-02-28-20-18.json
+++ b/common/changes/office-ui-fabric-react/import-componentbases_2018-02-28-20-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added index import for base files in Layer, Nav, Image, ScrollablePane, ResizeGroup, and Rating components so unstyled component can be used.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/index.ts
@@ -1,2 +1,3 @@
 export * from './Image';
+export * from './Image.base';
 export * from './Image.types';

--- a/packages/office-ui-fabric-react/src/components/Layer/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/index.ts
@@ -1,3 +1,4 @@
 export * from './Layer';
+export * from './Layer.base';
 export * from './Layer.types';
 export * from './LayerHost';

--- a/packages/office-ui-fabric-react/src/components/Nav/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/index.ts
@@ -1,2 +1,3 @@
 export * from './Nav';
+export * from './Nav.base';
 export * from './Nav.types';

--- a/packages/office-ui-fabric-react/src/components/Rating/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/index.ts
@@ -1,2 +1,3 @@
 export * from './Rating';
+export * from './Rating.base';
 export * from './Rating.types';

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/index.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/index.ts
@@ -1,2 +1,3 @@
 export * from './ResizeGroup';
+export * from './ResizeGroup.base';
 export * from './ResizeGroup.types';

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/index.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/index.ts
@@ -1,2 +1,3 @@
 export * from './ScrollablePane';
+export * from './ScrollablePane.base';
 export * from './ScrollablePane.types';


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added index import for base files in Layer, Nav, Image, ScrollablePane, ResizeGroup,
 and Rating components so unstyled component can be used.