### PR TITLE
Fix Bug #4525: ColorPicker does not update upon text field changes when alphaSliderHidden=true

### DIFF
--- a/common/changes/office-ui-fabric-react/wutonghao-UpdateColorPickerWhenAlphaIsHidden_2018-04-12-14-47.json
+++ b/common/changes/office-ui-fabric-react/wutonghao-UpdateColorPickerWhenAlphaIsHidden_2018-04-12-14-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed issue: ColorPicker does not update upon text field changes when alphaSliderHidden=true",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "wuthao@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/wutonghao-UpdateColorPickerWhenAlphaIsHidden_2018-04-12-14-47.json
+++ b/common/changes/office-ui-fabric-react/wutonghao-UpdateColorPickerWhenAlphaIsHidden_2018-04-12-14-47.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fixed issue: ColorPicker does not update upon text field changes when alphaSliderHidden=true",
+      "comment": "ColorPicker: text fields now update when `alphaSliderHidden` is `true`.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -166,7 +166,7 @@ export class ColorPicker extends BaseComponent<IColorPickerProps, IColorPickerSt
       r: Number(this.rText.value),
       g: Number(this.gText.value),
       b: Number(this.bText.value),
-      a: Number(this.aText.value)
+      a: Number((this.aText && this.aText.value) || 100)
     }));
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [✓ ] Addresses an existing issue: Fixes #4525 
- [✓] Include a change request file using `$ npm run change`

#### Description of changes

added additional check to assign default value "100" to alpha value when alphaSliderHidden=true

#### Focus areas to test

(optional)
