### PR TITLE
ContextualMenu: icons in high contrast mode

### DIFF
--- a/common/changes/office-ui-fabric-react/contextmenu-hc-icon_2018-03-13-22-21.json
+++ b/common/changes/office-ui-fabric-react/contextmenu-hc-icon_2018-03-13-22-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Improved high contrast support for icons.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -20,7 +20,12 @@ const getItemHighContrastStyles = memoizeFunction((): IRawStyle => {
         backgroundColor: 'Highlight',
         borderColor: 'Highlight',
         color: 'HighlightText',
-        MsHighContrastAdjust: 'none'
+        MsHighContrastAdjust: 'none',
+        selectors: {
+          '.ms-ContextualMenu-icon': {
+            color: 'HighlightText'
+          }
+        }
       }
     },
   };
@@ -128,11 +133,6 @@ export const getMenuItemStyles = memoizeFunction((
     },
     iconColor: {
       color: semanticColors.menuIcon,
-      selectors: {
-        [HighContrastSelector]: {
-          color: 'HighlightText',
-        }
-      }
     },
     iconDisabled: {
       color: semanticColors.disabledBodyText,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4248 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Icons weren't showing  up in high contrast mode. I moved styling to the 'root' item so that it works for item hover, etc, also.

#### Focus areas to test

(optional)
