### PR TITLE
Fixing bug dialog content does not grow fully to take up all the space provided by parent

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-03-27-10-19.json
+++ b/common/changes/office-ui-fabric-react/master_2018-03-27-10-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing bug dialog content does not grow fully to take up all the space provided by parent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "serkani@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
@@ -25,7 +25,7 @@ export const getStyles = (
       isLargeHeader && 'ms-Dialog-lgHeader',
       isClose && 'ms-Dialog--close',
       {
-        width: '100%'
+        flexGrow: 1
       },
       className
     ],

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
@@ -24,6 +24,9 @@ export const getStyles = (
     content: [
       isLargeHeader && 'ms-Dialog-lgHeader',
       isClose && 'ms-Dialog--close',
+      {
+        width: '100%'
+      },
       className
     ],
 

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Dialog renders Dialog correctly 1`] = `
   className=
 
       {
-        width: 100%;
+        flex-grow: 1;
       }
 >
   <div

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`Dialog renders Dialog correctly 1`] = `
 <div
   className=
 
-
+      {
+        width: 100%;
+      }
 >
   <div
     className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4371 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Added width:100% to the dialog content.