### PR TITLE
 Fix issue 3608: DetailsList horizontal scroll

### DIFF
--- a/common/changes/office-ui-fabric-react/aditima-header-sizer_2018-03-02-18-27.json
+++ b/common/changes/office-ui-fabric-react/aditima-header-sizer_2018-03-02-18-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix issue 3608: DetailsList horizontal scroll due to cellSizer",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aditima@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -85,7 +85,6 @@ $isPaddedMargin: 24px;
   cursor: ew-resize;
   bottom: 0;
   top: 0;
-  margin: 0 -8px;
   overflow: hidden;
   height: inherit;
   background: transparent;
@@ -113,6 +112,15 @@ $isPaddedMargin: 24px;
   &.cellIsResizing:after {
     @include ms-drop-shadow();
   }
+}
+
+.cellSizerStart {
+  margin: 0 -8px;
+}
+
+.cellSizerEnd {
+  margin: 0;
+  @include margin-left(-16px);
 }
 
 .collapseButton {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3608
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The column resizers span 8px on either side of the column boundary – but the last one needs special handling to be fully contained inside the last column. Somehow, this special handling is missing, so if the last column is resizable it always goes 8px beyond horizontally.

#### Focus areas to test

(optional)
