### PR TITLE
Remove extra tooltip in dropdown

### DIFF
--- a/common/changes/office-ui-fabric-react/racbatch-feature_2018-03-14-18-51.json
+++ b/common/changes/office-ui-fabric-react/racbatch-feature_2018-03-14-18-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove the redundant tooltip in a Dropdown command button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "racbatch@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -498,7 +498,6 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             role='option'
             aria-selected={ isItemSelected ? 'true' : 'false' }
             ariaLabel={ item.ariaLabel || item.text }
-            title={ item.text }
           >
             { onRenderOption(item, this._onRenderOption) }
           </CommandButton>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Remove the tooltip from the basic dropdown button.  The tooltip is the same as the text displayed in the button itself, so it is redundant.

#### Focus areas to test

(optional)
