### PR TITLE
Dropdowns not editable

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdownsNotEditable_2018-03-30-23-06.json
+++ b/common/changes/office-ui-fabric-react/dropdownsNotEditable_2018-03-30-23-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: aria role is `listbox` instead of `textbox`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -191,7 +191,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
               (errorMessage && errorMessage.length > 0 ? styles.titleIsError : null))
             }
             aria-atomic={ true }
-            role='textbox'
+            role='listbox'
             aria-readonly='true'
           >
             { // If option is selected render title, otherwise render the placeholder text

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
       aria-readonly="true"
       className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder"
       id="Dropdown94-option"
-      role="textbox"
+      role="listbox"
     />
     <span
       className="ms-Dropdown-caretDownWrapper"
@@ -76,7 +76,7 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
       aria-readonly="true"
       className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder"
       id="Dropdown0-option"
-      role="textbox"
+      role="listbox"
     />
     <span
       className="ms-Dropdown-caretDownWrapper"


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4360
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Dropdown now has aria role `listbox` instead of `textbox`, which is more accurate because the dropdown component is not editable.

