### PR TITLE
SwatchColorPickerBase: Run onCellFocused in componentWillUnmount and _onCellClick

### DIFF
--- a/common/changes/office-ui-fabric-react/Run_onCellFocused_Before_Unmount_And_Select_Color_2018-03-08-01-45.json
+++ b/common/changes/office-ui-fabric-react/Run_onCellFocused_Before_Unmount_And_Select_Color_2018-03-08-01-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Run onCellFocused before unmount and before select color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "madosal@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -38,6 +38,7 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
   } as ISwatchColorPickerProps;
 
   private _id: string;
+  private _cellFocused: boolean;
 
   private navigationIdleTimeoutId: number | undefined;
   private isNavigationIdle: boolean;
@@ -83,6 +84,13 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
       this.setState({
         selectedIndex: newSelectedIndex
       });
+    }
+  }
+
+  public componentWillUnmount() {
+    if (this.props.onCellFocused && this._cellFocused) {
+      this._cellFocused = false;
+      this.props.onCellFocused();
     }
   }
 
@@ -138,6 +146,7 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
   @autobind
   private _onSwatchColorPickerBlur() {
     if (this.props.onCellFocused) {
+      this._cellFocused = false;
       this.props.onCellFocused();
     }
   }
@@ -331,7 +340,13 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
   private _onGridCellFocused(item?: IColorCellProps): void {
     const { onCellFocused } = this.props;
     if (onCellFocused) {
-      return item ? onCellFocused(item.id, item.color) : onCellFocused();
+      if (item) {
+        this._cellFocused = true;
+        return onCellFocused(item.id, item.color);
+      } else {
+        this._cellFocused = false;
+        return onCellFocused();
+      }
     }
   }
 
@@ -350,6 +365,12 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
     // If we have a valid index and it is not already
     // selected, select it
     if (index >= 0 && index !== this.state.selectedIndex) {
+
+      if (this.props.onCellFocused && this._cellFocused) {
+        this._cellFocused = false;
+        this.props.onCellFocused();
+      }
+
       if (this.props.onColorChanged) {
         this.props.onColorChanged(item.id, item.color);
       }


### PR DESCRIPTION
#### Pull request checklist

- [x ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

Run onCellFocused when color picker will unmount and before a color is selected.

Tested locally and checked that callback is executed when a component is being unmounted. Also, when a color is selected using mouse or keyboard.
Tested in the demo app of office-online-ui
