### PR TITLE
Fix props validation for Breadcrumb

### DIFF
--- a/common/changes/office-ui-fabric-react/breadcrumb-validation_2018-04-24-20-18.json
+++ b/common/changes/office-ui-fabric-react/breadcrumb-validation_2018-04-24-20-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix props validation for Breadcrumb",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -204,7 +204,7 @@ export class Breadcrumb extends BaseComponent<IBreadcrumbProps, any> {
    */
   private _validateProps(props: IBreadcrumbProps): void {
     const { items, overflowIndex } = props;
-    if (overflowIndex! < 0 || overflowIndex! > items.length - 1) {
+    if (overflowIndex! < 0 || overflowIndex! > items.length) {
       throw new Error('Breadcrumb: overflowIndex out of range');
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -203,8 +203,10 @@ export class Breadcrumb extends BaseComponent<IBreadcrumbProps, any> {
    * @param props Props to validate
    */
   private _validateProps(props: IBreadcrumbProps): void {
-    const { items, overflowIndex } = props;
-    if (overflowIndex! < 0 || overflowIndex! > items.length) {
+    const { maxDisplayedItems, overflowIndex, items } = props;
+    if (overflowIndex! < 0 ||
+      maxDisplayedItems! > 1 && overflowIndex! > maxDisplayedItems! - 1 ||
+      items.length > 0 && overflowIndex! > items.length - 1) {
       throw new Error('Breadcrumb: overflowIndex out of range');
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -6,7 +6,17 @@ import * as renderer from 'react-test-renderer';
 import { Breadcrumb, IBreadcrumbItem } from './index';
 
 describe('Breadcrumb', () => {
-  it('renders breadcumb correctly', () => {
+  it('renders empty breadcrumb', () => {
+    const component = renderer.create(
+      <Breadcrumb items={ [] } />
+    );
+
+    const tree = component.toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  describe('basic rendering', () => {
     const items: IBreadcrumbItem[] = [
       { text: 'TestText1', key: 'TestKey1' },
       { text: 'TestText2', key: 'TestKey2' },
@@ -16,48 +26,56 @@ describe('Breadcrumb', () => {
 
     const divider = () => <span>*</span>;
 
-    let component = renderer.create(
-      <Breadcrumb
-        items={ items }
-      />
-    );
+    it('renders breadcumb correctly 1', () => {
+      const component = renderer.create(
+        <Breadcrumb
+          items={ items }
+        />
+      );
 
-    let tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
 
-    // With overflow
-    component = renderer.create(
-      <Breadcrumb
-        items={ items }
-        maxDisplayedItems={ 2 }
-      />
-    );
+    it('renders breadcumb correctly 2', () => {
+      // With overflow
+      const component = renderer.create(
+        <Breadcrumb
+          items={ items }
+          maxDisplayedItems={ 2 }
+        />
+      );
 
-    tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
 
-    // With custom divider
-    component = renderer.create(
-      <Breadcrumb
-        items={ items }
-        dividerAs={ divider }
-      />
-    );
+    it('renders breadcumb correctly 3', () => {
+      // With custom divider
+      const component = renderer.create(
+        <Breadcrumb
+          items={ items }
+          dividerAs={ divider }
+        />
+      );
 
-    tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
 
-    // With overflow and overflowIndex
-    component = renderer.create(
-      <Breadcrumb
-        items={ items }
-        maxDisplayedItems={ 2 }
-        overflowIndex={ 1 }
-      />
-    );
+    it('renders breadcumb correctly 4', () => {
+      // With overflow and overflowIndex
+      const component = renderer.create(
+        <Breadcrumb
+          items={ items }
+          maxDisplayedItems={ 2 }
+          overflowIndex={ 1 }
+        />
+      );
 
-    tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
   });
 
   it('can call the callback when an item is clicked', () => {

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1,6 +1,695 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Breadcrumb renders breadcumb correctly 1`] = `
+exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
+<div
+  className=
+      ms-ResizeGroup
+      {
+        display: block;
+        position: relative;
+      }
+>
+  <div
+    style={
+      Object {
+        "position": "fixed",
+        "visibility": "hidden",
+      }
+    }
+  >
+    <div
+      aria-label={undefined}
+      className="ms-Breadcrumb"
+      role="navigation"
+    >
+      <div
+        aria-describedby={undefined}
+        aria-labelledby={undefined}
+        className="ms-FocusZone"
+        data-focuszone-id="FocusZone1"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
+        role="presentation"
+      >
+        <ol
+          className="ms-Breadcrumb-list"
+        >
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText1
+              </div>
+            </span>
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Breadcrumb-chevron
+                  {
+                    display: inline-block;
+                  }
+              data-icon-name="ChevronRight"
+              role="presentation"
+            />
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText2
+              </div>
+            </span>
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Breadcrumb-chevron
+                  {
+                    display: inline-block;
+                  }
+              data-icon-name="ChevronRight"
+              role="presentation"
+            />
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText3
+              </div>
+            </span>
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Breadcrumb-chevron
+                  {
+                    display: inline-block;
+                  }
+              data-icon-name="ChevronRight"
+              role="presentation"
+            />
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText4
+              </div>
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
+<div
+  className=
+      ms-ResizeGroup
+      {
+        display: block;
+        position: relative;
+      }
+>
+  <div
+    style={
+      Object {
+        "position": "fixed",
+        "visibility": "hidden",
+      }
+    }
+  >
+    <div
+      aria-label={undefined}
+      className="ms-Breadcrumb"
+      role="navigation"
+    >
+      <div
+        aria-describedby={undefined}
+        aria-labelledby={undefined}
+        className="ms-FocusZone"
+        data-focuszone-id="FocusZone6"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
+        role="presentation"
+      >
+        <ol
+          className="ms-Breadcrumb-list"
+        >
+          <li
+            className="ms-Breadcrumb-overflow"
+          >
+            <button
+              aria-describedby={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label={undefined}
+              aria-labelledby={null}
+              aria-owns={null}
+              aria-pressed={undefined}
+              className=
+                  ms-Button
+                  ms-Breadcrumb-overflowButton
+                  ms-Button--icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:hover {
+                    background-color: #f4f4f4;
+                    color: #004578;
+                  }
+                  &:active {
+                    background-color: #eaeaea;
+                    color: #0078d4;
+                  }
+              data-is-focusable={true}
+              disabled={undefined}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Button-icon
+                      {
+                        display: inline-block;
+                      }
+                      {
+                        flex-shrink: 0;
+                        font-size: 16px;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="More"
+                  role="presentation"
+                />
+              </div>
+            </button>
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Breadcrumb-chevron
+                  {
+                    display: inline-block;
+                  }
+              data-icon-name="ChevronRight"
+              role="presentation"
+            />
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText3
+              </div>
+            </span>
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Breadcrumb-chevron
+                  {
+                    display: inline-block;
+                  }
+              data-icon-name="ChevronRight"
+              role="presentation"
+            />
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText4
+              </div>
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
+<div
+  className=
+      ms-ResizeGroup
+      {
+        display: block;
+        position: relative;
+      }
+>
+  <div
+    style={
+      Object {
+        "position": "fixed",
+        "visibility": "hidden",
+      }
+    }
+  >
+    <div
+      aria-label={undefined}
+      className="ms-Breadcrumb"
+      role="navigation"
+    >
+      <div
+        aria-describedby={undefined}
+        aria-labelledby={undefined}
+        className="ms-FocusZone"
+        data-focuszone-id="FocusZone12"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
+        role="presentation"
+      >
+        <ol
+          className="ms-Breadcrumb-list"
+        >
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText1
+              </div>
+            </span>
+            <span>
+              *
+            </span>
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText2
+              </div>
+            </span>
+            <span>
+              *
+            </span>
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText3
+              </div>
+            </span>
+            <span>
+              *
+            </span>
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText4
+              </div>
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
+<div
+  className=
+      ms-ResizeGroup
+      {
+        display: block;
+        position: relative;
+      }
+>
+  <div
+    style={
+      Object {
+        "position": "fixed",
+        "visibility": "hidden",
+      }
+    }
+  >
+    <div
+      aria-label={undefined}
+      className="ms-Breadcrumb"
+      role="navigation"
+    >
+      <div
+        aria-describedby={undefined}
+        aria-labelledby={undefined}
+        className="ms-FocusZone"
+        data-focuszone-id="FocusZone17"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
+        role="presentation"
+      >
+        <ol
+          className="ms-Breadcrumb-list"
+        >
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText1
+              </div>
+            </span>
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Breadcrumb-chevron
+                  {
+                    display: inline-block;
+                  }
+              data-icon-name="ChevronRight"
+              role="presentation"
+            />
+          </li>
+          <li
+            className="ms-Breadcrumb-overflow"
+          >
+            <button
+              aria-describedby={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label={undefined}
+              aria-labelledby={null}
+              aria-owns={null}
+              aria-pressed={undefined}
+              className=
+                  ms-Button
+                  ms-Breadcrumb-overflowButton
+                  ms-Button--icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:hover {
+                    background-color: #f4f4f4;
+                    color: #004578;
+                  }
+                  &:active {
+                    background-color: #eaeaea;
+                    color: #0078d4;
+                  }
+              data-is-focusable={true}
+              disabled={undefined}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Button-icon
+                      {
+                        display: inline-block;
+                      }
+                      {
+                        flex-shrink: 0;
+                        font-size: 16px;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="More"
+                  role="presentation"
+                />
+              </div>
+            </button>
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Breadcrumb-chevron
+                  {
+                    display: inline-block;
+                  }
+              data-icon-name="ChevronRight"
+              role="presentation"
+            />
+          </li>
+          <li
+            className="ms-Breadcrumb-listItem"
+          >
+            <span
+              className="ms-Breadcrumb-item"
+            >
+              <div
+                aria-describedby={undefined}
+                className="ms-TooltipHost"
+                onBlurCapture={[Function]}
+                onFocusCapture={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+              >
+                TestText4
+              </div>
+            </span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Breadcrumb renders empty breadcrumb 1`] = `
 <div
   className=
       ms-ResizeGroup
@@ -34,655 +723,7 @@ exports[`Breadcrumb renders breadcumb correctly 1`] = `
       >
         <ol
           className="ms-Breadcrumb-list"
-        >
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText1
-              </div>
-            </span>
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Breadcrumb-chevron
-                  {
-                    display: inline-block;
-                  }
-              data-icon-name="ChevronRight"
-              role="presentation"
-            />
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText2
-              </div>
-            </span>
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Breadcrumb-chevron
-                  {
-                    display: inline-block;
-                  }
-              data-icon-name="ChevronRight"
-              role="presentation"
-            />
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText3
-              </div>
-            </span>
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Breadcrumb-chevron
-                  {
-                    display: inline-block;
-                  }
-              data-icon-name="ChevronRight"
-              role="presentation"
-            />
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText4
-              </div>
-            </span>
-          </li>
-        </ol>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Breadcrumb renders breadcumb correctly 2`] = `
-<div
-  className=
-      ms-ResizeGroup
-      {
-        display: block;
-        position: relative;
-      }
->
-  <div
-    style={
-      Object {
-        "position": "fixed",
-        "visibility": "hidden",
-      }
-    }
-  >
-    <div
-      aria-label={undefined}
-      className="ms-Breadcrumb"
-      role="navigation"
-    >
-      <div
-        aria-describedby={undefined}
-        aria-labelledby={undefined}
-        className="ms-FocusZone"
-        data-focuszone-id="FocusZone5"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <ol
-          className="ms-Breadcrumb-list"
-        >
-          <li
-            className="ms-Breadcrumb-overflow"
-          >
-            <button
-              aria-describedby={null}
-              aria-expanded={false}
-              aria-haspopup={true}
-              aria-label={undefined}
-              aria-labelledby={null}
-              aria-owns={null}
-              aria-pressed={undefined}
-              className=
-                  ms-Button
-                  ms-Breadcrumb-overflowButton
-                  ms-Button--icon
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
-                    box-sizing: border-box;
-                    cursor: pointer;
-                    display: inline-block;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 32px;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
-                    vertical-align: top;
-                    width: 32px;
-                  }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    outline: 1px solid #666666;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    border: none;
-                    bottom: -2px;
-                    left: -2px;
-                    outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
-                  }
-                  &:hover {
-                    background-color: #f4f4f4;
-                    color: #004578;
-                  }
-                  &:active {
-                    background-color: #eaeaea;
-                    color: #0078d4;
-                  }
-              data-is-focusable={true}
-              disabled={undefined}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="button"
-              type="button"
-            >
-              <div
-                className=
-                    ms-Button-flexContainer
-                    {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
-                      height: 100%;
-                      justify-content: center;
-                    }
-              >
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Button-icon
-                      {
-                        display: inline-block;
-                      }
-                      {
-                        flex-shrink: 0;
-                        font-size: 16px;
-                        height: 16px;
-                        line-height: 16px;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                        text-align: center;
-                        vertical-align: middle;
-                      }
-                  data-icon-name="More"
-                  role="presentation"
-                />
-              </div>
-            </button>
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Breadcrumb-chevron
-                  {
-                    display: inline-block;
-                  }
-              data-icon-name="ChevronRight"
-              role="presentation"
-            />
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText3
-              </div>
-            </span>
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Breadcrumb-chevron
-                  {
-                    display: inline-block;
-                  }
-              data-icon-name="ChevronRight"
-              role="presentation"
-            />
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText4
-              </div>
-            </span>
-          </li>
-        </ol>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Breadcrumb renders breadcumb correctly 3`] = `
-<div
-  className=
-      ms-ResizeGroup
-      {
-        display: block;
-        position: relative;
-      }
->
-  <div
-    style={
-      Object {
-        "position": "fixed",
-        "visibility": "hidden",
-      }
-    }
-  >
-    <div
-      aria-label={undefined}
-      className="ms-Breadcrumb"
-      role="navigation"
-    >
-      <div
-        aria-describedby={undefined}
-        aria-labelledby={undefined}
-        className="ms-FocusZone"
-        data-focuszone-id="FocusZone11"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <ol
-          className="ms-Breadcrumb-list"
-        >
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText1
-              </div>
-            </span>
-            <span>
-              *
-            </span>
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText2
-              </div>
-            </span>
-            <span>
-              *
-            </span>
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText3
-              </div>
-            </span>
-            <span>
-              *
-            </span>
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText4
-              </div>
-            </span>
-          </li>
-        </ol>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Breadcrumb renders breadcumb correctly 4`] = `
-<div
-  className=
-      ms-ResizeGroup
-      {
-        display: block;
-        position: relative;
-      }
->
-  <div
-    style={
-      Object {
-        "position": "fixed",
-        "visibility": "hidden",
-      }
-    }
-  >
-    <div
-      aria-label={undefined}
-      className="ms-Breadcrumb"
-      role="navigation"
-    >
-      <div
-        aria-describedby={undefined}
-        aria-labelledby={undefined}
-        className="ms-FocusZone"
-        data-focuszone-id="FocusZone16"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="presentation"
-      >
-        <ol
-          className="ms-Breadcrumb-list"
-        >
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText1
-              </div>
-            </span>
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Breadcrumb-chevron
-                  {
-                    display: inline-block;
-                  }
-              data-icon-name="ChevronRight"
-              role="presentation"
-            />
-          </li>
-          <li
-            className="ms-Breadcrumb-overflow"
-          >
-            <button
-              aria-describedby={null}
-              aria-expanded={false}
-              aria-haspopup={true}
-              aria-label={undefined}
-              aria-labelledby={null}
-              aria-owns={null}
-              aria-pressed={undefined}
-              className=
-                  ms-Button
-                  ms-Breadcrumb-overflowButton
-                  ms-Button--icon
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
-                    box-sizing: border-box;
-                    cursor: pointer;
-                    display: inline-block;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 32px;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
-                    vertical-align: top;
-                    width: 32px;
-                  }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    outline: 1px solid #666666;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    border: none;
-                    bottom: -2px;
-                    left: -2px;
-                    outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
-                  }
-                  &:hover {
-                    background-color: #f4f4f4;
-                    color: #004578;
-                  }
-                  &:active {
-                    background-color: #eaeaea;
-                    color: #0078d4;
-                  }
-              data-is-focusable={true}
-              disabled={undefined}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="button"
-              type="button"
-            >
-              <div
-                className=
-                    ms-Button-flexContainer
-                    {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
-                      height: 100%;
-                      justify-content: center;
-                    }
-              >
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Button-icon
-                      {
-                        display: inline-block;
-                      }
-                      {
-                        flex-shrink: 0;
-                        font-size: 16px;
-                        height: 16px;
-                        line-height: 16px;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                        text-align: center;
-                        vertical-align: middle;
-                      }
-                  data-icon-name="More"
-                  role="presentation"
-                />
-              </div>
-            </button>
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Breadcrumb-chevron
-                  {
-                    display: inline-block;
-                  }
-              data-icon-name="ChevronRight"
-              role="presentation"
-            />
-          </li>
-          <li
-            className="ms-Breadcrumb-listItem"
-          >
-            <span
-              className="ms-Breadcrumb-item"
-            >
-              <div
-                aria-describedby={undefined}
-                className="ms-TooltipHost"
-                onBlurCapture={[Function]}
-                onFocusCapture={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                TestText4
-              </div>
-            </span>
-          </li>
-        </ol>
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Overview

This change is to address bug #4663:

- Added unit test for the empty-props case (`items` is `[]`).
- Updated the validation logic to handle the case where `items.length` is `0`, and also added validation against `maxDisplayedItems`, since that impacts overflow behavior, too.