### PR TITLE
Change docs for hidden to state true by default

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
@@ -42,7 +42,7 @@ export interface IDialogProps extends React.Props<DialogBase>, IWithResponsiveMo
 
   /**
   * Whether the dialog is hidden.
-  * @default false
+  * @default true
   */
   hidden?: boolean;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3387
- [x] Include a change request file using `$ npm run change`

#### Description of changes
As per issue, this isn't the greatest fix. Our guidelines state that Boolean props should always have 'true' as the exception (therefore false by default). But in this case, changing the behavior of the Dialog would be a large breaking change entailing reworking of a ton of components... so better to at least have the docs reflect the current state, even if not optimum. 
