### PR TITLE
Fixing npm start, after webpack 4 update.

### DIFF
--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -35,16 +35,16 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.45",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.45.tgz",
-      "integrity": "sha1-HlSdcoWg7MjJwSCj4c7EXq9Naxo="
+      "version": "1.7.46",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.46.tgz",
+      "integrity": "sha1-DpCStfhQSe0sG7JkPbAkGWSRcaE="
     },
     "@microsoft/loader-load-themed-styles": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.26.tgz",
-      "integrity": "sha1-cJz/TcjnGXFJSolr7xweNn9wH+4=",
+      "version": "1.7.27",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.27.tgz",
+      "integrity": "sha1-5p7y0ybyk/pYN3nIPRo/zjSPacY=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
+        "@microsoft/load-themed-styles": "1.7.46",
         "loader-utils": "1.1.0"
       }
     },
@@ -88,11 +88,11 @@
     },
     "@rush-temp/build": {
       "version": "file:projects/build.tgz",
-      "integrity": "sha1-SoAgkfCxTpEWHaZnUUUqWG57E90=",
+      "integrity": "sha1-QhYhpqrboojCB411HXaHxssXYA0=",
       "requires": {
         "@microsoft/api-extractor": "4.3.7",
-        "@microsoft/load-themed-styles": "1.7.45",
-        "@microsoft/loader-load-themed-styles": "1.7.26",
+        "@microsoft/load-themed-styles": "1.7.46",
+        "@microsoft/loader-load-themed-styles": "1.7.27",
         "autoprefixer": "7.2.6",
         "awesome-typescript-loader": "4.0.1",
         "bundlesize": "0.15.3",
@@ -134,13 +134,49 @@
           "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
         },
         "ajv": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
-          "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "requires": {
             "fast-deep-equal": "1.1.0",
             "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
+          }
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "requires": {
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "requires": {
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.1",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.0.4"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "enhanced-resolve": {
@@ -151,6 +187,46 @@
             "graceful-fs": "4.1.11",
             "memory-fs": "0.4.1",
             "tapable": "1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            }
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "opn": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+          "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+          "requires": {
+            "is-wsl": "1.1.0"
           }
         },
         "tapable": {
@@ -165,7 +241,7 @@
           "requires": {
             "acorn": "5.5.3",
             "acorn-dynamic-import": "3.0.0",
-            "ajv": "6.3.0",
+            "ajv": "6.4.0",
             "ajv-keywords": "3.1.0",
             "chrome-trace-event": "0.1.2",
             "enhanced-resolve": "4.0.0",
@@ -183,12 +259,69 @@
             "watchpack": "1.5.0",
             "webpack-sources": "1.1.0"
           }
+        },
+        "webpack-dev-server": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.1.tgz",
+          "integrity": "sha512-u5lz6REb3+KklgSIytUIOrmWgnpgFmfj/+I+GBXurhEoCsHXpG9twk4NO3bsu72GC9YtxIsiavjfRdhmNt0A/A==",
+          "requires": {
+            "ansi-html": "0.0.7",
+            "array-includes": "3.0.3",
+            "bonjour": "3.5.0",
+            "chokidar": "2.0.3",
+            "compression": "1.7.2",
+            "connect-history-api-fallback": "1.5.0",
+            "debug": "3.1.0",
+            "del": "3.0.0",
+            "express": "4.16.3",
+            "html-entities": "1.2.1",
+            "http-proxy-middleware": "0.17.4",
+            "import-local": "1.0.0",
+            "internal-ip": "1.2.0",
+            "ip": "1.1.5",
+            "killable": "1.0.0",
+            "loglevel": "1.6.1",
+            "opn": "5.3.0",
+            "portfinder": "1.0.13",
+            "selfsigned": "1.10.2",
+            "serve-index": "1.9.1",
+            "sockjs": "0.3.19",
+            "sockjs-client": "1.1.4",
+            "spdy": "3.4.7",
+            "strip-ansi": "3.0.1",
+            "supports-color": "5.3.0",
+            "webpack-dev-middleware": "3.0.1",
+            "webpack-log": "1.1.2",
+            "yargs": "9.0.1"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "9.0.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+              "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+              "requires": {
+                "camelcase": "4.1.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "read-pkg-up": "2.0.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "7.0.0"
+              }
+            }
+          }
         }
       }
     },
     "@rush-temp/example-app-base": {
       "version": "file:projects/example-app-base.tgz",
-      "integrity": "sha1-KBva74B+4R/VvJvth3u0svJ2+Js=",
+      "integrity": "sha1-vSlV+9fxYb7stQnW4YSA/wbjgq8=",
       "requires": {
         "@types/es6-promise": "0.0.32",
         "@types/highlight.js": "9.12.2",
@@ -199,7 +332,7 @@
         "es6-promise": "4.2.4",
         "es6-weak-map": "2.0.2",
         "highlight.js": "9.12.0",
-        "office-ui-fabric-react": "5.69.0",
+        "office-ui-fabric-react": "5.70.0",
         "react": "16.2.0",
         "react-dom": "16.2.0",
         "tslib": "1.9.0"
@@ -207,9 +340,9 @@
     },
     "@rush-temp/experiments": {
       "version": "file:projects/experiments.tgz",
-      "integrity": "sha1-7Q/37MuRfPHefGJwRc2cF23AZ0I=",
+      "integrity": "sha1-KF6XWDH7myaXmMLGBUNMhB1/HxQ=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
+        "@microsoft/load-themed-styles": "1.7.46",
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
         "@types/es6-promise": "0.0.32",
@@ -236,9 +369,9 @@
     },
     "@rush-temp/fabric-website": {
       "version": "file:projects/fabric-website.tgz",
-      "integrity": "sha1-KJ5KzQJBNsQaRum/kQkDYY+eMt0=",
+      "integrity": "sha1-xpwACFJQZVFA+Tu8/K81IHrmikI=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
+        "@microsoft/load-themed-styles": "1.7.46",
         "@types/es6-promise": "0.0.32",
         "@types/node": "8.0.26",
         "@types/prop-types": "15.5.2",
@@ -261,7 +394,7 @@
     },
     "@rush-temp/file-type-icons": {
       "version": "file:projects/file-type-icons.tgz",
-      "integrity": "sha1-QQ1CJ3onYpdMuk7QnW1h1I6WSVw=",
+      "integrity": "sha1-RuACdETvT9cdY0y6BCODedu7+yg=",
       "requires": {
         "@types/react": "16.0.25",
         "@types/react-dom": "16.0.3",
@@ -272,21 +405,21 @@
     },
     "@rush-temp/icons": {
       "version": "file:projects/icons.tgz",
-      "integrity": "sha1-44+W11Nu+5a8gcagJeUQbbJJ+Gw=",
+      "integrity": "sha1-WecUGnc9Og32wCsmdxZY+IQlDe4=",
       "requires": {
         "tslib": "1.9.0"
       }
     },
     "@rush-temp/jest-serializer-merge-styles": {
       "version": "file:projects/jest-serializer-merge-styles.tgz",
-      "integrity": "sha1-Pmde7S9Sm08+2JWxbjS5gg/vimQ=",
+      "integrity": "sha1-+tKmBXPZZsDVqwhgeTHavfq2wPo=",
       "requires": {
         "@types/jest": "21.1.8"
       }
     },
     "@rush-temp/merge-styles": {
       "version": "file:projects/merge-styles.tgz",
-      "integrity": "sha1-SppxNZID8vHUldcrSie2QxrFC1c=",
+      "integrity": "sha1-X0ZmV1Yb7f6p2+8KEf5/6y7ScaQ=",
       "requires": {
         "@types/jest": "21.1.8",
         "tslib": "1.9.0"
@@ -294,9 +427,9 @@
     },
     "@rush-temp/office-ui-fabric-react": {
       "version": "file:projects/office-ui-fabric-react.tgz",
-      "integrity": "sha1-T78IJRGICOZfsf3pshlfJEhGotA=",
+      "integrity": "sha1-cKJ6jpTIf9eAykQbBwGa35j8G8w=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
+        "@microsoft/load-themed-styles": "1.7.46",
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
         "@types/es6-promise": "0.0.32",
@@ -327,16 +460,16 @@
     },
     "@rush-temp/office-ui-fabric-react-tslint": {
       "version": "file:projects/office-ui-fabric-react-tslint.tgz",
-      "integrity": "sha1-rK/GrmYk9NkFNHUL1jKTuDFx1o8=",
+      "integrity": "sha1-MrHqc/2u2edbzU20LbzA/rd5UAI=",
       "requires": {
         "tslint-react": "3.5.1"
       }
     },
     "@rush-temp/ssr-tests": {
       "version": "file:projects/ssr-tests.tgz",
-      "integrity": "sha1-76IWsoPWbqC4O/zkYs+I6fCyGJw=",
+      "integrity": "sha1-f6mWsfM8vPRILr7M3Q46v2zM96w=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
+        "@microsoft/load-themed-styles": "1.7.46",
         "@types/es6-promise": "0.0.32",
         "@types/mocha": "2.2.39",
         "@types/webpack-env": "1.13.0",
@@ -355,13 +488,14 @@
           "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
         },
         "ajv": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
-          "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "requires": {
             "fast-deep-equal": "1.1.0",
             "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
           }
         },
         "enhanced-resolve": {
@@ -386,7 +520,7 @@
           "requires": {
             "acorn": "5.5.3",
             "acorn-dynamic-import": "3.0.0",
-            "ajv": "6.3.0",
+            "ajv": "6.4.0",
             "ajv-keywords": "3.1.0",
             "chrome-trace-event": "0.1.2",
             "enhanced-resolve": "4.0.0",
@@ -409,9 +543,9 @@
     },
     "@rush-temp/styling": {
       "version": "file:projects/styling.tgz",
-      "integrity": "sha1-RX6AKkNOqVOqAp3cCzJspClqih4=",
+      "integrity": "sha1-SHopywGitY08qfEaQzPclf8+ElI=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
+        "@microsoft/load-themed-styles": "1.7.46",
         "@types/jest": "21.1.8",
         "@types/react": "16.0.25",
         "@types/webpack-env": "1.13.0",
@@ -424,7 +558,7 @@
     },
     "@rush-temp/test-bundle-button": {
       "version": "file:projects/test-bundle-button.tgz",
-      "integrity": "sha1-qoRfMqgV1Icn3Rs3xx88L0+7m8s=",
+      "integrity": "sha1-EcGgp7zKSyWJ5ev+2mY0ROp1R6E=",
       "requires": {
         "@types/prop-types": "15.5.2",
         "@types/react": "16.0.25",
@@ -437,9 +571,9 @@
     },
     "@rush-temp/todo-app": {
       "version": "file:projects/todo-app.tgz",
-      "integrity": "sha1-SuF62/C0N5IAPphEoCLr2QE20H4=",
+      "integrity": "sha1-2pb+29t6wH1SiGeze7qvL01DVkc=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
+        "@microsoft/load-themed-styles": "1.7.46",
         "@types/es6-promise": "0.0.32",
         "@types/react": "16.0.25",
         "@types/react-dom": "16.0.3",
@@ -454,9 +588,9 @@
     },
     "@rush-temp/utilities": {
       "version": "file:projects/utilities.tgz",
-      "integrity": "sha1-pfI86PFgbQ9xI0fDBv/O6ovFWAM=",
+      "integrity": "sha1-CisGAEAPYzR6+kI2omF1qwNGGUw=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
+        "@microsoft/load-themed-styles": "1.7.46",
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
         "@types/jest": "21.1.8",
@@ -475,7 +609,7 @@
     },
     "@rush-temp/variants": {
       "version": "file:projects/variants.tgz",
-      "integrity": "sha1-V1INEh6mmTzAx/UlEzR8BoulgcE=",
+      "integrity": "sha1-US5WWQpWzDZLpgbYMTWk3qi0ULA=",
       "requires": {
         "@types/jest": "21.1.8",
         "tslib": "1.9.0"
@@ -483,7 +617,7 @@
     },
     "@rush-temp/vr-tests": {
       "version": "file:projects/vr-tests.tgz",
-      "integrity": "sha1-zHYPih8/xXmUDNZrSJTzkiGzNH4=",
+      "integrity": "sha1-ncw042rsZsWu4Y01MDq4h6iUXr0=",
       "requires": {
         "@storybook/addon-options": "3.2.3",
         "@storybook/react": "3.3.15",
@@ -692,7 +826,7 @@
         "url-loader": "0.6.2",
         "util-deprecate": "1.0.2",
         "uuid": "3.2.1",
-        "webpack": "3.10.0",
+        "webpack": "3.11.0",
         "webpack-dev-middleware": "1.12.2",
         "webpack-hot-middleware": "2.21.2"
       },
@@ -916,40 +1050,40 @@
       "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw="
     },
     "@uifabric/icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.6.0.tgz",
-      "integrity": "sha512-yF7px9hFI6Pif/cvA1WLVNlXrdFU4ap9ivng17JTJ8Lt709NyuSyhvrrFiGhRnBlRhkBmOGoJHrgtT494TKLYQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.7.0.tgz",
+      "integrity": "sha512-3aYM53nPq+nAftXK3bN6ozjsTon0ms/yn5OW6Ht0fFDrhkx88At1i4rQXNJxECglM37VCAPRHVtb486dRaUZzA==",
       "requires": {
-        "@uifabric/styling": "5.20.0",
+        "@uifabric/styling": "5.21.0",
         "tslib": "1.9.0"
       }
     },
     "@uifabric/merge-styles": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.13.0.tgz",
-      "integrity": "sha512-F45U4pVJbXYmP4pSXdSGa7uq9JhsaYovuA1COb7wXCgv4NWIRqdofTLGFF6rvVddK4hXxWN55ANo2DZUCU+CgA==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.14.0.tgz",
+      "integrity": "sha512-vUmoMpyxsWGEr0XsCAyGM5tRg2nlQmnGrEEEP1xh8rv+M1YVnux3/E6IN6QvN9UGZZWF4UT1xS3vgPalv/vjyQ==",
       "requires": {
         "tslib": "1.9.0"
       }
     },
     "@uifabric/styling": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.20.0.tgz",
-      "integrity": "sha512-kyb2zzW7731jWNM5IGOGOrtWV0Vm0Gricie7XO3Jy2/pc0JfYOJa2blqhr2MSVscEg5lIkqG3SI2+OJO2obYKQ==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.21.0.tgz",
+      "integrity": "sha512-c67vSvOUgr6KblS/neRiOXnTvxLOJ6VblYGtylWyOQiIl9nU9RxL4HiTCeULsVCKuXRAQeYLEnzqOksGrw/Dvw==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
-        "@uifabric/merge-styles": "5.13.0",
-        "@uifabric/utilities": "5.20.0",
+        "@microsoft/load-themed-styles": "1.7.46",
+        "@uifabric/merge-styles": "5.14.0",
+        "@uifabric/utilities": "5.21.0",
         "tslib": "1.9.0"
       }
     },
     "@uifabric/utilities": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.20.0.tgz",
