### PR TITLE
Addressing Issue #4209 - [Accessibility][ChoiceGroup] Provide field for aria label on IChoiceGroupOption

### DIFF
--- a/common/changes/office-ui-fabric-react/choicegroup-voiceoverfix-4209_2018-03-14-21-48.json
+++ b/common/changes/office-ui-fabric-react/choicegroup-voiceoverfix-4209_2018-03-14-21-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Targeted the aria-labelledby on ChoiceGroup's input field to the span tag inside the span tag inside label ( option.labelId ) instead of thelabel itself ( option.id ). ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -122,7 +122,7 @@ export class ChoiceGroup extends BaseComponent<IChoiceGroupProps, IChoiceGroupSt
                       onChange={ this._onChange.bind(this, option) }
                       onFocus={ this._onFocus.bind(this, option) }
                       onBlur={ this._onBlur.bind(this, option) }
-                      aria-labelledby={ option.id }
+                      aria-labelledby={ option.labelId }
                       { ...getNativeProps(option, inputProperties) }
                     />
                     { onRenderField(option, this._onRenderField) }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
           className="ms-ChoiceField-wrapper"
         >
           <input
-            aria-labelledby="ChoiceGroup0-1"
+            aria-labelledby="ChoiceGroupLabel1-1"
             checked={false}
             className="ms-ChoiceField-input"
             data-automation-id="auto1"
@@ -53,7 +53,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
           className="ms-ChoiceField-wrapper"
         >
           <input
-            aria-labelledby="ChoiceGroup0-2"
+            aria-labelledby="ChoiceGroupLabel1-2"
             checked={false}
             className="ms-ChoiceField-input"
             disabled={undefined}
@@ -85,7 +85,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
           className="ms-ChoiceField-wrapper"
         >
           <input
-            aria-labelledby="ChoiceGroup0-3"
+            aria-labelledby="ChoiceGroupLabel1-3"
             checked={false}
             className="ms-ChoiceField-input"
             disabled={undefined}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4209
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Voiceover was not reading the label for the ChoiceGroup option so I targeted the **aria-labelledby** on ChoiceGroup's input field to the span tag inside the span tag inside label ( option.labelId ) instead of the label itself ( option.id ).  This seems to have remedies the situation when using Voiceover

#### Focus areas to test

I need someone with Narrator on Windows setup to give this change a run to make sure the change does not someone break Narrator.