### PR TITLE
Add more customization hooks to ProgressIndicator

### DIFF
--- a/common/changes/office-ui-fabric-react/progress-indicator_2018-04-16-14-56.json
+++ b/common/changes/office-ui-fabric-react/progress-indicator_2018-04-16-14-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add more customization hooks to ProgressIndicator",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
@@ -38,16 +38,19 @@ export class ProgressIndicatorBase extends BaseComponent<IProgressIndicatorProps
 
   public render() {
     const {
-      ariaValueText,
       barHeight,
       className,
+      label = this.props.title, // Fall back to deprecated value.
       description,
       getStyles,
       theme,
-      title,
+      progressHidden,
+      onRenderProgress = this._onRenderProgress
     } = this.props;
 
-    let { label, percentComplete } = this.props;
+    const percentComplete = typeof this.props.percentComplete === 'number' ?
+      Math.min(100, Math.max(0, this.props.percentComplete * 100)) :
+      undefined;
 
     const classNames = getClassNames(getStyles, {
       theme: theme!,
@@ -56,14 +59,47 @@ export class ProgressIndicatorBase extends BaseComponent<IProgressIndicatorProps
       indeterminate: percentComplete === undefined ? true : false,
     });
 
-    // Handle deprecated value.
-    if (title) {
-      label = title;
-    }
+    return (
+      <div className={ classNames.root }>
+        {
+          label ? (
+            <div className={ classNames.itemName }>{ label }</div>
+          ) : null
+        }
+        {
+          !progressHidden ? onRenderProgress({
+            ...(this.props as IProgressIndicatorProps),
+            percentComplete: percentComplete
+          }, this._onRenderProgress) : null
+        }
+        {
+          description ? (
+            <div className={ classNames.itemDescription }>{ description }</div>
+          ) : null
+        }
+      </div>
+    );
+  }
 
