### PR TITLE
Addressing Issue #3747 - Rating: Not working on OSX 10.10.5

### DIFF
--- a/common/changes/office-ui-fabric-react/rating-osx-fix-3747_2018-04-27-23-12.json
+++ b/common/changes/office-ui-fabric-react/rating-osx-fix-3747_2018-04-27-23-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added onClick handler to rating star in the Rating component that calls _onFocus redundently for support with Firefox & Safari on OSX.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -156,13 +156,15 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
   }
 
   private _onFocus(value: number, ev: React.FocusEvent<HTMLElement>): void {
-    this.setState({
-      rating: value
-    } as IRatingState);
+    if (this.state.rating !== value) {
+      this.setState({
+        rating: value
+      } as IRatingState);
 
-    const { onChanged } = this.props;
-    if (onChanged) {
-      onChanged(value);
+      const { onChanged } = this.props;
+      if (onChanged) {
+        onChanged(value);
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -120,6 +120,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
             key={ i }
             { ...((i === Math.ceil(this.state.rating as number)) ? { 'data-is-current': true } : {}) }
             onFocus={ this._onFocus.bind(this, i) }
+            onClick={ this._onFocus.bind(this, i) } // For Safari & Firefox on OSX
             disabled={ disabled || readOnly ? true : false }
             role='presentation'
             type='button'

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -71,6 +71,7 @@ exports[`Rating Renders Rating correctly 1`] = `
       data-is-current={true}
       disabled={false}
       id="Rating0-star-0"
+      onClick={[Function]}
       onFocus={[Function]}
       role="presentation"
       type="button"
@@ -195,6 +196,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
       disabled={false}
       id="Rating0-star-1"
+      onClick={[Function]}
       onFocus={[Function]}
       role="presentation"
       type="button"
@@ -319,6 +321,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
       disabled={false}
       id="Rating0-star-2"
+      onClick={[Function]}
       onFocus={[Function]}
       role="presentation"
       type="button"
@@ -443,6 +446,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
       disabled={false}
       id="Rating0-star-3"
+      onClick={[Function]}
       onFocus={[Function]}
       role="presentation"
       type="button"
@@ -567,6 +571,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
       disabled={false}
       id="Rating0-star-4"
+      onClick={[Function]}
       onFocus={[Function]}
       role="presentation"
       type="button"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3747 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added onClick handler to rating star in the Rating component that calls _onFocus redundantly for support with Firefox & Safari on OSX.  Before you could not change the rating with a mouse click and the rating appeared broken - keyboard usage did work on those browsers.

The original implementation structured the control around **focus**.  This did make a nice keyboard experience where you can control the rating up and down with your arrow keys.  Most browsers seem to translate the click as a focus on that star element, so it makes sense that this solution seems like it would cover all bases, but Firefox and Safari on OSX systems only, seem to not 'focus on click'.

The simplest solution seemed to be to add an `onClick` handler that calls the same function as the `onFocus`.  Open to alternative solution ideas.
