### PR TITLE
Panel: pass ID for header text element to custom renderer

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-header-id_2018-04-05-00-08.json
+++ b/common/changes/office-ui-fabric-react/panel-header-id_2018-04-05-00-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: pass ID for header text element to custom renderer",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -181,7 +181,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
                 { onRenderNavigation(this.props, this._onRenderNavigation) }
               </div>
               <div className={ css('ms-Panel-contentInner', styles.contentInner) } >
-                { onRenderHeader(this.props, this._onRenderHeader) }
+                { onRenderHeader(this.props, this._onRenderHeader, headerTextId) }
                 { onRenderBody(this.props, this._onRenderBody) }
                 { onRenderFooter(this.props, this._onRenderFooter) }
               </div>
@@ -252,7 +252,11 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     return null;
   }
 
-  private _onRenderHeader = (props: IPanelProps): JSX.Element | null => {
+  private _onRenderHeader = (
+    props: IPanelProps,
+    defaultRender?: (props?: IPanelProps) => JSX.Element | null,
+    headerTextId?: string | undefined
+  ): JSX.Element | null => {
     const {
       headerText,
       headerClassName = '',
@@ -263,7 +267,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
         <div className={ css('ms-Panel-header', styles.header) }>
           <p
             className={ css('ms-Panel-headerText', styles.headerText, headerClassName) }
-            id={ this.state.id + '-headerText' }
+            id={ headerTextId }
             role='heading'
           >
             { headerText }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -152,7 +152,7 @@ export interface IPanelProps extends React.Props<Panel> {
   /**
    * Optional custom renderer for header region. Replaces current title
    */
-  onRenderHeader?: IRenderFunction<IPanelProps>;
+  onRenderHeader?: IPanelHeaderRenderer;
 
   /**
    * Optional custom renderer for body region. Replaces any children passed into the component.
@@ -174,6 +174,25 @@ export interface IPanelProps extends React.Props<Panel> {
    * @deprecated
    */
   componentId?: string;
+}
+
+
+/**
+ * Renderer function which takes an additional parameter, the ID to use for the element containing
+ * the panel's title. This allows the aria-labelledby for the panel popup to work correctly.
+ */
+export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
+  /**
+   * @param props Props given to the panel
+   * @param defaultRender Default header renderer
+   * @param headerTextId Use this as the ID of the element containing the panel's title,
+   * because the panel popup uses this ID as its aria-labelledby.
+   */
+  (
+    props?: IPanelProps,
+    defaultRender?: (props?: IPanelProps) => JSX.Element | null,
+    headerTextId?: string | undefined
+  ): JSX.Element | null;
 }
 
 export enum PanelType {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The dialog inside Panel uses the panel header text as its ARIA label, referencing the header text element using `aria-labelledby=<header text id>`. That works fine with the default renderer, but custom renderers had no way to assign the correct ID, meaning the panel title was not read.

As a fix, this PR adds an additional `headerTextId` param to the header renderer.
