### PR TITLE
ContextualMenuSample: Use DefaultButton instead of html button

### DIFF
--- a/common/changes/@uifabric/example-app-base/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
+++ b/common/changes/@uifabric/example-app-base/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
+++ b/common/changes/@uifabric/experiments/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
+++ b/common/changes/@uifabric/fabric-website/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
+++ b/common/changes/@uifabric/styling/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
+++ b/common/changes/@uifabric/utilities/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
+++ b/common/changes/office-ui-fabric-react/hotfix-ContextMenu-sample-styles_2018-03-06-19-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix ContextualMenu customization sample",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
@@ -204,7 +204,7 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
       <ul className='ms-ContextualMenu-customizationExample-categoriesList'>
         <li className='ms-ContextualMenu-item'>
           { item.categoryList.map((category: any) =>
-            <button className='ms-ContextualMenu-link' role='menuitem' key={ category.name }>
+            <DefaultButton className='ms-ContextualMenu-link ms-ContextualMenu-customizationExample-button' role='menuitem' key={ category.name }>
               <div>
                 <span
                   className='ms-ContextualMenu-icon ms-ContextualMenu-customizationExample-categorySwatch'
@@ -214,7 +214,7 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
                   { category.name }
                 </span>
               </div>
-            </button>
+            </DefaultButton>
           ) }
         </li>
       </ul>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
@@ -215,7 +215,7 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
       <ul className='ms-ContextualMenu-customizationExample-categoriesList'>
         <li className='ms-ContextualMenu-item'>
           { item.categoryList.map((category: any) =>
-            <button key={ category.name } className='ms-ContextualMenu-link' role='menuitem'>
+            <DefaultButton key={ category.name } className='ms-ContextualMenu-link ms-ContextualMenu-customizationExample-button' role='menuitem'>
               <div>
                 <span
                   className='ms-ContextualMenu-icon ms-ContextualMenu-customizationExample-categorySwatch'
@@ -225,7 +225,7 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
                   { category.name }
                 </span>
               </div>
-            </button>
+            </DefaultButton>
           ) }
         </li>
       </ul>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenuExample.scss
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenuExample.scss
@@ -47,7 +47,6 @@
   }
 
   .ms-ContextualMenu-customizationExample-categorySwatch {
-    margin: 6px 8px;
     width: 24px;
     height: 24px;
     vertical-align: top;
@@ -67,5 +66,9 @@
     .ms-ContextualMenu-item {
       height: auto;
     }
+  }
+
+  .ms-ContextualMenu-customizationExample-button {
+    max-width: 50%;
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4148
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Replace `<button>` tags with `<DefaultButton>` fabric components to fix button appearance in the Customization example.
