### PR TITLE
Fix bug for OWA+Safari+popup

### DIFF
--- a/apps/fabric-website/src/components/DOSearchBox/DOSearchBox.scss
+++ b/apps/fabric-website/src/components/DOSearchBox/DOSearchBox.scss
@@ -35,6 +35,7 @@
 
   .od-SearchBox-button {
     background: none;
+    background-color: transparent;
     border: 0;
     color: transparent;
     position: absolute;

--- a/common/changes/@uifabric/example-app-base/master_2018-04-26-07-20.json
+++ b/common/changes/@uifabric/example-app-base/master_2018-04-26-07-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "vibailly@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/master_2018-04-26-07-20.json
+++ b/common/changes/@uifabric/experiments/master_2018-04-26-07-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "vibailly@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/master_2018-04-26-07-20.json
+++ b/common/changes/@uifabric/fabric-website/master_2018-04-26-07-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix corner case bug with Safari",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "vibailly@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.scss
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.scss
@@ -25,6 +25,7 @@
     .ms-Button.ExampleCard-codeButton {
       @include ms-margin-right(0);
       background: none;
+      background-color: transparent;
       border: 1px solid $ms-color-neutralTertiary;
       border-bottom: 0;
       border-top-left-radius: 4px;

--- a/packages/example-app-base/src/components/Header/Header.scss
+++ b/packages/example-app-base/src/components/Header/Header.scss
@@ -47,6 +47,7 @@ $Header-fabricWebsiteHeaderColor: #272630;
     position: relative;
     text-decoration: none;
     background: none;
+    background-color: transparent;
     border: none;
     padding: 0;
     padding: 0px 10px;

--- a/packages/experiments/src/components/FloatingPicker/Suggestions/SuggestionsControl.scss
+++ b/packages/experiments/src/components/FloatingPicker/Suggestions/SuggestionsControl.scss
@@ -7,6 +7,7 @@
 
 .actionButton {
   background: none;
+  background-color: transparent;
   border: 0;
   cursor: pointer;
   margin: 0;

--- a/packages/experiments/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/experiments/src/components/Shimmer/Shimmer.styles.ts
@@ -89,6 +89,7 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
         opacity: '0',
         lineHeight: '1',
         background: 'none',
+        backgroundColor: 'transparent',
         border: 'none',
         transition: 'opacity 200ms'
       },

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -157,6 +157,7 @@
   @include right(0);
   border: none;
   background: none;
+  background-color: transparent;
   opacity: 0;
   box-sizing: border-box;
   padding: 6px;

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -37,6 +37,7 @@ export const getStyles = memoizeFunction((
         padding: '0',
         border: 'none',
         background: 'none',
+        backgroundColor: 'transparent',
         margin: '0',
         outline: 'none',
         display: 'block',

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -15,8 +15,8 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
-        background: none;
         background-color: transparent;
+        background: none;
         border: none;
         cursor: pointer;
         display: block;

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
         background: none;
+        background-color: transparent;
         border: none;
         cursor: pointer;
         display: block;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.scss
@@ -98,6 +98,7 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
 
   position: relative;
   background: none;
+  background-color: transparent;
   border: none;
   line-height: $CommandBarItem-height;
   min-width: 20px;
@@ -172,7 +173,7 @@ $SearchBox-sidePadding: 8px; // padding in input on left and right sides without
   &.itemLinkIsExpanded:hover {
     background-color: $ms-color-neutralQuaternary;
   }
-  
+
   &.inactive {
     color: $ms-color-neutralTertiaryAlt;
     cursor: default;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -219,6 +219,7 @@ export const getStyles = memoizeFunction((
         fontWeight: FontWeights.semibold,
         color: ContextualMenuHeaderColor,
         background: 'none',
+        backgroundColor: 'transparent',
         border: 'none',
         height: ContextualMenuItemHeight,
         lineHeight: ContextualMenuItemHeight,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.scss
@@ -11,6 +11,7 @@
   box-sizing: border-box;
   vertical-align: top;
   background: none;
+  background-color: transparent;
   border: none;
   opacity: 0;
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.scss
@@ -253,6 +253,7 @@ $DropDown-item-height: 32px;
   font-weight: $ms-font-weight-semibold;
   color: $ms-color-themePrimary;
   background: none;
+  background-color: transparent;
   border: none;
   height: $DropDown-item-height;
   line-height: $DropDown-item-height;

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.scss
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.scss
@@ -40,6 +40,7 @@ $spacingAroundItemButton: 2px;
 button.itemButton {
   display: inline;
   background: none;
+  background-color: transparent;
   padding: 0;
   cursor: pointer;
   border: none;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.scss
@@ -38,6 +38,7 @@ $groupHeader-ease-in-back: cubic-bezier(0.600, -0.280, 0.735, 0.045);
   @include focus-border();
   cursor: default;
   background: none;
+  background-color: transparent;
   border: none;
   font-size: $ms-icon-size-l;
 }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.scss
@@ -23,6 +23,7 @@
     box-sizing: border-box;
     vertical-align: top;
     background: none;
+    background-color: transparent;
     border: none;
     padding-left: 32px;
   }

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -20,6 +20,7 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
       },
       isButton && {
         background: 'none',
+        backgroundColor: 'transparent',
         border: 'none',
         cursor: 'pointer',
         display: 'inline',

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`Link renders Link with no href as a button 1`] = `
       ms-Link
       {
         background: none;
+        background-color: transparent;
         border: none;
         color: #0078d4;
         cursor: pointer;
@@ -178,6 +179,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       is-disabled
       {
         background: none;
+        background-color: transparent;
         border: none;
         color: #a6a6a6;
         cursor: default;

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -85,8 +85,8 @@ exports[`Link renders Link with no href as a button 1`] = `
   className=
       ms-Link
       {
-        background: none;
         background-color: transparent;
+        background: none;
         border: none;
         color: #0078d4;
         cursor: pointer;
@@ -178,8 +178,8 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       ms-Link
       is-disabled
       {
-        background: none;
         background-color: transparent;
+        background: none;
         border: none;
         color: #a6a6a6;
         cursor: default;

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.scss
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.scss
@@ -15,6 +15,7 @@
 
   @include high-contrast {
     background: none;
+    background-color: transparent;
   }
 }
 
@@ -42,5 +43,6 @@
 
   @include high-contrast {
     background: none;
+    background-color: transparent;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
@@ -66,6 +66,7 @@ export function getStyles(props: IRatingStyleProps): IRatingStyles {
       'ms-Rating-button',
       {
         background: 'none',
+        backgroundColor: 'transparent',
         margin: '3px 3px 0px 0px',
         padding: '0px',
         border: 'none',

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating--small
           {
             background: none;
+            background-color: transparent;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -94,7 +95,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-1"
       >
-        
+
       </span>
       <div
         className=
@@ -154,6 +155,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating--small
           {
             background: none;
+            background-color: transparent;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -217,7 +219,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-2"
       >
-        
+
       </span>
       <div
         className=
@@ -277,6 +279,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating--small
           {
             background: none;
+            background-color: transparent;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -340,7 +343,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-3"
       >
-        
+
       </span>
       <div
         className=
@@ -400,6 +403,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating--small
           {
             background: none;
+            background-color: transparent;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -463,7 +467,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-4"
       >
-        
+
       </span>
       <div
         className=
@@ -523,6 +527,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating--small
           {
             background: none;
+            background-color: transparent;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -586,7 +591,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-5"
       >
-        
+
       </span>
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -29,8 +29,8 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating-button
           ms-Rating--small
           {
-            background: none;
             background-color: transparent;
+            background: none;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -95,7 +95,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-1"
       >
-
+        
       </span>
       <div
         className=
@@ -154,8 +154,8 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating-button
           ms-Rating--small
           {
-            background: none;
             background-color: transparent;
+            background: none;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -219,7 +219,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-2"
       >
-
+        
       </span>
       <div
         className=
@@ -278,8 +278,8 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating-button
           ms-Rating--small
           {
-            background: none;
             background-color: transparent;
+            background: none;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -343,7 +343,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-3"
       >
-
+        
       </span>
       <div
         className=
@@ -402,8 +402,8 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating-button
           ms-Rating--small
           {
-            background: none;
             background-color: transparent;
+            background: none;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -467,7 +467,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-4"
       >
-
+        
       </span>
       <div
         className=
@@ -526,8 +526,8 @@ exports[`Rating Renders Rating correctly 1`] = `
           ms-Rating-button
           ms-Rating--small
           {
-            background: none;
             background-color: transparent;
+            background: none;
             border: none;
             cursor: pointer;
             margin-bottom: 0px;
@@ -591,7 +591,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             }
         id="RatingLabel1-5"
       >
-
+        
       </span>
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.scss
@@ -121,6 +121,7 @@ $field-error-color: $errorTextColor;
   border-radius: 0;
   border: none;
   background: none;
+  background-color: transparent;
   color: $field-text-color;
   @include ms-padding(0, 12px, 0, 12px);
   width: 100%;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -63,6 +63,7 @@
 
 .actionButton {
   background: none;
+  background-color: transparent;
   border: 0;
   cursor: pointer;
   margin: 0;

--- a/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Example.scss
+++ b/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Example.scss
@@ -8,6 +8,7 @@
     box-sizing: border-box;
     vertical-align: top;
     background: none;
+    background-color: transparent;
     border: none;
   }
 
@@ -24,6 +25,7 @@
     box-sizing: border-box;
     vertical-align: top;
     background: none;
+    background-color: transparent;
     border: none;
   }
 


### PR DESCRIPTION
#### Description of changes

In OWA, safari, popup buttons have grey background (instead of transparent).
This is because the logic OWA relies on to copy the style over to the popup window have a bug:
.h1{background: none} is added in the popup as .h1{background-image: none}.
The bug has been submitted to the Safari team, but we have no guaranty that they are going to fix it.

Repro of the Safari bug: https://codepen.io/VincentBailly/pen/pVbgob
<img width="668" alt="screen shot 2018-04-26 at 10 08 06" src="https://user-images.githubusercontent.com/28921716/39293662-bda6fdcc-4939-11e8-8cd0-90f8ca43f78f.png">

