### PR TITLE
SplitButton: When in a menu allow the primary portion to collapse submenu

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-AllowSubMenusToCollapseOnPrimarySplitButton_2018-04-11-14-51.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-AllowSubMenusToCollapseOnPrimarySplitButton_2018-04-11-14-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SplitButton: Allow the primary portion of a splitButton (when it a menu) to collapse a submenu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -604,6 +604,9 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         aria-checked={ item.isChecked || item.checked }
         aria-posinset={ focusableElementIndex + 1 }
         aria-setsize={ totalItemCount }
+        onMouseEnter={ this._onItemMouseEnter.bind(this, { ...item, subMenuProps: null, items: null }) }
+        onMouseLeave={ this._onMouseItemLeave.bind(this, { ...item, subMenuProps: null, items: null }) }
+        onMouseMove={ this._onItemMouseMove.bind(this, { ...item, subMenuProps: null, items: null }) }
         onKeyDown={ this._onSplitContainerItemKeyDown.bind(this, item) }
         onClick={ this._executeItemClick.bind(this, item) }
         tabIndex={ 0 }
@@ -639,9 +642,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       checked: item.checked,
       icon: item.icon,
       iconProps: item.iconProps,
-      onMouseEnter: this._onItemMouseEnter.bind(this, item, true /* isSplitButtonPrimary */),
-      onMouseLeave: this._onMouseItemLeave.bind(this, item),
-      onMouseMove: this._onItemMouseMove.bind(this, item, true /* isSplitButtonPrimary */),
       'data-is-focusable': false
     } as IContextualMenuItem;
     return React.createElement('button',
@@ -763,15 +763,15 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     this._scrollIdleTimeoutId = this._async.setTimeout(() => { this._isScrollIdle = true; }, this._navigationIdleDelay);
   }
 
-  private _onItemMouseEnter(item: any, ev: React.MouseEvent<HTMLElement>, isSplitButtonPrimary: boolean = false) {
+  private _onItemMouseEnter(item: any, ev: React.MouseEvent<HTMLElement>) {
     if (!this._isScrollIdle) {
       return;
     }
 
-    this._updateFocusOnMouseEvent(item, ev, isSplitButtonPrimary);
+    this._updateFocusOnMouseEvent(item, ev);
   }
 
-  private _onItemMouseMove(item: any, ev: React.MouseEvent<HTMLElement>, isSplitButtonPrimary: boolean = false) {
+  private _onItemMouseMove(item: any, ev: React.MouseEvent<HTMLElement>) {
 
     const targetElement = ev.currentTarget as HTMLElement;
 
@@ -779,7 +779,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       return;
     }
 
-    this._updateFocusOnMouseEvent(item, ev, isSplitButtonPrimary);
+    this._updateFocusOnMouseEvent(item, ev);
   }
 
   private _onMouseItemLeave = (item: any, ev: React.MouseEvent<HTMLElement>): void => {
@@ -813,7 +813,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
    * As part of updating focus, This function will also update
    * the expand/collapse state accordingly.
    */
-  private _updateFocusOnMouseEvent(item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>, isSplitButtonPrimary: boolean) {
+  private _updateFocusOnMouseEvent(item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>) {
     const targetElement = ev.currentTarget as HTMLElement;
     const { subMenuHoverDelay: timeoutDuration = this._navigationIdleDelay } = this.props;
 
@@ -836,7 +836,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     // Also if we are on the primary portion of a splitButton
     // (and we know from above that we are not the expanded item)
     // collapse the submenu
-    if (hasSubmenu(item) && !isSplitButtonPrimary) {
+    if (hasSubmenu(item)) {
+      ev.stopPropagation();
       this._enterTimerId = this._async.setTimeout(() => {
         targetElement.focus();
         const splitButtonContainer = this._splitButtonContainers.get(item.key);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -639,6 +639,9 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       checked: item.checked,
       icon: item.icon,
       iconProps: item.iconProps,
+      onMouseEnter: this._onItemMouseEnter.bind(this, item, true /* isSplitButtonPrimary */),
+      onMouseLeave: this._onMouseItemLeave.bind(this, item),
+      onMouseMove: this._onItemMouseMove.bind(this, item, true /* isSplitButtonPrimary */),
       'data-is-focusable': false
     } as IContextualMenuItem;
     return React.createElement('button',
@@ -760,15 +763,15 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     this._scrollIdleTimeoutId = this._async.setTimeout(() => { this._isScrollIdle = true; }, this._navigationIdleDelay);
   }
 
-  private _onItemMouseEnter(item: any, ev: React.MouseEvent<HTMLElement>) {
+  private _onItemMouseEnter(item: any, ev: React.MouseEvent<HTMLElement>, isSplitButtonPrimary: boolean = false) {
     if (!this._isScrollIdle) {
       return;
     }
 
-    this._updateFocusOnMouseEvent(item, ev);
+    this._updateFocusOnMouseEvent(item, ev, isSplitButtonPrimary);
   }
 
-  private _onItemMouseMove(item: any, ev: React.MouseEvent<HTMLElement>) {
+  private _onItemMouseMove(item: any, ev: React.MouseEvent<HTMLElement>, isSplitButtonPrimary: boolean = false) {
 
     const targetElement = ev.currentTarget as HTMLElement;
 
@@ -776,7 +779,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       return;
     }
 
-    this._updateFocusOnMouseEvent(item, ev);
+    this._updateFocusOnMouseEvent(item, ev, isSplitButtonPrimary);
   }
 
   private _onMouseItemLeave = (item: any, ev: React.MouseEvent<HTMLElement>): void => {
@@ -810,7 +813,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
    * As part of updating focus, This function will also update
    * the expand/collapse state accordingly.
    */
-  private _updateFocusOnMouseEvent(item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>) {
+  private _updateFocusOnMouseEvent(item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>, isSplitButtonPrimary: boolean) {
     const targetElement = ev.currentTarget as HTMLElement;
     const { subMenuHoverDelay: timeoutDuration = this._navigationIdleDelay } = this.props;
 
@@ -829,8 +832,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     }
 
     // Delay updating expanding/dismissing the submenu
-    // and only set focus if we have not already done so
-    if (hasSubmenu(item)) {
+    // and only set focus if we have not already done so.
+    // Also if we are on the primary portion of a splitButton
+    // (and we know from above that we are not the expanded item)
+    // collapse the submenu
+    if (hasSubmenu(item) && !isSplitButtonPrimary) {
       this._enterTimerId = this._async.setTimeout(() => {
         targetElement.focus();
         const splitButtonContainer = this._splitButtonContainers.get(item.key);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -832,10 +832,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     }
 
     // Delay updating expanding/dismissing the submenu
-    // and only set focus if we have not already done so.
-    // Also if we are on the primary portion of a splitButton
-    // (and we know from above that we are not the expanded item)
-    // collapse the submenu
+    // and only set focus if we have not already done so
     if (hasSubmenu(item)) {
       ev.stopPropagation();
       this._enterTimerId = this._async.setTimeout(() => {


### PR DESCRIPTION
SplitButton: Allow the primary portion of a splitButton (when it a menu) to collapse a submenu

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Before this PR, the primary portion of a splitButton when in a menu would not collapse another item's submenu (you could only hover over the split portion of the splitButton). This did not align with the behavior of other menu items and felt weird/broken

#### Focus areas to test
Verified that now the primary portion of splitButtons can collapse submenus (if it is not its own item's submenu) on hover just like all other menu items AND no other behavior changed
