### PR TITLE
Variants: fix theming output so original input theme values are respected

### DIFF
--- a/common/changes/@uifabric/variants/phkuo-fixMerging_2018-03-28-23-01.json
+++ b/common/changes/@uifabric/variants/phkuo-fixMerging_2018-03-28-23-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/variants",
+      "comment": "fix theme output from variants",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/variants/src/variants.ts
+++ b/packages/variants/src/variants.ts
@@ -54,7 +54,13 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
     bodyBackground: p.neutralLighter
   };
 
-  return createTheme({ ...theme, ...{ palette: partialPalette, semanticColors: partialSemantic } });
+  return createTheme({
+    ...theme,
+    ...{
+      palette: { ...theme.palette, ...partialPalette },
+      semanticColors: { ...theme.semanticColors, ...partialSemantic }
+    }
+  });
 }
 
 /* Variants
@@ -121,7 +127,13 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     // inputFocusBorderAlt: p.themePrimary,
   };
 
-  return createTheme({ ...theme, ...{ palette: partialPalette, semanticColors: partialSemantic } });
+  return createTheme({
+    ...theme,
+    ...{
+      palette: { ...theme.palette, ...partialPalette },
+      semanticColors: { ...theme.semanticColors, ...partialSemantic }
+    }
+  });
 }
 
 /**
@@ -186,5 +198,11 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
     // inputFocusBorderAlt: p.themePrimary,
   };
 
-  return createTheme({ ...theme, ...{ palette: partialPalette, semanticColors: partialSemantic } });
+  return createTheme({
+    ...theme,
+    ...{
+      palette: { ...theme.palette, ...partialPalette },
+      semanticColors: { ...theme.semanticColors, ...partialSemantic }
+    }
+  });
 }

--- a/packages/variants/src/variants.ts
+++ b/packages/variants/src/variants.ts
@@ -6,7 +6,10 @@ import {
 } from '@uifabric/styling/lib/index';
 import { createTheme } from '@uifabric/styling/lib/index';
 
-function makeThemeFromPartials(originalTheme: IPartialTheme, partialPalette: Partial<IPalette>, partialSemantic: Partial<ISemanticColors>): ITheme {
+function makeThemeFromPartials(
+  originalTheme: IPartialTheme,
+  partialPalette: Partial<IPalette>,
+  partialSemantic: Partial<ISemanticColors>): ITheme {
   return createTheme({
     ...originalTheme,
     ...{

--- a/packages/variants/src/variants.ts
+++ b/packages/variants/src/variants.ts
@@ -6,6 +6,16 @@ import {
 } from '@uifabric/styling/lib/index';
 import { createTheme } from '@uifabric/styling/lib/index';
 
+function makeThemeFromPartials(originalTheme: IPartialTheme, partialPalette: Partial<IPalette>, partialSemantic: Partial<ISemanticColors>): ITheme {
+  return createTheme({
+    ...originalTheme,
+    ...{
+      palette: { ...originalTheme.palette, ...partialPalette },
+      semanticColors: { ...originalTheme.semanticColors, ...partialSemantic }
+    }
+  });
+}
+
 /**
  * A variant where the background soft shade of the neutral color. Most other colors remain unchanged.
  *
@@ -54,23 +64,8 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
     bodyBackground: p.neutralLighter
   };
 
-  return createTheme({
-    ...theme,
-    ...{
-      palette: { ...theme.palette, ...partialPalette },
-      semanticColors: { ...theme.semanticColors, ...partialSemantic }
-    }
-  });
+  return makeThemeFromPartials(theme, partialPalette, partialSemantic);
 }
-
-/* Variants
- * Variants are themes based off the current theme.
- * Each variant is a subset of the current theme, rearranging slots to create a theme of a different style.
- * Variants are meant to be applied to sections of a page, not the entire page.
- * They can be used to highlight or de-emphasize sections of a page.
- *
- * Variants are still under development.
- */
 
 /**
  * A variant where the background a softer version of the primary color. Most other colors remain unchanged.
@@ -127,13 +122,7 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     // inputFocusBorderAlt: p.themePrimary,
   };
 
-  return createTheme({
-    ...theme,
-    ...{
-      palette: { ...theme.palette, ...partialPalette },
-      semanticColors: { ...theme.semanticColors, ...partialSemantic }
-    }
-  });
+  return makeThemeFromPartials(theme, partialPalette, partialSemantic);
 }
 
 /**
@@ -198,11 +187,5 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
     // inputFocusBorderAlt: p.themePrimary,
   };
 
-  return createTheme({
-    ...theme,
-    ...{
-      palette: { ...theme.palette, ...partialPalette },
-      semanticColors: { ...theme.semanticColors, ...partialSemantic }
-    }
-  });
+  return makeThemeFromPartials(theme, partialPalette, partialSemantic);
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The old code was not using the input theme's original values as default values.
...still verifying build

#### Focus areas to test

(optional)
