### PR TITLE
Fix theme slots for DetailsList header colors

### DIFF
--- a/common/changes/@uifabric/styling/header-themes_2018-04-23-23-33.json
+++ b/common/changes/@uifabric/styling/header-themes_2018-04-23-23-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Add theme slots for DetailsList header colors",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "tmichon@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/header-themes_2018-04-23-23-33.json
+++ b/common/changes/office-ui-fabric-react/header-themes_2018-04-23-23-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix theme slots for DetailsList header colors",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -50,8 +50,8 @@ $menuHeaderColor: "[theme:menuHeader, default: #0078d4]";
 /* Lists */
 $listBackgroundColor: "[theme:listBackground, default: #ffffff]";
 $listTextColor: "[theme:listText, default: #333333]";
-$listItemHeaderHoveredColor: "[theme:listItemHeaderHovered, default: #f4f4f4]";
-$listItemHeaderActivatedColor: "[theme:listItemActivatedHovered, default: #eaeaea]";
+$listHeaderBackgroundHoveredColor: "[theme:listHeaderBackgroundHovered, default: #f4f4f4]";
+$listHeaderBackgroundPressedColor: "[theme:listHeaderBackgroundPressed, default: #eaeaea]";
 $listItemBackgroundHoveredColor: "[theme:listItemBackgroundHovered, default: #f8f8f8]";
 $listItemBackgroundCheckedColor: "[theme:listItemBackgroundChecked, default: #eaeaea]";
 $listItemBackgroundCheckedHoveredColor: "[theme:listItemBackgroundCheckedHovered, default: #d0d0d0]";

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -64,11 +64,11 @@ $isPaddedMargin: 24px;
 
     &:hover {
       color: $bodyTextColor;
-      background: $listItemHeaderHoveredColor;
+      background: $listHeaderBackgroundHoveredColor;
     }
 
     &:active {
-      background: $listItemHeaderActivatedColor;
+      background: $listHeaderBackgroundPressedColor;
     }
   }
 

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -272,6 +272,16 @@ export interface ISemanticColors {
   listItemBackgroundCheckedHovered: string;
 
   /**
+   * The background color for a hovered list header.
+   */
+  listHeaderBackgroundHovered: string;
+
+  /**
+   * The background color for a pressed list header.
+   */
+  listHeaderBackgroundPressed: string;
+
+  /**
    * The color of a link.
    */
   link: string;

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -178,6 +178,9 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean, depCom
     listItemBackgroundChecked: p.neutralLight,
     listItemBackgroundCheckedHovered: p.neutralQuaternaryAlt,
 
+    listHeaderBackgroundHovered: p.neutralLighter,
+    listHeaderBackgroundPressed: p.neutralLight,
+
     link: p.themePrimary,
     linkHovered: p.themeDarker,
 


### PR DESCRIPTION
# Overview

This change fixes an issue with the recently-added `DetailsHeader` theming slots, by properly integrating them into the `ITheme` interface and assigning correct defaults.