### PR TITLE
Pickers Accessibility: fix activedescendant so it no longer has sug--1 if nothing is selected.

### DIFF
--- a/common/changes/office-ui-fabric-react/pickers-fix-activedescendant_2018-03-12-18-09.json
+++ b/common/changes/office-ui-fabric-react/pickers-fix-activedescendant_2018-03-12-18-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pickers: Fix aria bug where activedescendant would be sug--1",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -176,6 +176,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     const currentIndex = this.suggestionStore.currentIndex;
     const selectedSuggestion = currentIndex > -1 ? this.suggestionStore.getSuggestionAtIndex(this.suggestionStore.currentIndex) : undefined;
     const selectedSuggestionAlert = selectedSuggestion ? selectedSuggestion.ariaLabel : undefined;
+    const activeDescendant = currentIndex > -1 ? 'sug-' + currentIndex : undefined;
 
     return (
       <div
@@ -202,7 +203,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
                 onBlur={ this.onInputBlur }
                 onInputValueChange={ this.onInputChange }
                 suggestedDisplayValue={ suggestedDisplayValue }
-                aria-activedescendant={ 'sug-' + this.suggestionStore.currentIndex }
+                aria-activedescendant={ activeDescendant }
                 aria-owns='suggestion-list'
                 aria-expanded={ !!this.state.suggestionsVisible }
                 aria-haspopup='true'

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Pickers BasePicker renders BasePicker correctly 1`] = `
         role="list"
       >
         <input
-          aria-activedescendant="sug--1"
+          aria-activedescendant={undefined}
           aria-controls="selected-suggestion-alert"
           aria-expanded={false}
           aria-haspopup="true"
@@ -107,7 +107,7 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
         role="list"
       >
         <input
-          aria-activedescendant="sug--1"
+          aria-activedescendant={undefined}
           aria-controls="selected-suggestion-alert"
           aria-expanded={false}
           aria-haspopup="true"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix activedescendant so it no longer has sug--1 if nothing is selected.

#### Focus areas to test

(optional)
