### PR TITLE
Contextual Menu: Moved the creation of Splitbutton containers into the constructor

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-fixCreationOfSplitButtonContainer_2018-04-09-16-47.json
+++ b/common/changes/office-ui-fabric-react/chiechan-fixCreationOfSplitButtonContainer_2018-04-09-16-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Contexual Menu: Move SplitButtonContainer to be defined in the constructor instead of ComponentDidMount",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -114,6 +114,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
     this._isFocusingPreviousElement = false;
     this._isScrollIdle = true;
+    this._splitButtonContainers = new Map();
   }
 
   public dismiss = (ev?: any, dismissAll?: boolean) => {
@@ -141,7 +142,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   // Invoked once, only on the client (not on the server), immediately after the initial rendering occurs.
   public componentDidMount() {
     this._events.on(this._targetWindow, 'resize', this.dismiss);
-    this._splitButtonContainers = new Map();
     if (this.props.onMenuOpened) {
       this.props.onMenuOpened(this.props);
     }


### PR DESCRIPTION
**Problem:**
It doesn't make sense to initialize the split button container in componentDidMount, especially if it's being used in the ref callback during the render.

**Solution:**
Moved the initialization to be in the constructor where it should be.