### PR TITLE
Move fabric to TypeScript 2.7.2

### DIFF
--- a/apps/todo-app/package.json
+++ b/apps/todo-app/package.json
@@ -22,7 +22,7 @@
     "office-ui-fabric-react": ">=5.56.0 <6.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "typescript": "2.6.2",
+    "typescript": "2.7.2",
     "tslib": "^1.7.1"
   }
 }

--- a/apps/todo-app/src/DataProvider.ts
+++ b/apps/todo-app/src/DataProvider.ts
@@ -110,7 +110,7 @@ export default class DataProvider implements IDataProvider {
    */
   public toggleComplete(item: ITodoItem): Promise<ITodoItem[]> {
     // Create a new Item in which the PercentComplete value has been changed.
-    const newItem: ITodoItem = update(item, {
+    const newItem: ITodoItem = (update as any)(item, {
       isComplete: { $set: item.isComplete === true ? false : true }
     });
 

--- a/apps/todo-app/src/components/TodoForm.tsx
+++ b/apps/todo-app/src/components/TodoForm.tsx
@@ -42,7 +42,7 @@ export interface ITodoFormState {
  * Button: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/button
  */
 export default class TodoForm extends BaseComponent<ITodoFormProps, ITodoFormState> {
-  private _textField: ITextField;
+  private _textField!: ITextField;
 
   constructor(props: ITodoFormProps) {
     super(props);

--- a/apps/todo-app/src/components/TodoItem.tsx
+++ b/apps/todo-app/src/components/TodoItem.tsx
@@ -20,8 +20,8 @@ import strings from './../strings';
 export default class TodoItem extends React.Component<ITodoItemProps, {}> {
   private static ANIMATION_TIMEOUT = 200;
 
-  private _animationTimeoutId: number;
-  private _rowItem: HTMLDivElement;
+  private _animationTimeoutId!: number;
+  private _rowItem!: HTMLDivElement;
 
   constructor(props: ITodoItemProps) {
     super(props);

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -31,7 +31,7 @@
     "office-ui-fabric-react": ">=5.56.0 <6.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "typescript": "2.6.2",
+    "typescript": "2.7.2",
     "tslib": "^1.7.1"
   }
 }

--- a/common/changes/@uifabric/example-app-base/chrisgo-ts-2-7-final_2018-03-01-21-36.json
+++ b/common/changes/@uifabric/example-app-base/chrisgo-ts-2-7-final_2018-03-01-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Upgrade to TypeScript 2.7.2",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/@uifabric/merge-styles/chrisgo-ts-2-7-final_2018-03-01-21-36.json
+++ b/common/changes/@uifabric/merge-styles/chrisgo-ts-2-7-final_2018-03-01-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Upgrade to TypeScript 2.7.2",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/@uifabric/utilities/chrisgo-ts-2-7-final_2018-03-01-21-36.json
+++ b/common/changes/@uifabric/utilities/chrisgo-ts-2-7-final_2018-03-01-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Upgrade to TypeScript 2.7.2",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/chrisgo-ts-2-7-final_2018-03-01-21-36.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-ts-2-7-final_2018-03-01-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Upgrade to TypeScript 2.7.2",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -35,16 +35,16 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.29",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.29.tgz",
-      "integrity": "sha1-KG8rZZsgFbC5VRcrdYsNvVvzalw="
+      "version": "1.7.35",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.35.tgz",
+      "integrity": "sha1-R0hnGj9ENnN0vZ+i3mUIg5/DXG0="
     },
     "@microsoft/loader-load-themed-styles": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.10.tgz",
-      "integrity": "sha1-nvH6PAF2eZ1++f/QpWekYj1RY6g=",
+      "version": "1.7.16",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.16.tgz",
+      "integrity": "sha1-D9UEsZp7iY+xfMQwS80OxviQzZA=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "loader-utils": "1.1.0"
       }
     },
@@ -75,7 +75,7 @@
       "requires": {
         "@types/argparse": "1.0.33",
         "@types/node": "6.0.88",
-        "argparse": "1.0.9",
+        "argparse": "1.0.10",
         "colors": "1.1.2"
       },
       "dependencies": {
@@ -88,18 +88,18 @@
     },
     "@rush-temp/build": {
       "version": "file:projects/build.tgz",
-      "integrity": "sha1-b/0rm0AlrCQ72dOpittRoaChESA=",
+      "integrity": "sha1-Ver5mhBaDTlt7Y5nDUvWPDdQhPI=",
       "requires": {
         "@microsoft/api-extractor": "4.3.7",
-        "@microsoft/load-themed-styles": "1.7.29",
-        "@microsoft/loader-load-themed-styles": "1.7.10",
+        "@microsoft/load-themed-styles": "1.7.35",
+        "@microsoft/loader-load-themed-styles": "1.7.16",
         "autoprefixer": "7.2.6",
-        "awesome-typescript-loader": "3.4.1",
+        "awesome-typescript-loader": "3.5.0",
         "bundlesize": "0.15.3",
         "chalk": "2.3.1",
         "command-line-args": "4.0.7",
         "cpx": "1.5.0",
-        "css-loader": "0.28.9",
+        "css-loader": "0.28.10",
         "github": "7.3.2",
         "glob": "7.1.2",
         "gzip-size": "3.0.0",
@@ -108,8 +108,8 @@
         "mustache": "2.3.0",
         "node-sass": "4.7.2",
         "open": "0.0.5",
-        "postcss": "6.0.17",
-        "postcss-loader": "2.1.0",
+        "postcss": "6.0.19",
+        "postcss-loader": "2.1.1",
         "postcss-modules": "0.8.0",
         "raf": "3.4.0",
         "raw-loader": "0.5.1",
@@ -118,19 +118,19 @@
         "style-loader": "0.19.1",
         "ts-jest": "21.2.4",
         "tslint": "5.9.1",
-        "tslint-microsoft-contrib": "5.0.2",
-        "typescript": "2.6.2",
+        "tslint-microsoft-contrib": "5.0.3",
+        "typescript": "2.7.2",
         "uglifyjs-webpack-plugin": "0.4.6",
         "webpack": "3.11.0",
-        "webpack-bundle-analyzer": "2.10.0",
-        "webpack-dev-server": "2.11.1",
+        "webpack-bundle-analyzer": "2.11.0",
+        "webpack-dev-server": "2.11.2",
         "webpack-notifier": "1.5.1",
         "yargs": "6.6.0"
       }
     },
     "@rush-temp/example-app-base": {
       "version": "file:projects/example-app-base.tgz",
-      "integrity": "sha1-LV6ExSpkKngD93QHjMXpAU1X2Ak=",
+      "integrity": "sha1-9dFwsZXpye1aVKCC4clouHgGnBE=",
       "requires": {
         "@types/es6-promise": "0.0.32",
         "@types/highlight.js": "9.12.2",
@@ -141,7 +141,7 @@
         "es6-promise": "4.2.4",
         "es6-weak-map": "2.0.2",
         "highlight.js": "9.12.0",
-        "office-ui-fabric-react": "5.49.2",
+        "office-ui-fabric-react": "5.56.0",
         "react": "16.2.0",
         "react-dom": "16.2.0",
         "tslib": "1.9.0"
@@ -149,9 +149,9 @@
     },
     "@rush-temp/experiments": {
       "version": "file:projects/experiments.tgz",
-      "integrity": "sha1-UaWwyEGM5mXZNeweA2POBGayJPg=",
+      "integrity": "sha1-DN9S5Fs/j/ZkpFT0xo2wzGt34+I=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
         "@types/es6-promise": "0.0.32",
@@ -167,20 +167,20 @@
         "enzyme": "3.3.0",
         "enzyme-adapter-react-16": "1.1.1",
         "es6-weak-map": "2.0.2",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react": "16.2.0",
         "react-dom": "16.2.0",
         "react-highlight": "0.10.0",
         "react-test-renderer": "16.2.0",
-        "sinon": "4.3.0",
+        "sinon": "4.4.2",
         "tslib": "1.9.0"
       }
     },
     "@rush-temp/fabric-website": {
       "version": "file:projects/fabric-website.tgz",
-      "integrity": "sha1-nGJiE4jMIhiQ48ra19peu7WL3FY=",
+      "integrity": "sha1-ZiTAxKp6omRHIlx54OVhUZsnloo=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "@types/es6-promise": "0.0.32",
         "@types/node": "8.0.26",
         "@types/prop-types": "15.5.2",
@@ -203,7 +203,7 @@
     },
     "@rush-temp/file-type-icons": {
       "version": "file:projects/file-type-icons.tgz",
-      "integrity": "sha1-WNiMlnuaua8SYuo1Moc5JiK60z4=",
+      "integrity": "sha1-4G9oT36P2AYqCpjXHfSm2Nlt2PI=",
       "requires": {
         "@types/react": "16.0.25",
         "@types/react-dom": "16.0.3",
@@ -214,21 +214,21 @@
     },
     "@rush-temp/icons": {
       "version": "file:projects/icons.tgz",
-      "integrity": "sha1-C9GkDWFFIVRO+gLcom+N2JnUGes=",
+      "integrity": "sha1-DnOJqyGa3UW80sWtP83EaHf3cGM=",
       "requires": {
         "tslib": "1.9.0"
       }
     },
     "@rush-temp/jest-serializer-merge-styles": {
       "version": "file:projects/jest-serializer-merge-styles.tgz",
-      "integrity": "sha1-+MCeidPU9OKloQmiGdGozBtl0t4=",
+      "integrity": "sha1-kit2DYaoDkGt01iWhFQnsRGFoTc=",
       "requires": {
         "@types/jest": "21.1.8"
       }
     },
     "@rush-temp/merge-styles": {
       "version": "file:projects/merge-styles.tgz",
-      "integrity": "sha1-3KNQc0lwQRpSzAXHg8p9tYmt61c=",
+      "integrity": "sha1-N4mnfc8Hv2i6QE1IvJxt4gi9AuY=",
       "requires": {
         "@types/jest": "21.1.8",
         "tslib": "1.9.0"
@@ -236,9 +236,9 @@
     },
     "@rush-temp/office-ui-fabric-react": {
       "version": "file:projects/office-ui-fabric-react.tgz",
-      "integrity": "sha1-MND9Li663/9tbmFYfmNQxhoGxxU=",
+      "integrity": "sha1-ADTTmStgRKaou3YbaCqOSn0awyU=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
         "@types/es6-promise": "0.0.32",
@@ -257,28 +257,28 @@
         "es6-weak-map": "2.0.2",
         "highlight.js": "9.12.0",
         "office-ui-fabric-core": "9.4.0",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react": "16.2.0",
         "react-dom": "16.2.0",
         "react-highlight": "0.10.0",
         "react-test-renderer": "16.2.0",
         "resemblejs": "2.2.6",
-        "sinon": "4.3.0",
+        "sinon": "4.4.2",
         "tslib": "1.9.0"
       }
     },
     "@rush-temp/office-ui-fabric-react-tslint": {
       "version": "file:projects/office-ui-fabric-react-tslint.tgz",
-      "integrity": "sha1-wfJIcEzB9c1v+5eNV5c8kMoVfTQ=",
+      "integrity": "sha1-RqQY3nSg/9snfOzrcQNVR41UiP8=",
       "requires": {
-        "tslint-react": "3.5.0"
+        "tslint-react": "3.5.1"
       }
     },
     "@rush-temp/ssr-tests": {
       "version": "file:projects/ssr-tests.tgz",
-      "integrity": "sha1-Ww9vJarq435YVGT/pb2F5l94PXA=",
+      "integrity": "sha1-/RiZyyAIm4YIGMN/gmh0EFB/2Jw=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "@types/es6-promise": "0.0.32",
         "@types/mocha": "2.2.39",
         "@types/webpack-env": "1.13.0",
@@ -293,9 +293,9 @@
     },
     "@rush-temp/styling": {
       "version": "file:projects/styling.tgz",
-      "integrity": "sha1-SSb9aI6B3V9iwyZjAr7ZSmwsYN8=",
+      "integrity": "sha1-yooDPN6j4bEXiRcw/nKoruCTENM=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "@types/jest": "21.1.8",
         "@types/react": "16.0.25",
         "@types/webpack-env": "1.13.0",
@@ -308,7 +308,7 @@
     },
     "@rush-temp/test-bundle-button": {
       "version": "file:projects/test-bundle-button.tgz",
-      "integrity": "sha1-lN0tQocYh2OEZCa5P/K85OXzjkI=",
+      "integrity": "sha1-hHSH1ybHvJHL39pq1wIYc+s71lU=",
       "requires": {
         "@types/prop-types": "15.5.2",
         "@types/react": "16.0.25",
@@ -321,26 +321,26 @@
     },
     "@rush-temp/todo-app": {
       "version": "file:projects/todo-app.tgz",
-      "integrity": "sha1-nre4a9QdHlXZFhtK6PBPHVuM8Gc=",
+      "integrity": "sha1-TgRNk3WpedPAxOPIzAAWpZWU69I=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "@types/es6-promise": "0.0.32",
         "@types/react": "16.0.25",
         "@types/react-dom": "16.0.3",
         "@types/webpack-env": "1.13.0",
         "es6-promise": "4.2.4",
-        "immutability-helper": "2.6.4",
+        "immutability-helper": "2.6.5",
         "react": "16.2.0",
         "react-dom": "16.2.0",
         "tslib": "1.9.0",
-        "typescript": "2.6.2"
+        "typescript": "2.7.2"
       }
     },
     "@rush-temp/utilities": {
       "version": "file:projects/utilities.tgz",
-      "integrity": "sha1-GNjb2ebTodto0adRpvjnRiR8S9w=",
+      "integrity": "sha1-PEyJRbuw/Ha4QmT2cGhecacPKEs=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
         "@types/jest": "21.1.8",
@@ -350,35 +350,43 @@
         "@types/sinon": "2.2.2",
         "enzyme": "3.3.0",
         "enzyme-adapter-react-16": "1.1.1",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react": "16.2.0",
         "react-dom": "16.2.0",
-        "sinon": "4.3.0",
+        "sinon": "4.4.2",
+        "tslib": "1.9.0"
+      }
+    },
+    "@rush-temp/variants": {
+      "version": "file:projects/variants.tgz",
+      "integrity": "sha1-vxbJXzxQp+9DbiRutWD7vAQX7ew=",
+      "requires": {
+        "@types/jest": "21.1.8",
         "tslib": "1.9.0"
       }
     },
     "@rush-temp/vr-tests": {
       "version": "file:projects/vr-tests.tgz",
-      "integrity": "sha1-W2Vs4MI7qoJFVlZlraVkhB5t3jM=",
+      "integrity": "sha1-NzAoR+bMCugFFdIuBZSNjwY5yXM=",
       "requires": {
         "@storybook/addon-options": "3.2.3",
-        "@storybook/react": "3.3.13",
+        "@storybook/react": "3.3.14",
         "@types/react": "16.0.25",
         "@types/react-dom": "16.0.3",
         "@types/storybook__react": "3.0.5",
-        "awesome-typescript-loader": "3.4.1",
-        "css-loader": "0.28.9",
+        "awesome-typescript-loader": "3.5.0",
+        "css-loader": "0.28.10",
         "file-loader": "0.11.2",
-        "postcss-loader": "2.1.0",
+        "postcss-loader": "2.1.1",
         "raw-loader": "0.5.1",
         "react": "16.2.0",
         "react-dom": "16.2.0",
         "screener-runner": "0.6.19",
-        "screener-storybook": "0.11.1",
+        "screener-storybook": "0.11.3",
         "storybook-readme": "3.0.6",
         "style-loader": "0.19.1",
         "tslib": "1.9.0",
-        "typescript": "2.6.2"
+        "typescript": "2.7.2"
       }
     },
     "@sinonjs/formatio": {
@@ -390,26 +398,26 @@
       }
     },
     "@storybook/addon-actions": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.3.13.tgz",
-      "integrity": "sha512-fceT2O3tXkeSHZJI/sh51FXpaBiWuGwjfFKDn8e4QAJrEeA4Ig59AQeoiWMMy1RdgPooUXuQvg7WKCvWj/IBWQ==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.3.14.tgz",
+      "integrity": "sha512-MU+Sz80hlC3+VJW15yoa9y7mzsNechtd9X7WvugIB1Pg6AwY2IYNZoagy2dXwdBD6+sUTj1zWt0c7P7y5A/EAg==",
       "requires": {
         "deep-equal": "1.0.1",
         "global": "4.3.2",
-        "make-error": "1.3.3",
-        "prop-types": "15.6.0",
+        "make-error": "1.3.4",
+        "prop-types": "15.6.1",
         "react-inspector": "2.2.2",
         "uuid": "3.2.1"
       }
     },
     "@storybook/addon-links": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.3.13.tgz",
-      "integrity": "sha512-9xfz46SV+0PrLPcP2UWR+ajGiK6fjH8SAiEaFIM9hAwY7Xe5DefpS0A49dRdZ2UPxTohuzGJAlS5J2MXCeWEUg==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.3.14.tgz",
+      "integrity": "sha512-pD+/aOpGPcDQ/4h7UHA+nu3ye0w1KJ8GFz4MCX7a+38rYDUe1ePD5xmLT56zHCKqyKZgrrIoGZg/yEQjpQCJug==",
       "requires": {
-        "@storybook/components": "3.3.13",
+        "@storybook/components": "3.3.14",
         "global": "4.3.2",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "@storybook/addon-options": {
@@ -417,42 +425,42 @@
       "resolved": "https://registry.npmjs.org/@storybook/addon-options/-/addon-options-3.2.3.tgz",
       "integrity": "sha1-6jdA0onUKc52fpaZvzpkfddBWS0=",
       "requires": {
-        "@storybook/addons": "3.3.13"
+        "@storybook/addons": "3.3.14"
       }
     },
     "@storybook/addons": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.3.13.tgz",
-      "integrity": "sha512-c7LNVMQbpvGdWiW6D9tONlM/DA6pIMJ0IkO9JT89Of1gLwFAJyKVQKGOYBzcKa1G0I0qzzmdXAc9lzCfmGYKMg=="
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.3.14.tgz",
+      "integrity": "sha512-cVSowQdWOr/XxWk60ykr4a+0gnpVnfWkJ0pIbGQUBcq6tvGrAoZ76Cq18lYS7NHNL2lwoEQT3wBs7w0UaJtOTA=="
     },
     "@storybook/channel-postmessage": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.3.13.tgz",
-      "integrity": "sha512-WiEN4wlL07eOq5aE0j60jECH6ppCKeyJqC+qqeRoDoRRY7OlJFpKXuZnhmV6TKGIDgvtsNBSCg6DhfytuQMGJw==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.3.14.tgz",
+      "integrity": "sha512-xFmc2F/OKqrrdMjrvJTfADOl3+fKxKCs4vNr8w26k8gBLDp/JuoSomnar7kR7PfX9mAAfVgVle8erUMkHc0Tsg==",
       "requires": {
-        "@storybook/channels": "3.3.13",
+        "@storybook/channels": "3.3.14",
         "global": "4.3.2",
         "json-stringify-safe": "5.0.1"
       }
     },
     "@storybook/channels": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.3.13.tgz",
-      "integrity": "sha512-e4eHNogqLpUxb/imixsQDt4sa/kOLKQb3EBatQ8DCzUpLdPgZJnJRElcMic/mjJ33Wowb/wtSi3dR44SDKz+ww=="
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.3.14.tgz",
+      "integrity": "sha512-qrd7WnQDmdX0uMGbTmRKlLL9R8mrVClsT2Idb1YsL7gbTE2X4QyOTt4ANFeCmvZ8LxqOmEv5glcBmfBRNjBPgQ=="
     },
     "@storybook/client-logger": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.3.13.tgz",
