### PR TITLE
Fix input type for Tile ARIA label prop

### DIFF
--- a/common/changes/@uifabric/experiments/tile-aria_2018-04-24-23-01.json
+++ b/common/changes/@uifabric/experiments/tile-aria_2018-04-24-23-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fix bad aria-label prop in Tile",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -348,7 +348,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     return (
       <span
         role='checkbox'
-        aria-label={ String(toggleSelectionAriaLabel) }
+        aria-label={ toggleSelectionAriaLabel }
         className={ css('ms-Tile-check', TileStyles.check, CheckStyles.checkHost, {
           [CheckStyles.hostShowCheck]: this.state.isModal
         }) }

--- a/packages/experiments/src/components/Tile/Tile.types.ts
+++ b/packages/experiments/src/components/Tile/Tile.types.ts
@@ -120,10 +120,10 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
   /**
    * The accessible label for the selection checkbox.
    *
-   * @type {string | boolean}
+   * @type {string}
    * @memberof ITileProps
    */
-  toggleSelectionAriaLabel?: string | boolean;
+  toggleSelectionAriaLabel?: string;
 
   /**
    * Link ref


### PR DESCRIPTION
# Overview

This removes `boolean` as an allowed type for `selectionCheckboxAriaLabel` in `Tile`.
This never worked, and really *should* break consumers if they somehow were setting this to a `boolean` previously.
