### PR TITLE
Fix for onMenuClick firing on every keyDown

### DIFF
--- a/common/changes/office-ui-fabric-react/mapol-fix-onMenuClick-firing-on-every-key-down_2018-04-14-10-09.json
+++ b/common/changes/office-ui-fabric-react/mapol-fix-onMenuClick-firing-on-every-key-down_2018-04-14-10-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Do not call the onMenuClick on every keyDown event",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -570,14 +570,14 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       this.props.onKeyDown(ev);
     }
 
-    const { onMenuClick } = this.props;
-    if (onMenuClick) {
-      onMenuClick(ev, this);
-    }
-
     if (!ev.defaultPrevented &&
       this.props.menuTriggerKeyCode !== null &&
       this._isValidMenuOpenKey(ev)) {
+      const { onMenuClick } = this.props;
+      if (onMenuClick) {
+        onMenuClick(ev, this);
+      }
+
       this._onToggleMenu();
       ev.preventDefault();
       ev.stopPropagation();

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -571,7 +571,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     if (!ev.defaultPrevented &&
-      this.props.menuTriggerKeyCode &&
       this._isValidMenuOpenKey(ev)) {
       const { onMenuClick } = this.props;
       if (onMenuClick) {

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -571,7 +571,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     if (!ev.defaultPrevented &&
-      this.props.menuTriggerKeyCode !== null &&
+      this.props.menuTriggerKeyCode &&
       this._isValidMenuOpenKey(ev)) {
       const { onMenuClick } = this.props;
       if (onMenuClick) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Bryan pointed out to me that i introduced a bug during a previous fix. The `onMenuClick` for a button should only be fired in the `onKeyDown` handler when a key that should open the menu is pressed. 
In the current version it's fired on each `keyPress`

#### Focus areas to test

(optional)
