### PR TITLE
Use the `data-is-scrollable` attribute on the correct ScrollablePane div

### DIFF
--- a/common/changes/office-ui-fabric-react/scrollable-pane-fix_2018-04-18-20-42.json
+++ b/common/changes/office-ui-fabric-react/scrollable-pane-fix_2018-04-18-20-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Use `data-is-scrollable` attribute on correct ScrollablePane div",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "spelliot@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -102,12 +102,11 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, {}> 
         { ...getNativeProps(this.props, divProperties) }
         ref={ this._root }
         className={ classNames.root }
+        data-is-scrollable={ true }
       >
         <div ref={ this._stickyAboveRef } className={ classNames.stickyAbove } />
         <div ref={ this._stickyBelowRef } className={ classNames.stickyBelow } />
-        <div data-is-scrollable={ true }>
-          { this.props.children }
-        </div>
+        { this.props.children }
       </div>
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4601
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Move the `data-is-scrollable` attribute to the correct scrollable div: the one which has the `overflow-y: auto;` CSS property.

#### Focus areas to test

Run `npm start`, then visit
http://localhost:4322/#/examples/scrollablepane

The DetailsList example should behave like this:
![kapture 2018-04-18 at 13 35 56](https://user-images.githubusercontent.com/2177366/38957196-c293ae38-430e-11e8-9b78-cecd9513a150.gif)