-      "integrity": "sha512-RbLVifLd4tfbG45FH9YPe6SRmJxu02X7nB7279LFJvGB0H9p4/rF2SAnVk4tbia7AnS5DYGFe2ILUyVlD/PQ5g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.21.0.tgz",
+      "integrity": "sha512-hFN6ZLHQAJfAKsW/9IT1AodytXrkfOJ2+VHSAaJw/L9RfBy0Q7QxDxwy9iwShDFeoJm2YsRgc1QMJvCKqywUPA==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
-        "@uifabric/merge-styles": "5.13.0",
+        "@microsoft/load-themed-styles": "1.7.46",
+        "@uifabric/merge-styles": "5.14.0",
         "prop-types": "15.6.1",
         "tslib": "1.9.0"
       }
@@ -1425,7 +1559,7 @@
       "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
       "requires": {
         "browserslist": "2.11.3",
-        "caniuse-lite": "1.0.30000819",
+        "caniuse-lite": "1.0.30000820",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.21",
@@ -3088,7 +3222,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
-        "caniuse-lite": "1.0.30000819",
+        "caniuse-lite": "1.0.30000820",
         "electron-to-chromium": "1.3.40"
       }
     },
@@ -3311,7 +3445,7 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000819",
+        "caniuse-db": "1.0.30000820",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -3321,21 +3455,21 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000819",
+            "caniuse-db": "1.0.30000820",
             "electron-to-chromium": "1.3.40"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000819",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000819.tgz",
