### PR TITLE
Addressing Issue #4174 - 5.59.0 crashing in <ImageBase>

### DIFF
--- a/common/changes/office-ui-fabric-react/image-decorator-fix_2018-03-06-00-27.json
+++ b/common/changes/office-ui-fabric-react/image-decorator-fix_2018-03-06-00-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Temporarily commented out @customizable decorator in Image component to restore usage of static functions and variables.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
@@ -5,7 +5,7 @@ import {
   autobind,
   BaseComponent,
   classNamesFunction,
-  customizable,
+  // customizable,
   getNativeProps,
   imageProperties
 } from '../../Utilities';
@@ -26,7 +26,7 @@ export interface IImageState {
 
 const KEY_PREFIX = 'fabricImage';
 
-@customizable('Image', ['theme'])
+// @customizable('Image', ['theme'])
 export class ImageBase extends BaseComponent<IImageProps, IImageState> {
   public static defaultProps = {
     shouldFadeIn: true


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4174
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Temporarily commented out `@customizable` decorator in Image component to restore usage of static functions and variables.
