### PR TITLE
Fix improper imports from index files

### DIFF
--- a/common/changes/@uifabric/experiments/fix-index-imports_2018-04-17-16-09.json
+++ b/common/changes/@uifabric/experiments/fix-index-imports_2018-04-17-16-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fix improper imports from index files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fix-index-imports_2018-04-17-16-09.json
+++ b/common/changes/office-ui-fabric-react/fix-index-imports_2018-04-17-16-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix improper imports from index files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.base.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.base.tsx
@@ -8,7 +8,7 @@ import {
   IShimmerTileStyleProps,
   IShimmerTileStyles
 } from './ShimmerTile.types';
-import { TileLayoutSizes, TileSize } from '../../Tile';
+import { TileLayoutSizes, TileSize } from '../../../Tile';
 import { ShimmerGap } from '../ShimmerGap/ShimmerGap';
 import { getRenderedElements } from '../Shimmer.base';
 import { ShimmerElementType as ElemType } from '../Shimmer.types';

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.test.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { ActivityItem } from './ActivityItem';
-import { Icon } from '../Icon';
+import { Icon } from '../../Icon';
 import { TestImages } from '../../common/TestImages';
 
 const defaultProps = {
@@ -34,7 +34,7 @@ describe('ActivityItem', () => {
   it('renders with an icon correctly', () => {
     const component = renderer.create(
       <ActivityItem
-        {...defaultProps}
+        { ...defaultProps }
         activityIcon={ <Icon iconName={ 'Message' } /> }
       />
     );
@@ -45,7 +45,7 @@ describe('ActivityItem', () => {
   it('renders with a single persona correctly', () => {
     const component = renderer.create(
       <ActivityItem
-        {...defaultProps}
+        { ...defaultProps }
         activityPersonas={ [defaultPersonaProps[0]] }
       />
     );
@@ -56,7 +56,7 @@ describe('ActivityItem', () => {
   it('renders with multiple personas correctly', () => {
     const component = renderer.create(
       <ActivityItem
-        {...defaultProps}
+        { ...defaultProps }
         activityPersonas={ defaultPersonaProps }
       />
     );
@@ -67,7 +67,7 @@ describe('ActivityItem', () => {
   it('renders compact with an icon correctly', () => {
     const component = renderer.create(
       <ActivityItem
-        {...defaultProps}
+        { ...defaultProps }
         activityIcon={ <Icon iconName={ 'Message' } /> }
         isCompact={ true }
       />
@@ -79,7 +79,7 @@ describe('ActivityItem', () => {
   it('renders compact with a single persona correctly', () => {
     const component = renderer.create(
       <ActivityItem
-        {...defaultProps}
+        { ...defaultProps }
         activityPersonas={ [defaultPersonaProps[0]] }
         isCompact={ true }
       />
@@ -91,7 +91,7 @@ describe('ActivityItem', () => {
   it('renders compact with multiple personas correctly', () => {
     const component = renderer.create(
       <ActivityItem
-        {...defaultProps}
+        { ...defaultProps }
         activityPersonas={ defaultPersonaProps }
         isCompact={ true }
       />

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { IRenderFunction } from '../../Utilities';
 import { PersonaBase } from './Persona.base';
-import { PersonaCoinBase } from './PersonaCoin';
-import { PersonaPresenceBase } from './PersonaPresence';
+import { PersonaCoinBase } from './PersonaCoin/index';
+import { PersonaPresenceBase } from './PersonaPresence/index';
 import { ImageLoadState } from '../../Image';
 import { IStyle, ITheme } from '../../Styling';
 import { IStyleFunction } from '../../Utilities';

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -9,15 +9,15 @@ import {
   getRTL,
 } from '../../../Utilities';
 import { mergeStyles } from '../../../Styling';
-import { PersonaPresence } from '../PersonaPresence';
+import { PersonaPresence } from '../PersonaPresence/index';
 import {
   Icon
-} from '../../Icon';
+} from '../../../Icon';
 import {
   Image,
   ImageFit,
   ImageLoadState
-} from '../../Image';
+} from '../../../Image';
 import {
   IPersonaCoinProps,
   IPersonaCoinStyleProps,

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
@@ -5,7 +5,7 @@ import {
   customizable,
 } from '../../../Utilities';
 import { IStyleSet } from '../../../Styling';
-import { Icon } from '../../Icon';
+import { Icon } from '../../../Icon';
 import {
   IPersonaPresenceProps,
   IPersonaPresenceStyleProps,

--- a/packages/office-ui-fabric-react/src/components/Persona/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/index.ts
@@ -1,5 +1,5 @@
 export * from './Persona';
 export * from './Persona.base';
 export * from './Persona.types';
-export * from './PersonaCoin';
+export * from './PersonaCoin/index';
 export * from './PersonaConsts';


### PR DESCRIPTION
Various downstream build systems cannot handle imports from `/index` files, so they need to be removed from this repository. Updated recently-added code to point to direct modules where appropriate.