### PR TITLE
Addressing Issue #4143 - is-selected missing on ms-Nav-link

### DIFF
--- a/common/changes/office-ui-fabric-react/nav-isselected-4143_2018-03-01-23-30.json
+++ b/common/changes/office-ui-fabric-react/nav-isselected-4143_2018-03-01-23-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added is-selected and is-expanded semantic classes to compositelink style sets",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
@@ -75,7 +75,9 @@ export const getStyles = (
         position: 'relative',
         color: semanticColors.bodyText,
         backgroundColor: semanticColors.bodyBackground,
-      }
+      },
+      isExpanded && 'is-expanded',
+      isSelected && 'is-selected'
     ],
     link: [
       'ms-Nav-link',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4143
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added `.is-selected` and `.is-expanded` semantic classes to compositeLink style sets.  This was originally part of the Nav component, but was missed in the conversion to MergeStyles sets.

I'll note the request was to add `.is-selected` to `.ms-Nav-link`, but I actually added it to the outer `.ms-Nav-compositeLink` so you can target both or either with styles when selected or expanded which was the original functionality - `.is-selected .ms-Nav-link` will now work.
