### PR TITLE
Declare user-select in Link component.

### DIFF
--- a/common/changes/office-ui-fabric-react/selectable-link-button_2018-04-02-11-28.json
+++ b/common/changes/office-ui-fabric-react/selectable-link-button_2018-04-02-11-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make the link button selectable.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lijunle@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -28,7 +28,8 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
         overflow: 'inherit',
         padding: 0,
         textAlign: 'left',
-        textOverflow: 'inherit'
+        textOverflow: 'inherit',
+        userSelect: 'text'
       },
       !isButton && {
         textDecoration: 'none'

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`Link renders Link with no href as a button 1`] = `
         position: relative;
         text-align: left;
         text-overflow: inherit;
+        user-select: text;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -195,6 +196,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
         position: relative;
         text-align: left;
         text-overflow: inherit;
+        user-select: text;
       }
       &::-moz-focus-inner {
         border: 0;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4429
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Make the Link Button selectable.

#### Focus areas to test

Try to select text inside the link button.

- Firefox and Chrome is working well.
- IE is treating `user-select:text` as `user-select:all`. It means, it can select all text inside the button, or select none.
