### PR TITLE
Addressing Issue #4454 - Readonly rating control with null rating shows one star selected instead of no selected star, on re-rendering

### DIFF
--- a/common/changes/office-ui-fabric-react/rating-nostartfix-4454_2018-04-04-23-54.json
+++ b/common/changes/office-ui-fabric-react/rating-nostartfix-4454_2018-04-04-23-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added support for zero star situations in the Rating component.  Before it would write out a star for  the number zero showing 6 stars when there should be 5.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -97,32 +97,34 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
     });
 
     for (let i = min as number; i <= (max as number); i++) {
-      const ratingStarProps: IRatingStarProps = {
-        fillPercentage: this._getFillingPercentage(i),
-        disabled: disabled ? true : false,
-        classNames: this._classNames
-      };
+      if (i != 0) {
+        const ratingStarProps: IRatingStarProps = {
+          fillPercentage: this._getFillingPercentage(i),
+          disabled: disabled ? true : false,
+          classNames: this._classNames
+        };
 
-      starIds.push(this._getStarId(i - 1));
+        starIds.push(this._getStarId(i - 1));
 
-      stars.push(
-        <button
-          className={ css(this._classNames.ratingButton, {
-            [this._classNames.rootIsLarge]: size === RatingSize.Large,
-            [this._classNames.rootIsSmall]: size !== RatingSize.Large
-          }) }
-          id={ starIds[i - 1] }
-          key={ i }
-          { ...((i === Math.ceil(this.state.rating as number)) ? { 'data-is-current': true } : {}) }
-          onFocus={ this._onFocus.bind(this, i) }
-          disabled={ disabled || readOnly ? true : false }
-          role='presentation'
-          type='button'
-        >
-          { this._getLabel(i) }
-          <RatingStar key={ i + 'rating' }  {...ratingStarProps} />
-        </button>
-      );
+        stars.push(
+          <button
+            className={ css(this._classNames.ratingButton, {
+              [this._classNames.rootIsLarge]: size === RatingSize.Large,
+              [this._classNames.rootIsSmall]: size !== RatingSize.Large
+            }) }
+            id={ starIds[i - 1] }
+            key={ i }
+            { ...((i === Math.ceil(this.state.rating as number)) ? { 'data-is-current': true } : {}) }
+            onFocus={ this._onFocus.bind(this, i) }
+            disabled={ disabled || readOnly ? true : false }
+            role='presentation'
+            type='button'
+          >
+            { this._getLabel(i) }
+            <RatingStar key={ i + 'rating' }  { ...ratingStarProps } />
+          </button>
+        );
+      }
     }
 
     return (


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #4454
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Added support for "zero stars" on the rating component.  The module was built with a 'click the 3rd star to set the rating to 3 stars' where zero would not be functional.  It is possible to control the rating in other ways and also possible to set the 'min' prop to '0', but the zero star was writing out (so you could click zero to select zero (e.g. https://codepen.io/oengusmacinog/pen/KoxXqy).

This simply adds a check to the star builder, and skips the '0' star.
