### PR TITLE
Website: Fix in page nav / left nav display bug

### DIFF
--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -105,8 +105,6 @@ function _isPageActive(page: INavPage): boolean {
   path = getPathMinusLastHash(path);
   if (path === target) {
     // Match a url that has navigated to a location in page.
-
-
     return true;
   }
   return false;

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
+import { getPathMinusLastHash } from '../../utilities/pageroute';
 import * as stylesImport from './Nav.module.scss';
 const styles: any = stylesImport;
 import {
@@ -115,11 +116,8 @@ function _isPageActive(page: INavPage): boolean {
   if (location.href) {
     // Match a url that has navigated to a location in page.
     let path = location.href;
-    const hashIndex = path.lastIndexOf('#');
+    path = getPathMinusLastHash(path);
 
-    if (hashIndex > 0) {
-      path = path.substr(0, hashIndex);
-    }
     return path === target;
   }
   return false;

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -92,33 +92,22 @@ function _isPageActive(page: INavPage): boolean {
   }
   _urlResolver.href = page.url || '';
   const target: string = _urlResolver.href;
+  let path = location.href;
 
   if (location.protocol + '//' + location.host + location.pathname === target) {
     return true;
   }
 
-  if (location.href === target) {
+  if (path === target) {
     return true;
   }
 
-  if (location.hash) {
-    // Match the hash to the url.
-    if (location.hash === page.url) {
-      return true;
-    }
-
-    // Match a rebased url. (e.g. #foo becomes http://hostname/foo)
-    _urlResolver.href = location.hash.substring(1);
-
-    return _urlResolver.href === target;
-  }
-
-  if (location.href) {
+  path = getPathMinusLastHash(path);
+  if (path === target) {
     // Match a url that has navigated to a location in page.
-    let path = location.href;
-    path = getPathMinusLastHash(path);
 
-    return path === target;
+
+    return true;
   }
   return false;
 }

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -69,7 +69,7 @@ export class Nav extends React.Component<INavProps, INavState> {
     const links: React.ReactElement<{}>[] = pages
       .filter(page => !page.hasOwnProperty('isHiddenFromMainNav'))
       .map(
-      (page: INavPage, linkIndex: number) => this._renderLink(page, linkIndex)
+        (page: INavPage, linkIndex: number) => this._renderLink(page, linkIndex)
       );
 
     return (
@@ -112,6 +112,16 @@ function _isPageActive(page: INavPage): boolean {
     return _urlResolver.href === target;
   }
 
+  if (location.href) {
+    // Match a url that has navigated to a location in page.
+    let path = location.href;
+    const hashIndex = path.lastIndexOf('#');
+
+    if (hashIndex > 0) {
+      path = path.substr(0, hashIndex);
+    }
+    return path === target;
+  }
   return false;
 }
 

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -98,15 +98,15 @@ function _isPageActive(page: INavPage): boolean {
     return true;
   }
 
+  const hashCount = path.split('#').length - 1
+  if (hashCount > 1) {
+    path = getPathMinusLastHash(path);
+  }
+
   if (path === target) {
     return true;
   }
 
-  path = getPathMinusLastHash(path);
-  if (path === target) {
-    // Match a url that has navigated to a location in page.
-    return true;
-  }
   return false;
 }
 

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -98,7 +98,7 @@ function _isPageActive(page: INavPage): boolean {
     return true;
   }
 
-  const hashCount = path.split('#').length - 1
+  const hashCount = path.split('#').length - 1;
   if (hashCount > 1) {
     path = getPathMinusLastHash(path);
   }

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
-import { getPathMinusLastHash } from '../../utilities/pageroute';
 import * as stylesImport from './Nav.module.scss';
 const styles: any = stylesImport;
 import {
@@ -116,8 +115,11 @@ function _isPageActive(page: INavPage): boolean {
   if (location.href) {
     // Match a url that has navigated to a location in page.
     let path = location.href;
-    path = getPathMinusLastHash(path);
+    const hashIndex = path.lastIndexOf('#');
 
+    if (hashIndex > 0) {
+      path = path.substr(0, hashIndex);
+    }
     return path === target;
   }
   return false;

--- a/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
+++ b/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { css, BaseComponent, IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
 import * as stylesImport from './PageHeader.module.scss';
 const styles: any = stylesImport;
-import { getPageRouteFromState } from '../../utilities/pageroute';
 import AttachedScrollUtility from '../../utilities/AttachedScrollUtility';
 import { PageHeaderLink } from '../../components/PageHeaderLink/PageHeaderLink';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
@@ -84,9 +83,6 @@ export class PageHeader extends BaseComponent<IPageHeaderProps, IPageHeaderState
   public render() {
     let { pageTitle, links, backgroundColor, backgroundImage } = this.props;
     let { isAttached } = this.state;
-    let baseRoute: string = getPageRouteFromState(
-      this.props.pageTitle
-    );
     let inPageNav;
     let backgroundStyle = {
       bottom: this.state.headerBottom,
@@ -149,6 +145,7 @@ export class PageHeader extends BaseComponent<IPageHeaderProps, IPageHeaderState
     const hashIndex = path.lastIndexOf('#')
 
     if (hashIndex > 0) {
+      // This makes sure that location hash changes don't append
       path = path.substr(0, hashIndex);
     }
 

--- a/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
+++ b/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
@@ -102,7 +102,7 @@ export class PageHeader extends BaseComponent<IPageHeaderProps, IPageHeaderState
             <ul>
               { links.map((link, linkIndex) => (
                 <li key={ linkIndex }>
-                  <PageHeaderLink href={ baseRoute + '#' + link.location } text={ link.text } />
+                  <PageHeaderLink href={ this._getPagePath(link) } text={ link.text } />
                 </li>
               )) }
             </ul>
@@ -142,5 +142,16 @@ export class PageHeader extends BaseComponent<IPageHeaderProps, IPageHeaderState
       headerBottom: headerBottom,
       headerTop: headerTop
     });
+  }
+
+  private _getPagePath(link): string {
+    let path = location.hash;
+    const hashIndex = path.lastIndexOf('#')
+
+    if (hashIndex > 0) {
+      path = path.substr(0, hashIndex);
+    }
+
+    return path + '#' + link.location;
   }
 }

--- a/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
+++ b/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
@@ -3,7 +3,6 @@ import { css, BaseComponent, IBaseProps } from 'office-ui-fabric-react/lib/Utili
 import * as stylesImport from './PageHeader.module.scss';
 const styles: any = stylesImport;
 import AttachedScrollUtility from '../../utilities/AttachedScrollUtility';
-import { getPathMinusLastHash } from '../../utilities/pageroute';
 import { PageHeaderLink } from '../../components/PageHeaderLink/PageHeaderLink';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 
@@ -143,8 +142,12 @@ export class PageHeader extends BaseComponent<IPageHeaderProps, IPageHeaderState
 
   private _getPagePath(link): string {
     let path = location.hash;
-    // This makes sure that location hash changes don't append
-    path = getPathMinusLastHash(path);
+    const hashIndex = path.lastIndexOf('#')
+
+    if (hashIndex > 0) {
+      // This makes sure that location hash changes don't append
+      path = path.substr(0, hashIndex);
+    }
 
     return path + '#' + link.location;
   }

--- a/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
+++ b/apps/fabric-website/src/components/PageHeader/PageHeader.tsx
@@ -3,6 +3,7 @@ import { css, BaseComponent, IBaseProps } from 'office-ui-fabric-react/lib/Utili
 import * as stylesImport from './PageHeader.module.scss';
 const styles: any = stylesImport;
 import AttachedScrollUtility from '../../utilities/AttachedScrollUtility';
+import { getPathMinusLastHash } from '../../utilities/pageroute';
 import { PageHeaderLink } from '../../components/PageHeaderLink/PageHeaderLink';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 
@@ -142,12 +143,8 @@ export class PageHeader extends BaseComponent<IPageHeaderProps, IPageHeaderState
 
   private _getPagePath(link): string {
     let path = location.hash;
-    const hashIndex = path.lastIndexOf('#')
-
-    if (hashIndex > 0) {
-      // This makes sure that location hash changes don't append
-      path = path.substr(0, hashIndex);
-    }
+    // This makes sure that location hash changes don't append
+    path = getPathMinusLastHash(path);
 
     return path + '#' + link.location;
   }

--- a/apps/fabric-website/src/utilities/pageroute.ts
+++ b/apps/fabric-website/src/utilities/pageroute.ts
@@ -1,7 +1,11 @@
 
 /*
-  Retreive the route URL for a page in a group from the the AppState
+  Retreive the route URL for a page without the string after the last hash.
 */
-export function getPageRouteFromState(pageName: string): string {
-  return '';
+export function getPathMinusLastHash(path: string): string {
+  const hashIndex = path.lastIndexOf('#')
+  if (hashIndex > 0) {
+    path = path.substr(0, hashIndex);
+  }
+  return path;
 }

--- a/apps/fabric-website/src/utilities/pageroute.ts
+++ b/apps/fabric-website/src/utilities/pageroute.ts
@@ -3,7 +3,7 @@
   Retreive the route URL for a page without the string after the last hash.
 */
 export function getPathMinusLastHash(path: string): string {
-  const hashIndex = path.lastIndexOf('#')
+  const hashIndex = path.lastIndexOf('#');
   if (hashIndex > 0) {
     path = path.substr(0, hashIndex);
   }

--- a/apps/fabric-website/src/utilities/pageroute.ts
+++ b/apps/fabric-website/src/utilities/pageroute.ts
@@ -1,11 +1,7 @@
 
 /*
-  Retreive the route URL for a page without the string after the last hash.
+  Retreive the route URL for a page in a group from the the AppState
 */
-export function getPathMinusLastHash(path: string): string {
-  const hashIndex = path.lastIndexOf('#')
-  if (hashIndex > 0) {
-    path = path.substr(0, hashIndex);
-  }
-  return path;
+export function getPageRouteFromState(pageName: string): string {
+  return '';
 }

--- a/common/changes/@uifabric/fabric-website/in-page-nav-bug_2018-03-06-23-06.json
+++ b/common/changes/@uifabric/fabric-website/in-page-nav-bug_2018-03-06-23-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fixed in page nav so that the left nav links will display properly.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Left nav would disappear when you clicked on an in-page navigation link (like 'Best Practices' or 'Implementation'). 

By default, links in the nav are set to `display: none`. The logic to check whether the link isActive or hasActiveChild (and set display to visible) was failing. Not sure why, because no recent changes have been made.

I changed up how paths are generated for in-page nav to be more informative. They now will look like this:
#/components/activityitem#BestPractices
instead of:
#BestPractices

Then I reworked the logic for displaying the appropriate links.

#### Focus areas to test

(optional)
