### PR TITLE
Prevent SelectionZone from interfering with nested links and buttons

### DIFF
--- a/common/changes/office-ui-fabric-react/selection-link_2018-04-13-14-47.json
+++ b/common/changes/office-ui-fabric-react/selection-link_2018-04-13-14-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Prevent SelectionZone from interfering with links and buttons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -128,6 +128,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           selectionMode={ selectionMode }
           constrainMode={ constrainMode }
           groupProps={ groupProps }
+          enterModalSelectionOnTouch={ true }
           onItemInvoked={ this._onItemInvoked }
           onItemContextMenu={ this._onItemContextMenu }
           ariaLabelForListHeader='Column headers. Use menus to perform column operations like sort and filter'
@@ -602,7 +603,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       } else if (column.key === 'key') {
         column.columnActionsMode = ColumnActionsMode.disabled;
         column.onRender = (item) => (
-          <Link href='#'>{ item.key }</Link>
+          <Link href='https://microsoft.com' target='_blank' rel='noopener'>{ item.key }</Link>
         );
         column.minWidth = 90;
         column.maxWidth = 90;

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -196,6 +196,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         } else if (target === itemRoot && !this._isShiftPressed && !this._isCtrlPressed) {
           this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;
+        } else if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {
+          return;
         }
       }
 
@@ -238,6 +240,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         } else if (target === itemRoot) {
           this._onItemSurfaceClick(ev, index);
           break;
+        } else if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {
+          return;
         }
       }
 


### PR DESCRIPTION
# Overview

Right now, if the user clicks an `<a>` or `<button>` within a selectable item in a `<SelectionZone>`, the selection logic still executes, so the underlying item becomes selected before the default behavior of the child element gets to execute. This can be a problem if changing the selection state reconfigures the elements, or the modal state blocks the next UX events from firing.

To fix this, `SelectionZone` should not intercept `mouseDown` or `click` events dispatched to a child `<a>`, `<button>`, or `<input>` element, unless that element has `data-selection-invoke` or `data-selection-toggle` applied.