### PR TITLE
Remove module entries to avoid duplicate modules in webpack bundles.

### DIFF
--- a/common/changes/@uifabric/example-app-base/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/@uifabric/example-app-base/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Removing module entry temporarily. (Will be added back in 6.0.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/@uifabric/experiments/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Removing module entry temporarily. (Will be added back in 6.0.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/file-type-icons/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/@uifabric/file-type-icons/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Removing module entry temporarily. (Will be added back in 6.0.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/icons/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/@uifabric/icons/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/icons",
+      "comment": "Removing module entry temporarily. (Will be added back in 6.0.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/merge-styles/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/@uifabric/merge-styles/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Removing module entry temporarily. (Will be added back in 6.0.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/@uifabric/styling/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Removing module entry temporarily. (Will be added back in 6.0.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/@uifabric/utilities/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Removing module entry temporarily. (Will be added back in 6.0.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/@uifabric/variants/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/variants",
+      "comment": "Removing module entry temporarily. (Will be added back in 6.0.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/remove-module-entries_2018-04-15-20-25.json
+++ b/common/changes/office-ui-fabric-react/remove-module-entries_2018-04-15-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removing module entry until we change `lib` to output es6 modules in 6.0. If you would like tree shaking to work, please use webpack aliasing to alias `{packageName}/lib` to `{packageName}/lib-es2015`. In 6.0, we will change `lib` to be es6, so that current partners will just get tree shaking out of the box without aliasing.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -3,7 +3,6 @@
   "version": "5.9.0",
   "description": "Office UI Fabric example app base utilities for building example sites.",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": true,
   "repository": {

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -3,7 +3,6 @@
   "version": "5.31.0",
   "description": "Experimental React components for building experiences for Office 365.",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": true,
   "repository": {

--- a/packages/file-type-icons/package.json
+++ b/packages/file-type-icons/package.json
@@ -3,7 +3,6 @@
   "version": "0.6.0",
   "description": "Office UI Fabric file type icon set.",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": false,
   "repository": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -3,7 +3,6 @@
   "version": "5.7.0",
   "description": "Office UI Fabric icon set.",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": false,
   "repository": {

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -3,7 +3,6 @@
   "version": "5.15.0",
   "description": "Office UI Fabric style loading utilities.",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": false,
   "repository": {

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -3,7 +3,6 @@
   "version": "5.81.1",
   "description": "Reusable React components for building experiences for Office 365.",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": true,
   "repository": {

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -8,7 +8,6 @@
   },
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": false,
   "scripts": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -3,7 +3,6 @@
   "version": "5.23.0",
   "description": "Office UI Fabric utilities for building React components.",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": false,
   "repository": {

--- a/packages/variants/package.json
+++ b/packages/variants/package.json
@@ -3,7 +3,6 @@
   "version": "5.3.2",
   "description": "Office UI Fabric subtheme generator.",
   "main": "lib/index.js",
-  "module": "lib-es2015/index.js",
   "typings": "lib-es2015/index.d.ts",
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
We are seeing that by default, people importing things from Fabric may see duplicate bundles when using webpack 3 or 4. This is due to the recent `module` addition to package.json files, which are not compatible with `/lib/` imports.

We will be moving the `/lib` folders to be es6 modules in 6.0. For now we are removing these entry points.

If you would like to take advantage of tree shaking NOW (before 6.0), you can use webpack aliasing:

```
    resolve: {
      alias: {
        'office-ui-fabric-react/lib': 'office-ui-fabric-react/lib-es2015',
        '@uifabric/styling/lib':  '@uifabric/styling/lib-es2015',
        '@uifabric/utilities/lib':  '@uifabric/utilities/lib-es2015',
        '@uifabric/merge-styles/lib':  '@uifabric/merge-styles/lib-es2015',
        '@uifabric/experiments/lib':  '@uifabric/experiments/lib-es2015',
        '@uifabric/icons/lib':  '@uifabric/icons/lib-es2015',
      }
```

