### PR TITLE
Fix Calendar component PREV/NEXT month, year, and "Go to today" handlers firing twice

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-calendar-keydown-regression_2018-04-24-15-57.json
+++ b/common/changes/office-ui-fabric-react/keco-calendar-keydown-regression_2018-04-24-15-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Gate calendar month, year, and today keydowns for only ENTER as onClick handles space with button nodes to fix double date change regression.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -260,7 +260,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
   }
 
   private _onGotoTodayKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
+    if (ev.which === KeyCodes.enter) {
       ev.preventDefault();
       this._onGotoToday();
     } else if (ev.which === KeyCodes.tab && !ev.shiftKey) {

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -566,11 +566,15 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
   }
 
   private _onPrevMonthKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    this._onKeyDown(this._onSelectPrevMonth, ev);
+    if (ev.which === KeyCodes.enter) {
+      this._onKeyDown(this._onSelectPrevMonth, ev);
+    }
   }
 
   private _onNextMonthKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    this._onKeyDown(this._onSelectNextMonth, ev);
+    if (ev.which === KeyCodes.enter) {
+      this._onKeyDown(this._onSelectNextMonth, ev);
+    }
   }
 
   private _getWeeks(propsToUse: ICalendarDayProps): IDayInfo[][] {

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -178,7 +178,9 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
   }
 
   private _onSelectNextYearKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    this._onKeyDown(this._onSelectNextYear, ev);
+    if (ev.which === KeyCodes.enter) {
+      this._onKeyDown(this._onSelectNextYear, ev);
+    }
   }
 
   private _onSelectPrevYear = (): void => {
@@ -187,7 +189,9 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
   }
 
   private _onSelectPrevYearKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    this._onKeyDown(this._onSelectPrevYear, ev);
+    if (ev.which === KeyCodes.enter) {
+      this._onKeyDown(this._onSelectPrevYear, ev);
+    }
   }
 
   private _onSelectMonth = (newMonth: number): void => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4620
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In https://github.com/OfficeDev/office-ui-fabric-react/pull/3741 we refactored all the Calendar `<span/>` nodes to `<button/>`, which was a good change 👍 . However, React invokes `onClick` for `KeyboardEvent` if the `keyCode` is `SPACE`. Since each `<button/>` node had an `onClick` and `onKeyDown` it would invoke the PREV/NEXT month, year, and also "Go to today" callbacks twice.

**Solution Options:**

I went with # 1, but there's an alternative solution:

1. If we wish to still allow for `ENTER` to invoke the `<button/>` then the change is what is in this PR. We need to only invoke the `onKeyDown` callbacks if the key was `ENTER`.
1. If we only want `SPACE` to invoke the callback then we can safely remove the `onKeyDown` handlers.

Since # 2 would would change prior behavior so I left went with option # 1.

#### Focus areas to test

- Use the Calendar component's PREV/NEXT month and year buttons with both the mouse and keyboard.
- The time unit either month or year should change 1 unit per invocation.
- "Go to today" should also only fire once, but you'll likely need to set a break-point to verify.

**Note:** that the UI doesn't update when "Go to today" is invoked. Looks like a preexisting bug on `master` that I'll look into but may file separately. I assume the UI updated at one point, but need to check behavior in prior commits.