### PR TITLE
Fix display long title without spaces in DocumentCardTitle

### DIFF
--- a/common/changes/office-ui-fabric-react/qihuang_2018-04-02-03-02.json
+++ b/common/changes/office-ui-fabric-react/qihuang_2018-04-02-03-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add overflow control to ms-Document-details",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nif_tony@outlook.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
@@ -43,6 +43,7 @@
     flex-direction: column;
     flex: 1;
     justify-content: space-between;
+    overflow: hidden;
   }
 
   .preview {


### PR DESCRIPTION
#### Pull request checklist

will add npm run change later

Addresses an issue: 
Example like https://github.com/OfficeDev/office-ui-fabric-react/blob/d4159b20c9b143248cf52d1f3cdda24fd2e1caae/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx#L71
When the title is too long and without spaces, the document card will be like 
![image](https://user-images.githubusercontent.com/15025186/38133086-44591b16-3440-11e8-8704-94a66a74ced4.png)


#### Description of changes

Give the .ms-DocumentCard-details the overflow:hidden.

