### PR TITLE
Addressing Issue #4231 - CommandBar Items with href should also support OnClick behavior

### DIFF
--- a/common/changes/office-ui-fabric-react/commandbar-onclick-4231_2018-03-19-19-26.json
+++ b/common/changes/office-ui-fabric-react/commandbar-onclick-4231_2018-03-19-19-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Reordered the logic in CommandBar that decides to render an anchor or button tag so that the anchor tag can have both an href and onclick attribute.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -194,7 +194,33 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     const ariaLabel = item.ariaLabel || (item.iconOnly ? item.name : undefined);
 
     let command: React.ReactNode;
-    if (isLink) {
+    if (item.href) {
+      // Allow the disabled property on anchor elements for commandbar
+      command = (
+        <a
+          { ...getNativeProps(item, anchorProperties.concat(['disabled'])) }
+          id={ this._id + item.key }
+          className={ className }
+          href={ item.disabled ? undefined : item.href }
+          onClick={ item.onClick }
+          data-command-key={ itemKey }
+          aria-haspopup={ hasSubmenu(item) }
+          role='menuitem'
+          aria-label={ ariaLabel }
+          aria-setsize={ setSize }
+          aria-posinset={ posInSet }
+        >
+          { (hasIcon) ? this._renderIcon(item) : (null) }
+          { isNameVisible && (
+            <span
+              className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
+            >
+              { item.name }
+            </span>
+          ) }
+        </a>
+      );
+    } else if (isLink) {
       command = (
         <button
           { ...getNativeProps(item, buttonProperties) }
@@ -221,31 +247,6 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
             <Icon className={ css('ms-CommandBarItem-chevronDown', styles.itemChevronDown) } iconName='ChevronDown' />
           ) : (null) }
         </button>
-      );
-    } else if (item.href) {
-      // Allow the disabled property on anchor elements for commandbar
-      command = (
-        <a
-          { ...getNativeProps(item, anchorProperties.concat(['disabled'])) }
-          id={ this._id + item.key }
-          className={ className }
-          href={ item.disabled ? undefined : item.href }
-          data-command-key={ itemKey }
-          aria-haspopup={ hasSubmenu(item) }
-          role='menuitem'
-          aria-label={ ariaLabel }
-          aria-setsize={ setSize }
-          aria-posinset={ posInSet }
-        >
-          { (hasIcon) ? this._renderIcon(item) : (null) }
-          { isNameVisible && (
-            <span
-              className={ css('ms-CommandBarItem-commandText', styles.itemCommandText) }
-            >
-              { item.name }
-            </span>
-          ) }
-        </a>
       );
     } else {
       // Allow the disabled property on div elements for commandbar


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4231
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Reordered the logic in **CommandBar** that decides to render an anchor or button tag so that the anchor tag can have both an `href` and `onClick` attribute.