-      "integrity": "sha1-w7fdVZ5ebWPV3Kpiusa9BMdhlwk="
+      "version": "1.0.30000820",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000820.tgz",
+      "integrity": "sha1-fCDiXOoXaLJhtyT4LjpqJTqqFGg="
     },
     "caniuse-lite": {
-      "version": "1.0.30000819",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000819.tgz",
-      "integrity": "sha512-9i1d8eiKA6dLvsMrVrXOTP9/1sd9iIv4iC/UbPbIa9iQd9Gcnozi2sQ0d69TiQY9l7Alt7YIWISOBwyGSM6H0Q=="
+      "version": "1.0.30000820",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000820.tgz",
+      "integrity": "sha512-E0dpVjnt1XTNmWlGgdiae/tOF0jrJ/s+dOnwk8PLmPdu5uSu8wTLJhhbhcgUWU4aO9Iy5yUMZYxT60JS259sbQ=="
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.1.2",
@@ -4408,7 +4542,7 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000819",
+            "caniuse-db": "1.0.30000820",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -4420,7 +4554,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000819",
+            "caniuse-db": "1.0.30000820",
             "electron-to-chromium": "1.3.40"
           }
         },
@@ -7659,9 +7793,9 @@
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -7712,7 +7846,7 @@
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
           "integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
           "requires": {
-            "ansi-escapes": "3.0.0",
+            "ansi-escapes": "3.1.0",
             "chalk": "2.3.2",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
@@ -10294,15 +10428,15 @@
       "integrity": "sha1-KhZgU8ye+wlWUGPn/Td8yKywNBw="
     },
     "office-ui-fabric-react": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.69.0.tgz",