-      "integrity": "sha512-fFBy7C/5j5vkYCVNcMzLpkP4hppcmO4ixPGoHkMxD5HMseBa2wRnOWIFsWti9hhGTh6mEIV86VRTySN25mIKDg=="
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.3.14.tgz",
+      "integrity": "sha512-dKuASmwvZqriu63CsNlvvUWyQ9EuYqS6sXmdy5yhusycFl+LfhvMMNKzENxb91ZSAcE75wH39VZVdLZTxsH9Fw=="
     },
     "@storybook/components": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.3.13.tgz",
-      "integrity": "sha512-htNVEUfW//Xw9RfXtNExDnVEJaHVIA4U08tsfKHOaCkeA3urpPkSZD9+4SCLixw2IYodbolbFWphaqBk1yrQDw==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.3.14.tgz",
+      "integrity": "sha512-MCUx0JWk21jspFUb/dqaqBB1ZCBHhSIHlkBt438+oub4CRlTHl5q3tDffyDUzgdzMULi1xubtEH8f9pet87A8w==",
       "requires": {
         "glamor": "2.20.40",
-        "glamorous": "4.11.4",
-        "prop-types": "15.6.0"
+        "glamorous": "4.11.6",
+        "prop-types": "15.6.1"
       }
     },
     "@storybook/mantra-core": {
@@ -466,30 +474,39 @@
       }
     },
     "@storybook/node-logger": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-3.3.13.tgz",
-      "integrity": "sha512-kKiCudlOJOt64+nq3uw96NdjxSGHOU6DXEVGC4TkjU8Q8BEigWiKNmitQjuk7yCodKtjIl9SUMQ/y3PzqKVAkg==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-3.3.14.tgz",
+      "integrity": "sha512-MBVr0J//5ENuDqNT5LWKTbLF7rmUJk0BpBnuJJrIif1Z+AfNs1gJz7MeL5V/3GNnUx8jc6NzNWCvNFJUIvf0uw==",
       "requires": {
         "chalk": "2.3.1",
         "npmlog": "4.1.2"
       }
     },
