### PR TITLE
Make sure componentRef types match base component type

### DIFF
--- a/common/changes/@uifabric/experiments/make-sure-componentRef-types-match-BaseComponent-type_2018-03-21-08-31.json
+++ b/common/changes/@uifabric/experiments/make-sure-componentRef-types-match-BaseComponent-type_2018-03-21-08-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Update componentRef types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "mark@thedutchies.com"
+}

--- a/common/changes/@uifabric/utilities/make-sure-componentRef-types-match-BaseComponent-type_2018-03-21-08-31.json
+++ b/common/changes/@uifabric/utilities/make-sure-componentRef-types-match-BaseComponent-type_2018-03-21-08-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Update createRef type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "mark@thedutchies.com"
+}

--- a/common/changes/office-ui-fabric-react/make-sure-componentRef-types-match-BaseComponent-type_2018-03-21-08-31.json
+++ b/common/changes/office-ui-fabric-react/make-sure-componentRef-types-match-BaseComponent-type_2018-03-21-08-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Update componentRef types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/experiments/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/experiments/src/components/CommandBar/CommandBar.types.ts
@@ -24,7 +24,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * Optional callback to access the ICommandBar interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ICommandBar) => void;
+  componentRef?: (component: ICommandBar | null) => void;
 
   /**
    * Items to render

--- a/packages/experiments/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/experiments/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -17,7 +17,7 @@ export interface IBaseExtendedPicker<T> {
 // and searched for by the people picker. For example, if the picker is
 // displaying persona's than type T could either be of Persona or Ipersona props
 export interface IBaseExtendedPickerProps<T> {
-  componentRef?: (component?: IBaseExtendedPicker<T>) => void;
+  componentRef?: (component?: IBaseExtendedPicker<T> | null) => void;
 
   /**
    * Header/title element for the picker

--- a/packages/experiments/src/components/Form/Form.types.ts
+++ b/packages/experiments/src/components/Form/Form.types.ts
@@ -1,11 +1,14 @@
 /* tslint:disable:no-any */
 import * as React from 'react';
 
