### PR TITLE
Bring back isResultsFooterVisible that is props but never used

### DIFF
--- a/common/changes/office-ui-fabric-react/hide_suggestions_footer_2018-04-13-18-56.json
+++ b/common/changes/office-ui-fabric-react/hide_suggestions_footer_2018-04-13-18-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Bring back isResultsFooterVisible that is props but never used.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joezha@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -125,7 +125,10 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
     if (isMostRecentlyUsedVisible && mostRecentlyUsedHeaderText) {
       headerText = mostRecentlyUsedHeaderText;
     }
-    const footerTitle = (suggestions.length >= (resultsMaximumNumber as number)) ? resultsFooterFull : resultsFooter;
+    let footerTitle: ((props: ISuggestionsProps<T>) => JSX.Element) | undefined = undefined;
+    if (isResultsFooterVisible !== false) {
+      footerTitle = (suggestions.length >= (resultsMaximumNumber as number)) ? resultsFooterFull : resultsFooter;
+    }
     const hasNoSuggestions = (!suggestions || !suggestions.length) && !isLoading;
     return (
       <div
@@ -184,9 +187,9 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
           />) : (null)
         }
         {
-          isResultsFooterVisible !== false && !moreSuggestionsAvailable && !isMostRecentlyUsedVisible && !isSearching ?
+          footerTitle && !moreSuggestionsAvailable && !isMostRecentlyUsedVisible && !isSearching ?
             (<div className={ css('ms-Suggestions-title', styles.suggestionsTitle) }>
-              { footerTitle && footerTitle(this.props) }
+              { footerTitle(this.props) }
             </div>) : (null)
         }
         { (!isLoading && !isSearching && suggestions && suggestions.length > 0 && suggestionsAvailableAlertText) ?

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -107,6 +107,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
       resultsMaximumNumber,
       resultsFooterFull,
       resultsFooter,
+      isResultsFooterVisible,
       suggestionsAvailableAlertText,
       suggestionsHeaderText,
     } = this.props;
@@ -183,7 +184,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
           />) : (null)
         }
         {
-          !moreSuggestionsAvailable && !isMostRecentlyUsedVisible && !isSearching ?
+          isResultsFooterVisible !== false && !moreSuggestionsAvailable && !isMostRecentlyUsedVisible && !isSearching ?
             (<div className={ css('ms-Suggestions-title', styles.suggestionsTitle) }>
               { footerTitle && footerTitle(this.props) }
             </div>) : (null)

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -126,7 +126,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
       headerText = mostRecentlyUsedHeaderText;
     }
     let footerTitle: ((props: ISuggestionsProps<T>) => JSX.Element) | undefined = undefined;
-    if (isResultsFooterVisible !== false) {
+    if (isResultsFooterVisible) {
       footerTitle = (suggestions.length >= (resultsMaximumNumber as number)) ? resultsFooterFull : resultsFooter;
     }
     const hasNoSuggestions = (!suggestions || !suggestions.length) && !isLoading;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -107,7 +107,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
       resultsMaximumNumber,
       resultsFooterFull,
       resultsFooter,
-      isResultsFooterVisible,
+      isResultsFooterVisible = true,
       suggestionsAvailableAlertText,
       suggestionsHeaderText,
     } = this.props;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -100,7 +100,7 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
   onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: IPersonaProps, index?: number) => void;
   /**
    * Indicates if the text in resultsFooter or resultsFooterFull should be shown at the end of the suggestion list.
-   * It defaults to true.
+   * @default true.
    */
   isResultsFooterVisible?: boolean;
   /**

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -100,6 +100,7 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
   onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: IPersonaProps, index?: number) => void;
   /**
    * Indicates if the text in resultsFooter or resultsFooterFull should be shown at the end of the suggestion list.
+   * It defaults to true.
    */
   isResultsFooterVisible?: boolean;
   /**

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -1541,9 +1541,6 @@ exports[`Suggestions renders a list properly 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="ms-Suggestions-title"
-  />
 </div>
 `;
 
@@ -3088,8 +3085,5 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
       </div>
     </div>
   </div>
-  <div
-    className="ms-Suggestions-title"
-  />
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Footer element has a default style which makes it difficult to hide (will still see border lines with no content) unless make css change on its ms- style. There is a prop isResultsFooterVisible but was never used and I am bringing it back.

#### Focus areas to test

(optional)
