### PR TITLE
Mark Panel content as scrollable

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-scroll_2018-04-17-00-29.json
+++ b/common/changes/office-ui-fabric-react/panel-scroll_2018-04-17-00-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Mark Panel content as scrollable",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -286,7 +286,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     );
 
     return (
-      <div ref={ this._content } className={ contentClass } >
+      <div ref={ this._content } className={ contentClass } data-is-scrollable={ true } >
         { props.children }
       </div>
     );


### PR DESCRIPTION
# Overview

Since `Panel`'s content element is scrollable (has `overflow-y: auto`), it needs `data-is-scrollable={ true }` so virtualized content works correctly.