+export interface IForm {
+}
+
 /**
  * The props for Form
  */
 export interface IFormProps extends React.AllHTMLAttributes<HTMLFormElement> {
-  componentRef?: (component: any) => void;
+  componentRef?: (component: IForm | null) => void;
 
   /** The submit handler. Passes back results keyed by the names of the inputs */
   onSubmit?: (results: { [key: string]: any }) => void;

--- a/packages/experiments/src/components/Keytip/Keytip.types.ts
+++ b/packages/experiments/src/components/Keytip/Keytip.types.ts
@@ -11,7 +11,7 @@ export interface IKeytipProps {
    * Optional callback to access the Keytip component. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IKeytip) => void;
+  componentRef?: (component: IKeytip | null) => void;
 
   /**
    * Content to put inside the keytip

--- a/packages/experiments/src/components/KeytipLayer/KeytipLayer.types.ts
+++ b/packages/experiments/src/components/KeytipLayer/KeytipLayer.types.ts
@@ -7,7 +7,7 @@ export interface IKeytipLayerProps extends React.Props<KeytipLayer> {
    * Optional callback to access the KeytipLayer component. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: KeytipLayer) => void;
+  componentRef?: (component: KeytipLayer | null) => void;
 
   /**
    * The DOM ID to use as the hostId for the child keytips

--- a/packages/experiments/src/components/SelectedItemsList/BaseSelectedItemsList.types.ts
+++ b/packages/experiments/src/components/SelectedItemsList/BaseSelectedItemsList.types.ts
@@ -17,7 +17,7 @@ export interface ISelectedItemProps<T> extends IPickerItemProps<T> {
 // For example, if the picker is displaying persona's than type T could either be of Persona or Ipersona props
 // tslint:disable-next-line:no-any
 export interface IBaseSelectedItemsListProps<T> extends React.Props<any> {
-  componentRef?: (component?: IBaseSelectedItemsList<T>) => void;
+  componentRef?: (component?: IBaseSelectedItemsList<T> | null) => void;
 
   /**
    * The selection

--- a/packages/experiments/src/components/Shimmer/Shimmer.types.ts
+++ b/packages/experiments/src/components/Shimmer/Shimmer.types.ts
@@ -16,7 +16,7 @@ export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
    * Optional callback to access the IShimmer interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IShimmer) => void;
+  componentRef?: (component: IShimmer | null) => void;
 
   /**
    * Sets the width of the shimmer wave wrapper in percentages.

--- a/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.types.ts
+++ b/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.types.ts
@@ -17,7 +17,7 @@ export interface IShimmerCircleProps extends React.AllHTMLAttributes<HTMLElement
    * Optional callback to access the IShimmerCircle interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IShimmerCircle) => void;
+  componentRef?: (component: IShimmerCircle | null) => void;
 
   /**
    * Sets the height of the circle.

--- a/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.types.ts
+++ b/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.types.ts
@@ -17,7 +17,7 @@ export interface IShimmerLineProps extends React.AllHTMLAttributes<HTMLElement> 
    * Optional callback to access the IShimmerLine interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IShimmerLine) => void;
+  componentRef?: (component: IShimmerLine | null) => void;
 
   /**
    * Sets the height of the rectangle.

--- a/packages/experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/experiments/src/components/TilesList/TilesList.types.ts
@@ -107,7 +107,7 @@ export interface ITilesListProps<TItem> extends IBaseProps, React.Props<TilesLis
   /**
    * Component ref for the focus zone within the list. Use this to control auto-focus.
    */
-  focusZoneComponentRef?: (focusZone: IFocusZone) => void;
+  focusZoneComponentRef?: (focusZone: IFocusZone | null) => void;
   /**
    * Callback for when the active element within the list's FocusZone changes.
    */

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
@@ -45,7 +45,7 @@ export interface IAutofillProps extends
   /**
    * Gets the compoonent ref.
    */
-  componentRef?: (componentRef?: IAutofill) => void;
+  componentRef?: (componentRef?: IAutofill | null) => void;
 
   /**
    * The suggested autofill value that will display.

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -13,7 +13,7 @@ export interface IBreadcrumbProps extends React.Props<Breadcrumb> {
    * Optional callback to access the IBreadcrumb interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IBreadcrumb) => void;
+  componentRef?: (component: IBreadcrumb | null) => void;
 
   /**
    * Collection of breadcrumbs to render

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -30,7 +30,7 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
    * Optional callback to access the IButton interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IButton) => void;
+  componentRef?: (component: IButton | null) => void;
 
   /**
    * If provided, this component will be rendered as an anchor.

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -14,7 +14,7 @@ export interface ICalendarProps extends React.Props<Calendar> {
    * Optional callback to access the ICalendar interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ICalendar) => void;
+  componentRef?: (component: ICalendar | null) => void;
 
   /**
   * Callback issued when a date is selected

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -16,7 +16,7 @@ export interface ICalloutProps {
    * Optional callback to access the ICallout interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ICallout) => void;
+  componentRef?: (component: ICallout | null) => void;
 
   /**
    * The target that the Callout should try to position itself based on.

--- a/packages/office-ui-fabric-react/src/components/Check/Check.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.types.ts
@@ -7,7 +7,7 @@ export interface ICheckProps extends React.Props<CheckBase> {
   /**
    * Gets the component ref.
    */
-  componentRef?: (component: ICheckProps) => void;
+  componentRef?: (component: ICheckProps | null) => void;
 
   /**
    * Whether or not this menu item is currently checked.

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
@@ -23,7 +23,7 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
    * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ICheckbox) => void;
+  componentRef?: (component: ICheckbox | null) => void;
 
   /**
    * Additional class name to provide on the root element, in addition to the ms-Checkbox class.

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -11,7 +11,7 @@ export interface IChoiceGroupProps extends React.InputHTMLAttributes<HTMLElement
    * Optional callback to access the IChoiceGroup interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IChoiceGroup) => void;
+  componentRef?: (component: IChoiceGroup | null) => void;
 
   /**
    * The options for the choice group.

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Beak/Beak.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Beak/Beak.types.ts
@@ -7,7 +7,7 @@ export interface IBeakProps extends React.Props<Beak> {
   /**
   * All props for your component are to be defined here.
   */
-  componentRef?: (component: IBeak) => void;
+  componentRef?: (component: IBeak | null) => void;
 
   /**
    * Beak width.

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
@@ -8,7 +8,7 @@ export interface ICoachmark {
 }
 
 export interface ICoachmarkTypes extends React.Props<Coachmark> {
-  componentRef?: (component: ICoachmark) => void;
+  componentRef?: (component: ICoachmark | null) => void;
 
   /**
    * Get styles method.

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
@@ -21,7 +21,7 @@ export interface IPositioningContainerTypes extends React.Props<PositioningConta
   /**
   * All props for your component are to be defined here.
   */
-  componentRef?: (component: IPositioningContainer) => void;
+  componentRef?: (component: IPositioningContainer | null) => void;
   /**
    * The target that the positioningContainer should try to position itself based on.
    * It can be either an HTMLElement a querySelector string of a valid HTMLElement

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -33,7 +33,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * Optional callback to access the IComboBox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IComboBox) => void;
+  componentRef?: (component: IComboBox | null) => void;
 
   /**
    * Collection of options for this ComboBox

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -13,7 +13,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * Optional callback to access the ICommandBar interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ICommandBar) => void;
+  componentRef?: (component: ICommandBar | null) => void;
 
   /**
    * Whether or not the search box is visible

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -33,7 +33,7 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
    * Optional callback to access the IContextualMenu interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IContextualMenu) => void;
+  componentRef?: (component: IContextualMenu | null) => void;
 
   /**
    * The target that the ContextualMenu should try to position itself based on.

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -14,7 +14,7 @@ export interface IDatePickerProps extends React.Props<DatePicker> {
    * Optional callback to access the IDatePicker interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IDatePicker) => void;
+  componentRef?: (component: IDatePicker | null) => void;
 
   /**
    * Pass calendar props to calendar component

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -33,7 +33,7 @@ export interface IDetailsHeader {
 }
 
 export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
-  componentRef?: (component: IDetailsHeader) => void;
+  componentRef?: (component: IDetailsHeader | null) => void;
   columns: IColumn[];
   selection: ISelection;
   selectionMode: SelectionMode;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -44,7 +44,7 @@ export interface IDetailsListProps extends React.Props<DetailsList>, IWithViewpo
    * Optional callback to access the IDetailsList interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IDetailsList) => void;
+  componentRef?: (component: IDetailsList | null) => void;
 
   /** A key that uniquely identifies the given items. If provided, the selection will be reset when the key changes. */
   setKey?: string;

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
@@ -18,7 +18,7 @@ export interface IDialogProps extends React.Props<DialogBase>, IWithResponsiveMo
    * Optional callback to access the IDialog interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IDialog) => void;
