### PR TITLE
Fixing accessibility issue: #4295

### DIFF
--- a/common/changes/office-ui-fabric-react/patch-1_2018-03-17-10-31.json
+++ b/common/changes/office-ui-fabric-react/patch-1_2018-03-17-10-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: Fixing issue with promise based error message not being announced by firefox + NVDA",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "prbhad@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -192,17 +192,17 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         { this._isDescriptionAvailable &&
           <span id={ this._descriptionId }>
             { description && <span className={ css('ms-TextField-description', styles.description) }>{ description }</span> }
+            <div aria-live='assertive'>
             { errorMessage &&
-              <div>
-                <DelayedRender>
-                  <p
-                    className={ css('ms-TextField-errorMessage', AnimationClassNames.slideDownIn20, styles.errorMessage) }
-                  >
-                    <span aria-live='assertive' className={ styles.errorText } data-automation-id='error-message'>{ errorMessage }</span>
-                  </p>
-                </DelayedRender>
-              </div>
+              <DelayedRender>
+                <p
+                  className={ css('ms-TextField-errorMessage', AnimationClassNames.slideDownIn20, styles.errorMessage) }
+                >
+                  <span className={ styles.errorText } data-automation-id='error-message'>{ errorMessage }</span>
+                </p>
+              </DelayedRender>
             }
+            </div>
           </span>
         }
       </div>

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -192,17 +192,17 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         { this._isDescriptionAvailable &&
           <span id={ this._descriptionId }>
             { description && <span className={ css('ms-TextField-description', styles.description) }>{ description }</span> }
-            <div aria-live='assertive'>
             { errorMessage &&
-              <DelayedRender>
-                <p
-                  className={ css('ms-TextField-errorMessage', AnimationClassNames.slideDownIn20, styles.errorMessage) }
-                >
-                  <span className={ styles.errorText } data-automation-id='error-message'>{ errorMessage }</span>
-                </p>
-              </DelayedRender>
+              <div aria-live='assertive'>
+                <DelayedRender>
+                  <p
+                    className={ css('ms-TextField-errorMessage', AnimationClassNames.slideDownIn20, styles.errorMessage) }
+                  >
+                    <span className={ styles.errorText } data-automation-id='error-message'>{ errorMessage }</span>
+                  </p>
+                </DelayedRender>
+              </div>
             }
-            </div>
           </span>
         }
       </div>


### PR DESCRIPTION
Promise based TextField error message is not read by firefox + NVDA

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4295
- [x] Include a change request file using `$ npm run change`

#### Description of changes

aria-live="assertive" attribute should be defined on a statically available element. Error message may be loaded dynamically inside that element. For TextField, this attribute was added to DOM dynamically. In order to announce message in live region, Assistive Technology (NVDA) need to detect some element with aria-live defined. Then it announces any message loaded dynamically inside it.

#### Focus areas to test
All error message combinations for TextField with:
EDGE + Narrator
FireFox + NVDA