-    "@storybook/react": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.3.13.tgz",
-      "integrity": "sha512-h+WmeTqsylG+X9KMHfIAm1ZbVJMYbXdZuvTkPz0Nns7t9yrTWd877dtZIOKzTHhA4GUxgla2qPYy7dF2+vsJtA==",
+    "@storybook/podda": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
+      "integrity": "sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==",
       "requires": {
-        "@storybook/addon-actions": "3.3.13",
-        "@storybook/addon-links": "3.3.13",
-        "@storybook/addons": "3.3.13",
-        "@storybook/channel-postmessage": "3.3.13",
-        "@storybook/client-logger": "3.3.13",
-        "@storybook/node-logger": "3.3.13",
-        "@storybook/ui": "3.3.13",
+        "babel-runtime": "6.26.0",
+        "immutable": "3.8.2"
+      }
+    },
+    "@storybook/react": {
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.3.14.tgz",
+      "integrity": "sha512-qeeEhP5JyqmZKKbNdkSIj2SqWN1Q4bqy8ed+b+CS3gPoSGPy7DscbSwykllXvaTO9NASYGjFHG9b6hohQSQurw==",
+      "requires": {
+        "@storybook/addon-actions": "3.3.14",
+        "@storybook/addon-links": "3.3.14",
+        "@storybook/addons": "3.3.14",
+        "@storybook/channel-postmessage": "3.3.14",
+        "@storybook/client-logger": "3.3.14",
+        "@storybook/node-logger": "3.3.14",
+        "@storybook/ui": "3.3.14",
         "airbnb-js-shims": "1.4.1",
         "autoprefixer": "7.2.6",
-        "babel-loader": "7.1.2",
-        "babel-plugin-react-docgen": "1.8.2",
+        "babel-loader": "7.1.3",
+        "babel-plugin-react-docgen": "1.8.3",
         "babel-plugin-transform-regenerator": "6.26.0",
         "babel-plugin-transform-runtime": "6.23.0",
         "babel-preset-env": "1.6.1",
@@ -504,13 +521,13 @@
         "common-tags": "1.7.2",
         "configstore": "3.1.1",
         "core-js": "2.5.3",
-        "css-loader": "0.28.9",
-        "dotenv-webpack": "1.5.4",
+        "css-loader": "0.28.10",
+        "dotenv-webpack": "1.5.5",
         "express": "4.16.2",
-        "file-loader": "1.1.6",
+        "file-loader": "1.1.10",
         "find-cache-dir": "1.0.0",
         "glamor": "2.20.40",
-        "glamorous": "4.11.4",
+        "glamorous": "4.11.6",
         "global": "4.3.2",
         "html-loader": "0.5.5",
         "html-webpack-plugin": "2.30.1",
@@ -521,73 +538,61 @@
         "markdown-loader": "2.0.2",
         "npmlog": "4.1.2",
         "postcss-flexbugs-fixes": "3.3.0",
-        "postcss-loader": "2.1.0",
-        "prop-types": "15.6.0",
+        "postcss-loader": "2.1.1",
+        "prop-types": "15.6.1",
         "qs": "6.5.1",
         "redux": "3.7.2",
         "request": "2.83.0",
         "serve-favicon": "2.4.5",
         "shelljs": "0.7.8",
         "style-loader": "0.19.1",
-        "uglifyjs-webpack-plugin": "1.1.8",
+        "uglifyjs-webpack-plugin": "1.2.2",
         "url-loader": "0.6.2",
         "util-deprecate": "1.0.2",
         "uuid": "3.2.1",
         "webpack": "3.11.0",
         "webpack-dev-middleware": "1.12.2",
-        "webpack-hot-middleware": "2.21.0"
+        "webpack-hot-middleware": "2.21.1"
       },
       "dependencies": {
         "file-loader": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.6.tgz",
-          "integrity": "sha512-873ztuL+/hfvXbLDJ262PGO6XjERnybJu2gW1/5j8HUfxSiFJI9Hj/DhZ50ZGRUxBvuNiazb/cM2rh9pqrxP6Q==",
+          "version": "1.1.10",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.10.tgz",
+          "integrity": "sha512-dNnT4yJgUPtGDg0+m03kQ0b/PZi3Y12EnqYuRPNCsbYkBZc6j+fwVWy40jWzZjn5kIzQ4BLIxzJimbwAYlnPGw==",
           "requires": {
             "loader-utils": "1.1.0",
-            "schema-utils": "0.3.0"
-          }
-        },
-        "schema-utils": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-          "requires": {
-            "ajv": "5.5.2"
+            "schema-utils": "0.4.5"
           }
         },
         "uglify-es": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.10.tgz",
-          "integrity": "sha512-rPzPisCzW68Okj1zNrfa2dR9uEm43SevDmpR6FChoZABFk9dANGnzzBMgHYUXI3609//63fnVkyQ1SQmAMyjww==",
+          "version": "3.3.9",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "requires": {
-            "commander": "2.14.1",
+            "commander": "2.13.0",
             "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.13.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+              "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+            }
           }
         },
         "uglifyjs-webpack-plugin": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.8.tgz",
-          "integrity": "sha512-XG8/QmR1pyPeE1kj2aigo5kos8umefB31zW+PMvAAytHSB0T/vQvN6sqt8+Sh+y0b0A7zlmxNi2dzRnj0wcqGA==",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.2.tgz",
+          "integrity": "sha512-CG/NvzXfemUAm5Y4Guh5eEaJYHtkG7kKNpXEJHp9QpxsFVB5/qKvYWoMaq4sa99ccZ0hM3MK8vQV9XPZB4357A==",
           "requires": {
-            "cacache": "10.0.2",
+            "cacache": "10.0.4",
             "find-cache-dir": "1.0.0",
-            "schema-utils": "0.4.3",
+            "schema-utils": "0.4.5",
             "serialize-javascript": "1.4.0",
             "source-map": "0.6.1",
-            "uglify-es": "3.3.10",
+            "uglify-es": "3.3.9",
             "webpack-sources": "1.1.0",
-            "worker-farm": "1.5.2"
-          },
-          "dependencies": {
-            "schema-utils": {
-              "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.3.tgz",
-              "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
-              "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1"
-              }
-            }
+            "worker-farm": "1.5.4"
           }
         }
       }
@@ -612,7 +617,7 @@
         "babel-runtime": "6.26.0",
         "create-react-class": "15.6.3",
         "hoist-non-react-statics": "1.2.0",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "@storybook/react-stubber": {
@@ -624,12 +629,13 @@
       }
     },
     "@storybook/ui": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.3.13.tgz",
-      "integrity": "sha512-ecmu9l0Pr2PyZ6gWcK+AW0ZHNCQ1t1FkYm7JIYXWpAP0cBQ6EtvEoQLowzJ9GXw5s/s4hwdHmoxJ8j2SRuUulw==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.3.14.tgz",
+      "integrity": "sha512-aL5mqZ8WNW+bRGVaLuvCfxiLtKvorL9poXosgyc1jZurwi3Z05k7injkg16LuA1dE0wSib/mgHXjgzKXHN+Fhg==",
       "requires": {
-        "@storybook/components": "3.3.13",
+        "@storybook/components": "3.3.14",
         "@storybook/mantra-core": "1.7.2",
+        "@storybook/podda": "1.2.3",
         "@storybook/react-komposer": "2.0.3",
         "babel-runtime": "6.26.0",
         "deep-equal": "1.0.1",
@@ -641,13 +647,12 @@
         "lodash.debounce": "4.0.8",
         "lodash.pick": "4.4.0",
         "lodash.sortby": "4.7.0",
-        "podda": "1.2.2",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "qs": "6.5.1",
-        "react-fuzzy": "0.5.1",
+        "react-fuzzy": "0.5.2",
         "react-icons": "2.2.7",
         "react-inspector": "2.2.2",
-        "react-modal": "3.1.13",
+        "react-modal": "3.3.1",
         "react-split-pane": "0.1.77",
         "react-treebeard": "2.1.0",
         "redux": "3.7.2"
@@ -782,37 +787,37 @@
       "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.4.2.tgz",
       "integrity": "sha512-JG0euHlQhcVsI9wCfKE/DYDoDjzQNcHDg2Wh1NeFeVPz/6L0s0D7Izw2ULkZgW1TCLFcNx0xdwN+SSnGjIlTkw==",
       "requires": {
-        "@uifabric/styling": "5.17.0",
+        "@uifabric/styling": "5.19.0",
         "tslib": "1.9.0"
       }
     },
     "@uifabric/merge-styles": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.11.2.tgz",
-      "integrity": "sha512-Qipbhp1J+yyBSAEDCGWjuv2mdkIEwRFB9qr8kNCew/8t4TNt2V2O8GbMjIqj0ieCOyj8M11rlALOGThOY91z0w==",
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.12.2.tgz",
+      "integrity": "sha512-PVUu9IIa6voT5YvZAfd3GJvHZpTyA6m3WCAqSjCvNScGJN1EdQ9YQjfJpC1FWsUNYcXIBQqLl7YiuAE+aCz99A==",
       "requires": {
         "tslib": "1.9.0"
       }
     },
     "@uifabric/styling": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.17.0.tgz",
-      "integrity": "sha512-FXw7GQEaGGkfEXnGJFSKgbk+uzlM+1PFYwb4BnxlscsXQe1sdmqCKYmY2XrAIdwywfQAZA3t6zshn/EjE+eS7g==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.19.0.tgz",
+      "integrity": "sha512-XZw+RFaw6RscwAvAO7+w4MXbLI0/lVqBcriU65EKYLvBXvMbYry3cY4AxobQ/5e0LdjXs8YPOFHOJHfTvw18Gg==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
-        "@uifabric/merge-styles": "5.11.2",
-        "@uifabric/utilities": "5.10.2",
+        "@microsoft/load-themed-styles": "1.7.35",
+        "@uifabric/merge-styles": "5.12.2",
+        "@uifabric/utilities": "5.13.0",
         "tslib": "1.9.0"
       }
     },
     "@uifabric/utilities": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.10.2.tgz",
-      "integrity": "sha512-mKJYVydBEekrBSDn8VDIafIWiqL82WnigdTSv2ooo3v4ClJc39zbV1NLWXC4T6RLSTZHIi/W4CTudtWOtdVcAA==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.13.0.tgz",
+      "integrity": "sha512-fgKKMs/tea/TTSvyWuBzDT/SpDLzeUp6/fNqrrK2iSM0CxSn8wfTQdAwL6WBVAsgR4TZvTU0RioJVM/Tg/H9QQ==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
-        "@uifabric/merge-styles": "5.11.2",
-        "prop-types": "15.6.0",
+        "@microsoft/load-themed-styles": "1.7.35",
+        "@uifabric/merge-styles": "5.12.2",
+        "prop-types": "15.6.1",
         "tslib": "1.9.0"
       }
     },
@@ -831,7 +836,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -878,8 +883,8 @@
       "integrity": "sha512-b7S3d+DPRMwaDAs0cgKQTMLO/JG/iSehIlzEGvt2FpxIztRDDABEjWI73AfTxkSiK3/OsraPRYxVNAX3yhSNLw==",
       "requires": {
         "array-includes": "3.0.3",
-        "array.prototype.flatmap": "1.2.0",
-        "array.prototype.flatten": "1.2.0",
+        "array.prototype.flatmap": "1.2.1",
+        "array.prototype.flatten": "1.2.1",
         "es5-shim": "4.5.10",
         "es6-shim": "0.35.3",
         "function.prototype.name": "1.1.0",
@@ -897,15 +902,15 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+      "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74="
     },
     "align-text": {
       "version": "0.1.4",
@@ -1061,9 +1066,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -1154,9 +1159,9 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flatmap": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.0.tgz",
-      "integrity": "sha512-Mks+PkOK0iOmxq0WtINn1rlPmFC8ZTdLq37MzgZG7ihF5eF+cT29H9MZ6TqbBvxGFLArGwuMxXl/DQjeNI3zeQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.1.tgz",
+      "integrity": "sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==",
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
@@ -1164,9 +1169,9 @@
       }
     },
     "array.prototype.flatten": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatten/-/array.prototype.flatten-1.2.0.tgz",
