### PR TITLE
Addressing Issue #4147 - Nav Buttons have invalid `aria-describedby` value

### DIFF
--- a/common/changes/office-ui-fabric-react/nav-ariadescribedby-4147_2018-03-02-00-43.json
+++ b/common/changes/office-ui-fabric-react/nav-ariadescribedby-4147_2018-03-02-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed aria-describedby bug causing it not to render properly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -159,7 +159,7 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
         styles={ buttonStyles }
         href={ link.url || (link.forceAnchor ? 'javascript:' : undefined) }
         iconProps={ link.iconProps || { iconName: link.icon || '' } }
-        description={ link.title || link.name }
+        ariaDescription={ link.title || link.name }
         onClick={ link.onClick ? this._onNavButtonLinkClicked.bind(this, link) : this._onNavAnchorLinkClicked.bind(this, link) }
         title={ link.title || link.name }
         target={ link.target }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4147 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

![nav-ariadescribedby](https://user-images.githubusercontent.com/3977969/36877727-7aaaa59a-1d70-11e8-8170-d0e22e290f11.png)

The **ActionButton** component used as a Nav item link in the Nav component, was being passed the description prop which wrote out the code highlighted in the before image.  The button props interface notes this as a prop only used on compound buttons.  My guess is that this was intended to be the `areaDescription` prop in the first place.  I have swapped out the prop name and it now renders as intended with the id reference on a screen reader only span tag.  

It currently passes the Nav Link prop **title** or falls back to **name** if title is undefined.