### PR TITLE
ComboBox and ChoiceGroup: no more margins.

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-css_2018-03-11-07-30.json
+++ b/common/changes/office-ui-fabric-react/fix-css_2018-03-11-07-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComoboBox and SpinButton: Removing excess margins and padding to make them consistent with TextField.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -232,7 +232,6 @@ export const getStyles = memoizeFunction((
       fonts.medium,
       {
         boxShadow: 'none',
-        marginBottom: '10px',
         marginLeft: '0',
         paddingTop: '1px', // The 1px padding centers the input field, avoiding overlap in the browser
         paddingBottom: '1px',

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
           font-size: 14px;
           font-weight: 400;
           height: 32px;
-          margin-bottom: 10px;
           margin-left: 0;
           outline: 0;
           overflow: hidden;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -139,8 +139,7 @@ export const getStyles = memoizeFunction((
       outline: 'none',
       fontSize: FontSizes.medium,
       width: '100%',
-      minWidth: '86px',
-      padding: '2px',
+      minWidth: '86px'
     },
     labelWrapper: {
       display: 'inline-flex'

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -8,10 +8,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
         font-size: 14px;
         min-width: 86px;
         outline: none;
-        padding-bottom: 2px;
-        padding-left: 2px;
-        padding-right: 2px;
-        padding-top: 2px;
         width: 100%;
       }
 >


### PR DESCRIPTION
Addresses #4028.

When rendering SpinButton, ComboBox, and TextField together, they should have 0 padding/margin and be all the same height. They aren't.

Before, extra weird paddings and margins:

![image](https://user-images.githubusercontent.com/1110944/37250921-aa221ec8-24bb-11e8-8e98-339b4d685f47.png)

After, these controls now are consistent with TextField, Dropdown, and Searchbox:

![image](https://user-images.githubusercontent.com/1110944/37250933-d5bcdb22-24bb-11e8-9229-8ce6aa0b0a67.png)
