### PR TITLE
DetailsHeader: reverting maxWidth behavior to previous.

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsheader_2018-03-23-21-41.json
+++ b/common/changes/office-ui-fabric-react/detailsheader_2018-03-23-21-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsHeader: reverting how maxWidth is handled to previous behavior.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -78,9 +78,9 @@ describe('DetailsHeader', () => {
     header._onSizerMouseMove({ clientX: 100 });
     expect(lastResize).toEqual({ index: 0, size: 300 });
 
-    // Mouse move 300 pixels to the right (should be capped at 400px width
+    // Mouse move 300 pixels to the right, should be 500.
     header._onSizerMouseMove({ clientX: 300 });
-    expect(lastResize).toEqual({ index: 0, size: 400 });
+    expect(lastResize).toEqual({ index: 0, size: 500 });
 
     // Complete sizing.
     header._onSizerMouseUp();

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -514,12 +514,9 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         movement = -movement;
       }
 
-      const column = columns[columnResizeDetails!.columnIndex];
-      const requestedSize = columnResizeDetails!.columnMinWidth + movement;
-
       onColumnResized(
-        column,
-        !!column.maxWidth ? Math.min(column.maxWidth, requestedSize) : requestedSize,
+        columns[columnResizeDetails!.columnIndex],
+        columnResizeDetails!.columnMinWidth + movement,
         columnResizeDetails!.columnIndex
       );
     }


### PR DESCRIPTION
Reverting DetaislHeader maxWidth handling to previous behavior, as I changed it slightly in a recent revision.