### PR TITLE
ScrollablePane:  Optimization on how component works

### DIFF
--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -38,7 +38,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
   private _root = createRef<HTMLDivElement>();
   private _stickyAboveRef = createRef<HTMLDivElement>();
-  private _stickyBelowContainerRef = createRef<HTMLDivElement>();
   private _stickyBelowRef = createRef<HTMLDivElement>();
   private _contentContainer = createRef<HTMLDivElement>();
   private _subscribers: Set<Function>;
@@ -61,10 +60,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
   public get stickyAbove(): HTMLDivElement | null {
     return this._stickyAboveRef.value;
-  }
-
-  public get stickyBelowContainer(): HTMLDivElement | null {
-    return this._stickyBelowContainerRef.value;
   }
 
   public get stickyBelow(): HTMLDivElement | null {
@@ -129,7 +124,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
           style={ this._getStickyContainerStyle(stickyTopHeight) }
         />
         <div
-          ref={ this._stickyBelowContainerRef }
           className={ classNames.stickyBelow }
           style={ this._getStickyContainerStyle(stickyBottomHeight) }
         >
@@ -205,7 +199,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
   public notifySubscribers = (): void => {
     this._subscribers.forEach((handle) => {
-      if (this._contentContainer && this.stickyBelowContainer) {
+      if (this._contentContainer) {
         handle(this._contentContainer.value, this.stickyBelow);
       }
     });

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -201,7 +201,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   public notifySubscribers = (sort?: boolean): void => {
     this._subscribers.forEach((handle) => {
       if (this._contentContainer && this.stickyBelowContainer) {
-        handle(this._contentContainer.value, this.stickyBelowContainer, this.stickyBelow);
+        handle(this._contentContainer.value, this.stickyBelow);
       }
     });
   }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -43,14 +43,10 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   private _contentContainer = createRef<HTMLDivElement>();
   private _subscribers: Set<Function>;
   private _stickies: Set<Sticky>;
-  private _stickyAbove: Set<Sticky>;
-  private _stickyBelow: Set<Sticky>;
 
   constructor(props: IScrollablePaneProps) {
     super(props);
     this._subscribers = new Set<Function>();
-    this._stickyAbove = new Set<Sticky>();
-    this._stickyBelow = new Set<Sticky>();
     this._stickies = new Set<Sticky>();
 
     this.state = {
@@ -113,22 +109,13 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
   public render() {
     const { className, theme, getStyles } = this.props;
+    const { stickyTopHeight, stickyBottomHeight } = this.state;
     const classNames = getClassNames(getStyles!,
       {
         theme: theme!,
         className
       }
     );
-
-    let stickyTopStyle = {};
-    stickyTopStyle = {
-      height: this.state.stickyTopHeight + 'px'
-    };
-
-    let stickyBottomStyle = {};
-    stickyBottomStyle = {
-      height: this.state.stickyBottomHeight + 'px'
-    };
 
     return (
       <div
@@ -139,12 +126,12 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
         <div
           ref={ this._stickyAboveRef }
           className={ classNames.stickyAbove }
-          style={ stickyTopStyle }
+          style={ this._getStickyContainerStyle(stickyTopHeight) }
         />
         <div
           ref={ this._stickyBelowContainerRef }
           className={ classNames.stickyBelow }
-          style={ stickyBottomStyle }
+          style={ this._getStickyContainerStyle(stickyBottomHeight) }
         >
           <div
             ref={ this._stickyBelowRef }
@@ -236,5 +223,11 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     this._async.setTimeout(() => {
       this.notifySubscribers();
     }, 5);
+  }
+
+  private _getStickyContainerStyle = (height: number): React.CSSProperties => {
+    return {
+      height: height
+    }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -66,6 +66,10 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     return this._stickyBelowRef.value;
   }
 
+  public get contentContainer(): HTMLDivElement | null {
+    return this._contentContainer.value;
+  }
+
   public getChildContext() {
     return {
       scrollablePane: {
@@ -80,20 +84,20 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   }
 
   public componentDidMount() {
-    this._events.on(this._contentContainer.value, 'scroll', this.notifySubscribers);
+    this._events.on(this.contentContainer, 'scroll', this.notifySubscribers);
     this._events.on(window, 'resize', this._onWindowResize);
     this.notifySubscribers();
   }
 
   public componentWillUnmount() {
-    this._events.off(this._contentContainer.value);
+    this._events.off(this.contentContainer);
     this._events.off(window);
   }
 
   public componentDidUpdate(prevProps: IScrollablePaneProps) {
     const initialScrollPosition = this.props.initialScrollPosition;
-    if (this._root.value && initialScrollPosition && prevProps.initialScrollPosition !== initialScrollPosition) {
-      this._root.value.scrollTop = initialScrollPosition;
+    if (this.root && initialScrollPosition && prevProps.initialScrollPosition !== initialScrollPosition) {
+      this.root.scrollTop = initialScrollPosition;
     }
 
     // Update subscribers when DOM changes
@@ -199,15 +203,15 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
   public notifySubscribers = (): void => {
     this._subscribers.forEach((handle) => {
-      if (this._contentContainer) {
-        handle(this._contentContainer.value, this.stickyBelow);
+      if (this.contentContainer) {
+        handle(this.contentContainer, this.stickyBelow);
       }
     });
   }
 
   public getScrollPosition = (): number => {
-    if (this._root.value) {
-      return this._root.value.scrollTop;
+    if (this.root) {
+      return this.root.scrollTop;
     }
 
     return 0;

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -104,6 +104,11 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     if (this._root.value && initialScrollPosition && prevProps.initialScrollPosition !== initialScrollPosition) {
       this._root.value.scrollTop = initialScrollPosition;
     }
+
+    // Update subscribers when DOM changes
+    if (prevProps.children !== this.props.children) {
+      this.notifySubscribers();
+    }
   }
 
   public render() {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -81,6 +81,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
         subscribe: this.subscribe,
         unsubscribe: this.unsubscribe,
         addSticky: this.addSticky,
+        removeSticky: this.removeSticky,
         updateStickyRefHeights: this.updateStickyRefHeights,
         notifySubscribers: this.notifySubscribers
       }
@@ -94,7 +95,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   }
 
   public componentWillUnmount() {
-    this._events.off(this._root.value);
+    this._events.off(this._contentContainer.value);
     this._events.off(window);
   }
 
@@ -175,6 +176,18 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     if (this.stickyBelow && sticky.stickyContentBottom.value) {
       this.stickyBelow.appendChild(sticky.stickyContentBottom.value);
     }
+    this.notifySubscribers();
+  }
+
+  public removeSticky = (sticky: Sticky): void => {
+    this._stickies.delete(sticky);
+    if (this.stickyAbove && sticky.stickyContentTop.value) {
+      this.stickyAbove.removeChild(sticky.stickyContentTop.value);
+    }
+    if (this.stickyBelow && sticky.stickyContentBottom.value) {
+      this.stickyBelow.removeChild(sticky.stickyContentBottom.value);
+    }
+    this.notifySubscribers();
   }
 
   public updateStickyRefHeights = (): void => {
@@ -198,7 +211,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     });
   }
 
-  public notifySubscribers = (sort?: boolean): void => {
+  public notifySubscribers = (): void => {
     this._subscribers.forEach((handle) => {
       if (this._contentContainer && this.stickyBelowContainer) {
         handle(this._contentContainer.value, this.stickyBelow);

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -185,10 +185,10 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
     stickyItems.forEach((sticky: Sticky) => {
       if (sticky.state.isStickyTop && sticky.stickyContentTop && sticky.stickyContentTop.value) {
-        stickyTopHeight += sticky.stickyContentTop.value.clientHeight;
+        stickyTopHeight += sticky.stickyContentTop.value.offsetHeight;
       }
       if (sticky.state.isStickyBottom && sticky.stickyContentBottom && sticky.stickyContentBottom.value) {
-        stickyBottomHeight += sticky.stickyContentBottom.value.clientHeight;
+        stickyBottomHeight += sticky.stickyContentBottom.value.offsetHeight;
       }
     });
 

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
@@ -14,7 +14,8 @@ export const getStyles = (
     pointerEvents: 'auto',
     width: '100%',
     zIndex: 1,
-    background: '#ffffff'
+    background: '#ffffff',
+    overflow: 'hidden'
   };
 
   const maxHeightStyles: IStyle = {
@@ -60,6 +61,12 @@ export const getStyles = (
             borderTop: '1px solid WindowText'
           }
         }
+      },
+      AboveAndBelowStyles
+    ],
+    stickyBelowItems: [
+      {
+        bottom: 0
       },
       AboveAndBelowStyles
     ]

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
@@ -13,19 +13,33 @@ export const getStyles = (
     position: 'absolute',
     pointerEvents: 'auto',
     width: '100%',
-    zIndex: 1
+    zIndex: 1,
+    background: '#ffffff'
   };
+
+  const maxHeightStyles: IStyle = {
+    height: 'inherit',
+    maxHeight: 'inherit'
+  }
 
   return ({
     root: [
       'ms-ScrollablePane',
       {
+        WebkitOverflowScrolling: 'touch',
+        position: 'relative'
+      },
+      maxHeightStyles,
+      className
+    ],
+    contentContainer: [
+      'ms-ScrollablePane--contentContainer',
+      {
         overflowY: 'auto',
-        maxHeight: 'inherit',
-        height: 'inherit',
+        position: 'relative',
         WebkitOverflowScrolling: 'touch'
       },
-      className
+      maxHeightStyles
     ],
     stickyAbove: [
       {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
@@ -15,7 +15,8 @@ export const getStyles = (
     width: '100%',
     zIndex: 1,
     background: '#ffffff',
-    overflow: 'hidden'
+    overflowY: 'hidden',
+    overflowX: 'auto'
   };
 
   const maxHeightStyles: IStyle = {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -69,6 +69,10 @@ export interface IScrollablePaneStyles {
    */
   stickyBelow: IStyle;
   /**
+   * Style set for the stickyBelowItems element.
+   */
+  stickyBelowItems: IStyle;
+  /**
    * Style set for the contentContainer element.
    */
   contentContainer: IStyle;

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -68,4 +68,8 @@ export interface IScrollablePaneStyles {
    * Style set for the stickyAbove element.
    */
   stickyBelow: IStyle;
+  /**
+   * Style set for the contentContainer element.
+   */
+  contentContainer: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
@@ -25,9 +25,9 @@ export class ScrollablePanePage extends React.Component<IComponentDemoPageProps,
             <ExampleCard title='Default' code={ ScrollablePaneDefaultExampleCode }>
               <ScrollablePaneDefaultExample />
             </ExampleCard>
-            {/* <ExampleCard title='DetailsList Locked Header' code={ ScrollablePaneDetailsListExampleCode }>
+            <ExampleCard title='DetailsList Locked Header' code={ ScrollablePaneDetailsListExampleCode }>
               <ScrollablePaneDetailsListExample />
-            </ExampleCard> */}
+            </ExampleCard>
           </div>
         }
         allowNativeProps={ true }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
@@ -58,6 +58,7 @@ export class ScrollablePanePage extends React.Component<IComponentDemoPageProps,
               <li>Ensure that a parent component has a CSS height, or max-height attribute set (and any intermediary containers have an inherit, or explicit height/max-height set).</li>
               <li>Use Sticky component on block level elements</li>
               <li>Sticky component are ideally section headers and/or footers</li>
+              <li>Ensure that the total height of Sticky components do not exceed the height of the ScrollablePane</li>
             </ul>
           </div>
         }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePanePage.tsx
@@ -25,9 +25,9 @@ export class ScrollablePanePage extends React.Component<IComponentDemoPageProps,
             <ExampleCard title='Default' code={ ScrollablePaneDefaultExampleCode }>
               <ScrollablePaneDefaultExample />
             </ExampleCard>
-            <ExampleCard title='DetailsList Locked Header' code={ ScrollablePaneDetailsListExampleCode }>
+            {/* <ExampleCard title='DetailsList Locked Header' code={ ScrollablePaneDetailsListExampleCode }>
               <ScrollablePaneDetailsListExample />
-            </ExampleCard>
+            </ExampleCard> */}
           </div>
         }
         allowNativeProps={ true }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
@@ -8,7 +8,7 @@ export class ScrollablePaneDefaultExample extends React.Component {
 
   public render() {
     const contentAreas: JSX.Element[] = [];
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 5; i++) {
       contentAreas.push(this._createContentArea(i));
     }
 

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
@@ -14,6 +14,7 @@ export class ScrollablePaneDefaultExample extends React.Component {
 
     return (
       <ScrollablePane className='scrollablePaneDefaultExample'>
+        testing testing <br />
         { contentAreas.map((ele) => {
           return ele;
         }) }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
@@ -37,7 +37,6 @@ export class ScrollablePaneDefaultExample extends React.Component {
       <div key={ index }>
         <Sticky
           stickyPosition={ StickyPositionType.Both }
-          stickyClassName='largeFont'
           stickyBackgroundColor={ style }
         >
           <div className='sticky'>

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Default.Example.tsx
@@ -14,7 +14,6 @@ export class ScrollablePaneDefaultExample extends React.Component {
 
     return (
       <ScrollablePane className='scrollablePaneDefaultExample'>
-        testing testing <br />
         { contentAreas.map((ele) => {
           return ele;
         }) }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -86,6 +86,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<{}, {
 
     return (
       <ScrollablePane>
+        hello world <br />
         <Sticky>{ selectionDetails }</Sticky>
         <TextField
           label='Filter by name:'

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -89,14 +89,17 @@ export class ScrollablePaneDetailsListExample extends React.Component<{}, {
       <ScrollablePane>
         hello world <br />
         <Sticky stickyPosition={ StickyPositionType.Header }>{ selectionDetails }</Sticky>
+        <br />
         <TextField
           label='Filter by name:'
           // tslint:disable-next-line:jsx-no-lambda
           onChanged={ text => this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items }) }
         />
+        <br />
         <Sticky stickyPosition={ StickyPositionType.Header }>
           <h1 style={ { margin: '0px' } }>Item List</h1>
         </Sticky>
+        <br />
         <MarqueeSelection selection={ this._selection }>
           <DetailsList
             items={ items }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -20,7 +20,8 @@ import {
   ScrollablePane
 } from 'office-ui-fabric-react/lib/ScrollablePane';
 import {
-  Sticky
+  Sticky,
+  StickyPositionType
 } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 
@@ -87,13 +88,13 @@ export class ScrollablePaneDetailsListExample extends React.Component<{}, {
     return (
       <ScrollablePane>
         hello world <br />
-        <Sticky>{ selectionDetails }</Sticky>
+        <Sticky stickyPosition={ StickyPositionType.Header }>{ selectionDetails }</Sticky>
         <TextField
           label='Filter by name:'
           // tslint:disable-next-line:jsx-no-lambda
           onChanged={ text => this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items }) }
         />
-        <Sticky>
+        <Sticky stickyPosition={ StickyPositionType.Header }>
           <h1 style={ { margin: '0px' } }>Item List</h1>
         </Sticky>
         <MarqueeSelection selection={ this._selection }>
@@ -105,7 +106,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<{}, {
             onRenderDetailsHeader={
               // tslint:disable-next-line:jsx-no-lambda
               (detailsHeaderProps: IDetailsHeaderProps, defaultRender: IRenderFunction<IDetailsHeaderProps>) => (
-                <Sticky>
+                <Sticky stickyPosition={ StickyPositionType.Header }>
                   { defaultRender({
                     ...detailsHeaderProps,
                     onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => <TooltipHost { ...tooltipHostProps } />

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -87,19 +87,15 @@ export class ScrollablePaneDetailsListExample extends React.Component<{}, {
 
     return (
       <ScrollablePane>
-        hello world <br />
         <Sticky stickyPosition={ StickyPositionType.Header }>{ selectionDetails }</Sticky>
-        <br />
         <TextField
           label='Filter by name:'
           // tslint:disable-next-line:jsx-no-lambda
           onChanged={ text => this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items }) }
         />
-        <br />
         <Sticky stickyPosition={ StickyPositionType.Header }>
           <h1 style={ { margin: '0px' } }>Item List</h1>
         </Sticky>
-        <br />
         <MarqueeSelection selection={ this._selection }>
           <DetailsList
             items={ items }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Example.scss
@@ -3,7 +3,6 @@
 :global {
   .scrollablePaneDefaultExample {
     max-width: 400px;
-    max-height: inherit;
     border: 1px solid $ms-color-neutralLight;
   }
 
@@ -21,7 +20,8 @@
     -o-transform: translateZ(0);
     transform: translateZ(0);
     will-change: font-size;
-    box-shadow: 0 0 5px -1px $ms-color-neutralDark;
+    border-top: 1px solid black;
+    border-bottom: 1px solid black;
   }
 
   .largeFont {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.Example.scss
@@ -20,8 +20,8 @@
     -o-transform: translateZ(0);
     transform: translateZ(0);
     will-change: font-size;
-    border-top: 1px solid black;
-    border-bottom: 1px solid black;
+    border-top: 1px solid $ms-color-black;
+    border-bottom: 1px solid $ms-color-black;
   }
 
   .largeFont {

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -31,7 +31,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       subscribe: (handler: Function) => void;
       unsubscribe: (handler: Function) => void;
       addSticky: (sticky: Sticky) => void;
-      updateStickyAboveHeight: () => void;
+      updateStickyRefHeights: () => void;
       notifySubscribers: (sort?: boolean) => void;
     }
   };
@@ -56,24 +56,15 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     const { scrollablePane } = this.context;
     scrollablePane.subscribe(this._onScrollEvent2);
     scrollablePane.addSticky(this);
-    console.log('distance from top', this._getStickyDistanceFromTop());
-    // console.log(this, this.root.value);
-    if (this.root.value) {
-      // console.log(' this root value', this.root.value, this.root.value.offsetParent, this.root.value.offsetTop);
-    }
-    // this.content = document.createElement('div');
-    // this.content.style.background = this.props.stickyBackgroundColor || this._getBackground();
-    // ReactDOM.render(<div>{ this.props.children }</div>, this.content);
-    // if (this.root.value) {
-    //   this.root.value.appendChild(this.content);
-    // }
+
+
     this.context.scrollablePane.notifySubscribers(true);
   }
 
   public componentWillUnmount(): void {
     const { isStickyTop, isStickyBottom } = this.state;
     const { scrollablePane } = this.context;
-    scrollablePane.unsubscribe(this._onScrollEvent);
+    scrollablePane.unsubscribe(this._onScrollEvent2);
   }
 
   public componentDidUpdate(prevProps: IStickyProps, prevState: IStickyState): void {
@@ -124,7 +115,6 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
     return (
       <div ref={ this.root }>
-        {/* <div style={ { height: (isSticky ? placeholderHeight : 0) } } /> */ }
         <div ref={ this.stickyContentTop }
           style={ isStickyStyleTop }
         >
@@ -142,26 +132,38 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     );
   }
 
-  private _onScrollEvent2 = (container: HTMLElement): void => {
+  private _onScrollEvent2 = (container: HTMLElement, bottomStickyContainer: HTMLElement, footerStickyVisible: HTMLElement): void => {
     const { scrollablePane } = this.context;
 
-    if (container && this.root.value) {
-      let distanceFromTop = this._getNonStickyDistanceFromTop(container);
-      let stickyDistanceFromTop = this._getStickyDistanceFromTop();
-      let distanceToStick = distanceFromTop - stickyDistanceFromTop;
-      if (container.scrollTop <= distanceToStick) {
+    if (container && this.root.value && this.nonStickyContent.value && this.stickyContentBottom.value) {
+      const distanceFromTop = this._getNonStickyDistanceFromTop(container);
+
+      const stickyDistanceFromTop = this._getStickyDistanceFromTop();
+      let distanceToStickTop = distanceFromTop - stickyDistanceFromTop;
+      if (container.scrollTop <= distanceToStickTop) {
         this.setState({
           isStickyTop: false
         });
-        console.log('distance from top', this.root.value, distanceFromTop, stickyDistanceFromTop, container.scrollTop);
       } else {
         this.setState({
           isStickyTop: true
         });
-        console.log('element is sticky', this.root.value);
       }
 
-      scrollablePane.updateStickyAboveHeight();
+      // Can sticky bottom if the scrollablePane height is smaller than the sticky's distance from the top of the pane
+      if (container.clientHeight <= distanceFromTop) {
+        if (distanceFromTop - container.scrollTop > this._getStickyDistanceFromTopForFooter(container, footerStickyVisible)) {
+          this.setState({
+            isStickyBottom: true
+          });
+        } else {
+          this.setState({
+            isStickyBottom: false
+          });
+        }
+      }
+
+      scrollablePane.updateStickyRefHeights();
     }
   }
 
@@ -169,6 +171,15 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     let distance: number = 0;
     if (this.stickyContentTop.value) {
       distance = this.stickyContentTop.value.offsetTop;
+    }
+
+    return distance;
+  }
+
+  private _getStickyDistanceFromTopForFooter = (container: HTMLElement, footerStickyVisibleContainer: HTMLElement): number => {
+    let distance: number = 0;
+    if (this.stickyContentBottom.value) {
+      distance = container.clientHeight - footerStickyVisibleContainer.offsetHeight + this.stickyContentBottom.value.offsetTop;
     }
 
     return distance;
@@ -193,23 +204,6 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       }
     }
     return distance;
-  }
-
-  private _onScrollEvent = (headerBound: ClientRect, footerBound: ClientRect): void => {
-    if (!this.root.value) {
-      return;
-    }
-
-    const { top, bottom } = this.root.value.getBoundingClientRect();
-    const { isStickyTop, isStickyBottom } = this.state;
-    const { stickyPosition } = this.props;
-    const canStickyHeader = stickyPosition === StickyPositionType.Both || stickyPosition === StickyPositionType.Header;
-    const canStickyFooter = stickyPosition === StickyPositionType.Both || stickyPosition === StickyPositionType.Footer;
-
-    this.setState({
-      isStickyTop: canStickyHeader && ((top <= headerBound.bottom) || (isStickyTop && bottom < headerBound.bottom)),
-      isStickyBottom: canStickyFooter && ((bottom >= footerBound.top) || (isStickyBottom && top > footerBound.top))
-    });
   }
 
   // Gets background of nearest parent element that has a declared background-color attribute

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -30,16 +30,16 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     scrollablePane: {
       subscribe: (handler: Function) => void;
       unsubscribe: (handler: Function) => void;
-      addStickyHeader: (sticky: Sticky) => void;
-      removeStickyHeader: (sticky: Sticky) => void;
-      addStickyFooter: (sticky: Sticky) => void;
-      removeStickyFooter: (sticky: Sticky) => void;
+      addSticky: (sticky: Sticky) => void;
+      updateStickyAboveHeight: () => void;
       notifySubscribers: (sort?: boolean) => void;
     }
   };
 
-  public content: HTMLElement;
   public root = createRef<HTMLDivElement>();
+  public stickyContentTop = createRef<HTMLDivElement>();
+  public stickyContentBottom = createRef<HTMLDivElement>();
+  public nonStickyContent = createRef<HTMLDivElement>();
 
   constructor(props: IStickyProps) {
     super(props);
@@ -54,29 +54,25 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       throw new TypeError('Expected Sticky to be mounted within ScrollablePane');
     }
     const { scrollablePane } = this.context;
-    scrollablePane.subscribe(this._onScrollEvent);
-    this.content = document.createElement('div');
-    this.content.style.background = this.props.stickyBackgroundColor || this._getBackground();
-    ReactDOM.render(<div>{ this.props.children }</div>, this.content);
+    scrollablePane.subscribe(this._onScrollEvent2);
+    scrollablePane.addSticky(this);
+    console.log('distance from top', this._getStickyDistanceFromTop());
+    // console.log(this, this.root.value);
     if (this.root.value) {
-      this.root.value.appendChild(this.content);
+      // console.log(' this root value', this.root.value, this.root.value.offsetParent, this.root.value.offsetTop);
     }
+    // this.content = document.createElement('div');
+    // this.content.style.background = this.props.stickyBackgroundColor || this._getBackground();
+    // ReactDOM.render(<div>{ this.props.children }</div>, this.content);
+    // if (this.root.value) {
+    //   this.root.value.appendChild(this.content);
+    // }
     this.context.scrollablePane.notifySubscribers(true);
   }
 
   public componentWillUnmount(): void {
     const { isStickyTop, isStickyBottom } = this.state;
     const { scrollablePane } = this.context;
-    if (isStickyTop) {
-      this._resetSticky(() => {
-        scrollablePane.removeStickyHeader(this);
-      });
-    }
-    if (isStickyBottom) {
-      this._resetSticky(() => {
-        scrollablePane.removeStickyFooter(this);
-      });
-    }
     scrollablePane.unsubscribe(this._onScrollEvent);
   }
 
@@ -84,29 +80,6 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     const { isStickyTop, isStickyBottom } = this.state;
     const { scrollablePane } = this.context;
 
-    if (this.props.children !== prevProps.children) {
-      ReactDOM.render(<div>{ this.props.children }</div>, this.content);
-    }
-
-    if (isStickyTop && !prevState.isStickyTop) {
-      this._setSticky(() => {
-        scrollablePane.addStickyHeader(this);
-      });
-    } else if (!isStickyTop && prevState.isStickyTop) {
-      this._resetSticky(() => {
-        scrollablePane.removeStickyHeader(this);
-      });
-    }
-
-    if (isStickyBottom && !prevState.isStickyBottom) {
-      this._setSticky(() => {
-        scrollablePane.addStickyFooter(this);
-      });
-    } else if (!isStickyBottom && prevState.isStickyBottom) {
-      this._resetSticky(() => {
-        scrollablePane.removeStickyFooter(this);
-      });
-    }
   }
 
   public shouldComponentUpdate(nextProps: IStickyProps, nextState: IStickyState): boolean {
@@ -127,11 +100,99 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     const { isStickyTop, isStickyBottom, placeholderHeight } = this.state;
     const isSticky = isStickyTop || isStickyBottom;
 
+    let isStickyStyleTop = {};
+    if (isStickyTop) {
+      isStickyStyleTop = {
+        opacity: '1'
+      };
+    } else {
+      isStickyStyleTop = {
+        opacity: '0'
+      };
+    }
+
+    let isStickyStyleBottom = {};
+    if (isStickyBottom) {
+      isStickyStyleBottom = {
+        opacity: '1'
+      };
+    } else {
+      isStickyStyleBottom = {
+        opacity: '0'
+      };
+    }
+
     return (
       <div ref={ this.root }>
-        <div style={ { height: (isSticky ? placeholderHeight : 0) } } />
+        {/* <div style={ { height: (isSticky ? placeholderHeight : 0) } } /> */ }
+        <div ref={ this.stickyContentTop }
+          style={ isStickyStyleTop }
+        >
+          { this.props.children }
+        </div>
+        <div ref={ this.stickyContentBottom }
+          style={ isStickyStyleBottom }
+        >
+          { this.props.children }
+        </div>
+        <div ref={ this.nonStickyContent }>
+          { this.props.children }
+        </div>
       </div>
     );
+  }
+
+  private _onScrollEvent2 = (container: HTMLElement): void => {
+    const { scrollablePane } = this.context;
+
+    if (container && this.root.value) {
+      let distanceFromTop = this._getNonStickyDistanceFromTop(container);
+      let stickyDistanceFromTop = this._getStickyDistanceFromTop();
+      let distanceToStick = distanceFromTop - stickyDistanceFromTop;
+      if (container.scrollTop <= distanceToStick) {
+        this.setState({
+          isStickyTop: false
+        });
+        console.log('distance from top', this.root.value, distanceFromTop, stickyDistanceFromTop, container.scrollTop);
+      } else {
+        this.setState({
+          isStickyTop: true
+        });
+        console.log('element is sticky', this.root.value);
+      }
+
+      scrollablePane.updateStickyAboveHeight();
+    }
+  }
+
+  private _getStickyDistanceFromTop = (): number => {
+    let distance: number = 0;
+    if (this.stickyContentTop.value) {
+      distance = this.stickyContentTop.value.offsetTop;
+    }
+
+    return distance;
+  }
+
+  private _getNonStickyDistanceFromTop = (container: HTMLElement): number => {
+    let distance: number = 0;
+    let currElem = this.root.value;
+
+    if (currElem) {
+      if (currElem.offsetParent === container) {
+        return currElem.offsetTop;
+      }
+
+      if (currElem.offsetParent) {
+        do {
+          distance += currElem.offsetTop;
+          if (currElem) {
+            currElem = currElem.offsetParent as HTMLDivElement;
+          }
+        } while (currElem && currElem.offsetParent !== container)
+      }
+    }
+    return distance;
   }
 
   private _onScrollEvent = (headerBound: ClientRect, footerBound: ClientRect): void => {
@@ -149,26 +210,6 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       isStickyTop: canStickyHeader && ((top <= headerBound.bottom) || (isStickyTop && bottom < headerBound.bottom)),
       isStickyBottom: canStickyFooter && ((bottom >= footerBound.top) || (isStickyBottom && top > footerBound.top))
     });
-  }
-
-  private _setSticky(callback: () => void): void {
-    if (this.content.parentElement) {
-      this.content.parentElement.removeChild(this.content);
-    }
-    callback();
-  }
-
-  private _resetSticky(callback: () => void): void {
-    if (this.root.value) {
-      this.root.value.appendChild(this.content);
-    }
-
-    setTimeout(() => {
-      if (this.props.stickyClassName) {
-        this.content.children[0].classList.remove(this.props.stickyClassName);
-      }
-    }, 1);
-    callback();
   }
 
   // Gets background of nearest parent element that has a declared background-color attribute

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -60,14 +60,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
   public componentWillUnmount(): void {
     const { scrollablePane } = this.context;
-
-    scrollablePane.removeSticky(this);
     scrollablePane.unsubscribe(this._onScrollEvent);
-  }
-
-  public componentDidUpdate(prevProps: IStickyProps, prevState: IStickyState): void {
-    const { isStickyTop, isStickyBottom } = this.state;
-    const { scrollablePane } = this.context;
+    scrollablePane.removeSticky(this);
   }
 
   public shouldComponentUpdate(nextProps: IStickyProps, nextState: IStickyState): boolean {
@@ -137,8 +131,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
     if (container && this.root.value && this.nonStickyContent.value && this.stickyContentBottom.value) {
       const distanceFromTop = this._getNonStickyDistanceFromTop(container);
-      const stickyDistanceFromTop = this._getStickyDistanceFromTop();
-      const distanceToStickTop = distanceFromTop - stickyDistanceFromTop;
+      const distanceToStickTop = distanceFromTop - this._getStickyDistanceFromTop();
       const canStickyTop = stickyPosition === StickyPositionType.Both || stickyPosition === StickyPositionType.Header;
       const canStickyBottom = stickyPosition === StickyPositionType.Both || stickyPosition === StickyPositionType.Footer;
 
@@ -153,6 +146,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         isStickyTop: canStickyTop && isStickyTop,
         isStickyBottom: canStickyBottom && isStickyBottom
       }, () => {
+        // Update ScrollablePane's Sticky bop and Sticky bottom heights
         scrollablePane.updateStickyRefHeights();
       });
     }

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -71,46 +71,27 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       this.props.children !== nextProps.children;
   }
 
+  private _getStickyStyles(isSticky: boolean): React.CSSProperties {
+    return {
+      visibility: isSticky ? 'visible' : 'hidden',
+      backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
+    };
+  }
+
   public render(): JSX.Element {
     const { isStickyTop, isStickyBottom } = this.state;
-
-    let isStickyStyleTop = {};
-    if (isStickyTop) {
-      isStickyStyleTop = {
-        opacity: '1',
-        backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
-      };
-    } else {
-      isStickyStyleTop = {
-        opacity: '0',
-        backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
-      };
-    }
-
-    let isStickyStyleBottom = {};
-    if (isStickyBottom) {
-      isStickyStyleBottom = {
-        opacity: '1',
-        backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
-      };
-    } else {
-      isStickyStyleBottom = {
-        opacity: '0',
-        backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
-      };
-    }
 
     return (
       <div ref={ this.root }>
         <div
           ref={ this.stickyContentTop }
-          style={ isStickyStyleTop }
+          style={ this._getStickyStyles(isStickyTop) }
         >
           { this.props.children }
         </div>
         <div
           ref={ this.stickyContentBottom }
-          style={ isStickyStyleBottom }
+          style={ this._getStickyStyles(isStickyBottom) }
         >
           { this.props.children }
         </div>

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -85,12 +85,12 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     if (isStickyTop) {
       isStickyStyleTop = {
         opacity: '1',
-        backgroundColor: this.props.stickyBackgroundColor
+        backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
       };
     } else {
       isStickyStyleTop = {
         opacity: '0',
-        backgroundColor: this.props.stickyBackgroundColor
+        backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
       };
     }
 
@@ -98,12 +98,12 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     if (isStickyBottom) {
       isStickyStyleBottom = {
         opacity: '1',
-        backgroundColor: this.props.stickyBackgroundColor
+        backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
       };
     } else {
       isStickyStyleBottom = {
         opacity: '0',
-        backgroundColor: this.props.stickyBackgroundColor
+        backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
       };
     }
 
@@ -132,7 +132,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     );
   }
 
-  private _onScrollEvent = (container: HTMLElement, bottomStickyContainer: HTMLElement, footerStickyVisible: HTMLElement): void => {
+  private _onScrollEvent = (container: HTMLElement, footerStickyVisible: HTMLElement): void => {
     const { scrollablePane } = this.context;
     const { stickyPosition } = this.props;
 

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -134,11 +134,14 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
   private _onScrollEvent = (container: HTMLElement, bottomStickyContainer: HTMLElement, footerStickyVisible: HTMLElement): void => {
     const { scrollablePane } = this.context;
+    const { stickyPosition } = this.props;
 
     if (container && this.root.value && this.nonStickyContent.value && this.stickyContentBottom.value) {
       const distanceFromTop = this._getNonStickyDistanceFromTop(container);
       const stickyDistanceFromTop = this._getStickyDistanceFromTop();
       const distanceToStickTop = distanceFromTop - stickyDistanceFromTop;
+      const canStickyTop = stickyPosition === StickyPositionType.Both || stickyPosition === StickyPositionType.Header;
+      const canStickyBottom = stickyPosition === StickyPositionType.Both || stickyPosition === StickyPositionType.Footer;
 
       const isStickyTop = distanceToStickTop <= container.scrollTop;
       let isStickyBottom: boolean = false;
@@ -148,8 +151,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         isStickyBottom = distanceFromTop - container.scrollTop > this._getStickyDistanceFromTopForFooter(container, footerStickyVisible);
       }
       this.setState({
-        isStickyTop: isStickyTop,
-        isStickyBottom: isStickyBottom
+        isStickyTop: canStickyTop && isStickyTop,
+        isStickyBottom: canStickyBottom && isStickyBottom
       });
 
       scrollablePane.updateStickyRefHeights();

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -56,12 +56,10 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     scrollablePane.subscribe(this._onScrollEvent);
     scrollablePane.addSticky(this);
 
-
     this.context.scrollablePane.notifySubscribers(true);
   }
 
   public componentWillUnmount(): void {
-    const { isStickyTop, isStickyBottom } = this.state;
     const { scrollablePane } = this.context;
     scrollablePane.unsubscribe(this._onScrollEvent);
   }
@@ -182,17 +180,13 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     let currElem = this.root.value;
 
     if (currElem) {
-      if (currElem.offsetParent === container) {
-        return currElem.offsetTop;
+      while (currElem.offsetParent !== container) {
+        distance += currElem.offsetTop;
+        currElem = currElem.offsetParent as HTMLDivElement;
       }
 
-      if (currElem.offsetParent) {
-        do {
-          distance += currElem.offsetTop;
-          if (currElem) {
-            currElem = currElem.offsetParent as HTMLDivElement;
-          }
-        } while (currElem && currElem.offsetParent !== container)
+      if (currElem.offsetParent === container) {
+        distance += currElem.offsetTop;
       }
     }
     return distance;

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -71,25 +71,20 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       this.props.children !== nextProps.children;
   }
 
-  private _getStickyStyles(isSticky: boolean): React.CSSProperties {
-    return {
-      visibility: isSticky ? 'visible' : 'hidden',
-      backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
-    };
-  }
-
   public render(): JSX.Element {
     const { isStickyTop, isStickyBottom } = this.state;
 
     return (
       <div ref={ this.root }>
         <div
+          className={ this.props.stickyClassName }
           ref={ this.stickyContentTop }
           style={ this._getStickyStyles(isStickyTop) }
         >
           { this.props.children }
         </div>
         <div
+          className={ this.props.stickyClassName }
           ref={ this.stickyContentBottom }
           style={ this._getStickyStyles(isStickyBottom) }
         >
@@ -97,6 +92,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         </div>
         <div
           ref={ this.nonStickyContent }
+          className={ isStickyTop || isStickyBottom ? this.props.stickyClassName : undefined }
           style={ {
             backgroundColor: this.props.stickyBackgroundColor
           } }>
@@ -104,6 +100,13 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         </div>
       </div>
     );
+  }
+
+  private _getStickyStyles = (isSticky: boolean): React.CSSProperties => {
+    return {
+      visibility: isSticky ? 'visible' : 'hidden',
+      backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
+    };
   }
 
   private _onScrollEvent = (container: HTMLElement, footerStickyContainer: HTMLElement): void => {
@@ -127,7 +130,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         isStickyTop: canStickyTop && isStickyTop,
         isStickyBottom: canStickyBottom && isStickyBottom
       }, () => {
-        // Update ScrollablePane's Sticky bop and Sticky bottom heights
+        // Update ScrollablePane's Sticky top and Sticky bottom heights
         scrollablePane.updateStickyRefHeights();
       });
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4204
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

- Fixes #4204 
- Changes how ScrollablePane calculates whether Sticky components are Sticky or not (does not rely on expensive getBoundingClientRect anymore)
- Fixes mounting/unmounting Sticky component after ScrollablePane has already been mounted.  No more using unreliable setTimeouts to wait and re-render the pane/Stickies.
- Instead of moving Sticky component's DOM contents to and from the ScrollablePane stickyAbove/Below region, this method duplicates `this.props.children` and toggle `visibility` of Sticky component if the Sticky scrollable child is higher/lower than its respective Sticky header/footer element.

#### Focus areas to test

(optional)
