### PR TITLE
[Pickers] Add async debounce option to BasePicker

### DIFF
--- a/common/changes/office-ui-fabric-react/basepicker-async-debounce_2018-03-02-17-42.json
+++ b/common/changes/office-ui-fabric-react/basepicker-async-debounce_2018-03-02-17-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add async debounce option to BasePicker",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jabrassi@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -74,6 +74,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
 
   public componentDidMount() {
     this.selection.setItems(this.state.items);
+    this._onResolveSuggestions = this._async.debounce(this._onResolveSuggestions, this.props.resolveDelay);
   }
 
   public componentWillReceiveProps(newProps: P) {
@@ -313,8 +314,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   }
 
   protected updateValue(updatedValue: string) {
-    const suggestions: T[] | PromiseLike<T[]> = this.props.onResolveSuggestions(updatedValue, this.state.items);
-    this.updateSuggestionsList(suggestions, updatedValue);
+    this._onResolveSuggestions(updatedValue);
   }
 
   protected updateSuggestionsList(suggestions: T[] | PromiseLike<T[]>, updatedValue?: string) {
@@ -681,6 +681,14 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   private _onSelectedItemsUpdated(items?: T[], focusIndex?: number) {
     this.resetFocus(focusIndex);
     this.onChange(items);
+  }
+
+  private _onResolveSuggestions(updatedValue: string): void {
+    const suggestions: T[] | PromiseLike<T[]> | null = this.props.onResolveSuggestions(updatedValue, this.state.items);
+
+    if (suggestions !== null) {
+      this.updateSuggestionsList(suggestions, updatedValue);
+    }
   }
 
   private _onValidateInput() {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -33,8 +33,15 @@ export interface IBasePickerProps<T> extends React.Props<any> {
   /**
    * A callback for what should happen when a person types text into the input.
    * Returns the already selected items so the resolver can filter them out.
+   * If used in conjunction with resolveDelay this will ony kick off after the delay throttle.
    */
   onResolveSuggestions: (filter: string, selectedItems?: T[]) => T[] | PromiseLike<T[]>;
+  /**
+   * The delay time in ms before resolving suggestions, which is kicked off when input has been cahnged.
+   * e.g. If a second input change happens within the resolveDelay time, the timer will start over.
+   * Only until after the timer completes will onResolveSuggestions be called.
+   */
+  resolveDelay?: number;
   /**
    * A callback for what should happen when a user clicks the input.
    */

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -151,6 +151,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
           'aria-label': 'People Picker'
         } }
         componentRef={ this._resolveRef('_picker') }
+        resolveDelay={ 300 }
       />
     );
   }
@@ -174,6 +175,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         } }
         componentRef={ this._resolveRef('_picker') }
         onInputChange={ this._onInputChange }
+        resolveDelay={ 300 }
       />
     );
   }
@@ -194,6 +196,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
           'aria-label': 'People Picker'
         } }
         componentRef={ this._resolveRef('_picker') }
+        resolveDelay={ 300 }
       />
     );
   }
@@ -216,6 +219,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
           'aria-label': 'People Picker'
         } }
         componentRef={ this._resolveRef('_picker') }
+        resolveDelay={ 300 }
       />
     );
   }
@@ -238,6 +242,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
           'aria-label': 'People Picker'
         } }
         componentRef={ this._resolveRef('_picker') }
+        resolveDelay={ 300 }
       />
     );
   }
@@ -260,6 +265,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
           'aria-label': 'People Picker'
         } }
         componentRef={ this._resolveRef('_picker') }
+        resolveDelay={ 300 }
       />
     );
   }
@@ -287,6 +293,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
             onFocus: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onFocus called')
           } }
           componentRef={ this._resolveRef('_picker') }
+          resolveDelay={ 300 }
         />
         <label> Click to Add a person </label>
         { controlledItems.map((item, index) => <div key={ index }>


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add mechanism to debounce searching in pickers

Add resolveDelay to allow consumer to add a delay on calling resolveSuggestions (to not burden services and not waste cycles on throw away searches)

#### Focus areas to test

PeoplePicker