### PR TITLE
Choicegroup: Improved states for focus, HC focus, HC hover

### DIFF
--- a/common/changes/office-ui-fabric-react/choicegroup-focus_2018-04-16-21-59.json
+++ b/common/changes/office-ui-fabric-react/choicegroup-focus_2018-04-16-21-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: Style polish for focus, high contrast focus, and high contrast hover.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -129,6 +129,10 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
 
     :global(.ms-Label) {
       color: $radioButton-text-hover-color;
+
+      @include high-contrast {
+        color: Highlight;
+      }
     }
   }
 
@@ -308,6 +312,7 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
 
         @include high-contrast {
           border-color: Highlight;
+          color: Highlight;
         }
 
         &::before {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -121,6 +121,10 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
   &:focus {
     &::before {
       border-color: $radioButton-border-hover-color;
+
+      @include high-contrast {
+        border-color: Highlight;
+      }
     }
 
     :global(.ms-Label) {
@@ -302,6 +306,10 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
       &:focus {
         border-color: $ms-color-neutralTertiaryAlt;
 
+        @include high-contrast {
+          border-color: Highlight;
+        }
+
         &::before {
           opacity: 1;
         }
@@ -367,10 +375,10 @@ $ms-choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
 :global(.ms-Fabric.is-focusVisible) .choiceFieldIsInFocus {
   &.choiceFieldIsImage .choiceFieldWrapper,
   &.choiceFieldIsIcon .choiceFieldWrapper {
-    @include focus-border(1px, $ms-color-neutralPrimary, 2px, false);
+    @include focus-border(-2px, $ms-color-neutralSecondary, 1px, false);
 
     @include high-contrast {
-      @include focus-border(1px, WindowText, 2px, false);
+      @include focus-border(-2px, WindowText, 1px, false);
     }
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3621 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Focus + Hover (with image / icon):
![cg-nonhc-focus-hover](https://user-images.githubusercontent.com/16619843/38837449-e322a08e-4186-11e8-94c7-5f53dc5c6de1.png)

Focus:
![cg-nonhc-focus](https://user-images.githubusercontent.com/16619843/38837451-e4b5d970-4186-11e8-89ed-7e43d328108b.png)

Hover:
![cg-hover-default](https://user-images.githubusercontent.com/16619843/38837454-e650d744-4186-11e8-9c2e-6505c789355f.png)

HC Focus + Hover:
![cg-focus-hover](https://user-images.githubusercontent.com/16619843/38837461-ebdcd3d4-4186-11e8-8ead-a658b7223665.png)

HC Focus:
![cg-focus](https://user-images.githubusercontent.com/16619843/38837462-ed81b1dc-4186-11e8-880c-0c6036ce02eb.png)

#### Focus areas to test

(optional)
