### PR TITLE
Invoke CommandBar's onItemClick vs item onClick when item has an href set to avoid item is undefined in handler

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-href-commandbar-item_2018-04-16-18-12.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-href-commandbar-item_2018-04-16-18-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Passes item when href set onClick for CommandBar control",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -417,7 +417,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     });
   }
 
-  private _onItemClick(item: IContextualMenuItem): (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => void {
+  private _onItemClick(item: IContextualMenuItem): (ev: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void {
     return (ev: React.MouseEvent<HTMLButtonElement>): void => {
       if (item.inactive) {
         return;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -210,7 +210,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
           id={ this._id + item.key }
           className={ className }
           href={ item.disabled ? undefined : item.href }
-          onClick={ item.onClick }
+          onClick={ this._onItemClick(item) }
           title={ '' }
           aria-disabled={ item.inactive }
           data-command-key={ itemKey }
@@ -417,7 +417,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
     });
   }
 
-  private _onItemClick(item: IContextualMenuItem): (ev: React.MouseEvent<HTMLButtonElement>) => void {
+  private _onItemClick(item: IContextualMenuItem): (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => void {
     return (ev: React.MouseEvent<HTMLButtonElement>): void => {
       if (item.inactive) {
         return;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4556
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When a CommandBar's item had an `href` set we would create an `<a>` with an `onClick` bound to that item's `onClick` handler, rather than invoking the `onClick` delegate in CommandBar. Because of this `onClick` was invoked without the backing item for this scenario compared with not having an `href` set. This change attempts to normalize the click handling by invoking CommandBar's `onClick` handler which in turn invokes the item's `onClick` handler.

#### Focus areas to test

1) Set "Persist Logs" to `true` in your console or set a break-point at https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx#L437
2) If you're checking logs, put a print statement in the `onClick` callback for the CommandBar example here: https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/CommandBar/examples/data-nonFocusable.ts#L25
3) Also set an `href` on that item, for example `{ ... href: 'https://www.bing.com/ }`
4) Run the solution locally and navigate to http://localhost:4322/#/examples/commandbar. Click on both items with and without `href` set. 
    - If the `href` IS NOT set the behavior should be as it is on `master`.
    - If the `href` IS set, then the item's `onClick` handler should be invoked with the DOM event and backing item before handling the `href`. Previously `item` was `undefined`.

I feel like this change requires at least an additional test if we wish to merge it so I welcome any guidance there. Will look at what exists in the meantime.