### PR TITLE
Addressing Issue #3707 - OverflowSet: Add the ability to set aria-label

### DIFF
--- a/common/changes/office-ui-fabric-react/overflowset-nativeprops-3707_2018-04-24-22-09.json
+++ b/common/changes/office-ui-fabric-react/overflowset-nativeprops-3707_2018-04-24-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Enabled native props (aria-* and data-*) on OverflowSet even when the doNotContainWithinFocusZone prop is false",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.tsx
@@ -53,6 +53,7 @@ export class OverflowSet extends BaseComponent<IOverflowSetProps, {}> implements
     } else {
       Tag = FocusZone;
       uniqueComponentProps = {
+        ...getNativeProps(this.props, divProperties),
         ...focusZoneProps,
         componentRef: this._focusZone,
         direction: vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSetPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSetPage.tsx
@@ -29,6 +29,7 @@ export class OverflowSetPage extends React.Component<IComponentDemoPageProps, an
             { require<string>('!raw-loader!office-ui-fabric-react/src/components/OverflowSet/docs/OverflowSetOverview.md') }
           </PageMarkdown>
         }
+        allowNativeProps={ true }
         exampleCards={
           <LayerHost>
             <ExampleCard title='OverflowSet Basic Example' code={ OverflowSetBasicExampleCode }>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #3707 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Enabled native props (aria-* and data-*) on OverflowSet even when the `doNotContainWithinFocusZone` prop is false.  The component actually already implemented the `getNativeProps()` function, but did not apply the resulting props if `doNotContainWithinFocusZone` was not set to true, presumably because focusZoneProps could be used to do the same, so I added the `getNativeProps` result with the `focusZoneProps` coming after so anything explicitly passed as a `focusZoneProps` member will overwrite a matching native prop like **aria-label**.

Also added the documentation MessageBar to let users know they can pass native props.