### PR TITLE
Fix phantom popup scrollbar in Firefox

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-phantom-popup-scrollbar_2018-04-02-17-49.json
+++ b/common/changes/office-ui-fabric-react/fix-phantom-popup-scrollbar_2018-04-02-17-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix phantom scrollbar in Panel popups in Firefox",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -61,7 +61,8 @@ export class Popup extends BaseComponent<IPopupProps, {}> {
 
     let needsVerticalScrollBar = false;
     if (this._root.value && this._root.value.firstElementChild) {
-      needsVerticalScrollBar = this._root.value.firstElementChild.clientHeight > this._root.value.clientHeight;
+      needsVerticalScrollBar = this._root.value.clientHeight > 0
+        && this._root.value.firstElementChild.clientHeight > this._root.value.clientHeight;
     }
 
     return (

--- a/rush.json
+++ b/rush.json
@@ -4,7 +4,7 @@
   "repository": {
     "url": "https://github.com/OfficeDev/office-ui-fabric-react.git"
   },
-  "nodeSupportedVersionRange": ">=6.9.0 <9.0.0",
+  "nodeSupportedVersionRange": ">=6.9.0 <10.0.0",
   "projects": [
     {
       "packageName": "office-ui-fabric-react",


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

In Firefox, when a Panel is opened, the underlying Popup will show a scrollbar because it has `overflow-y: scroll` applied. This normally isn't noticeable, as the Panel overlays it; however, if the Panel is shifted down (as it is in Outlook), the scrollbar shows up:

![image](https://user-images.githubusercontent.com/20823465/38207774-d08715fa-3663-11e8-98c7-a7f6a4b84f95.png)

This change makes it so the `overflow-y: scroll` is not applied if the Popup height is 0 (likely because all children are absolutely positioned.

#### Focus areas to test

(optional)
