### PR TITLE
ComboBox: Make comboBox menus wrap

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-MakeComboBoxesWrap_2018-04-06-19-49.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-MakeComboBoxesWrap_2018-04-06-19-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Make focus wrap in in the menu (to align with dropdwn and customer feedback)_",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -9,6 +9,7 @@ import { KeyCodes } from '../../Utilities';
 
 import { ComboBox } from './ComboBox';
 import { IComboBox, IComboBoxOption } from './ComboBox.types';
+import { SelectableOptionMenuItemType } from '../../utilities/selectableOption/SelectableOption.types';
 import { expectOne, expectMissing } from '../../common/testUtilities';
 
 const DEFAULT_OPTIONS: IComboBoxOption[] = [
@@ -18,6 +19,12 @@ const DEFAULT_OPTIONS: IComboBoxOption[] = [
 ];
 
 const DEFAULT_OPTIONS2: IComboBoxOption[] = [
+  { key: '1', text: 'One' },
+  { key: '2', text: 'Foo' },
+  { key: '3', text: 'Bar' }
+];
+const DEFAULT_OPTIONS3: IComboBoxOption[] = [
+  { key: '0', text: 'Zero', itemType: SelectableOptionMenuItemType.Header },
   { key: '1', text: 'One' },
   { key: '2', text: 'Foo' },
   { key: '3', text: 'Bar' }
@@ -290,6 +297,18 @@ describe('ComboBox', () => {
     wrapper.find('input').simulate('keydown', { which: KeyCodes.down });
     wrapper.update();
     expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
+  it('Can change selected option with keyboard, looping from top to bottom', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS3 }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.up });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Bar');
   });
 
   it('Cannot insert text while disabled', () => {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -268,6 +268,30 @@ describe('ComboBox', () => {
     expect(wrapper.find('input').props().value).toEqual('Foo');
   });
 
+  it('Can change selected option with keyboard', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.up });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Bar');
+  });
+
+  it('Can change selected option with keyboard', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='3'
+        options={ DEFAULT_OPTIONS2 }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.down });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
   it('Cannot insert text while disabled', () => {
     const wrapper = mount(
       <ComboBox

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -268,7 +268,7 @@ describe('ComboBox', () => {
     expect(wrapper.find('input').props().value).toEqual('Foo');
   });
 
-  it('Can change selected option with keyboard', () => {
+  it('Can change selected option with keyboard, looping from top to bottom', () => {
     const wrapper = mount(
       <ComboBox
         label='testgroup'
@@ -280,7 +280,7 @@ describe('ComboBox', () => {
     expect(wrapper.find('input').props().value).toEqual('Bar');
   });
 
-  it('Can change selected option with keyboard', () => {
+  it('Can change selected option with keyboard, looping from bottom to top', () => {
     const wrapper = mount(
       <ComboBox
         label='testgroup'

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1325,17 +1325,23 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       currentOptions
     } = this.state;
 
+    // update index to allow content to wrap
     if (searchDirection === SearchDirection.forward && index >= currentOptions.length - 1) {
-      index = 0;
+      index = -1;
     } else if (searchDirection === SearchDirection.backward && index <= 0) {
       index = currentOptions.length;
     }
 
-    let indexUpdate = this._getNextSelectableIndex(index, searchDirection);
+    // get the next "valid" index
+    const indexUpdate = this._getNextSelectableIndex(index, searchDirection);
 
+    // if the two indicies are equal we didn't move and
+    // we should attempt to get  get the first/last "valid" index to use
+    // (Note, this takes care of the potential cases where the first/last
+    // item is not focusable), otherwise use the updated index
     if (index === indexUpdate) {
       if (searchDirection === SearchDirection.forward) {
-        index = this._getNextSelectableIndex(0, searchDirection);
+        index = this._getNextSelectableIndex(-1, searchDirection);
       } else if (searchDirection === SearchDirection.backward) {
         index = this._getNextSelectableIndex(currentOptions.length, searchDirection);
       }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -346,8 +346,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             title={ title }
           />
           <IconButton
-            className={'ms-ComboBox-CaretDown-button'}
-            styles={this._getCaretButtonStyles()}
+            className={ 'ms-ComboBox-CaretDown-button' }
+            styles={ this._getCaretButtonStyles() }
             role='presentation'
             aria-hidden={ isButtonAriaHidden }
             data-is-focusable={ false }
@@ -359,7 +359,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           />
         </div>
 
-        {isOpen && (
+        { isOpen && (
           (onRenderContainer as any)({
             ...this.props,
             onRenderList,
@@ -368,13 +368,13 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             options: this.state.currentOptions.map((item, index) => ({ ...item, index: index }))
           },
             this._onRenderContainer)
-        )}
+        ) }
         {
           errorMessage &&
           <div
-            className={this._classNames.errorMessage}
+            className={ this._classNames.errorMessage }
           >
-            {errorMessage}
+            { errorMessage }
           </div>
         }
       </div>
@@ -481,7 +481,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         }
         displayValues.push(currentPendingValue !== '' ? currentPendingValue : (this._indexWithinBounds(currentOptions, index) ? currentOptions[index].text : ''));
       } else {
-        for (let idx = 0; selectedIndices && (idx < selectedIndices.length); idx ++) {
+        for (let idx = 0; selectedIndices && (idx < selectedIndices.length); idx++) {
           const index: number = selectedIndices[idx];
           displayValues.push(this._indexWithinBounds(currentOptions, index) ? currentOptions[index].text : suggestedDisplayValue);
         }
@@ -933,11 +933,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     return (
       <Callout
-        isBeakVisible={false}
-        gapSpace={0}
-        doNotLayer={false}
-        directionalHint={DirectionalHint.bottomLeftEdge}
-        directionalHintFixed={true}
+        isBeakVisible={ false }
+        gapSpace={ 0 }
+        doNotLayer={ false }
+        directionalHint={ DirectionalHint.bottomLeftEdge }
+        directionalHintFixed={ true }
         { ...calloutProps }
         className={ css(this._classNames.callout, calloutProps ? calloutProps.className : undefined) }
         target={ this._comboBoxWrapper.value }
@@ -952,7 +952,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         <div className={ this._classNames.optionsContainerWrapper } ref={ this._comboBoxMenu }>
           { (onRenderList as any)({ ...props }, this._onRenderList) }
         </div>
-        {onRenderLowerContent(this.props, this._onRenderLowerContent)}
+        { onRenderLowerContent(this.props, this._onRenderLowerContent) }
       </Callout>
     );
   }
@@ -967,12 +967,12 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     const id = this._id;
     return (
       <div
-        id={id + '-list'}
-        className={this._classNames.optionsContainer}
-        aria-labelledby={id + '-label'}
+        id={ id + '-list' }
+        className={ this._classNames.optionsContainer }
+        aria-labelledby={ id + '-label' }
         role='listbox'
       >
-        {options.map((item) => (onRenderItem as any)(item, this._onRenderItem))}
+        { options.map((item) => (onRenderItem as any)(item, this._onRenderItem)) }
       </div>
     );
   }
@@ -1002,8 +1002,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       return (
         <div
           role='separator'
-          key={key}
-          className={this._classNames.divider}
+          key={ key }
+          className={ this._classNames.divider }
         />
       );
     }
@@ -1039,8 +1039,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           onMouseMove={ this._onOptionMouseMove.bind(this, item.index) }
           onMouseLeave={ this._onOptionMouseLeave }
           role='option'
-          aria-selected={ isSelected ? 'true' : 'false'}
-          ariaLabel= {item.text }
+          aria-selected={ isSelected ? 'true' : 'false' }
+          ariaLabel={ item.text }
           disabled={ item.disabled }
         > { <span ref={ isSelected ? this._selectedElement : undefined }>
           { onRenderOption(item, this._onRenderOptionContent) }
@@ -1048,23 +1048,23 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           }
         </CommandButton>
       ) : (
-        <Checkbox
-          id={id + '-list' + item.index}
-          ref={'option' + item.index}
-          key={item.key}
-          data-index={item.index}
-          styles={optionStyles}
-          className={'ms-ComboBox-option'}
-          data-is-focusable={true}
-          onChange={this._onItemClick(item.index!)}
-          label={item.text}
-          role='option'
-          aria-selected={ isSelected ? 'true' : 'false' }
-          checked={isSelected}
-        >
-          {onRenderOption(item, this._onRenderOptionContent)}
-        </Checkbox>
-      )
+          <Checkbox
+            id={ id + '-list' + item.index }
+            ref={ 'option' + item.index }
+            key={ item.key }
+            data-index={ item.index }
+            styles={ optionStyles }
+            className={ 'ms-ComboBox-option' }
+            data-is-focusable={ true }
+            onChange={ this._onItemClick(item.index!) }
+            label={ item.text }
+            role='option'
+            aria-selected={ isSelected ? 'true' : 'false' }
+            checked={ isSelected }
+          >
+            { onRenderOption(item, this._onRenderOptionContent) }
+          </Checkbox>
+        )
     );
   }
 
@@ -1187,7 +1187,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
   private _onRenderOptionContent = (item: IComboBoxOption): JSX.Element => {
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
-    return <span className={optionClassNames.optionText}>{item.text}</span>;
+    return <span className={ optionClassNames.optionText }>{ item.text }</span>;
   }
 
   /**
@@ -1325,7 +1325,24 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       currentOptions
     } = this.state;
 
-    index = this._getNextSelectableIndex(index, searchDirection);
+    if (searchDirection === SearchDirection.forward && index >= currentOptions.length - 1) {
+      index = 0;
+    } else if (searchDirection === SearchDirection.backward && index <= 0) {
+      index = currentOptions.length;
+    }
+
+    let indexUpdate = this._getNextSelectableIndex(index, searchDirection);
+
+    if (index === indexUpdate) {
+      if (searchDirection === SearchDirection.forward) {
+        index = this._getNextSelectableIndex(0, searchDirection);
+      } else if (searchDirection === SearchDirection.backward) {
+        index = this._getNextSelectableIndex(currentOptions.length, searchDirection);
+      }
+    } else {
+      index = indexUpdate;
+    }
+
     if (this._indexWithinBounds(currentOptions, index)) {
       this._setPendingInfoFromIndex(index);
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
This PR updates comboBoxes so that arrowing through the items will wrap at the top and bottom. As a result comboBoxes will behave like dropdowns (and we also got customer feedback that they expected focus to loop around the items)

#### Focus areas to test
Verified that focus wraps from top to bottom and bottom to top in a flat list, a list that starts/ends with a non-focusable element (like a header or divider), and that this works with dynamically loaded items
