### PR TITLE
Add the ability to use custom props for the panel used to render options

### DIFF
--- a/common/changes/office-ui-fabric-react/jochiari-cutom-props_2018-04-02-22-34.json
+++ b/common/changes/office-ui-fabric-react/jochiari-cutom-props_2018-04-02-22-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add the ability to use custom props for the panel used to render options on small devices.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jchiarino@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -346,6 +346,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       onRenderList = this._onRenderList,
       responsiveMode,
       calloutProps,
+      panelProps,
       dropdownWidth
     } = this.props;
 
@@ -355,11 +356,12 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
       isSmall ?
         (
           <Panel
-            className={ css('ms-Dropdown-panel', styles.panel) }
+            className={ css('ms-Dropdown-panel', styles.panel, !!panelProps && panelProps.className) }
             isOpen={ true }
             isLightDismiss={ true }
             onDismissed={ this._onDismiss }
             hasCloseButton={ false }
+            { ...panelProps }
           >
             { onRenderList(props, this._onRenderList) }
           </Panel>
@@ -373,7 +375,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             directionalHintFixed={ true }
             directionalHint={ DirectionalHint.bottomLeftEdge }
             { ...calloutProps }
-            className={ css('ms-Dropdown-callout', styles.callout, calloutProps ? calloutProps.className : undefined) }
+            className={ css('ms-Dropdown-callout', styles.callout, !!calloutProps && calloutProps.className) }
             target={ this._dropDown.value }
             onDismiss={ this._onDismiss }
             onScroll={ this._onScroll }

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { IRenderFunction } from '../../Utilities';
 import { ICalloutProps } from '../../Callout';
+import { IPanelProps } from '../../Panel';
 import { ISelectableOption } from '../../utilities/selectableOption/SelectableOption.types';
 
 export interface ISelectableDroppableTextProps<T> extends React.HTMLAttributes<T> {
@@ -85,6 +86,11 @@ export interface ISelectableDroppableTextProps<T> extends React.HTMLAttributes<T
    * Custom properties for ISelectableDroppableText's Callout used to render options.
    */
   calloutProps?: ICalloutProps;
+
+  /**
+   * Custom properties for ISelectableDroppableText's Panel used to render options on small devices.
+   */
+  panelProps?: IPanelProps;
 
   /**
    * Descriptive label for the ISelectableDroppableText Error Message


### PR DESCRIPTION
Add the ability to use custom props for the panel used to render options on small devices.
This change follows the precedent of calloutProps used for rendering options on other devices.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`