-      "integrity": "sha512-GfDeDMS9gFiKtJrtJVPljbUQowQoo5X+TTGjMTAxZL1qs4xq758+R1QxRS6dToM4YHk8Mf/L0INMHOsF9hmHGw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatten/-/array.prototype.flatten-1.2.1.tgz",
+      "integrity": "sha512-3GhsA78XgK//wQKbhUe6L93kknekGlTRY0kvYcpuSi0aa9rVrMr/okeIIv/XSpN8fZ5iUM+bWifhf2/7CYKtIg==",
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
@@ -1189,9 +1194,9 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1.js": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
         "bn.js": "4.11.8",
         "inherits": "2.0.3",
@@ -1270,26 +1275,25 @@
       "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
       "requires": {
         "browserslist": "2.11.3",
-        "caniuse-lite": "1.0.30000808",
+        "caniuse-lite": "1.0.30000810",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "6.0.17",
+        "postcss": "6.0.19",
         "postcss-value-parser": "3.3.0"
       }
     },
     "awesome-typescript-loader": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.4.1.tgz",
-      "integrity": "sha512-fYxBtN6s4Dm6vtsROWi8IQ4I+KcmwRWePAVvhI06mFcHbtHfZopOs4qGNu9LyCPEw403LDROKFA+NVV6ig5yNw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.5.0.tgz",
+      "integrity": "sha512-qzgm9SEvodVkSi9QY7Me1/rujg+YBNMjayNSAyzNghwTEez++gXoPCwMvpbHRG7wrOkDCiF6dquvv9ESmUBAuw==",
       "requires": {
-        "colors": "1.1.2",
+        "chalk": "2.3.1",
         "enhanced-resolve": "3.3.0",
         "loader-utils": "1.1.0",
         "lodash": "4.17.5",
-        "micromatch": "3.1.5",
+        "micromatch": "3.1.9",
         "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "source-map-support": "0.4.18"
+        "source-map-support": "0.5.3"
       },
       "dependencies": {
         "lodash": {
@@ -1637,9 +1641,9 @@
       }
     },
     "babel-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
-      "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.3.tgz",
+      "integrity": "sha512-PeN29YvOynPMvNk7QCzsHqxpmfXwKAC+uxkiSNFQsmXBBVltzEkVWmv/Ip3tx7yk149dQUwk497bTXNu+DZjLA==",
       "requires": {
         "find-cache-dir": "1.0.0",
         "loader-utils": "1.1.0",
@@ -1678,8 +1682,8 @@
       "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
       "requires": {
         "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "test-exclude": "4.1.1"
+        "istanbul-lib-instrument": "1.9.2",
+        "test-exclude": "4.2.0"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -1772,13 +1776,13 @@
       }
     },
     "babel-plugin-react-docgen": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.8.2.tgz",
-      "integrity": "sha512-201wzLbDeeZri6p+KREqspsFA8rNV6SiVx65jiPC6lhM7TUTNcbEoacFHbB6ou8ONsQT3phTqLpd5Nl02mZaqw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.8.3.tgz",
+      "integrity": "sha512-yJVPObZu8HLQmOsiJATqBE/+6xZiF/b5SnWTxgV0nfELHjz5lWzIHgBzuAe5ael613+Hgf6VnRa98OVILZI07w==",
       "requires": {
         "babel-types": "6.26.0",
         "lodash": "4.17.5",
-        "react-docgen": "2.20.0"
+        "react-docgen": "2.20.1"
       },
       "dependencies": {
         "lodash": {
@@ -2370,7 +2374,7 @@
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
         "browserslist": "2.11.3",
-        "invariant": "2.2.2",
+        "invariant": "2.2.3",
         "semver": "5.5.0"
       }
     },
@@ -2515,6 +2519,19 @@
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "requires": {
+            "source-map": "0.5.7"
+          }
         }
       }
     },
@@ -2565,7 +2582,7 @@
         "babylon": "6.18.0",
         "debug": "2.6.9",
         "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "invariant": "2.2.3",
         "lodash": "4.17.5"
       },
       "dependencies": {
@@ -2616,12 +2633,22 @@
         "isobject": "3.0.1",
         "mixin-deep": "1.3.1",
         "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        }
       }
     },
     "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
     },
     "batch": {
       "version": "0.6.1",
@@ -2689,7 +2716,7 @@
         "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "1.6.16"
       }
     },
     "bonjour": {
@@ -2722,7 +2749,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "bowser": {
@@ -2740,9 +2767,9 @@
       }
     },
     "braces": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
-      "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
+      "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
       "requires": {
         "arr-flatten": "1.1.0",
         "array-unique": "0.3.2",
@@ -2750,11 +2777,30 @@
         "extend-shallow": "2.0.1",
         "fill-range": "4.0.0",
         "isobject": "3.0.1",
+        "kind-of": "6.0.2",
         "repeat-element": "1.1.2",
         "snapdragon": "0.8.1",
         "snapdragon-node": "2.1.1",
         "split-string": "3.1.0",
-        "to-regex": "3.0.1"
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "brcast": {
@@ -2856,8 +2902,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
-        "caniuse-lite": "1.0.30000808",
-        "electron-to-chromium": "1.3.33"
+        "caniuse-lite": "1.0.30000810",
+        "electron-to-chromium": "1.3.34"
       }
     },
     "bser": {
@@ -2873,7 +2919,7 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.2.1",
+        "base64-js": "1.2.3",
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
@@ -2937,23 +2983,30 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz",
-      "integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "requires": {
         "bluebird": "3.5.1",
         "chownr": "1.0.1",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "lru-cache": "4.1.1",
-        "mississippi": "1.3.1",
+        "mississippi": "2.0.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
         "rimraf": "2.6.2",
-        "ssri": "5.2.1",
+        "ssri": "5.2.4",
         "unique-filename": "1.1.0",
-        "y18n": "3.2.1"
+        "y18n": "4.0.0"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+        }
       }
     },
     "cache-base": {
@@ -3013,7 +3066,7 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000808",
+        "caniuse-db": "1.0.30000810",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -3023,21 +3076,21 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000808",
-            "electron-to-chromium": "1.3.33"
+            "caniuse-db": "1.0.30000810",
+            "electron-to-chromium": "1.3.34"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000808",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
-      "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs="
+      "version": "1.0.30000810",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000810.tgz",
+      "integrity": "sha1-vSWDDEHvq2Qzmi44H0lnc0PIRQk="
     },
     "caniuse-lite": {
-      "version": "1.0.30000808",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz",
-      "integrity": "sha512-vT0JLmHdvq1UVbYXioxCXHYdNw55tyvi+IUWyX0Zeh1OFQi2IllYtm38IJnSgHWCv/zUnX1hdhy3vMJvuTNSqw=="
+      "version": "1.0.30000810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz",
+      "integrity": "sha512-/0Q00Oie9C72P8zQHtFvzmkrMC3oOFUnMWjCy5F2+BE8lzICm91hQPhh0+XIsAFPKOe2Dh3pKgbRmU3EKxfldA=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.1.1",
@@ -3440,9 +3493,9 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -3481,21 +3534,21 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compressible": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+      "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
       }
     },
     "compression": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
-      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "requires": {
         "accepts": "1.3.4",
         "bytes": "3.0.0",
-        "compressible": "2.0.12",
+        "compressible": "2.0.13",
         "debug": "2.6.9",
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
@@ -3524,7 +3577,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
+        "make-dir": "1.2.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -3759,7 +3812,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -3779,7 +3832,7 @@
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.6",
-        "randomfill": "1.0.3"
+        "randomfill": "1.0.4"
       }
     },
     "crypto-random-string": {
@@ -3801,9 +3854,9 @@
       }
     },
     "css-loader": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.9.tgz",
-      "integrity": "sha512-r3dgelMm/mkPz5Y7m9SeiGE46i2VsEU/OYbez+1llfxtv8b2y5/b5StaeEvPK3S5tlNQI+tDW/xDIhKJoZgDtw==",
+      "version": "0.28.10",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.10.tgz",
+      "integrity": "sha512-X1IJteKnW9Llmrd+lJ0f7QZHh9Arf+11S7iRcoT2+riig3BK0QaCaOtubAulMK6Itbo08W6d3l8sW21r+Jhp5Q==",
       "requires": {
         "babel-code-frame": "6.26.0",
         "css-selector-tokenizer": "0.7.0",
@@ -4032,7 +4085,7 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000808",
+            "caniuse-db": "1.0.30000810",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -4044,8 +4097,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000808",
-            "electron-to-chromium": "1.3.33"
+            "caniuse-db": "1.0.30000810",
+            "electron-to-chromium": "1.3.34"
           }
         },
         "chalk": {
@@ -4145,7 +4198,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "dashdash": {
@@ -4254,11 +4307,12 @@
       }
     },
     "define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-      "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "1.0.2"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       }
     },
     "defined": {
@@ -4448,16 +4502,16 @@
       }
     },
     "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
     },
     "dotenv-webpack": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.5.4.tgz",
-      "integrity": "sha1-nJLkbkEqHPvGAhftM9adK7/dv58=",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.5.5.tgz",
+      "integrity": "sha1-NEEJTwTTBLYRnmtyUk5i+zJS9fI=",
       "requires": {
-        "dotenv": "4.0.0"
+        "dotenv": "5.0.1"
       }
     },
     "duplexer": {
@@ -4487,9 +4541,9 @@
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "electron-to-chromium": {
-      "version": "1.3.33",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
-      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU="
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz",
+      "integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -4586,7 +4640,7 @@
         "lodash": "4.17.5",
         "object.assign": "4.1.0",
         "object.values": "1.0.4",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react-reconciler": "0.7.0",
         "react-test-renderer": "16.2.0"
       },
@@ -4605,7 +4659,7 @@
       "requires": {
         "lodash": "4.17.5",
         "object.assign": "4.1.0",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       },
       "dependencies": {
         "lodash": {
@@ -4616,9 +4670,9 @@
       }
     },
     "errno": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "1.0.1"
       }
@@ -4654,9 +4708,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.38",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
-      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "version": "0.10.39",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
+      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
@@ -4673,7 +4727,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4683,7 +4737,7 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4701,7 +4755,7 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4718,7 +4772,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "es6-templates": {
@@ -4764,7 +4818,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.39",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4780,14 +4834,15 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
-        "optionator": "0.8.2"
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -4804,7 +4859,7 @@
       "requires": {
         "es6-map": "0.1.5",
         "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
+        "esrecurse": "4.2.1",
         "estraverse": "4.2.0"
       }
     },
