### PR TITLE
Experiments: Fixing tests to not generate warnings during `npm start`

### DIFF
--- a/packages/experiments/src/components/CommandBar/CommandBar.test.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.test.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 
 import { CommandBar } from './CommandBar';
-import { CommandBarBase } from './CommandBar.base';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
@@ -31,7 +30,7 @@ describe('CommandBar', () => {
   });
 
   it('opens a menu with IContextualMenuItem.subMenuProps.items property', () => {
-    const commandBar = mount<CommandBarBase>(
+    const commandBar = mount(
       <CommandBar
         items={ [
           {

--- a/packages/experiments/src/utilities/keytip/KeytipTree.test.tsx
+++ b/packages/experiments/src/utilities/keytip/KeytipTree.test.tsx
@@ -18,7 +18,7 @@ describe('KeytipTree', () => {
 
   beforeEach(() => {
     // Create layer
-    ReactTestUtils.renderIntoDocument<KeytipLayer>(
+    ReactTestUtils.renderIntoDocument(
       <KeytipLayer
         id={ layerID }
         keytipStartSequences={ keytipStartSequences }


### PR DESCRIPTION
Noticed there are some TypeScript errors showing up in npm start for experiments. I'm not sure exactly why they're showing up but I can repro them in npm start and not in build... 

I've adjusting typings and have fixed the issue.