### PR TITLE
Make it possible to block hover card in some special cases

### DIFF
--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
@@ -142,9 +142,13 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
     }
   }
 
+  private _shouldBlockHoverCard(): boolean {
+    return !!(this.props.shouldBlockHoverCard && this.props.shouldBlockHoverCard());
+  }
+
   // Show HoverCard
   private _cardOpen = (ev: MouseEvent): void => {
-    if (ev.type === 'keydown' && !(ev.which === KeyCodes.c)) {
+    if (this._shouldBlockHoverCard() || (ev.type === 'keydown' && !(ev.which === KeyCodes.c))) {
       return;
     }
     this._async.clearTimeout(this._dismissTimerId);

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -82,6 +82,11 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement | H
    * Trap focus or not
    */
   trapFocus?: boolean;
+
+  /**
+   * Should block hover card or not
+   */
+  shouldBlockHoverCard?: () => void;
 }
 
 export interface IHoverCardStyles {


### PR DESCRIPTION
Make it possible to block hover card in some special cases, for example: when user is in "drag and drop" status

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