@@ -4814,12 +4869,11 @@
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -4843,7 +4897,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.39"
       }
     },
     "eventemitter3": {
@@ -4909,9 +4963,9 @@
         "define-property": "0.2.5",
         "extend-shallow": "2.0.1",
         "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.0",
+        "regex-not": "1.0.2",
         "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -4920,6 +4974,14 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -5058,7 +5120,7 @@
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "2.0.3",
         "qs": "6.5.1",
         "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
@@ -5066,7 +5128,7 @@
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
       }
@@ -5077,11 +5139,22 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "is-extendable": "0.1.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
       }
     },
     "external-editor": {
@@ -5104,9 +5177,27 @@
         "expand-brackets": "2.1.4",
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
-        "regex-not": "1.0.0",
+        "regex-not": "1.0.2",
         "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "extsprintf": {
@@ -5115,9 +5206,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -5220,6 +5311,16 @@
         "is-number": "3.0.0",
         "repeat-string": "1.6.1",
         "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "finalhandler": {
@@ -5242,7 +5343,7 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.1.0",
+        "make-dir": "1.2.0",
         "pkg-dir": "2.0.0"
       }
     },
@@ -5334,13 +5435,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
       }
     },
     "forwarded": {
@@ -5556,7 +5657,7 @@
           "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
           "requires": {
             "debug": "2.6.9",
-            "stream-consume": "0.1.0"
+            "stream-consume": "0.1.1"
           }
         }
       }
@@ -5595,14 +5696,14 @@
         "fbjs": "0.8.16",
         "inline-style-prefixer": "3.0.8",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "through": "2.3.8"
       }
     },
     "glamorous": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.11.4.tgz",
-      "integrity": "sha512-H7e28mVL8IUGMD3yL6W3A/wtdZ7gM69xV6VMRe3ciI+5SgZxENiKDW49Tv14IhKeFVlUrBmhyAgzzUMMw4H0Cw==",
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.11.6.tgz",
+      "integrity": "sha512-fR9jTVipC3Vb4Jps4aQFjxEuGPexo/J74ZUZIA8ZpgENljGUL+9SdKk0Ut1iZc23tLLtbi6wRmAqQG3thwzjAw==",
       "requires": {
         "brcast": "3.0.1",
         "fast-memoize": "2.3.0",
@@ -5865,7 +5966,7 @@
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "sntp": "2.1.0"
       }
     },
@@ -5890,9 +5991,9 @@
       }
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
@@ -5971,13 +6072,13 @@
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.10"
+        "uglify-js": "3.3.12"
       },
       "dependencies": {
         "uglify-js": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.10.tgz",
-          "integrity": "sha512-dNib7aUDNZFJNTXFyq0CDmLRVOsnY1F+IQgt2FAOdZFx2+LvKVLbbIb/fL+BYKCv3YH3bPCE/6M/JaxChtQLHQ==",
+          "version": "3.3.12",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.12.tgz",
+          "integrity": "sha512-4jxrTXlV0HaXTsNILfXW0eey7Qo8qHYM6ih5ZNh45erDWU2GHmKDmekwBTskDb12h+kdd2DBvdzqVb47YzNmTA==",
           "requires": {
             "commander": "2.14.1",
             "source-map": "0.6.1"
@@ -6241,7 +6342,7 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "requires": {
-        "postcss": "6.0.17"
+        "postcss": "6.0.19"
       }
     },
     "ieee754": {
@@ -6255,11 +6356,11 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "immutability-helper": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.6.4.tgz",
-      "integrity": "sha512-jhFwZoBOOzfxKXGO86G0zrD0dHEUgAfFhDMOBRizonX2nUtWAG8vepjTVJkmJDoKV6XtPlm/21gNXcToBe0D/A==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.6.5.tgz",
+      "integrity": "sha512-nRj5RN2em1O3NK25Zz0eBszg+kQ3mR5WgZp3wRajbyeu/Ii/eXhpwjB8JG4Hd78JUnuFVXSchWF5EZBI6F+vEA==",
       "requires": {
-        "invariant": "2.2.2"
+        "invariant": "2.2.3"
       }
     },
     "immutable": {
@@ -6385,9 +6486,9 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -6403,9 +6504,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
     "is-absolute-url": {
       "version": "2.1.0",
@@ -6546,13 +6647,19 @@
         "is-extglob": "1.0.0"
       }
     },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+    },
     "is-my-json-valid": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
         "jsonpointer": "4.0.1",
         "xtend": "4.0.1"
       }
@@ -6586,11 +6693,18 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-odd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
-      "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        }
       }
     },
     "is-path-cwd": {
@@ -6693,6 +6807,11 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
@@ -6733,27 +6852,27 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
-      "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.2.tgz",
+      "integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
       "requires": {
         "async": "2.6.0",
         "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
+        "istanbul-lib-instrument": "1.9.2",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.1.4",
         "js-yaml": "3.7.0",
         "mkdirp": "0.5.1",
         "once": "1.4.0"
       }
     },
     "istanbul-lib-coverage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
+      "integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w=="
     },
     "istanbul-lib-hook": {
       "version": "1.1.0",
@@ -6764,25 +6883,25 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
-      "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
+      "integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
       "requires": {
         "babel-generator": "6.26.1",
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-      "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+      "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
       "requires": {
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "mkdirp": "0.5.1",
         "path-parse": "1.0.5",
         "supports-color": "3.2.3"
@@ -6804,12 +6923,12 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
-      "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+      "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
       "requires": {
         "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2",
         "source-map": "0.5.7"
@@ -6831,9 +6950,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
-      "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
+      "integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
       "requires": {
         "handlebars": "4.0.11"
       }
@@ -6910,10 +7029,10 @@
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
             "is-ci": "1.1.0",
-            "istanbul-api": "1.2.1",
-            "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-instrument": "1.9.1",
-            "istanbul-lib-source-maps": "1.2.2",
+            "istanbul-api": "1.2.2",
+            "istanbul-lib-coverage": "1.1.2",
+            "istanbul-lib-instrument": "1.9.2",
+            "istanbul-lib-source-maps": "1.2.3",
             "jest-changed-files": "21.2.0",
             "jest-config": "21.2.1",
             "jest-environment-jsdom": "21.2.1",
@@ -6932,7 +7051,7 @@
             "string-length": "2.0.0",
             "strip-ansi": "4.0.0",
             "which": "1.3.0",
-            "worker-farm": "1.5.2",
+            "worker-farm": "1.5.4",
             "yargs": "9.0.1"
           }
         },
@@ -7070,7 +7189,7 @@
         "jest-docblock": "21.2.0",
         "micromatch": "2.3.11",
         "sane": "2.4.1",
-        "worker-farm": "1.5.2"
+        "worker-farm": "1.5.4"
       },
       "dependencies": {
         "arr-diff": {
@@ -7288,7 +7407,7 @@
         "jest-util": "21.2.1",
         "pify": "3.0.0",
         "throat": "4.1.0",
-        "worker-farm": "1.5.2"
+        "worker-farm": "1.5.4"
       }
     },
     "jest-runtime": {
@@ -7452,7 +7571,7 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
       "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
       "requires": {
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "isemail": "2.2.1",
         "items": "2.1.1",
         "moment": "2.20.1",
@@ -7474,7 +7593,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
-        "argparse": "1.0.9",
+        "argparse": "1.0.10",
         "esprima": "2.7.3"
       }
     },
@@ -7490,14 +7609,14 @@
         "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
-        "escodegen": "1.9.0",
+        "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
         "nwmatcher": "1.4.3",
         "parse5": "1.5.1",
         "request": "2.83.0",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
         "whatwg-url": "4.8.0",
@@ -7877,17 +7996,17 @@
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
     },
     "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "requires": {
         "pify": "3.0.0"
       }
     },
     "make-error": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.3.tgz",
-      "integrity": "sha512-j3dZCri3cCd23wgPqK/0/KvTN8R+W6fXDqQe8BNLbTpONjbA8SPaRr+q0BQq9bx3Q/+g68/gDIh9FW3by702Tg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -7921,13 +8040,13 @@
       "integrity": "sha512-v/ej7DflZbb6t//3Yu9vg0T+sun+Q9EoqggifeyABKfvFROqPwwwpv+hd1NKT2QxTRg6VCFk10IIJcMI13yCoQ==",
       "requires": {
         "loader-utils": "1.1.0",
-        "marked": "0.3.12"
+        "marked": "0.3.17"
       }
     },
     "marked": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
+      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ=="
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -7972,7 +8091,7 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
-        "errno": "0.1.6",
+        "errno": "0.1.7",
         "readable-stream": "2.3.4"
       }
     },
@@ -8087,23 +8206,23 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
-      "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+      "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
-        "braces": "2.3.0",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
+        "braces": "2.3.1",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
         "extglob": "2.0.4",
         "fragment-cache": "0.2.1",
         "kind-of": "6.0.2",
-        "nanomatch": "1.2.7",
+        "nanomatch": "1.2.9",
         "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
+        "regex-not": "1.0.2",
         "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
+        "to-regex": "3.0.2"
       }
     },
     "miller-rabin": {
@@ -8121,16 +8240,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -8170,9 +8289,9 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mississippi": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
-      "integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+      "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
       "requires": {
         "concat-stream": "1.6.0",
         "duplexify": "3.5.3",
@@ -8180,7 +8299,7 @@
         "flush-write-stream": "1.0.2",
         "from2": "2.3.0",
         "parallel-transform": "1.1.0",
-        "pump": "1.0.3",
+        "pump": "2.0.1",
         "pumpify": "1.4.0",
         "stream-each": "1.2.2",
         "through2": "2.0.3"
@@ -8350,33 +8469,27 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw=="
     },
     "nanomatch": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
-      "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
         "fragment-cache": "0.2.1",
-        "is-odd": "1.0.0",
-        "kind-of": "5.1.0",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
         "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
+        "regex-not": "1.0.2",
         "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
+        "to-regex": "3.0.2"
       }
     },
     "natural-compare": {
@@ -8408,6 +8521,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "neo-async": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.0.tgz",
+      "integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g=="
+    },
     "netrc": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
@@ -8427,9 +8545,9 @@
       }
     },
     "nise": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.5.tgz",
-      "integrity": "sha512-Es4hGuq3lpip5PckrB+Qpuma282M0UJANJ+jxAgI+0wWTL9X6MtNv+M385JgqsAE8hv6NvD3lv8CQtXgEnvlpQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.7.tgz",
+      "integrity": "sha512-8LqP1pFLB1v5QU8KlT2WqWzhMRJ3o9LwnZHz+VCbVB8rTsRTFCjtOYv/BatcmLOWp21NedTrErVGinfxe6XYtA==",
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
@@ -8495,7 +8613,7 @@
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "npmlog": "4.1.2",
-        "osenv": "0.1.4",
+        "osenv": "0.1.5",
         "request": "2.83.0",
         "rimraf": "2.6.2",
         "semver": "5.3.0",
@@ -8573,7 +8691,7 @@
         "lodash.mergewith": "4.6.1",
         "meow": "3.7.0",
         "mkdirp": "0.5.1",
-        "nan": "2.8.0",
+        "nan": "2.9.2",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
         "request": "2.79.0",
