### PR TITLE
ContextualMenu: setting font to theme font

### DIFF
--- a/common/changes/office-ui-fabric-react/contextualmenu-font_2018-04-22-18-25.json
+++ b/common/changes/office-ui-fabric-react/contextualmenu-font_2018-04-22-18-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: in item root styling, replaced `font: inherit` with the appropriate font style from the theme.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -50,8 +50,8 @@ export const getMenuItemStyles = memoizeFunction((
     },
     root: [
       getFocusStyle(theme),
+      fonts.medium,
       {
-        font: 'inherit',
         color: 'inherit',
         backgroundColor: 'transparent',
         border: 'none',


### PR DESCRIPTION
When we say `font: inherit`, we can expose race conditions, if external styling races with ours.

Replacing with the font from the theme.