### PR TITLE
Allow user settings for editor.wordWrap mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,7 +37,6 @@
     "**/*.scss.ts": true
   },
   // Controls after how many characters the editor will wrap to the next line. Setting this to 0 turns on viewport width wrapping
-  "editor.wordWrap": "wordWrapColumn",
   "editor.wordWrapColumn": 140,
   "tslint.enable": true,
   "tslint.rulesDirectory": "./common/temp/node_modules/tslint-microsoft-contrib",


### PR DESCRIPTION
I believe this setting should be up to the individual developer as it doesn't affect the outputted code. I prefer `bounded` settings so I don't have to scroll sideways.

#### Description of changes

Remove `editor.wordWrap` setting from .vscode/settings.json
