### PR TITLE
Remove root-level imports of office-ui-fabric-react from /experiments

### DIFF
--- a/common/changes/@uifabric/experiments/import-fix_2018-03-28-21-10.json
+++ b/common/changes/@uifabric/experiments/import-fix_2018-03-28-21-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Remove root imports of office-ui-fabric-react",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
+++ b/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
@@ -5,7 +5,7 @@ import {
 import {
   IStyleSet,
   DefaultPalette
-} from 'office-ui-fabric-react';
+} from 'office-ui-fabric-react/lib/Styling';
 
 export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles {
   const {

--- a/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
+++ b/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
@@ -2,7 +2,7 @@ import {
   IShimmerLineStyleProps,
   IShimmerLineStyles
 } from './ShimmerLine.types';
-import { IStyleSet } from 'office-ui-fabric-react';
+import { IStyleSet } from 'office-ui-fabric-react/lib/Styling';
 
 export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
   const {

--- a/packages/experiments/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
+++ b/packages/experiments/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
@@ -11,7 +11,7 @@ import './Shimmer.Example.scss';
 import {
   Shimmer,
 } from 'experiments/lib/Shimmer';
-import { IColumn, DetailsList, buildColumns } from 'office-ui-fabric-react';
+import { IColumn, DetailsList, buildColumns } from 'office-ui-fabric-react/lib/DetailsList';
 
 const PAGING_DELAY = 3000;
 const ITEMS_COUNT = 1000;

--- a/packages/experiments/src/components/signals/examples/Signals.Basic.Example.tsx
+++ b/packages/experiments/src/components/signals/examples/Signals.Basic.Example.tsx
@@ -21,7 +21,8 @@ import {
   EmailedSignal,
   RecordSignal
 } from '../Signals';
-import { ChoiceGroup, IChoiceGroupOption, Checkbox } from 'office-ui-fabric-react';
+import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { lorem } from '@uifabric/example-app-base';
 import * as SignalStylesModule from '../Signal.scss';


### PR DESCRIPTION
# Overview

This change removes places in `@uifabric/experiments` which were importing from the bundle root of `office-ui-fabric-react`. Since most consuming applications cannot tree-shake, we need to be cautious of what gets pulled in.