### PR TITLE
TooltipPage: Update properties table to include TooltipHost types.

### DIFF
--- a/common/changes/office-ui-fabric-react/tooltip-docs_2018-04-10-15-54.json
+++ b/common/changes/office-ui-fabric-react/tooltip-docs_2018-04-10-15-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
@@ -50,6 +50,7 @@ export class TooltipPage extends React.Component<IComponentDemoPageProps, any> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts'),
               require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts')
             ] }
           />

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
@@ -50,15 +50,16 @@ export class TooltipPage extends React.Component<IComponentDemoPageProps, any> {
         propertiesTables={
           <PropertiesTableSet
             sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts'),
-              require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts')
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts'),
+              require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts')
             ] }
           />
         }
         overview={
           <div>
-            <Link target='_blank' href='http://dev.office.com/fabric/components/Tooltip'>Tooltips</Link>
-            <span> supplement content associated with a specific UI component.</span>
+            <p>Tooltips supplement content associated with a specific UI component. You can use two components, and each has different props:</p>
+            <p>Tooltip: A styled tooltip that you can display on a chosen target.</p>
+            <p>TooltipHost: A tooltip wrapped in a stateful parent. Tooltip will be displayed on hover or focus and removed when focus/hover removed.</p>
           </div>
         }
         isHeaderVisible={ this.props.isHeaderVisible }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4497 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

TooltipHost types were missing from from the example page, which made the props confusing to use. 

#### Focus areas to test

(optional)
