### PR TITLE
Remove unused iconClassName prop from Nav.types

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-nav-iconClassName_2018-04-20-18-21.json
+++ b/common/changes/office-ui-fabric-react/keco-nav-iconClassName_2018-04-20-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Deprecates INavLink.iconClassName in favor of IIconProps.className.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -155,7 +155,7 @@ export interface INavLink {
   icon?: string;
 
   /**
-   * iconClassName has been deprecated in favor of IIconProps. Use IIconProps.className instead.
+   * Deprecated. Use iconProps.className instead.
    * @deprecated
    */
   iconClassName?: string;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -155,7 +155,8 @@ export interface INavLink {
   icon?: string;
 
   /**
-   * Classname to apply to the icon link.
+   * iconClassName has been deprecated in favor of IIconProps. Use IIconProps.className instead.
+   * @deprecated
    */
   iconClassName?: string;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4581
- [x] Include a change request file using `$ npm run change`

#### Description of changes

https://github.com/OfficeDev/office-ui-fabric-react/issues/4581 reported that `iconClassName` does not apply a custom `className` to Nav button icons as the documentation says. Looking thru the changes this functionality seems to have been refactored to `IIConProps`. As far as I can tell this prop is unused across the lib code and can be safely removed. However, lets mark it as deprecated for now and advise using `IIconProps.className` inherited from `React.HTMLAttributes<HTMLElement>`.

Last time I can see `iconClassName` in use is: https://github.com/OfficeDev/office-ui-fabric-react/blob/5.0/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx#L152

#### Focus areas to test

Property is unused so it doesn't work now anyway. You can test that `IIConProps` works by looking at the "Delete" nav item's icon in https://codepen.io/kevintcoughlin/pen/aGoGvm?editors=1010. Deprecated for now so should not be a breaking change for anyone.
