### PR TITLE
OverflowSet: allow the OverflowSet to not be contained within a FocusZone

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-OverflowSetToNotBeInFocusZone_2018-03-29-14-40.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-OverflowSetToNotBeInFocusZone_2018-03-29-14-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "OverflowSet: Allow the OverflowSet to not be contained within a FocusZone",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -4,7 +4,7 @@ import {
   BaseComponent,
   createRef,
   getNativeProps,
-  buttonProperties,
+  divProperties,
   getId,
   focusFirstChild
 } from '../../Utilities';
@@ -47,6 +47,7 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
     if (doNotContainWithinFocusZone) {
       Tag = 'div';
       uniqueComponentProps = {
+        ...getNativeProps(this.props, divProperties),
         ref: this._divContainer
       };
     } else {
@@ -60,7 +61,6 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
 
     return (
       <Tag
-        { ...getNativeProps(this.props, buttonProperties) }
         { ...uniqueComponentProps }
         className={ mergeStyles(
           'ms-OverflowSet',

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -19,7 +19,6 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
 
   private _focusZone = createRef<FocusZone>();
   private _divContainer = createRef<HTMLDivElement>();
-  private _overflowButtonKey: string;
 
   constructor(props: IOverflowSetProps) {
     super(props);
@@ -29,8 +28,6 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
         'doNotContainWithinFocusZone': 'focusZoneProps'
       });
     }
-
-    this._overflowButtonKey = getId();
   }
 
   public render() {
@@ -109,7 +106,7 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
   private _onRenderOverflowButtonWrapper = (items: any[]): JSX.Element => {
     const wrapperDivProps: React.HTMLProps<HTMLDivElement> = { className: css('ms-OverflowSet-overflowButton', styles.item) };
     return (
-      <div key={ this._overflowButtonKey } { ...wrapperDivProps }>
+      <div { ...wrapperDivProps }>
         { this.props.onRenderOverflowButton(items) }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -5,7 +5,6 @@ import {
   createRef,
   getNativeProps,
   divProperties,
-  getId,
   focusFirstChild
 } from '../../Utilities';
 import { mergeStyles } from '../../Styling';

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -15,6 +15,16 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
 
   private _focusZone = createRef<FocusZone>();
 
+  constructor(props: IOverflowSetProps) {
+    super(props);
+
+    if (props.doNotContainWithinFocusZone) {
+      this._warnMutuallyExclusive({
+        'doNotContainWithinFocusZone': 'focusZoneProps'
+      });
+    }
+  }
+
   public render() {
     const {
       items,
@@ -22,10 +32,19 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
       className,
       focusZoneProps,
       vertical = false,
-      role = 'menubar'
+      role = 'menubar',
+      doNotContainWithinFocusZone
     } = this.props;
 
-    return (
+    const overflowSetItems = items && this._onRenderItems(items);
+    const overflowSetButtonWrapper = overflowItems && overflowItems.length > 0 && this._onRenderOverflowButtonWrapper(overflowItems);
+
+    const overflowSetContents = {
+      ...overflowSetItems,
+      ...overflowSetButtonWrapper
+    };
+
+    return doNotContainWithinFocusZone ? overflowSetContents : (
       <FocusZone
         { ...focusZoneProps }
         componentRef={ this._focusZone }
@@ -38,8 +57,7 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
         direction={ vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal }
         role={ role }
       >
-        { items && this._onRenderItems(items) }
-        { overflowItems && overflowItems.length > 0 && this._onRenderOverflowButtonWrapper(overflowItems) }
+        { overflowSetContents }
       </FocusZone>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -44,39 +44,40 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
       doNotContainWithinFocusZone
     } = this.props;
 
-    const overflowSetContents = [
-      items && this._onRenderItems(items),
-      overflowItems && overflowItems.length > 0 && this._onRenderOverflowButtonWrapper(overflowItems)
-    ];
+    let Tag;
+    let elementRef;
+    let direction;
 
-    const commonProps = {
-      className: mergeStyles(
-        'ms-OverflowSet',
-        styles.root,
-        vertical && styles.rootVertical,
-        className
-      ),
-      role: role
-    };
+    if (doNotContainWithinFocusZone) {
+      Tag = 'div';
+      elementRef = {
+        ref: this._divContainer
+      };
+    } else {
+      Tag = FocusZone;
+      elementRef = {
+        componentRef: this._focusZone
+      };
+      direction = vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal;
+    }
 
-    return doNotContainWithinFocusZone ? (
-      <div
+    return (
+      <Tag
         { ...getNativeProps(this.props, buttonProperties) }
-        ref={ this._divContainer }
-        { ...commonProps }
+        { ...elementRef }
+        className={ mergeStyles(
+          'ms-OverflowSet',
+          styles.root,
+          vertical && styles.rootVertical,
+          className
+        ) }
+        direction={ direction }
+        role={ role }
       >
-        { overflowSetContents }
-      </div>
-    ) : (
-        <FocusZone
-          { ...focusZoneProps }
-          componentRef={ this._focusZone }
-          direction={ vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal }
-          { ...commonProps }
-        >
-          { overflowSetContents }
-        </FocusZone>
-      );
+        { items && this._onRenderItems(items) }
+        { overflowItems && overflowItems.length > 0 && this._onRenderOverflowButtonWrapper(overflowItems) }
+      </Tag>
+    );
   }
 
   public focus() {

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -42,33 +42,32 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
     } = this.props;
 
     let Tag;
-    let elementRef;
-    let direction;
+    let uniqueComponentProps;
 
     if (doNotContainWithinFocusZone) {
       Tag = 'div';
-      elementRef = {
+      uniqueComponentProps = {
         ref: this._divContainer
       };
     } else {
       Tag = FocusZone;
-      elementRef = {
-        componentRef: this._focusZone
+      uniqueComponentProps = {
+        ...focusZoneProps,
+        componentRef: this._focusZone,
+        direction: vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal
       };
-      direction = vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal;
     }
 
     return (
       <Tag
         { ...getNativeProps(this.props, buttonProperties) }
-        { ...elementRef }
+        { ...uniqueComponentProps }
         className={ mergeStyles(
           'ms-OverflowSet',
           styles.root,
           vertical && styles.rootVertical,
           className
         ) }
-        direction={ direction }
         role={ role }
       >
         { items && this._onRenderItems(items) }

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
@@ -50,8 +50,18 @@ export interface IOverflowSetProps extends React.Props<OverflowSet> {
 
   /**
    * Custom properties for OverflowSet's FocusZone.
+   * If doNotContainWithinFocusZone is set to true focusZoneProps will be ignored.
+   * Use one or the other
    */
   focusZoneProps?: IFocusZoneProps;
+
+  /**
+   * If true do not contain the OverflowSet inside of a FocusZone,
+   * otherwise the OverflowSet will contain a FocusZone.
+   * If this is set to true focusZoneProps will be ignored.
+   * Use one or the other
+   */
+  doNotContainWithinFocusZone?: boolean;
 
   /**
    * The role for the OverflowSet.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Sometimes users of an OverflowSet may not want the OverflowSet to be contained within a FocusZone, this PR introduces the ability to tell the OverflowSet not to be contained within a FocusZone

#### Focus areas to test

Verified that existing functionality is not changed and the rendering of an OverflowSet is the same regardless of if it is or is not in a FocusZone
