### PR TITLE
Searchbox: deprecate defaultValue

### DIFF
--- a/common/changes/office-ui-fabric-react/searchbox--deprecate-defaultValue_2018-03-09-20-24.json
+++ b/common/changes/office-ui-fabric-react/searchbox--deprecate-defaultValue_2018-03-09-20-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Deprecate SearchBox defaultValue prop.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -30,7 +30,8 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
     super(props);
 
     this._warnDeprecations({
-      'labelText': 'placeholder'
+      'labelText': 'placeholder',
+      'defaultValue': 'value'
     });
 
     this._latestValue = props.value || '';

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -61,6 +61,9 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
 
   /**
    * The default value of the text in the SearchBox, in the case of an uncontrolled component.
+   * Up till now, this has not been implemented, deprecating. Will re-implement if uncontrolled
+   * component behavior is implemented.
+   * @deprecated
    */
   defaultValue?: string;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4181
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Deprecate the `defaultValue` prop as it's functionality was never implemented. We should look into re-implementing it when/if we implement uncontrolled textFields.
