### PR TITLE
 Re-focus DatePicker input after calendar is closed

### DIFF
--- a/common/changes/office-ui-fabric-react/brwatt-datepicker-focus_2018-04-05-22-01.json
+++ b/common/changes/office-ui-fabric-react/brwatt-datepicker-focus_2018-04-05-22-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Re-focus DatePicker input after calendar is closed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "brwatt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -300,9 +300,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       onSelectDate(date);
     }
 
-    this.setState({
-      isDatePickerShown: false,
-    });
+    this._dismissDatePickerPopup();
   }
 
   private _onCalloutPositioned = (): void => {

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -300,7 +300,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
       onSelectDate(date);
     }
 
-    this._dismissDatePickerPopup();
+    this._calendarDismissed();
   }
 
   private _onCalloutPositioned = (): void => {


### PR DESCRIPTION
#### Pull request checklist

- [x ] Include a change request file using `$ npm run change`

#### Description of changes

Date selection for the DatePicker already forces the calendar popup to close. However, it doesn't re-focus the input element again. This change fixes that.