### PR TITLE
DetailsList: link color invisible for selected row in high-contrast-white

### DIFF
--- a/common/changes/office-ui-fabric-react/aditima-contrast_2018-03-28-23-59.json
+++ b/common/changes/office-ui-fabric-react/aditima-contrast_2018-03-28-23-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: link color too close to selected background in high-contrast-white",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aditima@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
@@ -107,6 +107,9 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
       background: Highlight;
       color: HighlightText;
       -ms-high-contrast-adjust: none;
+      > a {
+        color: HighlightText;
+      }
     }
   }
 
@@ -132,6 +135,9 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
 
       @include high-contrast {
         color: HighlightText;
+        > a {
+          color: HighlightText;
+        }
       }
 
       // Selected State hover Header cell
@@ -155,6 +161,9 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
 
       @include high-contrast {
         color: HighlightText;
+        > a {
+          color: HighlightText;
+        }
       }
 
       // Row header cell


### PR DESCRIPTION
…rast-white

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4338
- [x] Include a change request file using `$ npm run change`

#### Description of changes
link color too close to selected background in high-contrast-white

#### Focus areas to test

(optional)