-    if (this.props.percentComplete !== undefined) {
-      percentComplete = Math.min(100, Math.max(0, percentComplete! * 100));
-    }
+  private _onRenderProgress = (props: IProgressIndicatorProps): JSX.Element => {
+    const {
+      ariaValueText,
+      barHeight,
+      className,
+      getStyles,
+      theme,
+    } = this.props;
+
+    const percentComplete = typeof this.props.percentComplete === 'number' ?
+      Math.min(100, Math.max(0, this.props.percentComplete * 100)) :
+      undefined;
+
+    const classNames = getClassNames(getStyles, {
+      theme: theme!,
+      className,
+      barHeight,
+      indeterminate: percentComplete === undefined ? true : false,
+    });
 
     const progressBarStyles = {
       width: percentComplete !== undefined ? percentComplete + '%' : undefined,
@@ -71,21 +107,17 @@ export class ProgressIndicatorBase extends BaseComponent<IProgressIndicatorProps
     };
 
     return (
-      <div className={ classNames.root }>
-        <div className={ classNames.itemName }>{ label }</div>
-        <div className={ classNames.itemProgress }>
-          <div className={ classNames.progressTrack } />
-          <div
-            className={ classNames.progressBar }
-            style={ progressBarStyles }
-            role='progressbar'
-            aria-valuemin={ 0 }
-            aria-valuemax={ 100 }
-            aria-valuenow={ Math.floor(percentComplete!) }
-            aria-valuetext={ ariaValueText }
-          />
-        </div>
-        <div className={ classNames.itemDescription }>{ description }</div>
+      <div className={ classNames.itemProgress }>
+        <div className={ classNames.progressTrack } />
+        <div
+          className={ classNames.progressBar }
+          style={ progressBarStyles }
+          role='progressbar'
+          aria-valuemin={ 0 }
+          aria-valuemax={ 100 }
+          aria-valuenow={ Math.floor(percentComplete!) }
+          aria-valuetext={ ariaValueText }
+        />
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -5,13 +5,31 @@ import { ProgressIndicator } from './ProgressIndicator';
 
 describe('ProgressIndicator', () => {
   it('renders ProgressIndicator correctly', () => {
-    const component = renderer.create(<ProgressIndicator percentComplete={ 0.75 } />);
+    const component = renderer.create(<ProgressIndicator label='Test' description='Test' percentComplete={ 0.75 } />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('renders indeterminate ProgressIndicator correctly', () => {
+    const component = renderer.create(<ProgressIndicator label='Test' description='Test' />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with no progress', () => {
+    const component = renderer.create(<ProgressIndicator label='Test' description='Test' progressHidden={ true } />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with no label or description', () => {
     const component = renderer.create(<ProgressIndicator />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders React content', () => {
+    const component = renderer.create(<ProgressIndicator label={ <span>Test</span> } description={ <span>Test</span> } />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
@@ -32,12 +32,12 @@ export interface IProgressIndicatorProps extends React.Props<ProgressIndicatorBa
   /**
    * Label to display above the control.
    */
-  label?: string;
+  label?: React.ReactNode;
 
   /**
    * Text describing or supplementing the operation.
    */
-  description?: string;
+  description?: React.ReactNode;
 
   /**
    * Percentage of the operation's completeness. If this is not set, the indeterminate progress animation will be shown instead.

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
@@ -30,12 +30,12 @@ export interface IProgressIndicatorProps extends React.Props<ProgressIndicatorBa
   className?: string;
 
   /**
-   * Label to display above the control.
+   * Label to display above the control. May be a string or React virtual elements.
    */
   label?: React.ReactNode;
 
   /**
-   * Text describing or supplementing the operation.
+   * Text describing or supplementing the operation. May be a string or React virtual elements.
    */
   description?: React.ReactNode;
 

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ProgressIndicatorBase } from './ProgressIndicator.base';
 import { IStyle, ITheme } from '../../Styling';
-import { IStyleFunction } from '../../Utilities';
+import { IStyleFunction, IRenderFunction } from '../../Utilities';
 
 export interface IProgressIndicator {
   focus: () => void;
@@ -43,6 +43,16 @@ export interface IProgressIndicatorProps extends React.Props<ProgressIndicatorBa
    * Percentage of the operation's completeness. If this is not set, the indeterminate progress animation will be shown instead.
    */
   percentComplete?: number;
+
+  /**
+   * Whether or not to hide the progress state.
+   */
+  progressHidden?: boolean;
+
+  /**
+   * A render override for the progress track.
+   */
+  onRenderProgress?: IRenderFunction<IProgressIndicatorProps>;
 
   /**
    * Text alternative of the progress status, used by screen readers for reading the value of the progress.

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
           white-space: nowrap;
         }
   >
-    
+    Test
   </div>
   <div
     className=
@@ -84,12 +84,12 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
           line-height: 18px;
         }
   >
-    
+    Test
   </div>
 </div>
 `;
 
-exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`] = `
+exports[`ProgressIndicator renders React content 1`] = `
 <div
   className=
       ms-ProgressIndicator
@@ -110,7 +110,9 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
           white-space: nowrap;
         }
   >
-    
+    <span>
+      Test
+    </span>
   </div>
   <div
     className=
@@ -176,7 +178,204 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
           line-height: 18px;
         }
   >
-    
+    <span>
+      Test
+    </span>
+  </div>
+</div>
+`;
+
+exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`] = `
+<div
+  className=
+      ms-ProgressIndicator
+      {
+        font-weight: 400;
+      }
+>
+  <div
+    className=
+        ms-ProgressIndicator-itemName
+        {
+          color: #333333;
+          font-size: 14px;
+          line-height: 20px;
+          overflow: hidden;
+          padding-top: 4px;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+  >
+    Test
+  </div>
+  <div
+    className=
+        ms-ProgressIndicator-itemProgress
+        {
+          height: 2px;
+          overflow: hidden;
+          padding-bottom: 8px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 8px;
+          position: relative;
+        }
+  >
+    <div
+      className=
+          ms-ProgressIndicator-progressTrack
+          {
+            background-color: #eaeaea;
+            height: 2px;
+            position: absolute;
+            width: 100%;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-bottom: 1px solid WindowText;
+          }
+    />
+    <div
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={NaN}
+      aria-valuetext={undefined}
+      className=
+          ms-ProgressIndicator-progressBar
+          {
+            animation: keyframes 0%{left:-30%;}100%{left:100%;} 3s infinite;
+            background-color: #0078d4;
+            background: linear-gradient(to right, transparent 0%, #0078d4 50%, transparent 100%);
+            height: 2px;
+            min-width: 33%;
+            position: absolute;
+            transition: width .3s ease;
+            width: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background-color: WindowText;
+          }
+      role="progressbar"
+      style={
+        Object {
+          "transition": undefined,
+          "width": undefined,
+        }
+      }
+    />
+  </div>
+  <div
+    className=
+        ms-ProgressIndicator-itemDescription
+        {
+          color: #666666;
+          font-size: 11px;
+          line-height: 18px;
+        }
+  >
+    Test
+  </div>
+</div>
+`;
+
+exports[`ProgressIndicator renders with no label or description 1`] = `
+<div
+  className=
+      ms-ProgressIndicator
+      {
+        font-weight: 400;
+      }
+>
+  <div
+    className=
+        ms-ProgressIndicator-itemProgress
+        {
+          height: 2px;
+          overflow: hidden;
+          padding-bottom: 8px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 8px;
+          position: relative;
+        }
+  >
+    <div
+      className=
+          ms-ProgressIndicator-progressTrack
+          {
+            background-color: #eaeaea;
+            height: 2px;
+            position: absolute;
+            width: 100%;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-bottom: 1px solid WindowText;
+          }
+    />
+    <div
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={NaN}
+      aria-valuetext={undefined}
+      className=
+          ms-ProgressIndicator-progressBar
+          {
+            animation: keyframes 0%{left:-30%;}100%{left:100%;} 3s infinite;
+            background-color: #0078d4;
+            background: linear-gradient(to right, transparent 0%, #0078d4 50%, transparent 100%);
+            height: 2px;
+            min-width: 33%;
+            position: absolute;
+            transition: width .3s ease;
+            width: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background-color: WindowText;
+          }
+      role="progressbar"
+      style={
+        Object {
+          "transition": undefined,
+          "width": undefined,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`ProgressIndicator renders with no progress 1`] = `
+<div
+  className=
+      ms-ProgressIndicator
+      {
+        font-weight: 400;
+      }
+>
+  <div
+    className=
+        ms-ProgressIndicator-itemName
+        {
+          color: #333333;
+          font-size: 14px;
+          line-height: 20px;
+          overflow: hidden;
+          padding-top: 4px;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+  >
+    Test
+  </div>
+  <div
+    className=
+        ms-ProgressIndicator-itemDescription
+        {
+          color: #666666;
+          font-size: 11px;
+          line-height: 18px;
+        }
+  >
+    Test
   </div>
 </div>
 `;


### PR DESCRIPTION
# Overview

This change adds a couple more customization hooks to `ProgressIndicator`, which make it more versatile as a reusable component:

- Changed `label` and `description` to support arbitrary content via `React.ReactNode` typing.
- Added a `progressHidden` prop so the label and description can be shown by themselves.
- Added an `onRenderProgress` prop to control rendering of the progress track itself.
- Added conditionals around rendering the label and description, so they collapse the elements properly.