### PR TITLE
Disable tree shaking (temporarily)

### DIFF
--- a/common/changes/@uifabric/example-app-base/disable-tree-shaking_2018-03-30-03-49.json
+++ b/common/changes/@uifabric/example-app-base/disable-tree-shaking_2018-03-30-03-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "We need to temporarily remove `sideEffects: false` flag from package.json which will disable w",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/disable-tree-shaking_2018-03-30-03-49.json
+++ b/common/changes/@uifabric/experiments/disable-tree-shaking_2018-03-30-03-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "We need to temporarily remove `sideEffects: false` flag from package.json which will disable w",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/disable-tree-shaking_2018-03-30-03-49.json
+++ b/common/changes/office-ui-fabric-react/disable-tree-shaking_2018-03-30-03-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "We need to temporarily remove `sideEffects: false` flag from package.json which will disable webpack 4 tree shaking until we can identify a good fix for it to not shake out the scss files.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/OfficeDev/office-ui-fabric-react"

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/OfficeDev/office-ui-fabric-react"

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/OfficeDev/office-ui-fabric-react"


### PR DESCRIPTION
We are seeing artifacts in webpack 4 due to treeshaking removing the sass. This applies specifically to global sass imports:

```
import './Foo.scss';
```
There is no module it imports and uses, and therefore webpack will assume no side effects would be caused by dropping the import when optimizing for production. We couldn't spot this issue until hitting the minified final result in the documentation website.

This is affecting the documentation site, and could affect partners as well, so we are temporarily removing the `sideEffects: false` flag from a few of the packages, which we know have side effects like this.

The better fix is any of these:

1. export a loadStyles function from scss file, which is called by the module. Call it to load styles.
2. move all global scss to modules, which should be been done a while ago. `:global` is the devil.
3. move to `mergeStyles` completely which is underway.

Once we've addressed the global scss issue per module, we can re-enable the boolean and thus re-enable tree shaking.