### PR TITLE
MessageBar: Dismiss button and overflow button aria labels

### DIFF
--- a/common/changes/office-ui-fabric-react/messagebar-aria_2018-03-02-23-40.json
+++ b/common/changes/office-ui-fabric-react/messagebar-aria_2018-03-02-23-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: Aria label for truncated text overflow button and added aria labels for buttons in examples.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -114,7 +114,7 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
             className={ css('ms-MessageBar-expand', styles.expand) }
             onClick={ this._onClick }
             iconProps={ { iconName: this.state.expandSingleLine ? 'DoubleChevronUp' : 'DoubleChevronDown' } }
-            ariaLabel={ this.props.dismissButtonAriaLabel }
+            ariaLabel={ this.props.overflowButtonAriaLabel }
           />
         </div>
       );

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.types.ts
@@ -54,6 +54,11 @@ export interface IMessageBarProps extends React.HTMLAttributes<HTMLElement> {
   * @defaultvalue false
   */
   truncated?: boolean;
+
+  /**
+  * Aria label on overflow button if truncated is defined.
+  */
+  overflowButtonAriaLabel?: string;
 }
 
 export enum MessageBarType {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
@@ -68,6 +68,7 @@ export const MessageBarBasicExample = () => (
     <Label>Warning MessageBar - defaults to multiline, with dismiss and action buttons</Label>
     <MessageBar
       onDismiss={ log('test') }
+      dismissButtonAriaLabel='Close'
       messageBarType={ MessageBarType.warning }
       ariaLabel='Aria help text here'
       actions={

--- a/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
@@ -20,6 +20,7 @@ export const MessageBarBasicExample = () => (
       messageBarType={ MessageBarType.error }
       isMultiline={ false }
       onDismiss={ log('test') }
+      dismissButtonAriaLabel='Close'
     >
       Error lorem ipsum dolor sit amet, a elit sem interdum consectetur adipiscing elit. <Link href='www.bing.com'>Visit our website.</Link>
     </MessageBar>
@@ -29,7 +30,9 @@ export const MessageBarBasicExample = () => (
       messageBarType={ MessageBarType.blocked }
       isMultiline={ false }
       onDismiss={ log('test') }
+      dismissButtonAriaLabel='Close'
       truncated={ true }
+      overflowButtonAriaLabel='Overflow'
     >
       Blocked lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio augue pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae orci nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac placerat erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi a, fermentum suscipit magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris. <Link href='www.bing.com'>Visit our website.</Link>
     </MessageBar>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #1608 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

- Examples weren't using the dismiss button's aria label
- The overflow button for use with there is truncated text did not have an aria label implementation

#### Focus areas to test

(optional)
