### PR TITLE
Addressing Issue #4305 - Input multiline inside Panel doesn't compatible with the auto spell check by Grammarly extension

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-grammarlyfix-4305_2018-04-06-19-47.json
+++ b/common/changes/office-ui-fabric-react/panel-grammarlyfix-4305_2018-04-06-19-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Set Panel's FocusTrapZone prop isClickableOutsideFocusTrap to true by default to allow click interactions while panel is open",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -175,9 +175,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
                 ) }
               style={ customWidthStyles }
               elementToFocusOnDismiss={ elementToFocusOnDismiss }
-              isClickableOutsideFocusTrap={
-                isLightDismiss || isHiddenOnDismiss || (focusTrapZoneProps && focusTrapZoneProps.isClickableOutsideFocusTrap)
-              }
+              isClickableOutsideFocusTrap={ true }
             >
               <div className={ css('ms-Panel-commands') } data-is-visible={ true } >
                 { onRenderNavigation(this.props, this._onRenderNavigation) }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -175,7 +175,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
                 ) }
               style={ customWidthStyles }
               elementToFocusOnDismiss={ elementToFocusOnDismiss }
-              isClickableOutsideFocusTrap={ true }
+              isClickableOutsideFocusTrap={ focusTrapZoneProps && !focusTrapZoneProps.isClickableOutsideFocusTrap ? false : true }
             >
               <div className={ css('ms-Panel-commands') } data-is-visible={ true } >
                 { onRenderNavigation(this.props, this._onRenderNavigation) }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4305 #3333 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The initial issue referenced the fact that the popular Chrome extension Grammarly was not working in Fabric's Panel component.  After some investigation, I found that the FocusTrapZone was blocking all click events while the Panel was open.

This is solved by setting **FocusTrapZone**'s prop `isClickableOutsideFocusTrap` to true.  As far as I can tell this is meant to keep the focus on the component, but in the case of the Panel, there is an overlay over the rest of the app so there is no obvious reason for this to default to false and block click events outside the FocusTrapZone completely.