### PR TITLE
Callout: move animation inline to greatly improve perf

### DIFF
--- a/common/changes/office-ui-fabric-react/callout-improveperf_2018-02-28-23-05.json
+++ b/common/changes/office-ui-fabric-react/callout-improveperf_2018-02-28-23-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout: move animation inline to greatly improve perf",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -183,7 +183,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
       >
         <div
           className={ css(this._classNames.root, positions && positions.targetEdge && ANIMATIONS[positions.targetEdge!]) }
-          style={ positions ? { ...positions.elementPosition } : OFF_SCREEN_STYLE }
+          style={ positions ? positions.elementPosition : OFF_SCREEN_STYLE }
           tabIndex={ -1 } // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
           // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
           ref={ this._resolveRef('_calloutElement') }

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -42,7 +42,6 @@ const ANIMATIONS: { [key: number]: string | undefined; } = {
   [RectangleEdge.right]: AnimationClassNames.slideRightIn10,
 };
 
-
 const getClassNames = classNamesFunction<ICalloutContentStyleProps, ICalloutContentStyles>();
 const BORDER_WIDTH = 1;
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -29,6 +29,18 @@ import {
 } from '../../utilities/positioning';
 import { Popup } from '../../Popup';
 import { classNamesFunction } from '../../Utilities';
+import {
+  AnimationStyles,
+  IRawStyle
+} from '../../Styling';
+
+const ANIMATIONS: { [key: number]: IRawStyle; } = {
+  [RectangleEdge.top]: AnimationStyles.slideUpIn10,
+  [RectangleEdge.bottom]: AnimationStyles.slideDownIn10,
+  [RectangleEdge.left]: AnimationStyles.slideLeftIn10,
+  [RectangleEdge.right]: AnimationStyles.slideRightIn10,
+};
+
 
 const getClassNames = classNamesFunction<ICalloutContentStyleProps, ICalloutContentStyles>();
 const BORDER_WIDTH = 1;
@@ -163,6 +175,8 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     );
 
     const overflowStyle: React.CSSProperties = overflowYHidden ? { overflowY: 'hidden' } : {};
+    // React.CSSProperties does not understand IRawStyle, so the inline animations will need to be cast as any for now.
+    const animationStyle: IRawStyle | undefined = positions && positions.targetEdge && ANIMATIONS[positions.targetEdge];
     const content = (
       <div
         ref={ this._resolveRef('_hostElement') }
@@ -170,7 +184,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
       >
         <div
           className={ this._classNames.root }
-          style={ positions ? positions.elementPosition : OFF_SCREEN_STYLE }
+          style={ positions ? { ...positions.elementPosition, ...(animationStyle as any) } : OFF_SCREEN_STYLE }
           tabIndex={ -1 } // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
           // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
           ref={ this._resolveRef('_calloutElement') }

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -32,8 +32,7 @@ import { Popup } from '../../Popup';
 import { classNamesFunction } from '../../Utilities';
 import {
   AnimationClassNames,
-  IRawStyle,
-  AnimationStyles
+  IRawStyle
 } from '../../Styling';
 
 const ANIMATIONS: { [key: number]: string | undefined; } = {

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -17,7 +17,8 @@ import {
   focusFirstChild,
   getWindow,
   getDocument,
-  customizable
+  customizable,
+  css
 } from '../../Utilities';
 import {
   positionCallout,
@@ -30,15 +31,16 @@ import {
 import { Popup } from '../../Popup';
 import { classNamesFunction } from '../../Utilities';
 import {
-  AnimationStyles,
-  IRawStyle
+  AnimationClassNames,
+  IRawStyle,
+  AnimationStyles
 } from '../../Styling';
 
-const ANIMATIONS: { [key: number]: IRawStyle; } = {
-  [RectangleEdge.top]: AnimationStyles.slideUpIn10,
-  [RectangleEdge.bottom]: AnimationStyles.slideDownIn10,
-  [RectangleEdge.left]: AnimationStyles.slideLeftIn10,
-  [RectangleEdge.right]: AnimationStyles.slideRightIn10,
+const ANIMATIONS: { [key: number]: string | undefined; } = {
+  [RectangleEdge.top]: AnimationClassNames.slideUpIn10,
+  [RectangleEdge.bottom]: AnimationClassNames.slideDownIn10,
+  [RectangleEdge.left]: AnimationClassNames.slideLeftIn10,
+  [RectangleEdge.right]: AnimationClassNames.slideRightIn10,
 };
 
 
@@ -176,15 +178,14 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
 
     const overflowStyle: React.CSSProperties = overflowYHidden ? { overflowY: 'hidden' } : {};
     // React.CSSProperties does not understand IRawStyle, so the inline animations will need to be cast as any for now.
-    const animationStyle: IRawStyle | undefined = positions && positions.targetEdge && ANIMATIONS[positions.targetEdge];
     const content = (
       <div
         ref={ this._resolveRef('_hostElement') }
         className={ this._classNames.container }
       >
         <div
-          className={ this._classNames.root }
-          style={ positions ? { ...positions.elementPosition, ...(animationStyle as any) } : OFF_SCREEN_STYLE }
+          className={ css(this._classNames.root, positions && positions.targetEdge && ANIMATIONS[positions.targetEdge!]) }
+          style={ positions ? { ...positions.elementPosition } : OFF_SCREEN_STYLE }
           tabIndex={ -1 } // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
           // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
           ref={ this._resolveRef('_calloutElement') }

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
@@ -1,6 +1,5 @@
 import {
   HighContrastSelector,
-  AnimationStyles,
   IRawStyle,
   focusClear
 } from '../../Styling';
@@ -12,12 +11,6 @@ import { ICalloutContentStyleProps, ICalloutContentStyles } from './Callout.type
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 
-const ANIMATIONS: { [key: number]: IRawStyle; } = {
-  [RectangleEdge.top]: AnimationStyles.slideUpIn20,
-  [RectangleEdge.bottom]: AnimationStyles.slideDownIn20,
-  [RectangleEdge.left]: AnimationStyles.slideLeftIn20,
-  [RectangleEdge.right]: AnimationStyles.slideRightIn20,
-};
 
 function getBeakStyle(beakWidth?: number,
   beakStyle?: string): IRawStyle {
@@ -75,8 +68,7 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
       },
       focusClear(),
       className,
-      positions && positions.targetEdge && ANIMATIONS[positions.targetEdge],
-      !!calloutWidth && { width: calloutWidth },
+      !!calloutWidth && { width: calloutWidth }
     ],
     beak: [
       'ms-Callout-beak',

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
@@ -11,7 +11,6 @@ import { ICalloutContentStyleProps, ICalloutContentStyles } from './Callout.type
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 
-
 function getBeakStyle(beakWidth?: number,
   beakStyle?: string): IRawStyle {
   let beakStyleWidth = beakWidth;

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
@@ -35,7 +35,6 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
     overflowYHidden,
     calloutWidth,
     contentMaxHeight,
-    positions,
     beakWidth,
     backgroundColor,
     beakStyle


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Move the animation of callout from getClassName to inline. This greatly improves both actual and perceived performance. Part of the reason it was slow was because the menu would position, which would then trigger the animation rule to be inserted into the page, which would then trigger reflows. Before the animation could start, all of the reflows would need to complete. So even though the menu was in place, ready to be displayed, it would not do so for another number of milliseconds.

#### Focus areas to test

(optional)
