### PR TITLE
mergeStyles: asynchronously reset the next style element being used

### DIFF
--- a/common/changes/@uifabric/merge-styles/async-style_2018-04-16-22-29.json
+++ b/common/changes/@uifabric/merge-styles/async-style_2018-04-16-22-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "mergeStyles: rules are now registered in separate styling objects, improving performance significantly.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -215,6 +215,11 @@ export class Stylesheet {
   private _getElement(): HTMLStyleElement | undefined {
     if (!this._styleElement && typeof document !== 'undefined') {
       this._styleElement = _createStyleElement();
+
+      // Reset the style element on the next frame.
+      window.requestAnimationFrame(() => {
+        this._styleElement = undefined;
+      });
     }
     return this._styleElement;
   }


### PR DESCRIPTION
Instead of always inserting into the same style element, now we will reset the style element on the next animation frame. This reduces the number of rules in a single style element, but also keeps the number of style elements created somewhat limited.