+  componentRef?: (component: IDialog | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -14,7 +14,7 @@ export interface IDialogContentProps extends React.Props<DialogContentBase> {
   * Optional callback to access the IDialogContent interface. Use this instead of ref for accessing
   * the public methods and properties of the component.
   */
-  componentRef?: (component: IDialogContent) => void;
+  componentRef?: (component: IDialogContent | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.types.ts
@@ -7,7 +7,7 @@ export interface IDialogFooterProps extends React.Props<DialogFooterBase> {
   /**
    * Gets the component ref.
    */
-  componentRef?: (component: IDialogFooterProps) => void;
+  componentRef?: (component: IDialogFooterProps | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -19,7 +19,7 @@ export interface IDocumentCardProps extends React.Props<DocumentCard> {
    * Optional callback to access the IDocumentCard interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IDocumentCard) => void;
+  componentRef?: (component: IDocumentCard | null) => void;
 
   /**
   * The type of DocumentCard to display.

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.types.ts
@@ -16,7 +16,7 @@ export interface IFacepileProps extends React.Props<Facepile> {
    * Optional callback to access the IFacepile interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IFacepile) => void;
+  componentRef?: (component: IFacepile | null) => void;
 
   /**
    * Array of IPersonaProps that define each Persona.

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.types.ts
@@ -12,7 +12,7 @@ export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement
    * Optional callback to access the IFocusTrapZone interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IFocusTrapZone) => void;
+  componentRef?: (component: IFocusTrapZone | null) => void;
 
   /**
    * Sets the HTMLElement to focus on when exiting the FocusTrapZone.

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
@@ -30,7 +30,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
    * Optional callback to access the IFocusZone interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IFocusZone) => void;
+  componentRef?: (component: IFocusZone | null) => void;
 
   /**
    * Additional class name to provide on the root element, in addition to the ms-FocusZone class.

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -42,7 +42,7 @@ export interface IGroupedListProps extends React.Props<GroupedList> {
    * Optional callback to access the IGroupedList interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component?: IGroupedList) => void;
+  componentRef?: (component?: IGroupedList | null) => void;
 
   /** Optional class name to add to the root element. */
   className?: string;

--- a/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.types.ts
@@ -16,7 +16,7 @@ export interface IExpandingCardProps extends React.HTMLAttributes<HTMLDivElement
    * Optional callback to access the IExpandingCard interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IExpandingCard) => void;
+  componentRef?: (component: IExpandingCard | null) => void;
 
   /**
    *  Item to be returned with onRender functions

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -15,7 +15,7 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement | H
    * Optional callback to access the IHoverCardHost interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IHoverCard) => void;
+  componentRef?: (component: IHoverCard | null) => void;
 
   /**
    * Additional properties to pass through for HoverCard, reference detail properties in IHoverCardProps

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -11,7 +11,7 @@ export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
    * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IImage) => void;
+  componentRef?: (component: IImage | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/Label/Label.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.types.ts
@@ -12,7 +12,7 @@ export interface ILabelProps extends React.LabelHTMLAttributes<HTMLLabelElement>
    * Optional callback to access the ILabel interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ILabel) => void;
+  componentRef?: (component: ILabel | null) => void;
 
   /**
    * Whether the associated form field is required or not

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.types.ts
@@ -12,7 +12,7 @@ export interface ILayerProps extends React.HTMLAttributes<HTMLDivElement | Layer
    * Optional callback to access the ILayer interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ILayer) => void;
+  componentRef?: (component: ILayer | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerHost.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerHost.types.ts
@@ -9,7 +9,7 @@ export interface ILayerHostProps extends React.HTMLAttributes<HTMLElement> {
    * Optional callback to access the ILayerHost interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ILayerHost) => void;
+  componentRef?: (component: ILayerHost | null) => void;
 
   /**
    * Defines the id for the layer host that Layers can target (using the hostId property.)

--- a/packages/office-ui-fabric-react/src/components/Link/Link.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.types.ts
@@ -19,7 +19,7 @@ export interface ILinkProps extends React.AllHTMLAttributes<HTMLAnchorElement | 
    * Optional callback to access the ILink interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ILink) => void;
+  componentRef?: (component: ILink | null) => void;
 
   /**
    * Whether the link is disabled

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -21,7 +21,7 @@ export interface IListProps extends React.HTMLAttributes<List | HTMLDivElement> 
    * Optional callback to access the IList interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IList) => void;
+  componentRef?: (component: IList | null) => void;
 
   /** Optional classname to append to root list. */
   className?: string;

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.types.ts
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.types.ts
@@ -11,7 +11,7 @@ export interface IMarqueeSelectionProps extends React.Props<MarqueeSelection> {
    * Optional callback to access the IMarqueeSelection interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IMarqueeSelection) => void;
+  componentRef?: (component: IMarqueeSelection | null) => void;
 
   /**
    * The selection object to interact with when updating selection changes.

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.types.ts
@@ -10,7 +10,7 @@ export interface IMessageBarProps extends React.HTMLAttributes<HTMLElement> {
    * Optional callback to access the IMessageBar interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IMessageBar) => void;
+  componentRef?: (component: IMessageBar | null) => void;
 
   /**
    * The type of MessageBar to render.

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.types.ts
@@ -15,7 +15,7 @@ export interface IModalProps extends React.Props<Modal>, IWithResponsiveModeStat
    * Optional callback to access the IDialog interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IModal) => void;
+  componentRef?: (component: IModal | null) => void;
 
   /**
   * Whether the dialog is displayed.

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -18,7 +18,7 @@ export interface INavProps {
    * Optional callback to access the INav interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: INav) => void;
+  componentRef?: (component: INav | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
@@ -14,7 +14,7 @@ export interface IOverflowSetProps extends React.Props<OverflowSet> {
   /**
    * Gets the component ref.
    */
-  componentRef?: (ref?: IOverflowSet) => void;
+  componentRef?: (ref?: IOverflowSet | null) => void;
 
   /**
    * Class name

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.types.ts
@@ -10,7 +10,7 @@ export interface IOverlayProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Gets the component ref.
    */
-  componentRef?: (component: IOverlayProps) => void;
+  componentRef?: (component: IOverlayProps | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -20,7 +20,7 @@ export interface IPanelProps extends React.Props<Panel> {
    * Optional callback to access the IPanel interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IPanel) => void;
+  componentRef?: (component: IPanel | null) => void;
 
   /**
   * Whether the panel is displayed.

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -14,7 +14,7 @@ export interface IPersonaProps extends React.HTMLAttributes<PersonaBase> {
    * Optional callback to access the IPersona interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IPersona) => void;
+  componentRef?: (component: IPersona | null) => void;
 
   /**
    * Primary text to display, usually the name of the person.

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -12,7 +12,7 @@ export interface IPivotProps extends React.Props<Pivot> {
    * Optional callback to access the IPivot interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IPivot) => void;
+  componentRef?: (component: IPivot | null) => void;
 
   /**
    * The index of the pivot item initially selected.

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.types.ts
@@ -12,7 +12,7 @@ export interface IPopupProps extends React.HTMLAttributes<Popup> {
    * Optional callback to access the IPopup interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IPopup) => void;
+  componentRef?: (component: IPopup | null) => void;
 
   /**
    * Aria role for popup

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
@@ -7,7 +7,7 @@ export interface IProgressIndicatorProps {
    * Optional callback to access the IProgressIndicator interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IProgressIndicator) => void;
+  componentRef?: (component: IProgressIndicator | null) => void;
 
   /**
    * Class name to apply to the root in addition to ms-ProgressIndicator.

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
@@ -17,7 +17,7 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
    * Optional callback to access the IRating interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IRating) => void;
+  componentRef?: (component: IRating | null) => void;
 
   /**
    * Selected rating, has to be an integer between min and max

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -15,7 +15,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
    * Optional callback to access the IResizeGroup interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IResizeGroup) => void;
+  componentRef?: (component: IResizeGroup | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -16,7 +16,7 @@ export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement |
    * Optional callback to access the IScrollablePane interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IScrollablePane) => void;
+  componentRef?: (component: IScrollablePane | null) => void;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -20,7 +20,7 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
    * Optional callback to access the ISearchBox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ISearchBox) => void;
+  componentRef?: (component: ISearchBox | null) => void;
 
   /**
    * Placeholder for the search box.

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
@@ -86,7 +86,7 @@ describe('Slider', () => {
   });
 
   it('can read the current value', () => {
-    let slider: ISlider | undefined;
+    let slider: ISlider | null;
 
     ReactTestUtils.renderIntoDocument(
       // tslint:disable-next-line:jsx-no-lambda

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
@@ -11,7 +11,7 @@ export interface ISliderProps {
    * Optional callback to access the ISlider interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ISlider) => void;
+  componentRef?: (component: ISlider | null) => void;
 
   /**
    * Description label of the Slider

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -24,7 +24,7 @@ export interface ISpinButtonProps {
   /**
    * Gets the component ref.
    */
-  componentRef?: (component?: ISpinButton) => void;
+  componentRef?: (component?: ISpinButton | null) => void;
 
   /**
    * The initial value of the SpinButton. Use this if you intend for the SpinButton to be an uncontrolled component.

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.types.ts
@@ -12,7 +12,7 @@ export interface ISpinnerProps extends React.HTMLAttributes<HTMLElement> {
    * Optional callback to access the ISpinner interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ISpinner) => void;
+  componentRef?: (component: ISpinner | null) => void;
 
   /**
    * Deprecated and will be removed at >= 2.0.0. Use SpinnerSize instead.

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.types.ts
@@ -5,7 +5,7 @@ export interface IStickyProps extends React.Props<Sticky> {
   /**
    * Gets ref to component interface.
    */
-  componentRef?: (component: IStickyProps) => void;
+  componentRef?: (component: IStickyProps | null) => void;
 
   /**
    * Class name to apply to the sticky element if component is sticky.

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -8,7 +8,7 @@ export interface ISwatchColorPickerProps {
   /**
    * Gets the component ref.
    */
-  componentRef?: (componentRef?: ISwatchColorPicker) => void;
+  componentRef?: (componentRef?: ISwatchColorPicker | null) => void;
 
   /**
    * the number of columns for the swatch color picker

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -19,7 +19,7 @@ export interface ITeachingBubbleProps extends React.Props<TeachingBubble | Teach
    * Optional callback to access the ISlider interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ITeachingBubble) => void;
+  componentRef?: (component: ITeachingBubble | null) => void;
 
   /**
    * Properties to pass through for Callout, reference detail properties in ICalloutProps

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -40,7 +40,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * Optional callback to access the ITextField interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ITextField) => void;
+  componentRef?: (component: ITextField | null) => void;
 
   /**
    * Whether or not the textfield is a multiline textfield.

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.types.ts
@@ -14,7 +14,7 @@ export interface IToggleProps extends React.HTMLAttributes<HTMLElement | Toggle>
    * Optional callback to access the IToggle interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: IToggle) => void;
+  componentRef?: (component: IToggle | null) => void;
 
   /**
    * A label for the toggle.

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
@@ -16,7 +16,7 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
    * Optional callback to access the ITooltip interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ITooltip) => void;
+  componentRef?: (component: ITooltip | null) => void;
 
   /**
    * Properties to pass through for Callout, reference detail properties in ICalloutProps

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
@@ -24,7 +24,7 @@ export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement |
    * Optional callback to access the ITooltipHost interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ITooltipHost) => void;
+  componentRef?: (component: ITooltipHost | null) => void;
 
   /**
    * Additional properties to pass through for Callout, reference detail properties in ICalloutProps

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -20,7 +20,7 @@ export interface IBasePicker<T> {
 // and searched for by the people picker. For example, if the picker is
 // displaying persona's than type T could either be of Persona or Ipersona props
 export interface IBasePickerProps<T> extends React.Props<any> {
-  componentRef?: (component?: IBasePicker<T>) => void;
+  componentRef?: (component?: IBasePicker<T> | null) => void;
 
   /**
    * Function that specifies how the selected item will appear.

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -7,7 +7,7 @@ export interface IGridProps {
   /**
    * Gets the component ref.
    */
-  componentRef?: (componentRef?: IGrid) => void;
+  componentRef?: (componentRef?: IGrid | null) => void;
 
   /**
    * The items to turn into a grid

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -8,7 +8,7 @@ export interface ISelectableDroppableTextProps<T> extends React.HTMLAttributes<T
   * Optional callback to access the ISelectableDroppableText interface. Use this instead of ref for accessing
   * the public methods and properties of the component.
   */
-  componentRef?: (component: T) => void;
+  componentRef?: (component: T | null) => void;
 
   /**
    * Descriptive label for the ISelectableDroppableText

--- a/packages/utilities/src/createRef.ts
+++ b/packages/utilities/src/createRef.ts
@@ -1,5 +1,5 @@
 export type RefObject<T> = {
-  (component: T): void;
+  (component: T | null): void;
   value: T | null;
 };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

BaseComponent defines the `componentRef` as receiving `null` as a possible value.
```ts
componentRef?: (ref: T | null) => (void | T);
```
However a lot of the components defined the prop without taking the `null` value into account. But do not guarantee that this is actually the case in the component. This caused  a hole in the type system as the function can be called with `null` but we don't protect against it.

```ts
componentRef?: (component: ICommandBar) => void;
```
This PR fixes up all the componentRef type definitions by adding the possible `null` value.

componentRef?: (component: ICommandBar | null) => void;

#### Focus areas to test

Effects types only, so should not have any effect on JS.
