### PR TITLE
Removing empty callout when tooltip content is empty

### DIFF
--- a/common/changes/office-ui-fabric-react/users-prbhad-HideTooltipForEmptyMessage_2018-03-21-05-49.json
+++ b/common/changes/office-ui-fabric-react/users-prbhad-HideTooltipForEmptyMessage_2018-03-21-05-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removing empty callout when tooltip content is empty",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "prbhad@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -56,6 +56,8 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
     } = this.props;
     const { isTooltipVisible } = this.state;
     const tooltipId = id || getId('tooltip');
+    const isContentPresent = !!(content || (tooltipProps && tooltipProps.onRenderContent && tooltipProps.onRenderContent()));
+    const showTooltip = isTooltipVisible && isContentPresent;
 
     return (
       <div
@@ -72,7 +74,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
         aria-describedby={ setAriaDescribedBy && isTooltipVisible && content ? tooltipId : undefined }
       >
         { children }
-        { isTooltipVisible && (
+        { showTooltip && (
           <Tooltip
             id={ tooltipId }
             delay={ delay }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4321 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Removing empty callout when tooltip content is empty


