### PR TITLE
DetailsRow: Flexshrink fix

### DIFF
--- a/common/changes/office-ui-fabric-react/flexshrink-fix_2018-04-19-20-18.json
+++ b/common/changes/office-ui-fabric-react/flexshrink-fix_2018-04-19-20-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsRow: applying `flex-shrink:0` to the check cell to prevent it from squishing in the flex layout.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
@@ -228,6 +228,7 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
     // cause other items to be deselected.
     padding-top: 1px;
     margin-top: -1px;
+    flex-shrink: 0;
   }
 
   & > button {


### PR DESCRIPTION
The fields in the details row are marked as `display:flex`. The check cell however is not marked as `flex-shrink:0` so the flexbox may squish it if the content in the rows is multiline text which consumes the full space.

Tweaking the cell definition to flex-shrink.
