### PR TITLE
Fix style and alignment issues in the DetailsList header

### DIFF
--- a/common/changes/office-ui-fabric-react/details-header_2018-04-07-01-42.json
+++ b/common/changes/office-ui-fabric-react/details-header_2018-04-07-01-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix style and alignment issues with DetailsList headers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -50,6 +50,8 @@ $menuHeaderColor: "[theme:menuHeader, default: #0078d4]";
 /* Lists */
 $listBackgroundColor: "[theme:listBackground, default: #ffffff]";
 $listTextColor: "[theme:listText, default: #333333]";
+$listItemHeaderHoveredColor: "[theme:listItemHeaderHovered, default: #f4f4f4]";
+$listItemHeaderActivatedColor: "[theme:listItemActivatedHovered, default: #eaeaea]";
 $listItemBackgroundHoveredColor: "[theme:listItemBackgroundHovered, default: #f8f8f8]";
 $listItemBackgroundCheckedColor: "[theme:listItemBackgroundChecked, default: #eaeaea]";
 $listItemBackgroundCheckedHoveredColor: "[theme:listItemBackgroundCheckedHovered, default: #d0d0d0]";

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -161,14 +161,21 @@ $isPaddedMargin: 24px;
 }
 
 .cellTitle {
-  display: block;
+  display: inline-flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: stretch;
+  box-sizing: border-box;
   overflow: hidden;
-  @include focus-border($position: absolute);
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
+  max-width: 100%;
+  @include focus-border($position: auto);
   padding: 0 8px;
+}
+
+.cellName {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 :global(.ms-TooltipHost).checkTooltip {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -64,11 +64,11 @@ $isPaddedMargin: 24px;
 
     &:hover {
       color: $bodyTextColor;
-      background: $bodyBackgroundColor;
+      background: $listItemHeaderHoveredColor;
     }
 
     &:active {
-      background: $listItemBackgroundHoveredColor;
+      background: $listItemHeaderActivatedColor;
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -253,7 +253,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                           className={ css('ms-DetailsHeader-cellTitle', styles.cellTitle) }
                           data-is-focusable={ column.columnActionsMode !== ColumnActionsMode.disabled }
                           role={ column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined }
-                          aria-describedby={ `${this._id}-${column.key}-tooltip` }
+                          aria-describedby={ this.props.onRenderColumnHeaderTooltip ? `${this._id}-${column.key}-tooltip` : undefined }
                           onContextMenu={ this._onColumnContextMenu.bind(this, column) }
                           onClick={ this._onColumnClick.bind(this, column) }
                           aria-haspopup={ column.columnActionsMode === ColumnActionsMode.hasDropdown }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`DetailsHeader can render 1`] = `
       className=""
     >
       <span
-        aria-describedby="header0-a-tooltip"
+        aria-describedby={undefined}
         aria-haspopup={false}
         aria-label={undefined}
         aria-labelledby="header0-a-name "
@@ -183,7 +183,7 @@ exports[`DetailsHeader can render 1`] = `
       className=""
     >
       <span
-        aria-describedby="header0-b-tooltip"
+        aria-describedby={undefined}
         aria-haspopup={false}
         aria-label={undefined}
         aria-labelledby="header0-b-name "

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`DetailsList renders List correctly 1`] = `
               className=""
             >
               <span
-                aria-describedby="header0-key-tooltip"
+                aria-describedby={undefined}
                 aria-haspopup={false}
                 aria-label={undefined}
                 aria-labelledby="header0-key-name "

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -104,6 +104,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         fieldName: 'name',
         minWidth: 16,
         maxWidth: 16,
+        onColumnClick: this._onColumnClick,
         onRender: (item: IDocument) => {
           return (
             <img


### PR DESCRIPTION
# Overview

This change fixes a couple long-standing issue with `DetailsHeader`:

- The header cells are missing hover styles. Added theme slots for the hover styles and made them match standard colors.
- If a header cell is narrow, then the status icon (sorted, grouped, etc) overflows the width, causing visual artifacts. Changed the cell title box to use `display: inline-flex` and made the name truncate in favor of the status indicator.
- Removed the phantom `aria-describedby` attribute if there is no attempt to provide a tooltip implementation for the header cells.