### PR TITLE
MessageBar: For single line, put action button before dismiss button

### DIFF
--- a/common/changes/office-ui-fabric-react/messagebar-button-order_2018-03-26-21-19.json
+++ b/common/changes/office-ui-fabric-react/messagebar-button-order_2018-03-26-21-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: For single line, put dismiss button after action buttons.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -169,9 +169,9 @@ export class MessageBar extends BaseComponent<IMessageBarProps, IMessageBarState
           { this._getIconSpan() }
           { this._renderInnerText() }
           { this._getExpandSingleLine() }
+          { this._getActionsDiv() }
           { this._getDismissSingleLine() }
         </div>
-        { this._getActionsDiv() }
       </div >
     );
   }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
@@ -65,6 +65,21 @@ export const MessageBarBasicExample = () => (
       Success lorem ipsum dolor sit amet. <Link href='www.bing.com'>Visit our website.</Link>
     </MessageBar>
 
+    <Label>Warning MessageBar - single line, with dismiss and action buttons</Label>
+    <MessageBar
+      messageBarType={ MessageBarType.warning }
+      isMultiline={ false }
+      onDismiss={ log('test') }
+      dismissButtonAriaLabel='Close'
+      actions={
+        <div>
+          <MessageBarButton>Action</MessageBarButton>
+        </div>
+      }
+    >
+      Warning lorem ipsum dolor sit amet, a elit sem interdum consectetur adipiscing elit. <Link href='www.bing.com'>Visit our website.</Link>
+    </MessageBar>
+
     <Label>Warning MessageBar - defaults to multiline, with dismiss and action buttons</Label>
     <MessageBar
       onDismiss={ log('test') }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4362 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Action button was rending after dismiss button in single line mode. This switches them (and matches the toolkit).

Also added an example of this variant to the demo page.

#### Focus areas to test

(optional)
