### PR TITLE
Addressing Issue #4077 - DetailsList "data-selection-disabled" doesn't work

### DIFF
--- a/common/changes/office-ui-fabric-react/detailslist-dataselectionfix-4077_2018-03-15-17-58.json
+++ b/common/changes/office-ui-fabric-react/detailslist-dataselectionfix-4077_2018-03-15-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added _isSelectionDisabled check in SelectionZone's onMouseDown event handler",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx
@@ -117,7 +117,7 @@ function _renderItemColumn(item: any, index: number, column: IColumn) {
       return <Link href='#'>{ fieldContent }</Link>;
 
     case 'color':
-      return <span data-selection-disabled={ true } style={ { color: fieldContent } }>{ fieldContent }</span>;
+      return <span data-selection-disabled={ true } style={ { color: fieldContent, height: '100%', display: 'block' } }>{ fieldContent }</span>;
 
     default:
       return <span>{ fieldContent }</span>;

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -180,6 +180,11 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     let target = ev.target as HTMLElement;
     const itemRoot = this._findItemRoot(target);
 
+    // No-op if selection is disabled
+    if (this._isSelectionDisabled(target)) {
+      return;
+    }
+
     while (target !== this._root) {
       if (this._hasAttribute(target, SELECTALL_TOGGLE_ALL_ATTRIBUTE_NAME)) {
         break;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4077 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added _isSelectionDisabled check in SelectionZone's onMouseDown event handler.