### PR TITLE
Add ability to use Customizer to control the default layer host

### DIFF
--- a/common/changes/office-ui-fabric-react/layer-host_2018-04-11-15-15.json
+++ b/common/changes/office-ui-fabric-react/layer-host_2018-04-11-15-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add ability to use Customer to provide a default layer host",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
@@ -23,7 +23,7 @@ let _defaultHostSelector: string | undefined;
 
 const getClassNames = classNamesFunction<ILayerStyleProps, ILayerStyles>();
 
-@customizable('Layer', ['theme'])
+@customizable('Layer', ['theme', 'hostId'])
 export class LayerBase extends BaseComponent<ILayerProps, {}> {
 
   public static defaultProps: ILayerProps = {

--- a/packages/office-ui-fabric-react/src/components/Layer/LayerPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/LayerPage.tsx
@@ -8,11 +8,13 @@ import {
 } from '@uifabric/example-app-base';
 import { LayerBasicExample } from './examples/Layer.Basic.Example';
 import { LayerHostedExample } from './examples/Layer.Hosted.Example';
+import { LayerCustomizedExample } from './examples/Layer.Customized.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { LayerStatus } from './Layer.checklist';
 
 const LayerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Basic.Example.tsx') as string;
 const LayerHostedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Hosted.Example.tsx') as string;
+const LayerCustomizedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx') as string;
 
 export class LayerPage extends React.Component<IComponentDemoPageProps, {}> {
   public render() {
@@ -27,6 +29,9 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, {}> {
             </ExampleCard>
             <ExampleCard title='Using LayerHost to control projection' code={ LayerHostedExampleCode }>
               <LayerHostedExample />
+            </ExampleCard>
+            <ExampleCard title='Using Customizer to control the default layer behavior' code={ LayerHostedExampleCode }>
+              <LayerCustomizedExample />
             </ExampleCard>
           </div>
         }
@@ -73,7 +78,7 @@ export class LayerPage extends React.Component<IComponentDemoPageProps, {}> {
         isHeaderVisible={ this.props.isHeaderVisible }
         componentStatus={
           <ComponentStatus
-            {...LayerStatus}
+            { ...LayerStatus }
           />
         }
       />

--- a/packages/office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx
@@ -1,0 +1,93 @@
+
+import * as React from 'react';
+import { Customizer } from '@uifabric/utilities';
+import { Panel } from '../../../Panel';
+import { Checkbox } from '../../../Checkbox';
+import { LayerHost } from '../LayerHost';
+
+export interface ILayerCustomizedExampleState {
+  showPanel: boolean;
+  trapPanel: boolean;
+}
+
+export class LayerCustomizedExample extends React.Component<{}, ILayerCustomizedExampleState> {
+  constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      showPanel: true,
+      trapPanel: true
+    };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div>
+        <p>
+          A <code>Panel</code> is rendered, trapped in a specified container.
+          Use 'Show panel' to show/hide the panel (or click the X to dismiss it).
+          Use 'Trap panel' to release the panel from its bounds.
+        </p>
+        <Checkbox label='Show panel' checked={ this.state.showPanel } onChange={ this._onShowPanelChange } />
+        <Checkbox label='Trap panel' checked={ this.state.trapPanel } onChange={ this._onTrapPanelChange } />
+        <Customizer
+          scopedSettings={
+            this.state.trapPanel ? {
+              Layer: {
+                hostId: 'test'
+              }
+            } : {}
+          }
+        >
+          {
+            this.state.showPanel ?
+              (
+                <Panel
+                  isOpen={ true }
+                  hasCloseButton={ true }
+                  headerText='Test'
+                  focusTrapZoneProps={
+                    {
+                      isClickableOutsideFocusTrap: true,
+                      forceFocusInsideTrap: false
+                    }
+                  }
+                  onDismissed={ this._onDismissPanel }
+                />
+              ) : (
+                <div />
+              )
+          }
+        </Customizer>
+        <LayerHost
+          id='test'
+          style={
+            {
+              position: 'relative',
+              height: '400px',
+              overflow: 'hidden'
+            }
+          }
+        />
+      </div>
+    );
+  }
+
+  private _onDismissPanel = (): void => {
+    this.setState({
+      showPanel: false
+    });
+  }
+
+  private _onShowPanelChange = (event: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean): void => {
+    this.setState({
+      showPanel: !!checked
+    });
+  }
+
+  private _onTrapPanelChange = (event: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean): void => {
+    this.setState({
+      trapPanel: !!checked
+    });
+  }
+}


### PR DESCRIPTION
# Overview

This change provides a way to control all `Layer` components within a scope using `Customizer`, so they all use a default `LayerHost` with the provided `hostId`. This is accomplished by adding `hostId` to the set of customizable props of `Layer`.

Added an example for how to customize `Layer` in this manner so it works with a provided `LayerHost`.