### PR TITLE
mergeStyles: when flipping the rtl setting, will allow re-evaluation of styling rules.

### DIFF
--- a/common/changes/@uifabric/merge-styles/rtl-fix_2018-04-05-23-54.json
+++ b/common/changes/@uifabric/merge-styles/rtl-fix_2018-04-05-23-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "mergeStyles: flipping RTL at runtime now resets the keys.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -50,16 +50,15 @@ let _stylesheet: Stylesheet;
  * @public
  */
 export class Stylesheet {
-  private _styleElement!: HTMLStyleElement;
-  private _rules!: string[];
+  private _styleElement: HTMLStyleElement;
+  private _rules: string[];
   private _config: IStyleSheetConfig;
-  private _rulesToInsert!: string[];
-  private _timerId!: number;
-  private _counter!: number;
-  private _keyToClassName!: { [key: string]: string };
+  private _rulesToInsert: string[];
+  private _counter: number;
+  private _keyToClassName: { [key: string]: string };
 
   // tslint:disable-next-line:no-any
-  private _classNameToArgs!: { [key: string]: { args: any, rules: string[] } };
+  private _classNameToArgs: { [key: string]: { args: any, rules: string[] } };
 
   /**
    * Gets the singleton instance.
@@ -208,11 +207,11 @@ export class Stylesheet {
     this._counter = 0;
     this._classNameToArgs = {};
     this._keyToClassName = {};
+  }
 
-    if (this._timerId) {
-      clearTimeout(this._timerId);
-      this._timerId = 0;
-    }
+  // Forces the regeneration of incoming styles without totally resetting the stylesheet.
+  public resetKeys(): void {
+    this._keyToClassName = {};
   }
 
   private _getElement(): HTMLStyleElement | undefined {

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -50,15 +50,15 @@ let _stylesheet: Stylesheet;
  * @public
  */
 export class Stylesheet {
-  private _styleElement: HTMLStyleElement;
-  private _rules: string[];
+  private _styleElement?: HTMLStyleElement;
+  private _rules: string[] = [];
   private _config: IStyleSheetConfig;
-  private _rulesToInsert: string[];
-  private _counter: number;
-  private _keyToClassName: { [key: string]: string };
+  private _rulesToInsert: string[] = [];
+  private _counter = 0;
+  private _keyToClassName: { [key: string]: string } = {};
 
   // tslint:disable-next-line:no-any
-  private _classNameToArgs: { [key: string]: { args: any, rules: string[] } };
+  private _classNameToArgs: { [key: string]: { args: any, rules: string[] } } = {};
 
   /**
    * Gets the singleton instance.
@@ -84,8 +84,6 @@ export class Stylesheet {
       defaultPrefix: 'css',
       ...config
     };
-
-    this.reset();
   }
 
   /**

--- a/packages/merge-styles/src/mergeStyles.test.ts
+++ b/packages/merge-styles/src/mergeStyles.test.ts
@@ -33,6 +33,16 @@ describe('mergeStyles', () => {
     expect(_stylesheet.getRules()).toEqual('.css-0{right:10px;}');
   });
 
+  it('can re-register rules when rtl is flipped', () => {
+    const result1 = mergeStyles({ left: 10 });
+    expect(_stylesheet.getRules()).toEqual('.css-0{left:10px;}');
+    expect(result1).toEqual('css-0');
+    setRTL(true);
+    const result2 = mergeStyles({ left: 10 });
+    expect(_stylesheet.getRules()).toEqual('.css-0{left:10px;}.css-1{right:10px;}');
+    expect(result2).toEqual('css-1');
+  });
+
   it('can join strings', () => {
     expect(mergeStyles('a', false, null, undefined, 'b')).toEqual('a b');
   });

--- a/packages/merge-styles/src/transforms/rtlifyRules.ts
+++ b/packages/merge-styles/src/transforms/rtlifyRules.ts
@@ -1,3 +1,5 @@
+import { Stylesheet } from '../Stylesheet';
+
 const LEFT = 'left';
 const RIGHT = 'right';
 const NO_FLIP = '@noflip';
@@ -17,7 +19,10 @@ let _rtl = getRTL();
  * Sets the current RTL value.
  */
 export function setRTL(isRTL: boolean): void {
-  _rtl = isRTL;
+  if (_rtl !== isRTL) {
+    Stylesheet.getInstance().resetKeys();
+    _rtl = isRTL;
+  }
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3903
- [X] Include a change request file using `$ npm run change`

#### Description of changes

See test for more details. Basically:

if you register `{ left: 50 }`, you get the resulting classname `css-0`.

If you call `setRTL(true)`, then doing the same registration should result in `{ right: 50 }`, with a new classname `css-1`.


