### PR TITLE
Add "isPassword" prop to TextField component

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-04-18-05-40.json
+++ b/common/changes/office-ui-fabric-react/master_2018-04-18-05-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added isPassword prop to TextField",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "luke.mcgartland@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -33,6 +33,7 @@ export interface ITextFieldState {
 
 export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> implements ITextField {
   public static defaultProps: ITextFieldProps = {
+    isPassword: false,
     multiline: false,
     resizable: true,
     autoAdjustHeight: false,
@@ -375,7 +376,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
 
     return (
       <input
-        type={ 'text' }
+        type={ this.props.isPassword === true ? 'password' : 'text' }
         id={ this._id }
         { ...inputProps }
         ref={ this._textElement }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -43,6 +43,12 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   componentRef?: (component: ITextField | null) => void;
 
   /**
+   * Whether or not the textfield is a password textfield.
+   * @default false
+   */
+  isPassword?: boolean;
+
+  /**
    * Whether or not the textfield is a multiline textfield.
    * @default false
    */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adds prop to TextField component "isPassword" to determine if input should be "text" or "password" type.

#### Focus areas to test

(optional)
