### PR TITLE
Add Button override to PageMarkdown.

### DIFF
--- a/common/changes/@uifabric/example-app-base/md2jsx-overrides_2018-04-02-18-26.json
+++ b/common/changes/@uifabric/example-app-base/md2jsx-overrides_2018-04-02-18-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "HTML button tags will be overridden with DefaultButton component.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/example-app-base/src/components/templates/PageMarkdown.tsx
+++ b/packages/example-app-base/src/components/templates/PageMarkdown.tsx
@@ -8,6 +8,7 @@ import {
 } from '../templates';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { Image, IImageProps } from 'office-ui-fabric-react/lib/Image';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import Markdown, { IMarkdownProps } from 'markdown-to-jsx';
 
 function _getImageSetProps(props: React.Props<{}>, markdownProps: IPageMarkdownProps): (IPageImageSetProps | undefined) {
@@ -97,6 +98,9 @@ const getMarkdownProps = (markdownProps: IPageMarkdownProps): IMarkdownProps => 
       img: {
         component: Image
       },
+      button: {
+        component: DefaultButton
+      }
     }
   }
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

If there is a `<button>` tag in md files, use DefaultButton. This allows props like `primary` as well.
