### PR TITLE
Stops propagation of Esc keypress from DatePicker

### DIFF
--- a/common/changes/office-ui-fabric-react/rebeba-esc-datepicker-propagation_2018-04-06-01-25.json
+++ b/common/changes/office-ui-fabric-react/rebeba-esc-datepicker-propagation_2018-04-06-01-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Stops event propagation of Esc keypress on DatePicker",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rebeba@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -419,6 +419,7 @@ export class DatePicker extends BaseComponent<IDatePickerProps, IDatePickerState
   }
 
   private _handleEscKey = (ev: React.KeyboardEvent<HTMLElement>): void => {
+    ev.stopPropagation();
     this._calendarDismissed();
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x ] Addresses an existing issue: Fixes #4476 
- [x ] Include a change request file using `$ npm run change`

#### Description of changes

Stops propagation of Esc key out of DatePicker.

#### Focus areas to test

(optional)
