### PR TITLE
SpinButton: Keep arrow keys inside spin button

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-KeepArrowKeysInsideSpinButton_2018-04-12-14-31.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-KeepArrowKeysInsideSpinButton_2018-04-12-14-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SpinButton: Make sure up/down Arrow do not leave the spinButton",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -415,7 +415,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
    */
   private _handleKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
 
-    // eat the up and down arrow keys to keep focus in the spinButtons
+    // eat the up and down arrow keys to keep focus in the spinButton
     // (especially when a spinButton is inside of a FocusZone)
     if (event.which === KeyCodes.up || event.which === KeyCodes.down) {
       event.preventDefault();

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -414,15 +414,16 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
    * @param event - the keyboardEvent that was fired
    */
   private _handleKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
+
+    // eat the up and down arrow keys to keep focus in the spinButtons
+    // (especially when a spinButton is inside of a FocusZone)
+    if (event.which === KeyCodes.up || event.which === KeyCodes.down) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
     if (this.props.disabled) {
       this._stop();
-
-      // eat the up and down arrow keys to keep the page from scrolling
-      if (event.which === KeyCodes.up || event.which === KeyCodes.down) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-
       return;
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Before this PR if a spinButton was in a FocusZone, focus would leave the spinButton if the user tried to update the value via the up/down arrow keys. This PR makes sure that the up/down arrow keys do not leave the spinButton

#### Focus areas to test
Verified that the arrow keys do not leave a spinButton and the of the spinButton is updated, both when inside and outside of a FocusZone. Also verified that in a menu I can navigate all the items by pressing TAB when focus is inside of a spinButton in a menu
