### PR TITLE
Addressing Issue #4176 - Datepicker add is-open css class

### DIFF
--- a/common/changes/office-ui-fabric-react/datepicker-isopen-4176_2018-03-12-18-20.json
+++ b/common/changes/office-ui-fabric-react/datepicker-isopen-4176_2018-03-12-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added an is-open class to the DatePicker root element to indicate when the datepicker is being shown based on the IDatePickerState.isDatePickerShown state property.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -206,7 +206,13 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     const { isDatePickerShown, formattedDate, selectedDate, errorMessage } = this.state;
 
     return (
-      <div className={ css('ms-DatePicker', styles.root, className) }>
+      <div className={ css(
+        'ms-DatePicker',
+        styles.root,
+        isDatePickerShown && 'is-open',
+        className
+      )
+      }>
         { label && (
           <Label required={ isRequired }>{ label }</Label>
         ) }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -206,13 +206,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
     const { isDatePickerShown, formattedDate, selectedDate, errorMessage } = this.state;
 
     return (
-      <div className={ css(
-        'ms-DatePicker',
-        styles.root,
-        isDatePickerShown && 'is-open',
-        className
-      )
-      }>
+      <div className={ css('ms-DatePicker', styles.root, isDatePickerShown && 'is-open', className) }>
         { label && (
           <Label required={ isRequired }>{ label }</Label>
         ) }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4176 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added an is-open class to the DatePicker root element to indicate when the datepicker is being shown based on the IDatePickerState.isDatePickerShown state property.
