### PR TITLE
CommandBar: Add aria label and change to single tab stop

### DIFF
--- a/common/changes/@uifabric/experiments/kathayer-commandbaraccessible_2018-04-27-18-09.json
+++ b/common/changes/@uifabric/experiments/kathayer-commandbaraccessible_2018-04-27-18-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Command bar accessibility: one tab stop with aria label",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kathayer@microsoft.com"
+}

--- a/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
@@ -61,10 +61,6 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   private _resizeGroup = createRef<IResizeGroup>();
   private _classNames: { [key in keyof ICommandBarStyles]: string };
 
-  constructor(props: ICommandBarProps) {
-    super(props);
-  }
-
   public render(): JSX.Element {
     const {
       className,

--- a/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
@@ -14,9 +14,11 @@ import {
 } from './CommandBar.types';
 import { IOverflowSet, OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
 import { IResizeGroup, ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
+import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import {
   classNamesFunction,
-  createRef
+  createRef,
+  getId
 } from '../../Utilities';
 
 import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
@@ -59,6 +61,13 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   private _overflowSet = createRef<IOverflowSet>();
   private _resizeGroup = createRef<IResizeGroup>();
   private _classNames: { [key in keyof ICommandBarStyles]: string };
+  private _ariaDescriptionId: string;
+
+  constructor(props: ICommandBarProps) {
+    super(props);
+
+    this._ariaDescriptionId = getId();
+  }
 
   public render(): JSX.Element {
     const {
@@ -67,6 +76,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       items,
       overflowItems,
       farItems,
+      ariaDescribedByText,
       elipisisAriaLabel,
       elipisisIconProps,
       overflowMenuProps,
@@ -98,12 +108,19 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
         // tslint:disable-next-line:jsx-no-lambda
         onRenderData={ (data: ICommandBarData) => {
           return (
-            <div className={ css(this._classNames.root) }>
-
+            <FocusZone
+              className={ css(this._classNames.root) }
+              direction={ FocusZoneDirection.horizontal }
+              role={ 'menubar' }
+              ariaDescribedBy={ ariaDescribedByText && this._ariaDescriptionId }
+            >
+              { this._onRenderAriaDescription() }
               {/*Primary Items*/ }
               <OverflowSet
                 componentRef={ this._overflowSet }
                 className={ css(this._classNames.primarySet) }
+                doNotContainWithinFocusZone={ true }
+                role={ 'presentation' }
                 items={ data.primaryItems }
                 overflowItems={ data.overflowItems.length ? data.overflowItems : undefined }
                 onRenderItem={ this._onRenderItems }
@@ -124,11 +141,13 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
               {/*Secondary Items*/ }
               <OverflowSet
                 className={ css(this._classNames.secondarySet) }
+                doNotContainWithinFocusZone={ true }
+                role={ 'presentation' }
                 items={ data.farItems }
                 onRenderItem={ this._onRenderItems }
                 onRenderOverflowButton={ () => null }
               />
-            </div>
+            </FocusZone>
           );
         } }
       />
@@ -238,5 +257,17 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   private _onRenderButton = (props: ICommandBarItemProps): JSX.Element => {
     // tslint:disable-next-line:no-any
     return <CommandBarButton { ...props as any } />;
+  }
+
+  private _onRenderAriaDescription = (): JSX.Element | null => {
+    const {
+      ariaDescribedByText
+    } = this.props;
+    
+    return ariaDescribedByText ? (
+      <span className={ 'ms-screenReaderOnly' } id={ this._ariaDescriptionId }>{ ariaDescribedByText }</span>
+    ) : (
+      null
+    );
   }
 }

--- a/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
@@ -17,8 +17,7 @@ import { IResizeGroup, ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGrou
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import {
   classNamesFunction,
-  createRef,
-  getId
+  createRef
 } from '../../Utilities';
 
 import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
@@ -61,12 +60,9 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   private _overflowSet = createRef<IOverflowSet>();
   private _resizeGroup = createRef<IResizeGroup>();
   private _classNames: { [key in keyof ICommandBarStyles]: string };
-  private _ariaDescriptionId: string;
 
   constructor(props: ICommandBarProps) {
     super(props);
-
-    this._ariaDescriptionId = getId();
   }
 
   public render(): JSX.Element {
@@ -112,9 +108,8 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
               className={ css(this._classNames.root) }
               direction={ FocusZoneDirection.horizontal }
               role={ 'menubar' }
-              ariaDescribedBy={ ariaDescribedByText && this._ariaDescriptionId }
+              aria-label={ ariaDescribedByText }
             >
-              { this._onRenderAriaDescription() }
               {/*Primary Items*/ }
               <OverflowSet
                 componentRef={ this._overflowSet }
@@ -257,17 +252,5 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   private _onRenderButton = (props: ICommandBarItemProps): JSX.Element => {
     // tslint:disable-next-line:no-any
     return <CommandBarButton { ...props as any } />;
-  }
-
-  private _onRenderAriaDescription = (): JSX.Element | null => {
-    const {
-      ariaDescribedByText
-    } = this.props;
-    
-    return ariaDescribedByText ? (
-      <span className={ 'ms-screenReaderOnly' } id={ this._ariaDescriptionId }>{ ariaDescribedByText }</span>
-    ) : (
-      null
-    );
   }
 }

--- a/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/experiments/src/components/CommandBar/CommandBar.base.tsx
@@ -72,7 +72,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       items,
       overflowItems,
       farItems,
-      ariaDescribedByText,
+      ariaLabel,
       elipisisAriaLabel,
       elipisisIconProps,
       overflowMenuProps,
@@ -108,7 +108,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
               className={ css(this._classNames.root) }
               direction={ FocusZoneDirection.horizontal }
               role={ 'menubar' }
-              aria-label={ ariaDescribedByText }
+              aria-label={ ariaLabel }
             >
               {/*Primary Items*/ }
               <OverflowSet

--- a/packages/experiments/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/experiments/src/components/CommandBar/CommandBar.types.ts
@@ -42,6 +42,14 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   overflowItems?: ICommandBarItemProps[];
 
   /**
+   * Accessibility text to be read by the screen reader when the user's
+   * focus enters the command bar. The screen reader will read this text
+   * after reading information about the first focusable item in the command
+   * bar.
+   */
+  ariaLabel?: string;
+
+  /**
    * Text to be read by screen readers if there are overflow items and focus is on elipsis button
    */
   elipisisAriaLabel?: string;
@@ -109,12 +117,6 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * @defaultvalue undefined
    */
   className?: string;
-
-  /**
-   * Accessibility text to be read by the screen reader when the user's
-   * focus is within the command bar.
-   */
-  ariaDescribedByText?: string;
 }
 
 export interface ICommandBarItemProps extends IContextualMenuItem {

--- a/packages/experiments/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/experiments/src/components/CommandBar/CommandBar.types.ts
@@ -109,6 +109,12 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * @defaultvalue undefined
    */
   className?: string;
+
+  /**
+   * Accessibility text to be read by the screen reader when the user's
+   * focus is within the command bar.
+   */
+  ariaDescribedByText?: string;
 }
 
 export interface ICommandBarItemProps extends IContextualMenuItem {

--- a/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`CommandBar renders commands correctly 1`] = `
   >
     <div
       aria-describedby={undefined}
+      aria-label={undefined}
       aria-labelledby={undefined}
       className=
           ms-FocusZone

--- a/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -19,7 +19,10 @@ exports[`CommandBar renders commands correctly 1`] = `
     }
   >
     <div
+      aria-describedby={undefined}
+      aria-labelledby={undefined}
       className=
+          ms-FocusZone
           ms-CommandBar
           TestClassName
           {
@@ -31,23 +34,21 @@ exports[`CommandBar renders commands correctly 1`] = `
             padding-right: 16px;
             padding-top: 0;
           }
+      data-focuszone-id="FocusZone0"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onMouseDownCapture={[Function]}
+      role="menubar"
     >
       <div
-        aria-describedby={undefined}
-        aria-labelledby={undefined}
         className=
-            ms-FocusZone
             ms-OverflowSet
             {
               align-items: stretch;
               display: flex;
               flex-grow: 1;
             }
-        data-focuszone-id="FocusZone0"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="menubar"
+        role="presentation"
       >
         <div
           className="ms-OverflowSet-item"
@@ -275,21 +276,14 @@ exports[`CommandBar renders commands correctly 1`] = `
         </div>
       </div>
       <div
-        aria-describedby={undefined}
-        aria-labelledby={undefined}
         className=
-            ms-FocusZone
             ms-OverflowSet
             {
               align-items: stretch;
               display: flex;
               flex-shrink: 0;
             }
-        data-focuszone-id="FocusZone7"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
-        role="menubar"
+        role="presentation"
       />
     </div>
   </div>

--- a/packages/experiments/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
+++ b/packages/experiments/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
@@ -18,8 +18,8 @@ export class CommandBarBasicExample extends React.Component<ICommandBarProps, {}
     return (
       <div>
         <CommandBar
+          ariaLabel='Use left and right arrow keys to navigate between commands'
           elipisisAriaLabel='More options'
-          ariaDescribedByText='Use left and right arrow keys to navigate between commands'
           items={ items }
           overflowItems={ overflowItems }
           farItems={ farItems }

--- a/packages/experiments/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
+++ b/packages/experiments/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
@@ -19,6 +19,7 @@ export class CommandBarBasicExample extends React.Component<ICommandBarProps, {}
       <div>
         <CommandBar
           elipisisAriaLabel='More options'
+          ariaDescribedByText='Use left and right arrow keys to navigate between commands'
           items={ items }
           overflowItems={ overflowItems }
           farItems={ farItems }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Improves CommandBar accessibility by changing it to contain a single tab stop with role="menubar" instead of two (one for near commands and one for far commands) and adding an aria label to be read when focus enters the command bar.

#### Focus areas to test

(optional)
