### PR TITLE
Fix bug in combo box where _selectedElement ref wasn't being set conditionally

### DIFF
--- a/common/changes/office-ui-fabric-react/keyou-fix-combobox-scrolling-to-end_2018-03-23-19-17.json
+++ b/common/changes/office-ui-fabric-react/keyou-fix-combobox-scrolling-to-end_2018-03-23-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix bug in combo box where _selectedElement ref wasn't being set conditionally",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1042,7 +1042,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           aria-selected={ isSelected ? 'true' : 'false'}
           ariaLabel= {item.text }
           disabled={ item.disabled }
-        > { <span ref={ isSelected ? this._selectedElement : '' }>
+        > { <span ref={ isSelected ? this._selectedElement : undefined }>
           { onRenderOption(item, this._onRenderOptionContent) }
         </span>
           }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1042,7 +1042,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           aria-selected={ isSelected ? 'true' : 'false'}
           ariaLabel= {item.text }
           disabled={ item.disabled }
-        > { <span ref={ this._selectedElement }>
+        > { <span ref={ isSelected ? this._selectedElement : '' }>
           { onRenderOption(item, this._onRenderOptionContent) }
         </span>
           }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There was a large change refs recently, and during that change a conditional ref assignment was omitted. The _selectedElement ref in ComboBox was always being set instead of only being set to the actual selected element. This meant the ComboBox Callout always scrolled to the bottom. This fix puts back that conditional ref assignment

PR of the original ref change: https://github.com/OfficeDev/office-ui-fabric-react/pull/4303

#### Focus areas to test

Tested in Fabric demo