@@ -8645,8 +8763,8 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "har-validator": {
@@ -8656,7 +8774,7 @@
           "requires": {
             "chalk": "1.1.3",
             "commander": "2.14.1",
-            "is-my-json-valid": "2.17.1",
+            "is-my-json-valid": "2.17.2",
             "pinkie-promise": "2.0.1"
           }
         },
@@ -8699,7 +8817,7 @@
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
             "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
             "form-data": "2.1.4",
@@ -8709,11 +8827,11 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
+            "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "tunnel-agent": "0.4.3",
             "uuid": "3.2.1"
           }
@@ -8770,7 +8888,7 @@
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -9003,16 +9121,16 @@
       "integrity": "sha1-z1dU/7D63H0ewKVoxnNxxw8ranE="
     },
     "office-ui-fabric-react": {
-      "version": "5.49.2",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.49.2.tgz",
-      "integrity": "sha512-A9M0viSXkJu4VRcoRrpWEN81Bz9p2QSjEEM1L9HhZLla0qnGcajOsePvMHuJIiCsf53zfpCHE/LAOvl32GqAVw==",
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.56.0.tgz",
+      "integrity": "sha512-sTVFSjqeUDQVGSekeTdSfyn/2BZNGqK0TfHDnpNnsYgrimKv7JsXoiln/yGus+rPkSGONhD5eNZVU02uOBygMw==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.29",
+        "@microsoft/load-themed-styles": "1.7.35",
         "@uifabric/icons": "5.4.2",
-        "@uifabric/merge-styles": "5.11.2",
-        "@uifabric/styling": "5.17.0",
-        "@uifabric/utilities": "5.10.2",
-        "prop-types": "15.6.0",
+        "@uifabric/merge-styles": "5.12.2",
+        "@uifabric/styling": "5.19.0",
+        "@uifabric/utilities": "5.13.0",
+        "prop-types": "15.6.1",
         "tslib": "1.9.0"
       }
     },
@@ -9180,9 +9298,9 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -9252,7 +9370,7 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
-        "asn1.js": "4.9.2",
+        "asn1.js": "4.10.1",
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
@@ -9391,15 +9509,6 @@
         "find-up": "2.1.0"
       }
     },
-    "podda": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/podda/-/podda-1.2.2.tgz",
-      "integrity": "sha1-FbDtvTNK3hRYEzQ/Xs+cEKcc9QA=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "immutable": "3.8.2"
-      }
-    },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
@@ -9423,9 +9532,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "6.0.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-      "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+      "version": "6.0.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+      "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
       "requires": {
         "chalk": "2.3.1",
         "source-map": "0.6.1",
@@ -10011,7 +10120,7 @@
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.3.0.tgz",
       "integrity": "sha512-15JauG6a2hu2XZHdB9BaOwCLrI9oyK2UB8kt1ToTGdP1Pd3BQ/TJI9tNiTALntll25/66xMLUIyUPA9w/3BLtg==",
       "requires": {
-        "postcss": "6.0.17"
+        "postcss": "6.0.19"
       }
     },
     "postcss-load-config": {
@@ -10044,14 +10153,14 @@
       }
     },
     "postcss-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.0.tgz",
-      "integrity": "sha512-S/dKzpDwGFmP9g8eyCu9sUIV+/+3UooeTpYlsKf23qKDdrhHuA4pTSfytVu0rEJ0iDqUavXrgtOPq5KhNyNMOw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.1.tgz",
+      "integrity": "sha512-f0J/DWE/hyO9/LH0WHpXkny/ZZ238sSaG3p1SRBtVZnFWUtD7GXIEgHoBg8cnAeRbmEvUxHQptY46zWfwNYj/w==",
       "requires": {
         "loader-utils": "1.1.0",
-        "postcss": "6.0.17",
+        "postcss": "6.0.19",
         "postcss-load-config": "1.2.0",
-        "schema-utils": "0.4.3"
+        "schema-utils": "0.4.5"
       }
     },
     "postcss-merge-idents": {
@@ -10204,8 +10313,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000808",
-            "electron-to-chromium": "1.3.33"
+            "caniuse-db": "1.0.30000810",
+            "electron-to-chromium": "1.3.34"
           }
         },
         "chalk": {
@@ -10531,7 +10640,7 @@
       "requires": {
         "css-modules-loader-core": "1.1.0",
         "generic-names": "1.0.3",
-        "postcss": "6.0.17",
+        "postcss": "6.0.19",
         "string-hash": "1.1.3"
       }
     },
@@ -10540,7 +10649,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
       "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
       "requires": {
-        "postcss": "6.0.17"
+        "postcss": "6.0.19"
       }
     },
     "postcss-modules-local-by-default": {
@@ -10549,7 +10658,7 @@
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.19"
       }
     },
     "postcss-modules-scope": {
@@ -10558,7 +10667,7 @@
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.19"
       }
     },
     "postcss-modules-values": {
@@ -10567,7 +10676,7 @@
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.19"
       }
     },
     "postcss-normalize-charset": {
@@ -11278,9 +11387,9 @@
       }
     },
     "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -11288,12 +11397,12 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.5.2"
+        "ipaddr.js": "1.6.0"
       }
     },
     "prr": {
@@ -11319,9 +11428,9 @@
       }
     },
     "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
         "end-of-stream": "1.4.1",
         "once": "1.4.0"
@@ -11335,17 +11444,6 @@
         "duplexify": "3.5.3",
         "inherits": "2.0.3",
         "pump": "2.0.1"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
-          }
-        }
       }
     },
     "punycode": {
@@ -11395,7 +11493,7 @@
         "array-find": "1.0.0",
         "exenv": "1.2.2",
         "inline-style-prefixer": "2.0.5",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       },
       "dependencies": {
         "inline-style-prefixer": {
@@ -11459,9 +11557,9 @@
       }
     },
     "randomfill": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
-      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
         "randombytes": "2.0.6",
         "safe-buffer": "5.1.1"
@@ -11496,13 +11594,13 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-docgen": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.20.0.tgz",
-      "integrity": "sha512-+fW1dthCr/cqrAreHTMk2Luzdb3I7xJishC/g4k+vIWiPj4/jM6Ij67WvUjXqio0/TRh7AQtRDYRwqNyinN0LA==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.20.1.tgz",
+      "integrity": "sha512-NYmD8nDPMWpIpqWqhSZjQ3P5iQml55IMkDG0ZInyWP7JD2ljaNhrxNWZnXPrOezUu6bYlcZUCxjw19s7zhE2uw==",
       "requires": {
         "async": "2.6.0",
         "babel-runtime": "6.26.0",
@@ -11528,18 +11626,18 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-fuzzy": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.1.tgz",
-      "integrity": "sha512-m2QClpw+Z51m6oEpfznVr7CQ9zdUGQ7vvidv05+drt0c3UMkpOWqmB0fQhYJYP/5QNh7ojyMCgu99cxvFaya6Q==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.2.tgz",
+      "integrity": "sha512-qIZZxaCheb/HhcBi5fABbiCFg85+K5r1TCps1D4uaL0LAMMD/1zm/x1/kNR130Tx7nnY9V7mbFyY0DquPYeLAw==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "fuse.js": "3.2.0",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-highlight": {
@@ -11561,7 +11659,7 @@
             "fbjs": "0.8.16",
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           }
         },
         "react-dom": {
@@ -11572,7 +11670,7 @@
             "fbjs": "0.8.16",
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           }
         }
       }
@@ -11608,12 +11706,12 @@
       }
     },
     "react-modal": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.13.tgz",
-      "integrity": "sha512-YSNoLKd/zgfILPwx6Uio2f6JNX7UqPvWO7vGKXXpFcsDaj+z97FVxJo82dMsbca4SSitu0A9Q+Xq750CPQUAYA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.3.1.tgz",
+      "integrity": "sha512-d1A8xXIvW+YVKwRMrFY5qneuC5FSa4OnOE78hgqfz+MYLb1Ai/B3D3Dzx1Zrw4ZD5rS16SKiPe5rl4UZt+AjpQ==",
       "requires": {
         "exenv": "1.2.2",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "warning": "3.0.0"
       }
     },
@@ -11625,7 +11723,7 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-remarkable": {
@@ -11642,7 +11740,7 @@
       "integrity": "sha512-xq0PPsbkNI9xEd6yTrGPr7hzf6XfIgnsxuUEdRJELq+kLPHMsO3ymFCjhiYP35wlDPn9W46+rHDsJd7LFYteMw==",
       "requires": {
         "inline-style-prefixer": "3.0.8",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react-style-proptype": "3.2.0"
       }
     },
@@ -11651,7 +11749,7 @@
       "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.0.tgz",
       "integrity": "sha512-Mafmkzj3oNmLSJNOlH+WWWyGIdzVLhPj+d12fDxQMQdwDQ5sMX7vQKOLpry4U+zRWieTCx448AyRKK0NLWuXmg==",
       "requires": {
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-test-renderer": {
@@ -11661,7 +11759,7 @@
       "requires": {
         "fbjs": "0.8.16",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-transition-group": {
@@ -11672,7 +11770,7 @@
         "chain-function": "1.0.0",
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "warning": "3.0.0"
       }
     },
@@ -11683,7 +11781,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "deep-equal": "1.0.1",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "radium": "0.19.6",
         "shallowequal": "0.2.2",
         "velocity-react": "1.3.3"
@@ -11841,11 +11939,12 @@
       }
     },
     "regex-not": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
-      "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpu-core": {
@@ -11898,11 +11997,6 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-        },
-        "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
         }
       }
     },
@@ -12004,23 +12098,23 @@
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
+        "form-data": "2.3.2",
         "har-validator": "5.0.3",
         "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
         "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
       }
@@ -12178,6 +12272,14 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "0.1.15"
+      }
     },
     "samsam": {
       "version": "1.3.0",
@@ -12371,12 +12473,24 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.3.tgz",
-      "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1"
+        "ajv": "6.2.0",
+        "ajv-keywords": "3.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.0.tgz",
+          "integrity": "sha1-r6wpW7qgFSRJ5SJ0LkVHwa6TKNI=",
+          "requires": {
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "screener-runner": {
@@ -12463,7 +12577,7 @@
           "requires": {
             "accepts": "1.3.4",
             "bytes": "2.3.0",
-            "compressible": "2.0.12",
+            "compressible": "2.0.13",
             "debug": "2.2.0",
             "on-headers": "1.0.1",
             "vary": "1.1.2"
@@ -12491,8 +12605,8 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "har-validator": {
@@ -12502,7 +12616,7 @@
           "requires": {
             "chalk": "1.1.3",
             "commander": "2.9.0",
-            "is-my-json-valid": "2.17.1",
+            "is-my-json-valid": "2.17.2",
             "pinkie-promise": "2.0.1"
           }
         },
@@ -12560,7 +12674,7 @@
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
             "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
             "form-data": "2.1.4",
@@ -12570,12 +12684,12 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
+            "mime-types": "2.1.18",
             "node-uuid": "1.4.8",
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "tunnel-agent": "0.4.3"
           }
         },
@@ -12600,9 +12714,9 @@
       }
     },
     "screener-storybook": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/screener-storybook/-/screener-storybook-0.11.1.tgz",
