### PR TITLE
Users/adtran/fixed kb focus ie11 toggle

### DIFF
--- a/common/changes/office-ui-fabric-react/users-adtran-fixed-kb-focus-ie11-toggle_2018-03-14-02-23.json
+++ b/common/changes/office-ui-fabric-react/users-adtran-fixed-kb-focus-ie11-toggle_2018-03-14-02-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed keyboard focus border visibility for IE11, where overflow is hidden by default.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "adtran@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/users-adtran-fixed-kb-focus-ie11-toggle_2018-03-14-02-23.json
+++ b/common/changes/office-ui-fabric-react/users-adtran-fixed-kb-focus-ie11-toggle_2018-03-14-02-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fixed keyboard focus border visibility for IE11, where overflow is hidden by default.",
+      "comment": "Fixed keyboard focus border visibility for Toggle on IE11, where overflow is hidden by default.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.classNames.ts
@@ -91,6 +91,7 @@ export const getClassNames = memoizeFunction((
         background: pillUncheckedBackground,
         borderColor: pillBorderColor,
         cursor: 'pointer',
+        overflow: 'visible',
       },
       styles.pill,
       !disabled && [

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`Toggle renders toggle correctly 1`] = `
             height: 1em;
             line-height: 1em;
             outline: transparent;
+            overflow: visible;
             position: relative;
             transition: all 0.1s ease;
             width: 2.2em;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4267
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixed keyboard focus border visibility for Toggle on IE11, where overflow is hidden by default for button.

#### Focus areas to test

(optional)
