### PR TITLE
Styled: Add display name to styled wrapper

### DIFF
--- a/common/changes/@uifabric/utilities/styledDisplayName_2018-03-07-00-54.json
+++ b/common/changes/@uifabric/utilities/styledDisplayName_2018-03-07-00-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Styled: Add display name to styled wrapper",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "erabelle@microsoft.com"
+}

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -9,6 +9,11 @@ export interface IPropsWithStyles<TStyleProps, TStyles> {
   };
 }
 
+interface IWrappedComponent<P> {
+  (props: P): JSX.Element;
+  displayName: string;
+}
+
 /**
  * The styled HOC wrapper allows you to create a functional wrapper around a given component which will resolve
  * getStyles functional props, and mix customized props passed in using concatStyleSets. Example:
@@ -29,7 +34,7 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
   getProps?: (props: TComponentProps) => Partial<TComponentProps>
 ): (props: TComponentProps) => JSX.Element {
 
-  return (componentProps: TComponentProps) => {
+  const Wrapped = ((componentProps: TComponentProps) => {
     const getStyles = (
       styleProps: TStyleProps
     ) => concatStyleSets(
@@ -45,5 +50,8 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
         getStyles={ getStyles }
       />
     );
-  };
+  }) as IWrappedComponent<TComponentProps>;
+
+  Wrapped.displayName = `Styled${Component.displayName}`;
+  return Wrapped;
 }

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -52,6 +52,6 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
     );
   }) as IWrappedComponent<TComponentProps>;
 
-  Wrapped.displayName = `Styled${Component.displayName}`;
+  Wrapped.displayName = `Styled${Component.displayName || Component.name}`;
   return Wrapped;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4084 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added a display name to the `styled` wrapper.

**Before**
![styled - not named](https://user-images.githubusercontent.com/15041132/37067640-a3ddebaa-215f-11e8-9188-a748d1e6000a.PNG)

**After**
![styled - named](https://user-images.githubusercontent.com/15041132/37067644-a9b070ac-215f-11e8-8dff-16651630ea38.PNG)


#### Focus areas to test

I only tested with the Nav component on the docs site. 