-      "integrity": "sha1-hIk6qwuWyBI7tmjz9o5pm+vSwK0=",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/screener-storybook/-/screener-storybook-0.11.3.tgz",
+      "integrity": "sha1-21arkALnjhJOUsvPk7TlettPjLY=",
       "requires": {
         "bluebird": "3.4.7",
         "colors": "1.1.2",
@@ -12611,12 +12725,12 @@
         "joi": "10.0.6",
         "jsdom": "9.8.3",
         "lodash": "4.17.5",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react": "15.6.2",
         "react-dom": "15.4.2",
         "request": "2.81.0",
         "requestretry": "1.12.3",
-        "screener-runner": "0.8.1"
+        "screener-runner": "0.8.2"
       },
       "dependencies": {
         "acorn": {
@@ -12708,7 +12822,7 @@
           "requires": {
             "accepts": "1.3.4",
             "bytes": "2.3.0",
-            "compressible": "2.0.12",
+            "compressible": "2.0.13",
             "debug": "2.2.0",
             "on-headers": "1.0.1",
             "vary": "1.1.2"
@@ -12736,8 +12850,8 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "requires": {
             "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "har-schema": {
@@ -12787,7 +12901,7 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.0.6.tgz",
           "integrity": "sha1-26y78wtNu50o72cW2CxFgLsEwJY=",
           "requires": {
-            "hoek": "4.2.0",
+            "hoek": "4.2.1",
             "isemail": "2.2.1",
             "items": "2.1.1",
             "topo": "2.0.2"
@@ -12805,7 +12919,7 @@
             "content-type-parser": "1.0.2",
             "cssom": "0.3.2",
             "cssstyle": "0.2.37",
-            "escodegen": "1.9.0",
+            "escodegen": "1.9.1",
             "html-encoding-sniffer": "1.0.2",
             "iconv-lite": "0.4.19",
             "nwmatcher": "1.4.3",
@@ -12813,7 +12927,7 @@
             "request": "2.81.0",
             "sax": "1.2.4",
             "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "webidl-conversions": "3.0.1",
             "whatwg-encoding": "1.0.3",
             "whatwg-url": "3.1.0",
@@ -12865,7 +12979,7 @@
             "fbjs": "0.8.16",
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           }
         },
         "react-dom": {
@@ -12886,7 +13000,7 @@
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
             "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
+            "combined-stream": "1.0.6",
             "extend": "3.0.1",
             "forever-agent": "0.6.1",
             "form-data": "2.1.4",
@@ -12896,21 +13010,21 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
+            "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "performance-now": "0.2.0",
             "qs": "6.4.0",
             "safe-buffer": "5.1.1",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
             "uuid": "3.2.1"
           }
         },
         "screener-runner": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.8.1.tgz",
-          "integrity": "sha1-EGUqCcftTH88ABSKX4HglNv3CnU=",
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.8.2.tgz",
+          "integrity": "sha1-6s1x1kjguLZLTc6BA/E2uElTUFc=",
           "requires": {
             "bluebird": "3.4.7",
             "colors": "1.1.2",
@@ -12938,7 +13052,7 @@
               "requires": {
                 "chalk": "1.1.3",
                 "commander": "2.9.0",
-                "is-my-json-valid": "2.17.1",
+                "is-my-json-valid": "2.17.2",
                 "pinkie-promise": "2.0.1"
               }
             },
@@ -12947,7 +13061,7 @@
               "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
               "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
               "requires": {
-                "hoek": "4.2.0",
+                "hoek": "4.2.1",
                 "isemail": "2.2.1",
                 "items": "2.1.1",
                 "moment": "2.20.1",
@@ -12972,7 +13086,7 @@
                 "aws-sign2": "0.6.0",
                 "aws4": "1.6.0",
                 "caseless": "0.11.0",
-                "combined-stream": "1.0.5",
+                "combined-stream": "1.0.6",
                 "extend": "3.0.1",
                 "forever-agent": "0.6.1",
                 "form-data": "2.1.4",
@@ -12982,12 +13096,12 @@
                 "is-typedarray": "1.0.0",
                 "isstream": "0.1.2",
                 "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
+                "mime-types": "2.1.18",
                 "node-uuid": "1.4.8",
                 "oauth-sign": "0.8.2",
                 "qs": "6.3.2",
                 "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
+                "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.4.3"
               }
             },
@@ -13125,7 +13239,7 @@
         "debug": "2.6.9",
         "escape-html": "1.0.3",
         "http-errors": "1.6.2",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "parseurl": "1.3.2"
       }
     },
@@ -13167,6 +13281,16 @@
         "is-extendable": "0.1.1",
         "is-plain-object": "2.0.4",
         "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
       }
     },
     "setimmediate": {
@@ -13267,15 +13391,15 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.3.0.tgz",
-      "integrity": "sha512-pmf05hFgEZUS52AGJcsVjOjqAyJW2yo14cOwVYvzCyw7+inv06YXkLyW75WG6X6p951lzkoKh51L2sNbR9CDvw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
+      "integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.4.0",
         "lodash.get": "4.4.2",
         "lolex": "2.3.2",
-        "nise": "1.2.5",
+        "nise": "1.2.7",
         "supports-color": "5.2.0",
         "type-detect": "4.0.8"
       }
@@ -13306,6 +13430,14 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -13374,6 +13506,16 @@
         "define-property": "1.0.0",
         "isobject": "3.0.1",
         "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        }
       }
     },
     "snapdragon-util": {
@@ -13399,7 +13541,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "sockjs": {
@@ -13488,18 +13630,11 @@
       }
     },
     "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+      "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
       "requires": {
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
+        "source-map": "0.6.1"
       }
     },
     "source-map-url": {
@@ -13508,22 +13643,32 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+    },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
     },
     "spdy": {
       "version": "3.4.7",
@@ -13558,25 +13703,6 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
         "extend-shallow": "3.0.2"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
-          }
-        },
-        "is-extendable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
-        }
       }
     },
     "sprintf-js": {
@@ -13596,9 +13722,9 @@
       }
     },
     "ssri": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.1.tgz",
-      "integrity": "sha512-y4PjOWlAuxt+yAcXitQYOnOzZpKaH3+f/qGV3OWxbyC2noC9FA9GNC9uILnVdV7jruA1aDKr4OKz3ZDBcVZwFQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+      "integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -13696,7 +13822,7 @@
       "resolved": "https://registry.npmjs.org/storybook-readme/-/storybook-readme-3.0.6.tgz",
       "integrity": "sha1-R1oUpbOdx6hcQjQxJTor8fWxx4Y=",
       "requires": {
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react-remarkable": "1.1.3",
         "string-raw": "1.0.1"
       }
@@ -13711,9 +13837,9 @@
       }
     },
     "stream-consume": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-      "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
+      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
     },
     "stream-each": {
       "version": "1.2.2",
@@ -13950,9 +14076,9 @@
       }
     },
     "test-exclude": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-      "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.0.tgz",
+      "integrity": "sha512-8hMFzjxbPv6xSlwGhXSvOMJ/vTy3bkng+2pxmf6E1z6VF7I9nIyNfvHtaw+NBPgvz647gADBbMSbwLfZYppT/w==",
       "requires": {
         "arrify": "1.0.1",
         "micromatch": "2.3.11",
@@ -14204,74 +14330,14 @@
       }
     },
     "to-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
-      "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -14288,7 +14354,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "toposort": {
@@ -14315,9 +14381,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -14419,14 +14485,6 @@
             "graceful-fs": "4.1.11"
           }
         },
-        "source-map-support": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
-          "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
-          "requires": {
-            "source-map": "0.6.1"
-          }
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -14485,29 +14543,29 @@
         "resolve": "1.5.0",
         "semver": "5.5.0",
         "tslib": "1.9.0",
-        "tsutils": "2.21.1"
+        "tsutils": "2.21.2"
       }
     },
     "tslint-microsoft-contrib": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.2.tgz",
-      "integrity": "sha1-7MKnl/d3oS8AZpRM7AyBqefFnuk=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.3.tgz",
+      "integrity": "sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==",
       "requires": {
-        "tsutils": "2.21.1"
+        "tsutils": "2.21.2"
       }
     },
     "tslint-react": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.5.0.tgz",
-      "integrity": "sha512-/530IQLogPjCMC1oVnn7pxw2g9gVN84SEgRF5BV9/BTc6mRXi0qoDfXvQsqejqvBBTxw39ntA1V1STP+xXwsnw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.5.1.tgz",
+      "integrity": "sha512-ndS/iOOGrasATcf5YU3JxoIwPGVykjrKhzmlVsRdT1xzl/RbNg9n627rtAGbCjkQepyiaQYgxWQT5G/qUpQCaA==",
       "requires": {
-        "tsutils": "2.21.1"
+        "tsutils": "2.21.2"
       }
     },
     "tsutils": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.21.1.tgz",
-      "integrity": "sha512-heMkdeQ9iUc90ynfiNo5Y+GXrEEGy86KMvnSTfHO+Q40AuNQ1lZGXcv58fuU9XTUxI0V7YIN9xPN+CO9b1Gn3w==",
+      "version": "2.21.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.21.2.tgz",
+      "integrity": "sha512-iaIuyjIUeFLdD39MYdzqBuY7Zv6+uGxSwRH4mf+HuzsnznjFz0R2tGrAe0/JvtNh91WrN8UN/DZRFTZNDuVekA==",
       "requires": {
         "tslib": "1.9.0"
       }
@@ -14539,12 +14597,12 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
       }
     },
     "typedarray": {
@@ -14553,9 +14611,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
     },
     "typical": {
       "version": "2.6.1",
@@ -14631,20 +14689,15 @@
         }
       }
     },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-    },
     "underscore": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "underscore.string": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
     },
     "union-value": {
       "version": "1.0.0",
@@ -14657,6 +14710,14 @@
         "set-value": "0.4.3"
       },
       "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
         "set-value": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
@@ -14759,20 +14820,9 @@
       }
     },
     "upath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.0.tgz",
-      "integrity": "sha1-tHBrlGHKhHOt+JEz0jVonKF/NlY=",
-      "requires": {
-        "lodash": "3.10.1",
-        "underscore.string": "2.3.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+      "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
     },
     "upper-case": {
       "version": "1.1.3",
@@ -14943,12 +14993,12 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validator": {
@@ -14972,7 +15022,7 @@
       "integrity": "sha1-1tRyds/Ivip1Yjh5sgFArFjBuCs=",
       "requires": {
         "lodash": "3.10.1",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react-transition-group": "1.2.1",
         "velocity-animate": "1.5.1"
       },
@@ -15040,13 +15090,74 @@
       }
     },
     "watchpack": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
-      "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
+      "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
       "requires": {
-        "async": "2.6.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
+        "chokidar": "2.0.2",
+        "graceful-fs": "4.1.11",
+        "neo-async": "2.5.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "requires": {
+            "micromatch": "3.1.9",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+          "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+          "requires": {
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.1",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.0.4"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
       }
     },
     "wbuf": {
@@ -15067,9 +15178,9 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
       "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "requires": {
-        "acorn": "5.4.1",
+        "acorn": "5.5.0",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.1.1",
+        "ajv": "6.2.0",
         "ajv-keywords": "3.1.0",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
@@ -15086,30 +15197,25 @@
         "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.4.0",
+        "watchpack": "1.5.0",
         "webpack-sources": "1.1.0",
         "yargs": "8.0.2"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-          "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
+          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
         },
         "ajv": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
