### PR TITLE
Users/kapriya/details list office fabric

### DIFF
--- a/common/changes/office-ui-fabric-react/users-kapriya-details_list_office_fabric_2018-04-24-06-33.json
+++ b/common/changes/office-ui-fabric-react/users-kapriya-details_list_office_fabric_2018-04-24-06-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "details link contrast issue",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kapriya@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.scss
@@ -131,7 +131,7 @@ $detailsList-item-focus-meta-text-color: $ms-color-neutralDark;
       background: Highlight;
       color: HighlightText;
       -ms-high-contrast-adjust: none;
-      > a {
+      a {
         color: HighlightText;
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: https://github.com/OfficeDev/office-ui-fabric-react/issues/4338
  In the bug fix that is done earlier: https://github.com/OfficeDev/office-ui-fabric-react/pull/4395/files, the issue is fixed only for direct `a` children of DetailsList. This pr is to apply the same change for all `a` tags inside DetailsList.
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

In high contrast mode, the links that are not direct children of any Office Fabric details list are not visible. In the issue: https://github.com/OfficeDev/office-ui-fabric-react/pull/4395/files, the fix is made only for direct children `a` tags inside the details list only. Modified that to any `a` tag that is inside the details list.

