### PR TITLE
High contrast dropdown

### DIFF
--- a/common/changes/office-ui-fabric-react/highContrastDropdown_2018-04-04-22-04.json
+++ b/common/changes/office-ui-fabric-react/highContrastDropdown_2018-04-04-22-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: color of caretDown changed to highlighttext on focus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -77,6 +77,7 @@ $DropDown-item-height: 32px;
       @include highContrastItemAndTitleState();
     }
     .caretDown {
+      color: HighlightText;
       @include highContrastAdjust();
     }
     .titleIsError {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
@@ -23,7 +23,7 @@ export class DropdownCustomExample extends React.Component {
           id='Customdrop1'
           ariaLabel='Custom dropdown example'
           onRenderPlaceHolder={ this._onRenderPlaceHolder }
-          onRenderTitle={ this._onRenderOption }
+          onRenderTitle={ this._onRenderTitle }
           onRenderOption={ this._onRenderOption }
           onRenderCaretDown={ this._onRenderCaretDown }
           options={
@@ -51,6 +51,24 @@ export class DropdownCustomExample extends React.Component {
   }
 
   private _onRenderOption = (option: IDropdownOption): JSX.Element => {
+    return (
+      <div className='dropdownExample-option'>
+        { option.data && option.data.icon &&
+          <Icon
+            style={ { marginRight: '8px' } }
+            iconName={ option.data.icon }
+            aria-hidden='true'
+            title={ option.data.icon }
+          />
+        }
+        <span>{ option.text }</span>
+      </div>
+    );
+  }
+
+  private _onRenderTitle = (options: IDropdownOption[]): JSX.Element => {
+    const option = options[0];
+
     return (
       <div className='dropdownExample-option'>
         { option.data && option.data.icon &&


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4373 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The color of caretDown in the Dropdown component now matches that of the text when in high contrast mode so that it can be seen.

In addition, this PR also fixes the Dropdown custom example, which was not showing the text on selection. It should now show the text.
