### PR TITLE
Added ability for anchor menu items to have sub menus.

### DIFF
--- a/common/changes/office-ui-fabric-react/users-demarcey-anchorMenuItems_2018-03-06-21-28.json
+++ b/common/changes/office-ui-fabric-react/users-demarcey-anchorMenuItems_2018-03-06-21-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Allow anchor menu items to have sub menus. Added prop for sub menu hover delay.",
+      "comment": "ContextualMenu: Allow anchor menu items to have sub menus. Added prop for sub menu hover delay.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/users-demarcey-anchorMenuItems_2018-03-06-21-28.json
+++ b/common/changes/office-ui-fabric-react/users-demarcey-anchorMenuItems_2018-03-06-21-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow anchor menu items to have sub menus. Added prop for sub menu hover delay.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "demarcey@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -478,11 +478,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       anchorRel = anchorRel ? anchorRel : 'nofollow noopener noreferrer';  // Safe default to prevent tabjacking
     }
 
-    let { subMenuId } = this.state;
-    if (item.subMenuProps && item.subMenuProps.id) {
-      subMenuId = item.subMenuProps.id;
-    }
-
+    const subMenuId = this._getSubMenuId(item);
     const itemHasSubmenu = hasSubmenu(item);
 
     return (
@@ -528,11 +524,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     const { expandedMenuItemKey } = this.state;
     const { contextualMenuItemAs: ChildrenRenderer = ContextualMenuItem } = this.props;
 
-    let { subMenuId } = this.state;
-    if (item.subMenuProps && item.subMenuProps.id) {
-      subMenuId = item.subMenuProps.id;
-    }
-
+    const subMenuId = this._getSubMenuId(item);
     let ariaLabel = '';
 
     if (item.ariaLabel) {
@@ -986,5 +978,15 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _isItemDisabled(item: IContextualMenuItem): boolean {
     return !!(item.isDisabled || item.disabled);
+  }
+
+  private _getSubMenuId(item: IContextualMenuItem): string | undefined {
+    let { subMenuId } = this.state;
+
+    if (item.subMenuProps && item.subMenuProps.id) {
+      subMenuId = item.subMenuProps.id;
+    }
+
+    return subMenuId;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -805,7 +805,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
    */
   private _updateFocusOnMouseEvent(item: any, ev: React.MouseEvent<HTMLElement>) {
     const targetElement = ev.currentTarget as HTMLElement;
-    const timeoutDuration = this.props.subMenuHoverDelay !== undefined ? this.props.subMenuHoverDelay : this._navigationIdleDelay;
+    const { subMenuHoverDelay: timeoutDuration = this._navigationIdleDelay } = this.props;
 
     if (item.key === this.state.expandedMenuItemKey) {
       return;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -135,7 +135,8 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
 
   /**
    * Click handler which is invoked if onClick is not passed for individual contextual
-   * menu item
+   * menu item.
+   * Returning true will dismiss the menu even if ev.preventDefault() was called.
    */
   onItemClick?: (ev?: React.MouseEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -137,7 +137,7 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * Click handler which is invoked if onClick is not passed for individual contextual
    * menu item
    */
-  onItemClick?: (ev?: React.MouseEvent<HTMLElement>, item?: IContextualMenuItem) => void;
+  onItemClick?: (ev?: React.MouseEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
 
   /**
    * CSS class to apply to the context menu.
@@ -220,6 +220,11 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
 
   /** Method to call when trying to render a submenu. */
   onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
+
+  /**
+   * Delay (in milliseconds) to wait before expanding / dismissing a submenu on mouseEnter or mouseLeave
+  */
+  subMenuHoverDelay?: number;
 
   /**
    * Method to override the render of the individual menu items
@@ -320,9 +325,10 @@ export interface IContextualMenuItem {
   data?: any;
 
   /**
-   * Callback issued when the menu item is invoked. If ev.preventDefault() is called in onClick, click will not close menu
+   * Callback issued when the menu item is invoked. If ev.preventDefault() is called in onClick, click will not close menu.
+   * Returning true will dismiss the menu even if ev.preventDefault() was called.
    */
-  onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: IContextualMenuItem) => void;
+  onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
 
   /**
    * An optional URL to navigate to upon selection

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -1,17 +1,32 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import './ContextualMenuExample.scss';
 
-export class ContextualMenuSubmenuExample extends React.Component<any, any> {
+export interface ContextualMenuSubmenuExampleState {
+  hoverDelay: number;
+}
+
+export class ContextualMenuSubmenuExample extends React.Component<any, ContextualMenuSubmenuExampleState> {
+
+  constructor(props: any) {
+    super(props);
+
+    this.state = {
+      hoverDelay: 250
+    };
+  }
 
   public render() {
     return (
       <div>
+        <TextField value={ String(this.state.hoverDelay) } onChanged={ this._onHoverDelayChanged } />
         <DefaultButton
           id='ContextualMenuButton2'
           text='Click for ContextualMenu'
           menuProps={ {
             shouldFocusOnMount: true,
+            subMenuHoverDelay: this.state.hoverDelay,
             items: [
               {
                 key: 'newItem',
@@ -29,6 +44,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, any> {
                     }
                   ],
                 },
+                href: "https://bing.com",
                 name: 'New'
               },
               {
@@ -71,5 +87,11 @@ export class ContextualMenuSubmenuExample extends React.Component<any, any> {
         />
       </div>
     );
+  }
+
+  private _onHoverDelayChanged = (newValue: string) => {
+    this.setState({
+      hoverDelay: +newValue
+    });
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -3,11 +3,11 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import './ContextualMenuExample.scss';
 
-export interface ContextualMenuSubmenuExampleState {
+export interface IContextualMenuSubmenuExampleState {
   hoverDelay: number;
 }
 
-export class ContextualMenuSubmenuExample extends React.Component<any, ContextualMenuSubmenuExampleState> {
+export class ContextualMenuSubmenuExample extends React.Component<any, IContextualMenuSubmenuExampleState> {
 
   constructor(props: any) {
     super(props);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -44,7 +44,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
                     }
                   ],
                 },
-                href: "https://bing.com",
+                href: 'https://bing.com',
                 name: 'New'
               },
               {


### PR DESCRIPTION
Added prop for subMenuHoverDelay.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4196, #4197
- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Allow anchor menu items to have sub menus. 
- Added a prop for sub menu hover delay.
- Added examples for each.
