### PR TITLE
Made DetailsList's onColumnClick's args non-optional

### DIFF
--- a/common/changes/office-ui-fabric-react/non-optional-details-list-on-column-click_2018-03-09-20-51.json
+++ b/common/changes/office-ui-fabric-react/non-optional-details-list-on-column-click_2018-03-09-20-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Made DetailsList's onColumnClick's args non-optional",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jogol@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -329,7 +329,7 @@ export interface IColumn {
   /**
    * If provided, will be executed when the user clicks on the column header.
    */
-  onColumnClick?: (ev?: React.MouseEvent<HTMLElement>, column?: IColumn) => any;
+  onColumnClick?: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => any;
 
   /**
    * If provided, will be executed when the user accesses the contextmenu on a column header.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

DetailsList shouldn't list event and column as optional because they're always provided to the callback. If the consumer doesn't need `ev` or `column`, they can just pass a function that takes no arguments.