-          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.0.tgz",
+          "integrity": "sha1-r6wpW7qgFSRJ5SJ0LkVHwa6TKNI=",
           "requires": {
-            "fast-deep-equal": "1.0.0",
+            "fast-deep-equal": "1.1.0",
             "fast-json-stable-stringify": "2.0.0",
             "json-schema-traverse": "0.3.1"
           }
-        },
-        "ajv-keywords": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74="
         },
         "enhanced-resolve": {
           "version": "3.4.1",
@@ -15163,11 +15269,11 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.10.0.tgz",
-      "integrity": "sha512-eA/9F/ZLFlVXfCLYqefHFbelJ3JcvyeFdmpAG6Vu3iJNcisj3KWNPqu00lCqK9caeaesipVrGb9alUSi2lEvAg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.11.0.tgz",
+      "integrity": "sha512-GGz//de6DHqKIBN75vRPUqwTUobgYCzygS+ei/Z5wRpKYEZ+HO2e8Pd6CbQewGfofjRHoCFqL10pi2lu+/fqDg==",
       "requires": {
-        "acorn": "5.4.1",
+        "acorn": "5.5.0",
         "bfj-node4": "5.2.1",
         "chalk": "2.3.1",
         "commander": "2.14.1",
@@ -15178,13 +15284,13 @@
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "opener": "1.4.3",
-        "ws": "4.0.0"
+        "ws": "4.1.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-          "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
+          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g=="
         },
         "gzip-size": {
           "version": "4.1.0",
@@ -15215,15 +15321,15 @@
       }
     },
     "webpack-dev-server": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.1.tgz",
-      "integrity": "sha512-ombhu5KsO/85sVshIDTyQ5HF3xjZR3N0sf5Ao6h3vFwpNyzInEzA1GV3QPVjTMLTNckp8PjfG1PFGznzBwS5lg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+      "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
       "requires": {
         "ansi-html": "0.0.7",
         "array-includes": "3.0.3",
         "bonjour": "3.5.0",
-        "chokidar": "2.0.1",
-        "compression": "1.7.1",
+        "chokidar": "2.0.2",
+        "compression": "1.7.2",
         "connect-history-api-fallback": "1.5.0",
         "debug": "3.1.0",
         "del": "3.0.0",
@@ -15253,18 +15359,18 @@
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "requires": {
-            "micromatch": "3.1.5",
+            "micromatch": "3.1.9",
             "normalize-path": "2.1.1"
           }
         },
         "chokidar": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.1.tgz",
-          "integrity": "sha512-rv5iP8ENhpqvDWr677rAXcB+SMoPQ1urd4ch79+PhM4lQwbATdJUQK69t0lJIKNB+VXpqxt5V1gvqs59XEPKnw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
+          "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
           "requires": {
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
-            "braces": "2.3.0",
+            "braces": "2.3.1",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -15272,7 +15378,7 @@
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.0"
+            "upath": "1.0.4"
           }
         },
         "debug": {
@@ -15326,9 +15432,9 @@
       }
     },
     "webpack-hot-middleware": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.21.0.tgz",
-      "integrity": "sha512-P6xiOLy10QlSVSO7GanU9PLxN6zLLQ7RG16MPTvmFwf2KUG7jMp6m+fmdgsR7xoaVVLA7OlX3YO6JjoZEKjCuA==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.21.1.tgz",
+      "integrity": "sha512-HaxZpATbq/bpuduum2i79pgE1vpSFfV2BVUyYi4lhocTJ5xpofWuYCCmd0c6eoJjY8szCuM5TsQk3M59Z9jpwA==",
       "requires": {
         "ansi-html": "0.0.7",
         "html-entities": "1.2.1",
@@ -15460,11 +15566,11 @@
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "worker-farm": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
-      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.4.tgz",
+      "integrity": "sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==",
       "requires": {
-        "errno": "0.1.6",
+        "errno": "0.1.7",
         "xtend": "4.0.1"
       }
     },
@@ -15550,13 +15656,12 @@
       }
     },
     "ws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
-      "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "requires": {
         "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "xdg-basedir": {

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -28,7 +28,7 @@ export interface IComponentPageProps {
   areBadgesVisible?: boolean;
   className?: string;
   componentStatus?: JSX.Element;
-  otherSections?: [IComponentPageSection];
+  otherSections?: IComponentPageSection[];
 }
 
 export class ComponentPage extends React.Component<IComponentPageProps, {}> {

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -50,16 +50,16 @@ let _stylesheet: Stylesheet;
  * @public
  */
 export class Stylesheet {
-  private _styleElement: HTMLStyleElement;
-  private _rules: string[];
+  private _styleElement!: HTMLStyleElement;
+  private _rules!: string[];
   private _config: IStyleSheetConfig;
-  private _rulesToInsert: string[];
-  private _timerId: number;
-  private _counter: number;
-  private _keyToClassName: { [key: string]: string };
+  private _rulesToInsert!: string[];
+  private _timerId!: number;
+  private _counter!: number;
+  private _keyToClassName!: { [key: string]: string };
 
   // tslint:disable-next-line:no-any
-  private _classNameToArgs: { [key: string]: { args: any, rules: string[] } };
+  private _classNameToArgs!: { [key: string]: { args: any, rules: string[] } };
 
   /**
    * Gets the singleton instance.

--- a/packages/merge-styles/src/concatStyleSets.ts
+++ b/packages/merge-styles/src/concatStyleSets.ts
@@ -6,7 +6,7 @@ export function concatStyleSets<T extends object>(
   ...args: (T | false | null | undefined)[]
 ): T {
   // tslint:disable-next-line:no-any
-  const mergedSet: T = {} as any;
+  const mergedSet = {} as any;
 
   for (const currentSet of args) {
     if (currentSet) {
@@ -28,5 +28,5 @@ export function concatStyleSets<T extends object>(
     }
   }
 
-  return mergedSet;
+  return mergedSet as T;
 }

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -18,8 +18,9 @@ describe('mergeStyleSets', () => {
   });
 
   it('can merge style sets', () => {
+    const empty: { c?: string } = {};
     const result: { root: string, a: string, b: string } = mergeStyleSets(
-      {},
+      empty,
       {
         root: { background: 'red' },
         a: { background: 'green' }

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -9,9 +9,9 @@ import { styleToRegistration, applyRegistration } from './styleToClassName';
  *
  * @public
  */
-export function mergeStyleSets<T>(
-  ...cssSets: ({[P in keyof T]?: IStyle } | null | undefined)[]
-): T {
+export function mergeStyleSets<K extends string>(
+  ...cssSets: ({[P in K]?: IStyle } | null | undefined)[]
+): {[P in K]: string} {
   // tslint:disable-next-line:no-any
   const classNameSet: any = {};
   const classMap: { [key: string]: string } = {};
@@ -49,5 +49,5 @@ export function mergeStyleSets<T>(
     }
   }
 
-  return classNameSet as T;
+  return classNameSet;
 }

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
@@ -17,8 +17,8 @@ export interface IPositioningContainerNames {
   container: string;
   main: string;
   overFlowYHidden: string;
-  beak: string;
-  beakCurtain: string;
+  beak?: string;
+  beakCurtain?: string;
 }
 
 // @TODO Remove this tslint disable statement after the styles are converted

--- a/packages/office-ui-fabric-react/src/demo/ComponentStatus/ComponentStatusPage.tsx
+++ b/packages/office-ui-fabric-react/src/demo/ComponentStatus/ComponentStatusPage.tsx
@@ -8,7 +8,7 @@ import './ComponentStatusPage.scss';
 
 export class ComponentStatusPage extends React.Component<{}, {}> {
   public render() {
-    const sections: [IComponentPageSection] = [{ title: 'Badges', section: this._renderStatusesInfo() }, { title: 'Status', section: this._renderComponents() }];
+    const sections: IComponentPageSection[] = [{ title: 'Badges', section: this._renderStatusesInfo() }, { title: 'Status', section: this._renderComponents() }];
 
     return (
       <ComponentPage
@@ -48,7 +48,7 @@ export class ComponentStatusPage extends React.Component<{}, {}> {
       <tr key={ componentName + '-key' }>
         <th className='componentCells'><h3>{ componentName } </h3> </th>
         <td className='componentBadgeCell'><ComponentStatus
-          {...component}
+          { ...component }
         /></td>
       </tr >
     );

--- a/packages/office-ui-fabric-react/src/demo/ComponentStatus/ComponentStatusState.tsx
+++ b/packages/office-ui-fabric-react/src/demo/ComponentStatus/ComponentStatusState.tsx
@@ -10,7 +10,7 @@ export interface InformationLink {
   renderedText: string;
 }
 
-export const ComponentStatusInfoState: [IComponentStatusInfoState] = [
+export const ComponentStatusInfoState: IComponentStatusInfoState[] = [
   {
     name: 'Keyboard Accessibility Support',
     description: 'Components should be fully usable with the keyboard.',

--- a/packages/utilities/src/classNamesFunction.ts
+++ b/packages/utilities/src/classNamesFunction.ts
@@ -1,4 +1,4 @@
-import { mergeStyleSets } from '@uifabric/merge-styles/lib/index';
+import { mergeStyleSets, IStyle } from '@uifabric/merge-styles/lib/index';
 import { IClassNames } from './IClassNames';
 import { IStyleFunction } from './IStyleFunction';
 
@@ -6,7 +6,7 @@ import { IStyleFunction } from './IStyleFunction';
  * Creates a getClassNames function which calls getStyles given the props, and injects them
  * into mergeStyleSets.
  */
-export function classNamesFunction<TStyleProps extends {}, TStyles extends {}>(): (
+export function classNamesFunction<TStyleProps extends {}, TStyles extends {[P in keyof TStyles]: IStyle}>(): (
   getStyles?: IStyleFunction<TStyleProps, TStyles>,
   styleProps?: TStyleProps
 ) => IClassNames<TStyles> {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -38,7 +38,7 @@
     "style-loader": "^0.19.0",
     "tslint": "^5.7.0",
     "tslint-microsoft-contrib": "^5.0.1",
-    "typescript": "2.6.2",
+    "typescript": "2.7.2",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "webpack": "^3.7.1",
     "webpack-bundle-analyzer": "^2.9.0",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Upgrades Fabric to TypeScript 2.7.2. The biggest change here is that we had to update the typings for mergeStyleSets. Tested that it is backwards compat with 2.6.2 against the office-online codebase. Though the new typings for mergeStyleSets are more correct than the old ones, so it may cause build breaks for consumers in the event that you aren't passing in all the required parameters for an interface into mergeStyleSets

An example that used to work, but now correctly compiles into an error is the following:
```typescript
interface ITestClassNames {
 a: string;
 b: string;
}

const result: ITestClassNames = mergeStyleSets({ a: {backgroundColor: 'red'});
```
