### PR TITLE
Fix #4146 indeterminate progress indicator overflow 

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-indeterminate-progress-indicator-overflow_2018-03-01-17-51.json
+++ b/common/changes/office-ui-fabric-react/fix-indeterminate-progress-indicator-overflow_2018-03-01-17-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "adding overflow:hidden to ProgressIndicator's .itemProgress class",
+      "comment": "ProgressIndicator: adjusting css so that the gleam doesn't go outside the indicator boundary.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/fix-indeterminate-progress-indicator-overflow_2018-03-01-17-51.json
+++ b/common/changes/office-ui-fabric-react/fix-indeterminate-progress-indicator-overflow_2018-03-01-17-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "adding overflow:hidden to ProgressIndicator's .itemProgress class",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "daniel@whitefamily.in"
+}

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.scss
@@ -1,17 +1,12 @@
 @import '../../common/common';
-
 // Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
-
 //
 // Office UI Fabric
 // --------------------------------------------------
 // ProgressIndicator Styles
-
-
 $ProgressIndicatorMarginBetweenText: 8px;
 $ProgressIndicatorButtonsWidth: 218px;
 $ProgressIndicatorTextHeight: 18px;
-
 .root {
   font-weight: $ms-font-weight-regular;
 }
@@ -34,6 +29,7 @@ $ProgressIndicatorTextHeight: 18px;
 
 .itemProgress {
   position: relative;
+  overflow: hidden;
   height: 2px;
   padding: $ProgressIndicatorMarginBetweenText 0;
 }
@@ -54,18 +50,15 @@ $ProgressIndicatorTextHeight: 18px;
   position: absolute;
   transition: width .3s ease;
   width: 0;
-
   &.indeterminate {
     position: absolute;
     min-width: 33%;
     background: linear-gradient(to right, transparent 0%, $ms-color-themePrimary 50%, transparent 100%);
     animation: indeterminateProgress 3s infinite;
   }
-
   @include high-contrast {
     background-color: WindowText;
   }
-
   @include RTL {
     &.indeterminate {
       animation: indeterminateProgressRTL 3s infinite;


### PR DESCRIPTION

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4146
- [x] Include a change request file using `$ npm run change`

#### Description of changes

I added `overflow: hidden` to the `.itemProgress` to constrain the `ProgressIndicator`

#### Focus areas to test

See #4146 for a repro script