### PR TITLE
Nav: wire a link to expand/collapse behavior if it has no URL but has children

### DIFF
--- a/common/changes/office-ui-fabric-react/Nav_2018-03-03-08-32.json
+++ b/common/changes/office-ui-fabric-react/Nav_2018-03-03-08-32.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Wire a link to expand/collapse behavior if it has no URL but has children.",
-      "type": "minor"
+      "comment": "Nav: Wire nav link to expand/collapse behavior if it has no URL but has children.",
+      "type": "patch"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/Nav_2018-03-03-08-32.json
+++ b/common/changes/office-ui-fabric-react/Nav_2018-03-03-08-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Wire a link to expand/collapse behavior if it has no URL but has children.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "s@warmsea.net"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -305,6 +305,9 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
     if (this.props.onLinkClick) {
       this.props.onLinkClick(ev, link);
     }
+    if (!link.url && link.links && link.links.length > 0) {
+      this._onLinkExpandClicked(link, ev);
+    }
 
     this.setState({ selectedKey: link.key });
   }
@@ -312,6 +315,9 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
   private _onNavButtonLinkClicked(link: INavLink, ev: React.MouseEvent<HTMLElement>): void {
     if (link.onClick) {
       link.onClick(ev, link);
+    }
+    if (!link.url && link.links && link.links.length > 0) {
+      this._onLinkExpandClicked(link, ev);
     }
 
     this.setState({ selectedKey: link.key });


### PR DESCRIPTION
In the Nav component, today, when a node has children, only the chevron icon triggers expand and collapse behavior. The link of the parent node can be set to a URL. But in some scenarios, we don't have a link for the parent node. Instead, we want it to trigger expand/collapse behavior too when clicking the node.

This PR is to wire a link to expand/collapse behavior if it has no URL but has children.