### PR TITLE
 DetailsList: reset focusedItemIndex after setKey changes to fix scrolling after folder navigation

### DIFF
--- a/common/changes/office-ui-fabric-react/aditima-initialFocusIndex_2018-03-21-23-20.json
+++ b/common/changes/office-ui-fabric-react/aditima-initialFocusIndex_2018-03-21-23-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: reset focusedItemIndex after setKey changes to fix scrolling after folder navigation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aditima@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -118,4 +118,41 @@ describe('DetailsList', () => {
     }, 0);
     jest.runOnlyPendingTimers();
   });
+
+  it('reset focused index after setKey updates', () => {
+    jest.useFakeTimers();
+
+    let component: any;
+    const detailsList = mount(
+      <DetailsList
+        items={ mockItems(5) }
+        setKey={ 'key1' }
+        initialFocusedIndex={ 0 }
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ ref => component = ref }
+        skipViewportMeasures={ true }
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={ () => false }
+      />);
+
+    expect(component).toBeDefined();
+    (component as IDetailsList).focusIndex(3);
+    setTimeout(() => {
+      expect(document.activeElement.textContent).toEqual('3');
+      expect(document.activeElement.className.split(' ')).toContain('ms-DetailsRow');
+    }, 0);
+    jest.runOnlyPendingTimers();
+
+    // update props to new setKey
+    const newProps = { items: mockItems(7), setKey: 'set2', initialFocusedIndex: 0 };
+    detailsList.setProps(newProps);
+    detailsList.update();
+
+    // verify that focus index is reset to 0
+    setTimeout(() => {
+      expect(document.activeElement.textContent).toEqual('0');
+      expect(document.activeElement.className.split(' ')).toContain('ms-DetailsRow');
+    }, 0);
+    jest.runOnlyPendingTimers();
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -119,7 +119,7 @@ describe('DetailsList', () => {
     jest.runOnlyPendingTimers();
   });
 
-  it('reset focused index after setKey updates', () => {
+  it('reset focusedItemIndex when setKey updates', () => {
     jest.useFakeTimers();
 
     let component: any;
@@ -136,10 +136,9 @@ describe('DetailsList', () => {
       />);
 
     expect(component).toBeDefined();
-    (component as IDetailsList).focusIndex(3);
+    component.setState({ focusedItemIndex: 3 });
     setTimeout(() => {
-      expect(document.activeElement.textContent).toEqual('3');
-      expect(document.activeElement.className.split(' ')).toContain('ms-DetailsRow');
+      expect(component.state.focusedItemIndex).toEqual(3);
     }, 0);
     jest.runOnlyPendingTimers();
 
@@ -148,8 +147,9 @@ describe('DetailsList', () => {
     detailsList.setProps(newProps);
     detailsList.update();
 
-    // verify that focus index is reset to 0
+    // verify that focusedItemIndex is reset to 0 and 0th row is focused
     setTimeout(() => {
+      expect(component.state.focusedItemIndex).toEqual(0);
       expect(document.activeElement.textContent).toEqual('0');
       expect(document.activeElement.className.split(' ')).toContain('ms-DetailsRow');
     }, 0);

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -210,6 +210,10 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
 
     if (shouldResetSelection) {
       this._initialFocusedIndex = newProps.initialFocusedIndex;
+      // reset focusedItemIndex when setKey changes
+      this.setState({
+        focusedItemIndex: this._initialFocusedIndex || -1
+      });
     }
 
     if (newProps.items !== items) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -212,7 +212,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       this._initialFocusedIndex = newProps.initialFocusedIndex;
       // reset focusedItemIndex when setKey changes
       this.setState({
-        focusedItemIndex: this._initialFocusedIndex || -1
+        focusedItemIndex: (this._initialFocusedIndex !== undefined) ? this._initialFocusedIndex : -1
       });
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X ] Include a change request file using `$ npm run change`

#### Description of changes

The bug is, in odsp-next doclib, if you scroll down to a folder (say, at index 12) and click to navigate in it, the new folder contents get focused on the 12th index from previous setkey, instead of focusing the first item row.

We first hit componentWillReceiveProps with initialFocusedIndex = 0, and since it’s a new setKey, we set this._initialFocusedIndex to 0. But then the rows mount, and call setFocusToRowIfPending, that resets it back to undefined. Then, componentDidUpdate gets called and this._initialFocusedIndex is undefined and this.state.focusedItemIndex is still at 12 (from previous itemset), so we end up focusing item 12 again.

The fix is to reset this.state.focusedItemIndex when we load a new setKey.

#### Focus areas to test

(optional)
