### PR TITLE
Remove usage of Number.NaN

### DIFF
--- a/common/changes/office-ui-fabric-react/IE11-NaN_2018-04-19-15-14.json
+++ b/common/changes/office-ui-fabric-react/IE11-NaN_2018-04-19-15-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove usage of Number.isNaN from SpinButton.tsx since it doesn't exist in IE11",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "christianjordangonzalez@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -202,8 +202,8 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
             type='text'
             role='spinbutton'
             aria-labelledby={ label && this._labelId }
-            aria-valuenow={ !Number.isNaN(Number(value)) ? Number(value) : undefined }
-            aria-valuetext={ Number.isNaN(Number(value)) ? value : undefined }
+            aria-valuenow={ !isNaN(Number(value)) ? Number(value) : undefined }
+            aria-valuetext={ isNaN(Number(value)) ? value : undefined }
             aria-valuemin={ min }
             aria-valuemax={ max }
             onBlur={ this._onBlur }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
SpinButton.tsx is not compatible with IE11 due to the usage of Number.isNaN, which is not supported in IE: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN

In this case isNaN should be sufficient for our needs, so updating the code to use that.

