### PR TITLE
Add ability to get and set scroll position on ScrollablePane

### DIFF
--- a/common/changes/office-ui-fabric-react/maxlus-scrollIntoView_2018-03-09-22-19.json
+++ b/common/changes/office-ui-fabric-react/maxlus-scrollIntoView_2018-03-09-22-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add ability to get and set scroll position on ScrollablePane",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "maxlus@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -69,6 +69,13 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
     this._events.off(window);
   }
 
+  public componentDidUpdate(prevProps: IScrollablePaneProps) {
+    const initialScrollPosition = this.props.initialScrollPosition;
+    if (initialScrollPosition && prevProps.initialScrollPosition !== initialScrollPosition) {
+      this.root.scrollTop = initialScrollPosition;
+    }
+  }
+
   public render() {
     const { className, theme, getStyles } = this.props;
     const classNames = getClassNames(getStyles!,
@@ -142,6 +149,11 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
     if (this._stickyBelow.size > 1) {
       this._sortStickies(this._stickyBelow, this.stickyBelow);
     }
+  }
+
+  @autobind
+  public getScrollPosition(): number {
+    return this.root.scrollTop;
   }
 
   private _addSticky(sticky: Sticky, stickyList: Set<Sticky>, container: HTMLElement, addStickyToContainer: () => void) {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -6,6 +6,8 @@ import { IStyleFunction } from '../../Utilities';
 export interface IScrollablePane {
   /** Triggers a layout update for the pane. */
   forceLayoutUpdate(): void;
+  /** Gets the current scroll position of the scrollable pane */
+  getScrollPosition(): number;
 }
 
 export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement | ScrollablePaneBase> {
@@ -31,6 +33,11 @@ export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement |
    * @defaultvalue undefined
    */
   className?: string;
+
+  /**
+   * Sets the initial scroll position of the ScrollablePane
+   */
+  initialScrollPosition?: number;
 }
 
 export interface IScrollablePaneStyleProps {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds the ability to get and set the scroll position on ScrollablePane. This is useful if you have functionality to stick headers to the top if you click them. If you then click it again, you can set the scroll position to the previous place.

#### Focus areas to test

(optional)
