### PR TITLE
Nav component sets aria-label on <nav> element

### DIFF
--- a/common/changes/office-ui-fabric-react/nav-element-aria-label_2018-03-14-01-34.json
+++ b/common/changes/office-ui-fabric-react/nav-element-aria-label_2018-03-14-01-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Nav component sets aria-label on nested element with role=navigation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "shiran.pasternak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -105,6 +105,7 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
         <nav
           role='navigation'
           className={ classNames.root }
+          aria-label={ this.props.ariaLabel }
         >
           { groupElements }
         </nav>
@@ -218,7 +219,7 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
     const classNames = getClassNames(getStyles!, { theme: theme!, groups });
 
     return (
-      <ul role='list' aria-label={ this.props.ariaLabel } className={ classNames.navItems }>
+      <ul role='list' className={ classNames.navItems }>
         { linkElements }
       </ul>
     );

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.test.tsx
@@ -46,4 +46,14 @@ describe('Nav', () => {
     link.simulate('click');
     expect(handler.mock.calls.length).toBe(1);
   });
+
+  it('sets ARIA label on the nav element', () => {
+    const label = 'The navigation label';
+    const nav = mount<NavBase>(
+      <Nav
+        ariaLabel={ label }
+        groups={ [] }
+      />);
+    expect(nav.find('[role="navigation"]').prop('aria-label')).toEqual(label);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Nav renders Nav correctly 1`] = `
   role="presentation"
 >
   <nav
+    aria-label={undefined}
     className=
         ms-Nav
         {
@@ -40,7 +41,6 @@ exports[`Nav renders Nav correctly 1`] = `
             }
       >
         <ul
-          aria-label={undefined}
           className=
               ms-Nav-navItems
               {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4265
- [x] Include a change request file using `$ npm run change`

#### Description of changes


The aria-label was set on the nested `<ul>` element. Per [WAI guidelines][1] the `aria-label` should be set on the element having the "navigation" role (`<nav>`). This is especially important when multiple navigation landmarks exist in the DOM tree (which need to be distinguished by their `aria-label`).

Includes unit test to isolate expected behavior.

[1]: https://www.w3.org/WAI/GL/wiki/Using_ARIA_landmarks_to_identify_regions_of_a_page