-      "integrity": "sha512-q2JhTQeHE2DItbCZwLE6wfGxTeywOVfVZsSZuOvZWhoEaRmawzsybF2GBbkpYM5VVoipNJzlSiUJfOeui+/4bQ==",
+      "version": "5.70.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.70.0.tgz",
+      "integrity": "sha512-JCuf72ex5WTefxlHzPkhFrO+C1HJxCk6hvm7SBOYPGFCm0iHBYv/LxjjVgIxsECewcSonyudSZgKXP4ONHryVw==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.45",
-        "@uifabric/icons": "5.6.0",
-        "@uifabric/merge-styles": "5.13.0",
-        "@uifabric/styling": "5.20.0",
-        "@uifabric/utilities": "5.20.0",
+        "@microsoft/load-themed-styles": "1.7.46",
+        "@uifabric/icons": "5.7.0",
+        "@uifabric/merge-styles": "5.14.0",
+        "@uifabric/styling": "5.21.0",
+        "@uifabric/utilities": "5.21.0",
         "prop-types": "15.6.1",
         "tslib": "1.9.0"
       }
@@ -11579,7 +11713,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000819",
+            "caniuse-db": "1.0.30000820",
             "electron-to-chromium": "1.3.40"
           }
         },
@@ -13850,18 +13984,19 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
       "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "requires": {
