### PR TITLE
SearchBox: Padding fixes

### DIFF
--- a/common/changes/office-ui-fabric-react/searchbox-polish_2018-04-10-17-12.json
+++ b/common/changes/office-ui-fabric-react/searchbox-polish_2018-04-10-17-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SearchBox: Fix padding left and add padding top and bottom to fix the field overlapping the border.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -20,7 +20,8 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         flexDirection: 'row',
         flexWrap: 'nowrap',
         alignItems: 'stretch',
-        padding: '0 0 0 8px',
+        // The 1px top and bottom padding ensure the input field does not overlap the border
+        padding: '1px 0 1px 4px',
         border: `1px solid ${palette.neutralTertiary}`,
         height: 32,
         selectors: {
@@ -61,7 +62,9 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
       underlined && [
         'is-underlined',
         {
-          borderWidth: '0 0 1px 0'
+          borderWidth: '0 0 1px 0',
+          // Underlined SearchBox has a larger padding left to vertically align with the waffle in product
+          padding: '1px 0 1px 8px'
         }
       ],
       underlined && disabled && {

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -23,10 +23,10 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
         margin-left: 0px;
         margin-right: 0px;
         margin-top: 0px;
-        padding-bottom: 0;
-        padding-left: 8px;
+        padding-bottom: 1px;
+        padding-left: 4px;
         padding-right: 0;
-        padding-top: 0;
+        padding-top: 1px;
       }
       @media screen and (-ms-high-contrast: active){& {
         border: 1px solid WindowText;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

We worked with a product team and design to come up with a more reasonable padding left for the default SearchBox. Underlined SearchBox needs to maintain its larger padding left for other product scenarios.

I also added a small top and bottom padding because the input field is sometimes overlaps the border when rendered.

#### Focus areas to test

(optional)
