### PR TITLE
ContexualMenuItem: Add onRenderIcon prop to allow override icon render for contextualMenuItem

### DIFF
--- a/common/changes/office-ui-fabric-react/yimwu-menuitemicon_2018-04-20-19-43.json
+++ b/common/changes/office-ui-fabric-react/yimwu-menuitemicon_2018-04-20-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add onRenderIcon prop to IContextualMenuItem to allow override icon render for contextualMenuItem.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "yimwu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -272,6 +272,11 @@ export interface IContextualMenuItem {
   iconProps?: IIconProps;
 
   /**
+   * Custom render function for the menu item icon
+   */
+  onRenderIcon?: IRenderFunction<IContextualMenuItemProps>;
+
+  /**
    * Props that go to the IconComponent used for the chevron.
    */
   submenuIconProps?: IIconProps;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
@@ -4,12 +4,24 @@ import { getRTL } from '../../Utilities';
 import { Icon } from '../../Icon';
 import { IContextualMenuItemProps } from './ContextualMenuItem.types';
 
-const renderItemIcon = ({ hasIcons, item, classNames }: IContextualMenuItemProps) => {
+const renderItemIcon = (props: IContextualMenuItemProps) => {
+  const {
+    item,
+    hasIcons,
+    classNames
+  } = props;
+
   // Only present to allow continued use of item.icon which is deprecated.
   const { iconProps, icon } = item;
 
   if (!hasIcons) {
     return null;
+  }
+
+  if (item.onRenderIcon) {
+    return (
+      item.onRenderIcon(props)
+    );
   }
 
   if (iconProps) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
-import { ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ContextualMenuItemType, IContextualMenuItemProps } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { Callout } from 'office-ui-fabric-react/lib/Callout';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import './ContextualMenuExample.scss';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import * as stylesImport from './ContextualMenuExample.scss';
+
+// tslint:disable-next-line:no-any
+const styles: any = stylesImport;
 
 export class ContextualMenuIconExample extends React.Component<{}, { showCallout: boolean }> {
 
@@ -24,6 +28,18 @@ export class ContextualMenuIconExample extends React.Component<{}, { showCallout
           menuProps={ {
             shouldFocusOnMount: true,
             items: [
+              {
+                key: 'openInWord',
+                name: 'Open in Word',
+                onRenderIcon: (props: IContextualMenuItemProps) => {
+                  return (
+                    <span className={ styles.iconContainer }>
+                      <Icon iconName={ 'WordLogoFill16' } className={ styles.logoFillIcon } />
+                      <Icon iconName={ 'WordLogo16' } className={ styles.logoIcon } />
+                    </span>
+                  );
+                }
+              },
               {
                 key: 'newItem',
                 iconProps: {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenuExample.scss
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenuExample.scss
@@ -72,3 +72,21 @@
     max-width: 50%;
   }
 }
+
+.iconContainer {
+  position: relative;
+  margin: 0 4px;
+  height: 32px;
+  width: 14px;
+}
+
+.logoFillIcon, .logoIcon {
+  position: absolute;
+  left: 0;
+  right: 0;
+  color: $ms-color-themeDarkAlt;
+}
+
+.logoFillIcon {
+  color: #FFFFFF;
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X ] Include a change request file using `$ npm run change`

#### Description of changes
Add onRenderIcon prop to allow override icon render for contextualMenuItem. Add example to render two stacked icons for 'Open in Word' command in contextualMenu. 

#### Focus areas to test

(optional)
![image](https://user-images.githubusercontent.com/9662034/39070715-46fb01e0-4499-11e8-821e-33d3af9c7aaf.png)

