### PR TITLE
Foucs: Fix getPreviousElement parent traversal

### DIFF
--- a/common/changes/@uifabric/utilities/jspurlin-FocusZoneTraversalFix_2018-03-08-16-48.json
+++ b/common/changes/@uifabric/utilities/jspurlin-FocusZoneTraversalFix_2018-03-08-16-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Focus: Update getPreviousElement to traverse a potential childMatch's parent siblings  (which was previously being skipped)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "jspurlin@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jspurlin-FocusZoneTraversalFix_2018-03-08-16-48.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-FocusZoneTraversalFix_2018-03-08-16-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add unit test to catch focus regression being fixed by this PR",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
@@ -149,4 +149,71 @@ describe('FocusTrapZone', () => {
     ReactTestUtils.Simulate.keyDown(buttonD, { which: KeyCodes.tab });
     expect(lastFocusedElement).toBe(buttonA);
   });
+
+  it('can tab across a FocusZone with different button structures', () => {
+    const component = ReactTestUtils.renderIntoDocument(
+      <div { ...{ onFocusCapture: _onFocus } }>
+        <FocusTrapZone forceFocusInsideTrap={ false }>
+          <div data-is-visible={ true }>
+            <button className='x'>x</button>
+          </div>
+          <FocusZone direction={ FocusZoneDirection.horizontal } data-is-visible={ true }>
+            <div data-is-visible={ true }>
+              <button className='a'>a</button>
+            </div>
+            <div data-is-visible={ true }>
+              <div data-is-visible={ true }>
+                <button className='b'>b</button>
+              </div>
+            </div>
+          </FocusZone>
+        </FocusTrapZone>
+      </div>
+    );
+
+    const focusTrapZone = ReactDOM.findDOMNode(component as React.ReactInstance) as Element;
+
+    const buttonX = focusTrapZone.querySelector('.x') as HTMLElement;
+    const buttonA = focusTrapZone.querySelector('.a') as HTMLElement;
+    const buttonB = focusTrapZone.querySelector('.b') as HTMLElement;
+
+    // Assign bounding locations to buttons.
+    setupElement(buttonX, {
+      clientRect: {
+        top: 0,
+        bottom: 30,
+        left: 0,
+        right: 30
+      }
+    });
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 30,
+        left: 0,
+        right: 30
+      }
+    });
+
+    setupElement(buttonB, {
+      clientRect: {
+        top: 0,
+        bottom: 30,
+        left: 30,
+        right: 60
+      }
+    });
+
+    // Focus the first button.
+    ReactTestUtils.Simulate.focus(buttonX);
+    expect(lastFocusedElement).toBe(buttonX);
+
+    // Pressing shift + tab should go to a.
+    ReactTestUtils.Simulate.keyDown(buttonX, { which: KeyCodes.tab, shiftKey: true });
+    expect(lastFocusedElement).toBe(buttonA);
+
+    // Pressing tab should go to x.
+    ReactTestUtils.Simulate.keyDown(buttonA, { which: KeyCodes.tab });
+    expect(lastFocusedElement).toBe(buttonX);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
@@ -164,6 +164,8 @@ describe('FocusTrapZone', () => {
             <div data-is-visible={ true }>
               <div data-is-visible={ true }>
                 <button className='b'>b</button>
+                <button className='c'>c</button>
+                <button className='d'>d</button>
               </div>
             </div>
           </FocusZone>
@@ -176,6 +178,8 @@ describe('FocusTrapZone', () => {
     const buttonX = focusTrapZone.querySelector('.x') as HTMLElement;
     const buttonA = focusTrapZone.querySelector('.a') as HTMLElement;
     const buttonB = focusTrapZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusTrapZone.querySelector('.c') as HTMLElement;
+    const buttonD = focusTrapZone.querySelector('.d') as HTMLElement;
 
     // Assign bounding locations to buttons.
     setupElement(buttonX, {
@@ -186,6 +190,7 @@ describe('FocusTrapZone', () => {
         right: 30
       }
     });
+
     setupElement(buttonA, {
       clientRect: {
         top: 0,
@@ -201,6 +206,24 @@ describe('FocusTrapZone', () => {
         bottom: 30,
         left: 30,
         right: 60
+      }
+    });
+
+    setupElement(buttonC, {
+      clientRect: {
+        top: 0,
+        bottom: 30,
+        left: 60,
+        right: 90
+      }
+    });
+
+    setupElement(buttonD, {
+      clientRect: {
+        top: 30,
+        bottom: 60,
+        left: 0,
+        right: 30
       }
     });
 

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -102,11 +102,33 @@ export function getPreviousElement(
     if (childMatch) {
       if ((tabbable && (isElementTabbable(childMatch, true))) || !tabbable) {
         return childMatch;
-      } else {
-        // Check previous sibling of the child match.
-        const childMatchSiblingMatch = getPreviousElement(
+      }
+
+      // Check previous sibling of the child match.
+      const childMatchSiblingMatch = getPreviousElement(
+        rootElement,
+        childMatch.previousElementSibling as HTMLElement,
+        true,
+        true,
+        true,
+        includeElementsInFocusZones,
+        allowFocusRoot,
+        tabbable
+      );
+      if (childMatchSiblingMatch) {
+        return childMatchSiblingMatch;
+      }
+
+      const childMatchParent = childMatch.parentElement;
+
+      // If we didn't find a match from the previous siblings
+      // of the child element, move to the parent's previous sibling
+      // as long as the parent element exists and
+      // it is also not the currentElement (which will be handled later)
+      if (childMatchParent && childMatchParent !== currentElement) {
+        const childMatchParentMatch = getPreviousElement(
           rootElement,
-          childMatch.previousElementSibling as HTMLElement,
+          childMatchParent.previousElementSibling as HTMLElement,
           true,
           true,
           true,
@@ -114,8 +136,9 @@ export function getPreviousElement(
           allowFocusRoot,
           tabbable
         );
-        if (childMatchSiblingMatch) {
-          return childMatchSiblingMatch;
+
+        if (childMatchParentMatch) {
+          return childMatchParentMatch;
         }
       }
     }

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -104,7 +104,6 @@ export function getPreviousElement(
         return childMatch;
       }
 
-      // Check previous sibling of the child match.
       const childMatchSiblingMatch = getPreviousElement(
         rootElement,
         childMatch.previousElementSibling as HTMLElement,
@@ -119,13 +118,13 @@ export function getPreviousElement(
         return childMatchSiblingMatch;
       }
 
-      const childMatchParent = childMatch.parentElement;
+      let childMatchParent = childMatch.parentElement;
 
-      // If we didn't find a match from the previous siblings
-      // of the child element, move to the parent's previous sibling
-      // as long as the parent element exists and
-      // it is also not the currentElement (which will be handled later)
-      if (childMatchParent && childMatchParent !== currentElement) {
+      // At this point if we have not found any potential matches
+      // start looking at the rest of the subtree under the currentParent.
+      // NOTE: We do not want to recurse here because doing so could
+      // cause elements to get skipped.
+      while (childMatchParent && childMatchParent !== currentElement) {
         const childMatchParentMatch = getPreviousElement(
           rootElement,
           childMatchParent.previousElementSibling as HTMLElement,
@@ -140,6 +139,8 @@ export function getPreviousElement(
         if (childMatchParentMatch) {
           return childMatchParentMatch;
         }
+
+        childMatchParent = childMatchParent.parentElement;
       }
     }
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -49,7 +49,7 @@
   "bundlesize": [
     {
       "path": "../apps/test-bundle-button/dist/main.min.js",
-      "maxSize": "44.6 kB"
+      "maxSize": "44.7 kB"
     }
   ]
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

I noticed that if the DOM was structured in a specific way (if a deeper nesting existed after a more simple nesting in the same `FocusZone`, when attempting to put focus in the `FocusZone` (via a `FocusTrapZone`, for example)) then `getPreviousElement` would fail to correctly find the element that should be focused.

Here is some example DOM structure where this issue could be seen:
```
<FocusTrapZone>
  // note: button a could be inside of a FocusZone, but it is only needed
  // because it is a focusable element outside of the below FocusZone
  <button>a</button>
  <FocusZone>
    <div>
      <button /* by default this has tabindex="0" */>b</button>
    </div>
    <div>
      <div>
        <button /* by default this has tabindex="-1" */>c</button>
        <button /* by default this has tabindex="-1" */>d</button>
        <button /* by default this has tabindex="-1" */>e</button>
      </div>
    </div>
  </FocusZone>
</FocusTrapZone>
```
Before this fix:

Focus would start on `button a`, the user presses TAB, the `FocusTrapZone` would move to the FocusZone and attempt to focus the first focusable (including tabindex) element starting at the lastChild. The issue came up because while traversing it would find `button c` which would be returned all the way up to the point where FocusZone was attempting to find a match. At that point it would make sure it is focusable (including tabindex) which `button c` is not, then would go to its previous sibling which is the button that already has focus...

After my fix:
Focus would start on `button a`, the user presses TAB, the `FocusTrapZone` would move to the FocusZone and attempt to focus the first focusable (including tabindex) element starting at the lastChild. When we get to to `button c` (like the before example) and we don't find a previous sibling we go to the parent's previous sibling (the inner div) and start looking for a match. This happens one more time and then we get to the div that contains `button b` and when we look for a match we find the button correctly. Note, the parent traversal starts at the potential childMatch (which was not focusable due to having a tabindex of -1) and we only go up until we hit the currentElement since traversing it's handled later in the function.

#### Focus areas to test
Verified that the focus moves as expected both forward and backwards and added a unit test to catch this kind of regression in the future
