### PR TITLE
Route ARIA label for 'remove suggestion' button

### DIFF
--- a/common/changes/office-ui-fabric-react/suggestions-aria_2018-04-13-13-06.json
+++ b/common/changes/office-ui-fabric-react/suggestions-aria_2018-04-13-13-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Plumb ARIA label for picker suggestion remove button",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -253,6 +253,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           isMostRecentlyUsedVisible={ this.state.isMostRecentlyUsedVisible }
           isResultsFooterVisible={ this.state.isResultsFooterVisible }
           refocusSuggestions={ this.refocusSuggestions }
+          removeSuggestionAriaLabel={ this.props.removeButtonAriaLabel }
           { ...this.props.pickerSuggestionsProps as any }
         />
       </Callout>

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -29,7 +29,8 @@ export class SuggestionsItem<T> extends BaseComponent<ISuggestionItemProps<T>, {
       onClick,
       className,
       onRemoveItem,
-      isSelectedOverride
+      isSelectedOverride,
+      removeButtonAriaLabel
     } = this.props;
     return (
       <div
@@ -51,8 +52,8 @@ export class SuggestionsItem<T> extends BaseComponent<ISuggestionItemProps<T>, {
         { this.props.showRemoveButton ? (
           <IconButton
             iconProps={ { iconName: 'Cancel', style: { fontSize: '12px' } } }
-            title='Remove'
-            ariaLabel='Remove'
+            title={ removeButtonAriaLabel }
+            ariaLabel={ removeButtonAriaLabel }
             onClick={ onRemoveItem }
             className={ css('ms-Suggestions-closeButton', styles.closeButton) }
           />) : (null)
@@ -325,6 +326,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
   private _renderSuggestions(): JSX.Element {
     const {
       onRenderSuggestion,
+      removeSuggestionAriaLabel,
       suggestionsItemClassName,
       resultsMaximumNumber,
       showRemoveButtons,
@@ -359,6 +361,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
               onClick={ this._onClickTypedSuggestionsItem(suggestion.item, index) }
               className={ suggestionsItemClassName }
               showRemoveButton={ showRemoveButtons }
+              removeButtonAriaLabel={ removeSuggestionAriaLabel }
               onRemoveItem={ this._onRemoveTypedSuggestionsItem(suggestion.item, index) }
             />
           </div>) }

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -131,6 +131,10 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
    * An ARIA label for the container that is the parent of the suggestions.
    */
   suggestionsContainerAriaLabel?: string;
+  /**
+   * An ARIA label to use for the buttons to remove individual suggestions.
+   */
+  removeSuggestionAriaLabel?: string;
 }
 
 export interface ISuggestionItemProps<T> {
@@ -143,4 +147,8 @@ export interface ISuggestionItemProps<T> {
   id?: string;
   showRemoveButton?: boolean;
   isSelectedOverride?: boolean;
+  /**
+   * The ARIA label for the button to remove the suggestion from the list.
+   */
+  removeButtonAriaLabel?: string;
 }


### PR DESCRIPTION
# Overview

This change removes the hard-coded and non-localized `'Remove'` text string from the `Suggestion` component and instead passes it down from `BasePicker`, which uses its `removeButtonAriaLabel` value by default for backwards compatibility. The specific ARIA label can still be overridden using `peopleSuggestionsProps`.