-        "ajv": "6.3.0",
+        "ajv": "6.4.0",
         "ajv-keywords": "3.1.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
-          "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "requires": {
             "fast-deep-equal": "1.1.0",
             "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
           }
         }
       }
@@ -16168,6 +16303,21 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
+    "uri-js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
+      }
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -16518,14 +16668,14 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webpack": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
-      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+      "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "requires": {
         "acorn": "5.5.3",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
+        "ajv": "6.4.0",
+        "ajv-keywords": "3.1.0",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
@@ -16566,10 +16716,16 @@
             }
           }
         },
-        "ajv-keywords": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+        "ajv": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+          "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+          "requires": {
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
+          }
         },
         "camelcase": {
           "version": "1.2.1",
@@ -16920,9 +17076,9 @@
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -16966,7 +17122,7 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.1.0.tgz",
           "integrity": "sha512-kn7N70US1MSZHZHSGJLiZ7iCwwncc7b0gc68YtlX29OjI3Mp0tSVV+snVXpZ1G+ONS3Ac9zd1m6hve2ibLDYfA==",
           "requires": {
-            "ansi-escapes": "3.0.0",
+            "ansi-escapes": "3.1.0",
             "chalk": "2.3.2",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
@@ -17050,9 +17206,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.1.tgz",
-      "integrity": "sha512-u5lz6REb3+KklgSIytUIOrmWgnpgFmfj/+I+GBXurhEoCsHXpG9twk4NO3bsu72GC9YtxIsiavjfRdhmNt0A/A==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+      "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
       "requires": {
         "ansi-html": "0.0.7",
         "array-includes": "3.0.3",
@@ -17079,9 +17235,8 @@
         "spdy": "3.4.7",
         "strip-ansi": "3.0.1",
         "supports-color": "5.3.0",
-        "webpack-dev-middleware": "3.0.1",
-        "webpack-log": "1.1.2",
-        "yargs": "9.0.1"
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
       },
       "dependencies": {
         "anymatch": {
@@ -17159,24 +17314,16 @@
             "is-wsl": "1.1.0"
           }
         },
-        "yargs": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-          "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+        "webpack-dev-middleware": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
+          "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "memory-fs": "0.4.1",
+            "mime": "1.6.0",
+            "path-is-absolute": "1.0.1",
+            "range-parser": "1.2.0",
+            "time-stamp": "2.0.0"
           }
         }
       }
@@ -17620,9 +17767,9 @@
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -17642,7 +17789,7 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "requires": {
-            "ansi-escapes": "3.0.0",
+            "ansi-escapes": "3.1.0",
             "chalk": "2.3.2",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",

--- a/common/config/rush/pinned-versions.json
+++ b/common/config/rush/pinned-versions.json
@@ -1,3 +1,4 @@
 {
-  "webpack": "3.10.0"
+  "webpack": "3.11.0",
+  "webpack-dev-server": "2.11.2"
 }


### PR DESCRIPTION
While everything built ok, the `npm start` was throwing an error. Adding a workaround by pinning webpack and webpack-dev-server.
