### PR TITLE
Allow DetailsRow to have a custom renderer

### DIFF
--- a/common/changes/office-ui-fabric-react/cyrusb-customrowrenderer_2018-03-08-19-51.json
+++ b/common/changes/office-ui-fabric-react/cyrusb-customrowrenderer_2018-03-08-19-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow DetailsRow to have a custom renderer",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cyrusb"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -13,7 +13,7 @@ import {
 import { IColumn, CheckboxVisibility } from './DetailsList.types';
 import { DetailsRowCheck, IDetailsRowCheckProps } from './DetailsRowCheck';
 import { GroupSpacer } from '../GroupedList/GroupSpacer';
-import { DetailsRowFields } from './DetailsRowFields';
+import { DetailsRowFields, IDetailsRowFieldsProps } from './DetailsRowFields';
 import { FocusZone, FocusZoneDirection, IFocusZone } from '../../FocusZone';
 import { ISelection, SelectionMode, SELECTION_CHANGE } from '../../utilities/selection/interfaces';
 import { CollapseAllVisibility } from '../../GroupedList';
@@ -52,6 +52,7 @@ export interface IDetailsRowProps extends React.Props<DetailsRow> {
   getRowAriaDescribedBy?: (item: any) => string;
   checkButtonAriaLabel?: string;
   checkboxCellClassName?: string;
+  customRowRenderer?: (props: IDetailsRowFieldsProps) => JSX.Element;
   className?: string;
 }
 
@@ -184,6 +185,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
       getRowAriaDescribedBy,
       checkButtonAriaLabel,
       checkboxCellClassName,
+      customRowRenderer,
       selection,
     } = this.props;
     const { columnMeasureInfo, isDropping, groupNestingDepth } = this.state;
@@ -248,7 +250,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
 
         { GroupSpacer({ count: groupNestingDepth! - (this.props.collapseAllVisibility === CollapseAllVisibility.hidden ? 1 : 0) }) }
 
-        { item && (
+        { item && (!customRowRenderer) && (
           <DetailsRowFields
             columns={ columns }
             item={ item }
@@ -256,6 +258,14 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
             columnStartIndex={ showCheckbox ? 1 : 0 }
             onRenderItemColumn={ onRenderItemColumn }
           />
+        ) }
+
+        { item && customRowRenderer && customRowRenderer({
+          columns: columns,
+          item: item,
+          itemIndex: itemIndex,
+          columnStartIndex: 0
+        }
         ) }
 
         { columnMeasureInfo && (

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -52,7 +52,7 @@ export interface IDetailsRowProps extends React.Props<DetailsRow> {
   getRowAriaDescribedBy?: (item: any) => string;
   checkButtonAriaLabel?: string;
   checkboxCellClassName?: string;
-  customRowRenderer?: (props: IDetailsRowFieldsProps) => JSX.Element;
+  rowFieldsAs?: React.StatelessComponent<IDetailsRowFieldsProps> | React.ComponentClass<IDetailsRowFieldsProps>;
   className?: string;
 }
 
@@ -185,7 +185,8 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
       getRowAriaDescribedBy,
       checkButtonAriaLabel,
       checkboxCellClassName,
-      customRowRenderer,
+      /** Alias rowFieldsAs as RowFields and default to DetailsRowFields if rowFieldsAs does not exist */
+      rowFieldsAs: RowFields = DetailsRowFields,
       selection,
     } = this.props;
     const { columnMeasureInfo, isDropping, groupNestingDepth } = this.state;
@@ -250,8 +251,8 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
 
         { GroupSpacer({ count: groupNestingDepth! - (this.props.collapseAllVisibility === CollapseAllVisibility.hidden ? 1 : 0) }) }
 
-        { item && (!customRowRenderer) && (
-          <DetailsRowFields
+        { item && (
+          <RowFields
             columns={ columns }
             item={ item }
             itemIndex={ itemIndex }
@@ -259,22 +260,13 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
             onRenderItemColumn={ onRenderItemColumn }
           />
         ) }
-
-        { item && customRowRenderer && customRowRenderer({
-          columns: columns,
-          item: item,
-          itemIndex: itemIndex,
-          columnStartIndex: 0
-        }
-        ) }
-
         { columnMeasureInfo && (
           <span
             role='presentation'
             className={ css('ms-DetailsRow-cellMeasurer ms-DetailsRow-cell', styles.cellMeasurer, styles.cell) }
             ref={ this._resolveRef('_cellMeasurer') }
           >
-            <DetailsRowFields
+            <RowFields
               columns={ [columnMeasureInfo.column] }
               item={ item }
               itemIndex={ itemIndex }


### PR DESCRIPTION
#### Pull request checklist

#### Description of changes
Allows the DetailsRow to have an optional Custom Renderer. So instead of rendering DetailsRowFields, if a customRowRenderer is specified, it will use that instead. This will allow all the logic of DetailsRow (including selection states etc.) to be utilized while still overriding the core rendering of the row.

#### Focus areas to test
Make sure that both cases work. That is with and without customRowRenderer specified.
