### PR TITLE
focusTrapZone stealing focus on close when focus wasn't inside of it

### DIFF
--- a/common/changes/office-ui-fabric-react/jolore-fixingFocusWithMultiplePopups_2018-04-17-23-59.json
+++ b/common/changes/office-ui-fabric-react/jolore-fixingFocusWithMultiplePopups_2018-04-17-23-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding check to focusTrapZone to only restore focus on close if focus was still inside the focusTrapZone",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -75,7 +75,11 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
       }
     }
 
-    if (!ignoreExternalFocusing && this._previouslyFocusedElement && typeof this._previouslyFocusedElement.focus === 'function') {
+    const activeElement = document.activeElement as HTMLElement;
+    if (!ignoreExternalFocusing &&
+      this._previouslyFocusedElement &&
+      typeof this._previouslyFocusedElement.focus === 'function' &&
+      elementContains(this._root.value, activeElement)) {
       focusAsync(this._previouslyFocusedElement);
     }
   }

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -379,12 +379,14 @@ export function focusAsync(element: HTMLElement | { focus: () => void } | undefi
 
     if (win) {
       // element.focus() is a no-op if the element is no longer in the DOM, meaning this is always safe
-      win.requestAnimationFrame(() => {
+      // win.requestAnimationFrame does not actually wait until React elements are fully rendered before firing, should
+      // wait until the next 'thread' available to set the focus because rendering will be fully finished
+      setTimeout(() => {
         targetToFocusOnNextRepaint && targetToFocusOnNextRepaint.focus();
 
         // We are done focusing for this frame, so reset the queued focus element
         targetToFocusOnNextRepaint = undefined;
-      });
+      }, 0);
     }
   }
 }

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -379,14 +379,12 @@ export function focusAsync(element: HTMLElement | { focus: () => void } | undefi
 
     if (win) {
       // element.focus() is a no-op if the element is no longer in the DOM, meaning this is always safe
-      // win.requestAnimationFrame does not actually wait until React elements are fully rendered before firing, should
-      // wait until the next 'thread' available to set the focus because rendering will be fully finished
-      setTimeout(() => {
+      win.requestAnimationFrame(() => {
         targetToFocusOnNextRepaint && targetToFocusOnNextRepaint.focus();
 
         // We are done focusing for this frame, so reset the queued focus element
         targetToFocusOnNextRepaint = undefined;
-      }, 0);
+      });
     }
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The focus trap zone was missing a check during the componentWillUnmount for sending focus back to the origin point. Without the extra check, even if focus wasn't inside the focusTrapZone, when it unmounted focus would get stolen and sent forcibly to a new place. This became apparent in our owa-calendar project with mutliple opening of Callouts (containing FocusTrapZones). With one Callout would open, then opening a second Callout (taking focus), then the first Callout would close, and focus would get stolen from out of the second Callout and sent back to the origin button. Adding a check to see if the FocusTrapZone actually contains the active element before restoring focus fixes this, and that check already exists elsewhere in the file.

#### Focus areas to test

(optional)
