### PR TITLE
OverflowSet: Add Focus(with forceIntoFirstChild) and focusElement() functions

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-OverflowSetAddFocusFunctions_2018-04-07-01-16.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-OverflowSetAddFocusFunctions_2018-04-07-01-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "OverflowSet: Add Foucs(firstChild) and focusElement() functions",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -5,7 +5,8 @@ import {
   createRef,
   getNativeProps,
   divProperties,
-  focusFirstChild
+  focusFirstChild,
+  elementContains
 } from '../../Utilities';
 import { mergeStyles } from '../../Styling';
 import { IOverflowSet, IOverflowSetProps, IOverflowSetItemProps } from './OverflowSet.types';
@@ -75,18 +76,50 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
     );
   }
 
-  public focus() {
+  /**
+   * Sets focus to the first tabbable item in the zone.
+   * @param {boolean} forceIntoFirstElement If true, focus will be forced into the first element, even if focus is already in the focus zone.
+   * @returns True if focus could be set to an active element, false if no operation was taken.
+   */
+  public focus(forceIntoFirstElement?: boolean): boolean {
+    let focusSucceeded = false;
+
     if (this.props.doNotContainWithinFocusZone) {
       if (this._divContainer.value) {
-        focusFirstChild(this._divContainer.value);
+        if (forceIntoFirstElement) {
+          focusSucceeded = focusFirstChild(this._divContainer.value);
+        } else {
+          this._divContainer.value.focus();
+          focusSucceeded = document.activeElement === (this._divContainer.value as Element);
+        }
       }
-
-      return;
+    } else if (this._focusZone.value) {
+      focusSucceeded = this._focusZone.value.focus(forceIntoFirstElement);
     }
 
-    if (this._focusZone.value) {
-      this._focusZone.value.focus();
+    return focusSucceeded;
+  }
+
+  /**
+   * Sets focus to a specific child element within the zone. This can be used in conjunction with
+   * onBeforeFocus to created delayed focus scenarios (like animate the scroll position to the correct
+   * location and then focus.)
+   * @param {HTMLElement} element The child element within the zone to focus.
+   * @returns True if focus could be set to an active element, false if no operation was taken.
+   */
+  public focusElement(element: HTMLElement): boolean {
+    let focusSucceeded = false;
+
+    if (this.props.doNotContainWithinFocusZone) {
+      if (this._divContainer.value && element && elementContains(this._divContainer.value, element)) {
+        element.focus();
+        focusSucceeded = document.activeElement === element;
+      }
+    } else if (this._focusZone.value) {
+      focusSucceeded = this._focusZone.value.focusElement(element);
     }
+
+    return focusSucceeded;
   }
 
   private _onRenderItems = (items: IOverflowSetItemProps[]): JSX.Element[] => {

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -99,19 +99,23 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
 
   /**
    * Sets focus to a specific child element within the OverflowSet.
-   * @param {HTMLElement} element The child element within the zone to focus.
+   * @param {HTMLElement} childElement The child element within the zone to focus.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  public focusElement(element: HTMLElement): boolean {
+  public focusElement(childElement?: HTMLElement): boolean {
     let focusSucceeded = false;
 
+    if (!childElement) {
+      return false;
+    }
+
     if (this.props.doNotContainWithinFocusZone) {
-      if (this._divContainer.value && element && elementContains(this._divContainer.value, element)) {
-        element.focus();
-        focusSucceeded = document.activeElement === element;
+      if (this._divContainer.value && elementContains(this._divContainer.value, childElement)) {
+        childElement.focus();
+        focusSucceeded = document.activeElement === childElement;
       }
     } else if (this._focusZone.value) {
-      focusSucceeded = this._focusZone.value.focusElement(element);
+      focusSucceeded = this._focusZone.value.focusElement(childElement);
     }
 
     return focusSucceeded;

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -6,6 +6,7 @@ import {
   getNativeProps,
   divProperties,
   focusFirstChild,
+  getFirstFocusable,
   elementContains
 } from '../../Utilities';
 import { mergeStyles } from '../../Styling';
@@ -77,8 +78,9 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
   }
 
   /**
-   * Sets focus to the first tabbable item in the zone.
-   * @param {boolean} forceIntoFirstElement If true, focus will be forced into the first element, even if focus is already in the focus zone.
+   * Sets focus to the first tabbable item in the OverflowSet.
+   * @param {boolean} forceIntoFirstElement If true, focus will be forced into the first element,
+   * even if focus is already in theOverflowSet
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   public focus(forceIntoFirstElement?: boolean): boolean {
@@ -86,12 +88,7 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
 
     if (this.props.doNotContainWithinFocusZone) {
       if (this._divContainer.value) {
-        if (forceIntoFirstElement) {
-          focusSucceeded = focusFirstChild(this._divContainer.value);
-        } else {
-          this._divContainer.value.focus();
-          focusSucceeded = document.activeElement === (this._divContainer.value as Element);
-        }
+        focusSucceeded = focusFirstChild(this._divContainer.value);
       }
     } else if (this._focusZone.value) {
       focusSucceeded = this._focusZone.value.focus(forceIntoFirstElement);
@@ -101,9 +98,7 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
   }
 
   /**
-   * Sets focus to a specific child element within the zone. This can be used in conjunction with
-   * onBeforeFocus to created delayed focus scenarios (like animate the scroll position to the correct
-   * location and then focus.)
+   * Sets focus to a specific child element within the OverflowSet.
    * @param {HTMLElement} element The child element within the zone to focus.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
@@ -5,9 +5,20 @@ import { IFocusZoneProps } from '../../FocusZone';
 
 export interface IOverflowSet {
   /**
- * Sets focus to the button.
- */
-  focus: () => void;
+   * Sets focus to the first tabbable item in the zone.
+   * @param {boolean} forceIntoFirstElement If true, focus will be forced into the first element, even if focus is already in the focus zone.
+   * @returns True if focus could be set to an active element, false if no operation was taken.
+   */
+  focus(forceIntoFirstElement?: boolean): boolean;
+
+  /**
+   * Sets focus to a specific child element within the zone. This can be used in conjunction with
+   * onBeforeFocus to created delayed focus scenarios (like animate the scroll position to the correct
+   * location and then focus.)
+   * @param {HTMLElement} element The child element within the zone to focus.
+   * @returns True if focus could be set to an active element, false if no operation was taken.
+   */
+  focusElement(childElement?: HTMLElement): boolean;
 }
 
 export interface IOverflowSetProps extends React.Props<OverflowSet> {

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
@@ -15,7 +15,7 @@ export interface IOverflowSet {
    * Sets focus to a specific child element within the zone. This can be used in conjunction with
    * onBeforeFocus to created delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
-   * @param {HTMLElement} element The child element within the zone to focus.
+   * @param {HTMLElement} childElement The child element within the zone to focus.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   focusElement(childElement?: HTMLElement): boolean;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Before OverflowSets didn't expose the goodness of being able to focus vs focus (firstChild), or a specific child element via foucsElement. This exposes the functionality that FocusZone has (and implements it for when it is not in a FocusZone)

#### Focus areas to test
Verified that this works as expected for both the case when the OverflowSet contains a FocusZone and when does not and everything works as expected
