### PR TITLE
Bundle size locks for every entrypoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,7 @@
         "--",
         "--production"
       ],
-      "cwd": "${workspaceRoot}/apps/fabric-website",
+      "cwd": "${workspaceRoot}/apps/test-bundles",
       "runtimeExecutable": null,
       "runtimeArgs": [
         "--nolazy",

--- a/apps/test-bundle-button/webpack.config.js
+++ b/apps/test-bundle-button/webpack.config.js
@@ -3,13 +3,15 @@ const resources = require('../../scripts/tasks/webpack-resources');
 
 const PACKAGE_NAME = 'test-bundle-button';
 
+const entry = {
+  'Button': './node_modules/office-ui-fabric-react/lib/Button.js'
+};
+
 module.exports = resources.createConfig(
   PACKAGE_NAME,
   true,
   {
-    entry: {
-      [PACKAGE_NAME]: './lib/index.js',
-    },
+    entry,
 
     externals: {
       'react': 'React',

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "test-bundles",
+  "version": "5.0.1",
+  "description": "Testing for bundling.",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OfficeDev/office-ui-fabric-react"
+  },
+  "license": "MIT",
+  "scripts": {
+    "build": "node ../../scripts/build.js",
+    "clean": "node ../../scripts/clean.js",
+    "start": "node ../../scripts/start.js"
+  },
+  "devDependencies": {
+    "@types/react": "16.3.10",
+    "@types/react-dom": "16.0.5",
+    "@types/webpack-env": "1.13.0",
+    "@types/prop-types": "15.5.2",
+    "office-ui-fabric-react-tslint": ">=5.0.0 <6.0.0"
+  },
+  "dependencies": {
+    "react": "^0.14 || ^15.0.1-0 || ^16.0.0-0",
+    "react-dom": "^0.14 || ^15.0.1-0 || ^16.0.0-0",
+    "office-ui-fabric-react": ">=5.91.0 <6.0.0",
+    "tslib": "^1.7.1"
+  },
+  "disabledTasks": [
+    "copy",
+    "sass",
+    "karma",
+    "jest",
+    "tslint",
+    "ts"
+  ]
+}

--- a/apps/test-bundles/webpack.config.js
+++ b/apps/test-bundles/webpack.config.js
@@ -81,6 +81,6 @@ module.exports = resources.createConfig(
       '@microsoft/load-themed-styles': 'LoadThemedStyles',
       'tslib': 'tslib'
     }
-
   },
+  true
 );

--- a/apps/test-bundles/webpack.config.js
+++ b/apps/test-bundles/webpack.config.js
@@ -1,0 +1,86 @@
+const path = require('path');
+const resources = require('../../scripts/tasks/webpack-resources');
+
+const AllEntries = [
+  'ActivityItem',
+  'Breadcrumb',
+  'Button',
+  'Calendar',
+  'Callout',
+  'Check',
+  'Checkbox',
+  'ChoiceGroup',
+  'ColorPicker',
+  'ComboBox',
+  'CommandBar',
+  'ContextualMenu',
+  'DatePicker',
+  'DetailsList',
+  'Dialog',
+  'DocumentCard',
+  'Dropdown',
+  'Fabric',
+  'Facepile',
+  'FocusTrapZone',
+  'FocusZone',
+  'GroupedList',
+  'HoverCard',
+  'Icon',
+  'Image',
+  'Label',
+  'Layer',
+  'Link',
+  'List',
+  'MessageBar',
+  'MarqueeSelection',
+  'Nav',
+  'OverflowSet',
+  'Overlay',
+  'Panel',
+  'Pickers',
+  'Persona',
+  'PersonaCoin',
+  'Pivot',
+  'ProgressIndicator',
+  'Rating',
+  'ResizeGroup',
+  'ScrollablePane',
+  'SearchBox',
+  'Slider',
+  'SpinButton',
+  'Spinner',
+  'Sticky',
+  'Styling',
+  'SwatchColorPicker',
+  'TeachingBubble',
+  'TextField',
+  'Toggle',
+  'Tooltip',
+  'Utilities',
+];
+
+const entry = {};
+
+AllEntries.forEach(
+  entryName => {
+    entry[entryName] = `./node_modules/office-ui-fabric-react/lib/${entryName}.js`;
+  }
+);
+
+module.exports = resources.createConfig(
+  'test',
+  true,
+  {
+    entry,
+    externals: {
+      'react': 'React',
+      'react-dom': 'ReactDOM',
+      '@uifabric/utilities/lib/index': 'FabricUtilities',
+      '@uifabric/styling/lib/index': 'FabricStyling',
+      '@uifabric/merge-styles/lib/index': 'MergeStyles',
+      '@microsoft/load-themed-styles': 'LoadThemedStyles',
+      'tslib': 'tslib'
+    }
+
+  },
+);

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -35,16 +35,16 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.50",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.50.tgz",
-      "integrity": "sha1-DHlTAVL3l85d8xOoARdzK2IIAqY="
+      "version": "1.7.54",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.54.tgz",
+      "integrity": "sha1-aaErcunte6aYeNwh1f3Gmni3hys="
     },
     "@microsoft/loader-load-themed-styles": {
-      "version": "1.7.32",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.32.tgz",
-      "integrity": "sha1-aJydwNQwGro5SIy6dh2WIBnMHgk=",
+      "version": "1.7.36",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.36.tgz",
+      "integrity": "sha1-xhmTr2eup9k3fY1JOLXxxncZhuA=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
+        "@microsoft/load-themed-styles": "1.7.54",
         "loader-utils": "1.1.0"
       }
     },
@@ -88,14 +88,14 @@
     },
     "@rush-temp/build": {
       "version": "file:projects/build.tgz",
-      "integrity": "sha1-T3Z8HKKujQsa0eU2LZzotfg3L4g=",
+      "integrity": "sha1-SFbm2jNOqNOtrGwYVcUx+ZNvOOU=",
       "requires": {
         "@microsoft/api-extractor": "4.3.7",
-        "@microsoft/load-themed-styles": "1.7.50",
-        "@microsoft/loader-load-themed-styles": "1.7.32",
+        "@microsoft/load-themed-styles": "1.7.54",
+        "@microsoft/loader-load-themed-styles": "1.7.36",
         "autoprefixer": "7.2.6",
         "bundlesize": "0.15.3",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "command-line-args": "4.0.7",
         "cpx": "1.5.0",
         "css-loader": "0.28.11",
@@ -106,7 +106,7 @@
         "jest": "21.2.1",
         "json-loader": "0.5.7",
         "mustache": "2.3.0",
-        "node-sass": "4.8.3",
+        "node-sass": "4.9.0",
         "open": "0.0.5",
         "postcss": "6.0.21",
         "postcss-loader": "2.1.4",
@@ -121,9 +121,9 @@
         "tslint": "5.9.1",
         "tslint-microsoft-contrib": "5.0.3",
         "typescript": "2.8.1",
-        "webpack": "4.5.0",
+        "webpack": "4.6.0",
         "webpack-bundle-analyzer": "2.11.1",
-        "webpack-cli": "2.0.14",
+        "webpack-cli": "2.0.15",
         "webpack-dev-server": "3.1.3",
         "webpack-notifier": "1.6.0",
         "yargs": "6.6.0"
@@ -211,13 +211,13 @@
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.4"
+            "upath": "1.0.5"
           }
         },
         "cliui": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -494,9 +494,9 @@
           }
         },
         "webpack": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.5.0.tgz",
-          "integrity": "sha512-6GrZsvQJnG7o7mjbfjp6s5CyMfdopjt1A/X8LcYwceis9ySjqBX6Lusso2wNZ06utHj2ZvfL6L3f7hfgVeJP6g==",
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.6.0.tgz",
+          "integrity": "sha512-Fu/k/3fZeGtIhuFkiYpIy1UDHhMiGKjG4FFPVuvG+5Os2lWA1ttWpmi9Qnn6AgfZqj9MvhZW/rmj/ip+nHr06g==",
           "requires": {
             "acorn": "5.5.3",
             "acorn-dynamic-import": "3.0.0",
@@ -514,8 +514,8 @@
             "node-libs-browser": "2.1.0",
             "schema-utils": "0.4.5",
             "tapable": "1.0.0",
-            "uglifyjs-webpack-plugin": "1.2.4",
-            "watchpack": "1.5.0",
+            "uglifyjs-webpack-plugin": "1.2.5",
+            "watchpack": "1.6.0",
             "webpack-sources": "1.1.0"
           }
         },
@@ -567,7 +567,7 @@
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
               "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
               "requires": {
-                "cliui": "4.0.0",
+                "cliui": "4.1.0",
                 "decamelize": "1.2.0",
                 "find-up": "2.1.0",
                 "get-caller-file": "1.0.2",
@@ -595,7 +595,7 @@
     },
     "@rush-temp/example-app-base": {
       "version": "file:projects/example-app-base.tgz",
-      "integrity": "sha1-DkUcfRVaa8xwsxbZRsRwvrr9KbU=",
+      "integrity": "sha1-VihiwBpIQLKTv1RNmPQcv18WvY4=",
       "requires": {
         "@types/es6-promise": "0.0.32",
         "@types/highlight.js": "9.12.2",
@@ -607,7 +607,7 @@
         "es6-weak-map": "2.0.2",
         "highlight.js": "9.12.0",
         "markdown-to-jsx": "6.6.1",
-        "office-ui-fabric-react": "5.82.1",
+        "office-ui-fabric-react": "5.91.0",
         "react": "16.3.2",
         "react-dom": "16.3.2",
         "react-syntax-highlighter": "7.0.2",
@@ -616,9 +616,9 @@
     },
     "@rush-temp/experiments": {
       "version": "file:projects/experiments.tgz",
-      "integrity": "sha1-daarXQdKu4kkuBeXhStW7KW9YK8=",
+      "integrity": "sha1-EZph/Qrz5KUkEu4lzDUyA6dGZcA=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
+        "@microsoft/load-themed-styles": "1.7.54",
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
         "@types/es6-promise": "0.0.32",
@@ -645,9 +645,9 @@
     },
     "@rush-temp/fabric-website": {
       "version": "file:projects/fabric-website.tgz",
-      "integrity": "sha1-a1mHbvDvXnWaXuyFJEIvClcuHpI=",
+      "integrity": "sha1-IxPdcpbijtHKxFuR5KfPHLpm3hM=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
+        "@microsoft/load-themed-styles": "1.7.54",
         "@types/es6-promise": "0.0.32",
         "@types/node": "8.0.26",
         "@types/prop-types": "15.5.2",
@@ -670,7 +670,7 @@
     },
     "@rush-temp/file-type-icons": {
       "version": "file:projects/file-type-icons.tgz",
-      "integrity": "sha1-Yn+JPy99YoMSgbFnw5ID2WktWNs=",
+      "integrity": "sha1-+TtUzyJzoLdGweY3rOeH+61IzJY=",
       "requires": {
         "@types/react": "16.3.10",
         "@types/react-dom": "16.0.5",
@@ -681,21 +681,21 @@
     },
     "@rush-temp/icons": {
       "version": "file:projects/icons.tgz",
-      "integrity": "sha1-pVQHHai8Itvqt9Yu8AHEDXB1BRs=",
+      "integrity": "sha1-d04UpM1whIdHNiNHM1GbGCQ2d0c=",
       "requires": {
         "tslib": "1.9.0"
       }
     },
     "@rush-temp/jest-serializer-merge-styles": {
       "version": "file:projects/jest-serializer-merge-styles.tgz",
-      "integrity": "sha1-n+RTd+E26yjhauT284rh4gXLfzo=",
+      "integrity": "sha1-kaALFAqZJde73VWkE3NooX91bLs=",
       "requires": {
         "@types/jest": "21.1.8"
       }
     },
     "@rush-temp/merge-styles": {
       "version": "file:projects/merge-styles.tgz",
-      "integrity": "sha1-KQC+5a/Yux9UOIoWq7SnCXAGbYI=",
+      "integrity": "sha1-HmwICcioZJCAEE2mqzDfo0n8SqI=",
       "requires": {
         "@types/jest": "21.1.8",
         "tslib": "1.9.0"
@@ -703,9 +703,9 @@
     },
     "@rush-temp/office-ui-fabric-react": {
       "version": "file:projects/office-ui-fabric-react.tgz",
-      "integrity": "sha1-15D4XJwcbRk65so2L5a1u+DEUCU=",
+      "integrity": "sha1-551zpW5FnqqZNkfbp3nkotUPGBg=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
+        "@microsoft/load-themed-styles": "1.7.54",
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
         "@types/es6-promise": "0.0.32",
@@ -736,16 +736,16 @@
     },
     "@rush-temp/office-ui-fabric-react-tslint": {
       "version": "file:projects/office-ui-fabric-react-tslint.tgz",
-      "integrity": "sha1-Lpw29kpo8XYUjrbjk3AiOmKBc2I=",
+      "integrity": "sha1-ySwIuAHfSLY+YqjnNsQytMqLno0=",
       "requires": {
         "tslint-react": "3.5.1"
       }
     },
     "@rush-temp/ssr-tests": {
       "version": "file:projects/ssr-tests.tgz",
-      "integrity": "sha1-ApHvumLVdD5xovN/qT2v5tac+0M=",
+      "integrity": "sha1-/rUrqHZshuiuG6eOvFZfBH5xGbk=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
+        "@microsoft/load-themed-styles": "1.7.54",
         "@types/es6-promise": "0.0.32",
         "@types/mocha": "2.2.39",
         "@types/webpack-env": "1.13.0",
@@ -755,7 +755,7 @@
         "react": "16.3.2",
         "react-dom": "16.3.2",
         "tslib": "1.9.0",
-        "webpack": "4.5.0"
+        "webpack": "4.6.0"
       },
       "dependencies": {
         "acorn": {
@@ -1031,9 +1031,9 @@
           }
         },
         "webpack": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.5.0.tgz",
-          "integrity": "sha512-6GrZsvQJnG7o7mjbfjp6s5CyMfdopjt1A/X8LcYwceis9ySjqBX6Lusso2wNZ06utHj2ZvfL6L3f7hfgVeJP6g==",
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.6.0.tgz",
+          "integrity": "sha512-Fu/k/3fZeGtIhuFkiYpIy1UDHhMiGKjG4FFPVuvG+5Os2lWA1ttWpmi9Qnn6AgfZqj9MvhZW/rmj/ip+nHr06g==",
           "requires": {
             "acorn": "5.5.3",
             "acorn-dynamic-import": "3.0.0",
@@ -1051,8 +1051,8 @@
             "node-libs-browser": "2.1.0",
             "schema-utils": "0.4.5",
             "tapable": "1.0.0",
-            "uglifyjs-webpack-plugin": "1.2.4",
-            "watchpack": "1.5.0",
+            "uglifyjs-webpack-plugin": "1.2.5",
+            "watchpack": "1.6.0",
             "webpack-sources": "1.1.0"
           }
         }
@@ -1060,9 +1060,9 @@
     },
     "@rush-temp/styling": {
       "version": "file:projects/styling.tgz",
-      "integrity": "sha1-oCh2p/rfJ1hLnsJ+kA4etUwi93s=",
+      "integrity": "sha1-1V370FPNiNa45cCM+mnOZZq4ONg=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
+        "@microsoft/load-themed-styles": "1.7.54",
         "@types/jest": "21.1.8",
         "@types/react": "16.3.10",
         "@types/webpack-env": "1.13.0",
@@ -1075,7 +1075,20 @@
     },
     "@rush-temp/test-bundle-button": {
       "version": "file:projects/test-bundle-button.tgz",
-      "integrity": "sha1-DEKsr3vPRqOJSyHa++oqhlnkt9Q=",
+      "integrity": "sha1-Q/sNxN305xPl6Do0HUYQD0vktdM=",
+      "requires": {
+        "@types/prop-types": "15.5.2",
+        "@types/react": "16.3.10",
+        "@types/react-dom": "16.0.5",
+        "@types/webpack-env": "1.13.0",
+        "react": "16.3.2",
+        "react-dom": "16.3.2",
+        "tslib": "1.9.0"
+      }
+    },
+    "@rush-temp/test-bundles": {
+      "version": "file:projects/test-bundles.tgz",
+      "integrity": "sha1-/uq7E8TxM8Z/x8S/pLl6B0fQCbg=",
       "requires": {
         "@types/prop-types": "15.5.2",
         "@types/react": "16.3.10",
@@ -1088,9 +1101,9 @@
     },
     "@rush-temp/todo-app": {
       "version": "file:projects/todo-app.tgz",
-      "integrity": "sha1-g+j/qa8VUW7jubOkemtdrdiWsRM=",
+      "integrity": "sha1-txSYa2cygClkMXqf1TXCjfA06WE=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
+        "@microsoft/load-themed-styles": "1.7.54",
         "@types/es6-promise": "0.0.32",
         "@types/react": "16.3.10",
         "@types/react-dom": "16.0.5",
@@ -1105,7 +1118,7 @@
     },
     "@rush-temp/utilities": {
       "version": "file:projects/utilities.tgz",
-      "integrity": "sha1-/OUe7tPLUU+ih/KZ/03w8cRa5L0=",
+      "integrity": "sha1-HAXgp+mSpcgoht5DZHCQzxDopVc=",
       "requires": {
         "@types/enzyme": "3.1.5",
         "@types/enzyme-adapter-react-16": "1.0.1",
@@ -1125,7 +1138,7 @@
     },
     "@rush-temp/variants": {
       "version": "file:projects/variants.tgz",
-      "integrity": "sha1-8x6mkzR8vS0Ro1fs0Ctch++yuY8=",
+      "integrity": "sha1-xDXJoFX9fU/hzpzm6/pRfUQ30M0=",
       "requires": {
         "@types/jest": "21.1.8",
         "tslib": "1.9.0"
@@ -1133,10 +1146,10 @@
     },
     "@rush-temp/vr-tests": {
       "version": "file:projects/vr-tests.tgz",
-      "integrity": "sha1-km3rck0pwUcIkwCcmzEE5OtXAtU=",
+      "integrity": "sha1-2jW0Tx9X8fWXAYBECbKA8gJzWRA=",
       "requires": {
         "@storybook/addon-options": "3.2.3",
-        "@storybook/react": "3.4.1",
+        "@storybook/react": "3.4.3",
         "@types/react": "16.3.10",
         "@types/react-dom": "16.0.5",
         "@types/storybook__react": "3.0.5",
@@ -1148,7 +1161,7 @@
         "react": "16.3.2",
         "react-dom": "16.3.2",
         "screener-runner": "0.6.19",
-        "screener-storybook": "0.12.5",
+        "screener-storybook": "0.12.6",
         "storybook-readme": "3.0.6",
         "style-loader": "0.19.1",
         "tslib": "1.9.0",
@@ -1169,15 +1182,15 @@
       }
     },
     "@storybook/addon-actions": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.4.1.tgz",
-      "integrity": "sha512-mCpEbzex7WYkyIHn9QUnIz83IwMO9Zi4D2LC6c/0u42HzQdkmTJWnyEg4NY5Az/1WZZTtwe9aep/pLc+Zzokdw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.4.3.tgz",
+      "integrity": "sha512-1Du2SIXeJElOXor03Gc+n49sWv8R0OOKs4BvQPcmdw6uRL8ow917dXr5nQOAmZjXILPpZJOkpJE5BWPPqE+0LQ==",
       "requires": {
-        "@storybook/components": "3.4.1",
+        "@storybook/components": "3.4.3",
         "babel-runtime": "6.26.0",
         "deep-equal": "1.0.1",
         "glamor": "2.20.40",
-        "glamorous": "4.12.3",
+        "glamorous": "4.12.4",
         "global": "4.3.2",
         "make-error": "1.3.4",
         "prop-types": "15.6.1",
@@ -1186,11 +1199,11 @@
       }
     },
     "@storybook/addon-links": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.4.1.tgz",
-      "integrity": "sha512-yOVStezQO/VTTlxoqDdVu6CCI2kHBNdLD6lY9w1ly20b6J4hg2Cgy/d/VyPUKfM3fTkdAHeBFayg41KmR9lrMQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.4.3.tgz",
+      "integrity": "sha512-TGOI4arJfYmqizSedx6WOGxtnZrYR1i4RUQJt6wdizQzelgZSyoXN2AyuFzX0RH5IlEmfdCyvnv2jw7mTDNMEg==",
       "requires": {
-        "@storybook/components": "3.4.1",
+        "@storybook/components": "3.4.3",
         "babel-runtime": "6.26.0",
         "global": "4.3.2",
         "prop-types": "15.6.1"
@@ -1201,57 +1214,57 @@
       "resolved": "https://registry.npmjs.org/@storybook/addon-options/-/addon-options-3.2.3.tgz",
       "integrity": "sha1-6jdA0onUKc52fpaZvzpkfddBWS0=",
       "requires": {
-        "@storybook/addons": "3.4.1"
+        "@storybook/addons": "3.4.3"
       }
     },
     "@storybook/addons": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.4.1.tgz",
-      "integrity": "sha512-WFHwVnJq6zItotj89fGFtEJ/MPdbUaOXu0QsNUbM1Muqw/kVX7gVAwXDPllBJ5y1/42aAzsJCQ/WMdrD2M9Tcg=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.4.3.tgz",
+      "integrity": "sha512-vi2E2f+QFt1sp1mMJBdb0wdfmopE+Oprr1sLYEM9+E3eV9eh1stu/WBelk8Es3KsPh6vrJw8dy/rHIrIcUUSyQ=="
     },
     "@storybook/channel-postmessage": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.4.1.tgz",
-      "integrity": "sha512-3LhieYOBJFPi5JRFUCc0axSj28GWAJjnXSNKRsWoRy+oSnj/Ux56ywkGLuh20Mze9NoA45MIKvtrsTPq2UiEkw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.4.3.tgz",
+      "integrity": "sha512-fWFCIEHtRk0inHuz6c91v5UlL+fB6RRZQZQkMrnFCZPCYpjtcJYBWp2mX+Pv1UFga57+d1NJKd/M0Jpy+xXLBA==",
       "requires": {
-        "@storybook/channels": "3.4.1",
+        "@storybook/channels": "3.4.3",
         "global": "4.3.2",
         "json-stringify-safe": "5.0.1"
       }
     },
     "@storybook/channels": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.4.1.tgz",
-      "integrity": "sha512-D8q64LsAmjZ+MeMUr/j0r+a2M9mm5y1yXBGkbEzucI2e48RP4zcc9ZVNB8yqCDPwtQLDU6w2idFWcaJaZNHXQw=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.4.3.tgz",
+      "integrity": "sha512-x6ika4smvYOcmjoPGzZpitRpKiNfpHeovLPhnWdGGHm5IiC/Z0up9qvM4yxGfDuQvxCQ70nT+8f8Jo3SlqtTMw=="
     },
     "@storybook/client-logger": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.4.1.tgz",
-      "integrity": "sha512-wGIdo9GxxZ8iRzjTD9IrOk5UycOm8cnxJfe1Pfw9G5pisthASsxBYeqSVI44K9WchV1fMSRZ4AKUPmpoJ1H+ww=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.4.3.tgz",
+      "integrity": "sha512-QUD0/iJsPhtBYexo/MAwpkO8i+ChS/kKdlzoGOY9pC/XjQALk24BJDT4EVk0VbDdDqp2K0Pvc+ShIBtEm34AzA=="
     },
     "@storybook/components": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.4.1.tgz",
-      "integrity": "sha512-STu4EkkUWZgMb/Cbpdf3YUKcQVTqIpg+kEP9zG7519/Eg0OuBgRZ4qRr5jiDbLQMsaGS8oxwjhCoHufG903oZw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.4.3.tgz",
+      "integrity": "sha512-++sBqTD6V6nZ5EaY8ecW+rMtgLEQBP18d2b2OYAdMuDffIKL7olfcgmlW9bchm40zLecbV5TGTjZFGbXXJ4sWw==",
       "requires": {
         "glamor": "2.20.40",
-        "glamorous": "4.12.3",
+        "glamorous": "4.12.4",
         "prop-types": "15.6.1"
       }
     },
     "@storybook/core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-3.4.1.tgz",
-      "integrity": "sha512-LGfJFaOjKKP2WQfVMcjxJ+Abv1DBJYmWcMXF1w5nt3sua/GYcidgFVj5txu6Ib44UZubp1iXXQAKr35T+iSNOg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-3.4.3.tgz",
+      "integrity": "sha512-92mFUf+W2hac36x9N7r8VjuUJwKHL/c5k6Jbri0quJTcPRvrypIO3UmwAxon+9z+eNmWKi+bQGFayMxHlDEDkw==",
       "requires": {
-        "@storybook/addons": "3.4.1",
-        "@storybook/channel-postmessage": "3.4.1",
-        "@storybook/client-logger": "3.4.1",
-        "@storybook/node-logger": "3.4.1",
-        "@storybook/ui": "3.4.1",
+        "@storybook/addons": "3.4.3",
+        "@storybook/channel-postmessage": "3.4.3",
+        "@storybook/client-logger": "3.4.3",
+        "@storybook/node-logger": "3.4.3",
+        "@storybook/ui": "3.4.3",
         "autoprefixer": "7.2.6",
         "babel-runtime": "6.26.0",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "commander": "2.15.1",
         "css-loader": "0.28.11",
         "dotenv": "5.0.1",
@@ -1270,7 +1283,7 @@
         "url-loader": "0.6.2",
         "webpack": "3.11.0",
         "webpack-dev-middleware": "1.12.2",
-        "webpack-hot-middleware": "2.21.2"
+        "webpack-hot-middleware": "2.22.1"
       },
       "dependencies": {
         "events": {
@@ -1321,9 +1334,9 @@
       }
     },
     "@storybook/node-logger": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-3.4.1.tgz",
-      "integrity": "sha512-vnM2+TIubLLsU5pcqydjnbPnska6zYvPSKIOO7lKTsGV0DdmDy7myvUn+oSRPubVyMh8+uno1J+XTHzdRkhsXQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-3.4.3.tgz",
+      "integrity": "sha512-RpHpWoo+HpR2yGyhzbQN22x3aoeAtADz+G4e7kwC11q/yaFawdQSMIAhIMGOpQLl1G+ojx+uCLU5HWDHb864bA==",
       "requires": {
         "npmlog": "4.1.2"
       }
@@ -1338,18 +1351,18 @@
       }
     },
     "@storybook/react": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.4.1.tgz",
-      "integrity": "sha512-fBeHDwQPmsLcEPjEEDrOzBJMjbcidNms9aAtv8yo+pf8uvLMbe4nOxwt5/goKrj994wpqUrZ0gXXzarcQW59Vg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.4.3.tgz",
+      "integrity": "sha512-vvhilLrBBSxZXUm8XApOnAscsci+XWQ5fXcZt1nYL4mjrD/vYngUuh42pTKVfZIYJcZ5jxWmxuSwCvLR0p6k6w==",
       "requires": {
-        "@storybook/addon-actions": "3.4.1",
-        "@storybook/addon-links": "3.4.1",
-        "@storybook/addons": "3.4.1",
-        "@storybook/channel-postmessage": "3.4.1",
-        "@storybook/client-logger": "3.4.1",
-        "@storybook/core": "3.4.1",
-        "@storybook/node-logger": "3.4.1",
-        "@storybook/ui": "3.4.1",
+        "@storybook/addon-actions": "3.4.3",
+        "@storybook/addon-links": "3.4.3",
+        "@storybook/addons": "3.4.3",
+        "@storybook/channel-postmessage": "3.4.3",
+        "@storybook/client-logger": "3.4.3",
+        "@storybook/core": "3.4.3",
+        "@storybook/node-logger": "3.4.3",
+        "@storybook/ui": "3.4.3",
         "airbnb-js-shims": "1.4.1",
         "babel-loader": "7.1.4",
         "babel-plugin-macros": "2.2.0",
@@ -1367,7 +1380,7 @@
         "dotenv-webpack": "1.5.5",
         "find-cache-dir": "1.0.0",
         "glamor": "2.20.40",
-        "glamorous": "4.12.3",
+        "glamorous": "4.12.4",
         "global": "4.3.2",
         "html-loader": "0.5.5",
         "html-webpack-plugin": "2.30.1",
@@ -1377,10 +1390,10 @@
         "prop-types": "15.6.1",
         "react-dev-utils": "5.0.1",
         "redux": "3.7.2",
-        "uglifyjs-webpack-plugin": "1.2.4",
+        "uglifyjs-webpack-plugin": "1.2.5",
         "util-deprecate": "1.0.2",
         "webpack": "3.11.0",
-        "webpack-hot-middleware": "2.21.2"
+        "webpack-hot-middleware": "2.22.1"
       }
     },
     "@storybook/react-komposer": {
@@ -1415,11 +1428,11 @@
       }
     },
     "@storybook/ui": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.4.1.tgz",
-      "integrity": "sha512-OX/mnl3jQwZwt1wltFcmO+8yPJlZgeQ4sksKy/jmMqfnk4GFP+UVmg2KIDYhh6Xl2/H1xi14iAdH9Z36losrpw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.4.3.tgz",
+      "integrity": "sha512-AZBsdw2rlm68X24jVmsTSlwOnqvYlTld+jeFKVpUTW6LdaTTF6xlqhYMiqBb3ykYeLP7/tyIcJkZJvZIGAoBZQ==",
       "requires": {
-        "@storybook/components": "3.4.1",
+        "@storybook/components": "3.4.3",
         "@storybook/mantra-core": "1.7.2",
         "@storybook/podda": "1.2.3",
         "@storybook/react-komposer": "2.0.4",
@@ -1437,7 +1450,7 @@
         "qs": "6.5.1",
         "react-fuzzy": "0.5.2",
         "react-icons": "2.2.7",
-        "react-modal": "3.3.2",
+        "react-modal": "3.4.4",
         "react-split-pane": "0.1.77",
         "react-treebeard": "2.1.0"
       },
@@ -1519,7 +1532,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.10.tgz",
       "integrity": "sha512-NGqrP0qhgn8hlFMO3I1w7vwT8KIcdEg1D1AFtYaNBhp1Uo4SZgUpNcbOBfrvgAPRr1nn+Ail/0VoPLI2n4SNMw==",
       "requires": {
-        "csstype": "2.2.0"
+        "csstype": "2.4.1"
       }
     },
     "@types/react-addons-test-utils": {
@@ -1581,35 +1594,35 @@
       "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-5.7.1.tgz",
       "integrity": "sha512-UwfDU6A0bj/QAdTsO20g9mrKXo3zxvumkBWx0F0sEHn1DF/IQDiq4zYVBjRZ3NikQe2o7koWe3Gb0NR84Qr2Sg==",
       "requires": {
-        "@uifabric/styling": "5.23.1",
+        "@uifabric/styling": "5.27.0",
         "tslib": "1.9.0"
       }
     },
     "@uifabric/merge-styles": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.15.1.tgz",
-      "integrity": "sha512-Uk9+80TEXlAYOE3eqRUPMnGYG8XMLYOpv3lSPcBK3suS7nBFWJdwpQlbuCMyCGVlxKPhHGOAaUU6bKgRs02+Gw==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.17.0.tgz",
+      "integrity": "sha512-xA4sbfKgOAx42gD56/ch8hWI6b7Gp70JM0kMnTIyF0oPWd12Lkvm5IVy1QZWxPE9YENIj5fn/mFWV2qkWKnJxQ==",
       "requires": {
         "tslib": "1.9.0"
       }
     },
     "@uifabric/styling": {
-      "version": "5.23.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.23.1.tgz",
-      "integrity": "sha512-u+DPLjz9YJIsxexqEogLcrHgvIvtz92sUKqlGHpVrcQdYuwD+wMmxdg/Bem671aXgGywfH5ypplXJ8+4Lix3qQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-5.27.0.tgz",
+      "integrity": "sha512-yGJD7jgEF7uvZjk9fExFJg8C9bfoGPa19QRDarA9KdPJ5cmalIh40VTn7d8BFukuuaV6loFSA18AVUjJ/yFhxg==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
-        "@uifabric/merge-styles": "5.15.1",
-        "@uifabric/utilities": "5.24.0",
+        "@microsoft/load-themed-styles": "1.7.54",
+        "@uifabric/merge-styles": "5.17.0",
+        "@uifabric/utilities": "5.29.0",
         "tslib": "1.9.0"
       }
     },
     "@uifabric/utilities": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.24.0.tgz",
-      "integrity": "sha512-SiAfpvncj68RrxvceBCGr1QtFXXVc7gtd2RBMkoLj3GTYSum5ZywMEcksa4BHyyY5haJYvQspkFiV9sIPDtX2w==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.29.0.tgz",
+      "integrity": "sha512-rhjtCzjI5mj4rleoMXh2aJm0oUSiIyN5mQOHOu1c80yqDtVq1dlb2zR2CRGvBufDpSiXpXjXydgSFhIRSq1ZoQ==",
       "requires": {
-        "@uifabric/merge-styles": "5.15.1",
+        "@uifabric/merge-styles": "5.17.0",
         "prop-types": "15.6.1",
         "tslib": "1.9.0"
       }
@@ -1999,9 +2012,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
     },
     "autolinker": {
       "version": "0.15.3",
@@ -2026,13 +2039,13 @@
       "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.5.0.tgz",
       "integrity": "sha512-qzgm9SEvodVkSi9QY7Me1/rujg+YBNMjayNSAyzNghwTEez++gXoPCwMvpbHRG7wrOkDCiF6dquvv9ESmUBAuw==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "enhanced-resolve": "3.3.0",
         "loader-utils": "1.1.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "micromatch": "3.1.10",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.5.4"
+        "source-map-support": "0.5.5"
       },
       "dependencies": {
         "arr-diff": {
@@ -2283,9 +2296,9 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "micromatch": {
           "version": "3.1.10",
@@ -2308,10 +2321,11 @@
           }
         },
         "source-map-support": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
-          "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
+          "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
           "requires": {
+            "buffer-from": "1.0.0",
             "source-map": "0.6.1"
           }
         },
@@ -2376,9 +2390,9 @@
       }
     },
     "babel-core": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.1",
@@ -2393,7 +2407,7 @@
         "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -2410,9 +2424,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "source-map": {
           "version": "0.5.7",
@@ -2431,7 +2445,7 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       },
@@ -2442,9 +2456,9 @@
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "source-map": {
           "version": "0.5.7",
@@ -2502,13 +2516,13 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -2604,13 +2618,13 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -2848,14 +2862,14 @@
       "integrity": "sha512-8lQ73p4BL+xcgba03NTiHrddl2X8J6PDMQHPpz73sesrRBf6JtAscQPLIjFWQR/abLokdv81HdshpjYGppOXgA==",
       "requires": {
         "babel-types": "6.26.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "react-docgen": "3.0.0-beta9"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -3016,13 +3030,13 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -3099,15 +3113,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -3419,7 +3433,7 @@
         "babel-plugin-transform-es2015-function-name": "6.24.1",
         "babel-plugin-transform-es2015-literals": "6.22.0",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
         "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
         "babel-plugin-transform-es2015-modules-umd": "6.24.1",
         "babel-plugin-transform-es2015-object-super": "6.24.1",
@@ -3454,7 +3468,7 @@
         "babel-plugin-transform-es2015-function-name": "6.24.1",
         "babel-plugin-transform-es2015-literals": "6.22.0",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
         "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
         "babel-plugin-transform-es2015-modules-umd": "6.24.1",
         "babel-plugin-transform-es2015-object-super": "6.24.1",
@@ -3576,19 +3590,19 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
         "core-js": "2.5.5",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -3617,13 +3631,13 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -3640,7 +3654,7 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "debug": {
@@ -3652,9 +3666,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -3665,14 +3679,14 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "to-fast-properties": "1.0.3"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -3747,9 +3761,9 @@
       }
     },
     "base64-js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "batch": {
       "version": "0.6.1",
@@ -3942,7 +3956,7 @@
         "create-hash": "1.2.0",
         "evp_bytestokey": "1.0.3",
         "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
@@ -4002,7 +4016,7 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
         "caniuse-lite": "1.0.30000830",
-        "electron-to-chromium": "1.3.42"
+        "electron-to-chromium": "1.3.44"
       }
     },
     "bser": {
@@ -4018,7 +4032,7 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.2.3",
+        "base64-js": "1.3.0",
         "ieee754": "1.1.11",
         "isarray": "1.0.0"
       }
@@ -4242,7 +4256,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
             "caniuse-db": "1.0.30000830",
-            "electron-to-chromium": "1.3.42"
+            "electron-to-chromium": "1.3.44"
           }
         }
       }
@@ -4285,9 +4299,9 @@
       }
     },
     "chalk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-      "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
@@ -4358,7 +4372,7 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
         "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "clap": {
@@ -4751,6 +4765,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         }
       }
     },
@@ -4926,7 +4945,7 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "resolve": "1.7.1",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "shell-quote": "1.6.1",
         "subarg": "1.0.0"
       }
@@ -4948,7 +4967,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "md5.js": "1.3.4",
-        "ripemd160": "2.0.1",
+        "ripemd160": "2.0.2",
         "sha.js": "2.4.11"
       }
     },
@@ -4960,8 +4979,8 @@
         "cipher-base": "1.0.4",
         "create-hash": "1.2.0",
         "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
         "sha.js": "2.4.11"
       }
     },
@@ -5015,7 +5034,7 @@
         "create-hmac": "1.1.7",
         "diffie-hellman": "5.0.3",
         "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
+        "pbkdf2": "3.0.16",
         "public-encrypt": "4.0.2",
         "randombytes": "2.0.6",
         "randomfill": "1.0.4"
@@ -5287,7 +5306,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
             "caniuse-db": "1.0.30000830",
-            "electron-to-chromium": "1.3.42"
+            "electron-to-chromium": "1.3.44"
           }
         },
         "chalk": {
@@ -5370,9 +5389,9 @@
       }
     },
     "csstype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.2.0.tgz",
-      "integrity": "sha512-5YHWQgAtzKIA8trr2AVg6Jq5Fs5eAR1UqKbRJjgQQevNx3IAhD3S9wajvqJdmO7bgIxy0MA5lFVPzJYjmMlNeQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.4.1.tgz",
+      "integrity": "sha512-JuXYT9dt8xtpc4mwHSOYnZtQS3TmYVhmZDyXbppTid29krM8Eyn5CmsZjIDTSvzunvutYOBwQmnziR5vgFkJGw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5415,7 +5434,7 @@
       "requires": {
         "abab": "1.0.4",
         "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.0"
+        "whatwg-url": "6.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -5432,9 +5451,9 @@
           }
         },
         "whatwg-url": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-          "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+          "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
           "requires": {
             "lodash.sortby": "4.7.0",
             "tr46": "1.0.1",
@@ -5725,7 +5744,7 @@
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
         "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "dns-txt": {
@@ -5865,14 +5884,14 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.8.tgz",
-      "integrity": "sha512-QIDZL54fyV8MDcAsO91BMH1ft2qGGaHIJsJIA/+t+7uvXol1dm413fPcUgUb4k8F/9457rx4/KFE4XfDifrQxQ=="
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
+      "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.42",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
-      "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk="
+      "version": "1.3.44",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.44.tgz",
+      "integrity": "sha1-72sVCmDVIwgjiMra2ICF7NL9RoQ="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -5952,7 +5971,7 @@
         "is-number-object": "1.0.3",
         "is-string": "1.0.4",
         "is-subset": "0.1.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "object-inspect": "1.5.0",
         "object-is": "1.0.1",
         "object.assign": "4.1.0",
@@ -5963,9 +5982,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -5975,7 +5994,7 @@
       "integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
       "requires": {
         "enzyme-adapter-utils": "1.3.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "object.assign": "4.1.0",
         "object.values": "1.0.4",
         "prop-types": "15.6.1",
@@ -5984,9 +6003,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -5995,15 +6014,15 @@
       "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
       "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
       "requires": {
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "object.assign": "4.1.0",
         "prop-types": "15.6.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -6258,9 +6277,9 @@
       }
     },
     "eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
     },
     "events": {
       "version": "1.1.1",
@@ -6281,7 +6300,7 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
         "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "exec-sh": {
@@ -6397,6 +6416,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         }
       }
     },
@@ -6636,9 +6660,9 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
     },
     "flow-parser": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.70.0.tgz",
-      "integrity": "sha512-gGdyVUZWswG5jcINrVDHd3RY4nJptBTAx9mR9thGsrGGmAUR7omgJXQSpR+fXrLtxSTAea3HpAZNU/yzRJc2Cg=="
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.71.0.tgz",
+      "integrity": "sha512-rXSvqSBLf8aRI6T3P99jMcUYvZoO1KZcKDkzGJmXvYdNAgRKu7sfGNtxEsn3cX4TgungBuJpX+K8aHRC9/B5MA=="
     },
     "flush-write-stream": {
       "version": "1.0.3",
@@ -6952,7 +6976,7 @@
             "lowercase-keys": "1.0.1",
             "p-cancelable": "0.3.0",
             "p-timeout": "1.2.1",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "timed-out": "4.0.1",
             "url-parse-lax": "1.0.0",
             "url-to-options": "1.0.1"
@@ -7061,17 +7085,17 @@
       }
     },
     "glamorous": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.12.3.tgz",
-      "integrity": "sha512-7p2IitkzbEx6oB0CO3EkSgyCgponfGrFKmyRSK6amV8gUBLne6Nw3RsASPpVw5zx/jsivYACTpWeixySpSbNNw==",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.12.4.tgz",
+      "integrity": "sha512-9XjKfMnVJlohSa6ZYrrOz/ZW1xu3JK6zjRTCTkLLJowlmEU7zt9uvIZeUHiYEkr8qDfhhSDDOYZrMiknz0r1Iw==",
       "requires": {
         "brcast": "3.0.1",
-        "csstype": "2.2.0",
+        "csstype": "2.4.1",
         "fast-memoize": "2.3.2",
         "html-tag-names": "1.1.2",
         "is-function": "1.0.1",
         "is-plain-object": "2.0.4",
-        "react-html-attributes": "1.4.1",
+        "react-html-attributes": "1.4.2",
         "svg-tag-names": "1.1.1"
       }
     },
@@ -7205,14 +7229,14 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "requires": {
         "glob": "7.1.2",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -7234,7 +7258,7 @@
         "p-cancelable": "0.4.1",
         "p-timeout": "2.0.1",
         "pify": "3.0.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "timed-out": "4.0.1",
         "url-parse-lax": "3.0.0",
         "url-to-options": "1.0.1"
@@ -7262,13 +7286,13 @@
       "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -7443,7 +7467,7 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
         "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -7599,13 +7623,13 @@
         "he": "1.1.1",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.21"
+        "uglify-js": "3.3.22"
       },
       "dependencies": {
         "uglify-js": {
-          "version": "3.3.21",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.21.tgz",
-          "integrity": "sha512-uy82472lH8tshK3jS3c5IFb5MmNKd/5qyBd0ih8sM42L3jWvxnE339U9gZU1zufnLVs98Stib9twq8dLm2XYCA==",
+          "version": "3.3.22",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.22.tgz",
+          "integrity": "sha512-tqw96rL6/BG+7LM5VItdhDjTQmL5zG/I0b2RqWytlgeHe2eydZHuBHdA9vuGpCDhH/ZskNGcqDhivoR2xt8RIw==",
           "requires": {
             "commander": "2.15.1",
             "source-map": "0.6.1"
@@ -7626,7 +7650,7 @@
         "bluebird": "3.5.1",
         "html-minifier": "3.5.15",
         "loader-utils": "0.2.17",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "pretty-error": "2.1.1",
         "toposort": "1.0.6"
       },
@@ -7643,9 +7667,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -7684,16 +7708,17 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
-      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA=="
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
+      "integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08="
     },
     "http-proxy": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
-        "eventemitter3": "1.2.0",
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.4.1",
         "requires-port": "1.0.0"
       }
     },
@@ -7702,9 +7727,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "requires": {
-        "http-proxy": "1.16.2",
+        "http-proxy": "1.17.0",
         "is-glob": "4.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "micromatch": "3.1.10"
       },
       "dependencies": {
@@ -7958,9 +7983,9 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "micromatch": {
           "version": "3.1.10",
@@ -8771,7 +8796,7 @@
           "integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
           "requires": {
             "ansi-escapes": "3.1.0",
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
             "is-ci": "1.1.0",
@@ -8844,7 +8869,7 @@
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
       "integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "glob": "7.1.2",
         "jest-environment-jsdom": "21.2.1",
         "jest-environment-node": "21.2.1",
@@ -8862,7 +8887,7 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
       "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "diff": "3.5.0",
         "jest-get-type": "21.2.0",
         "pretty-format": "21.2.1"
@@ -8915,7 +8940,7 @@
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
       "integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "expect": "21.2.1",
         "graceful-fs": "4.1.11",
         "jest-diff": "21.2.1",
@@ -8930,7 +8955,7 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
       "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "jest-get-type": "21.2.0",
         "pretty-format": "21.2.1"
       }
@@ -8940,7 +8965,7 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
       "integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "micromatch": "2.3.11",
         "slash": "1.0.0"
       }
@@ -8961,7 +8986,7 @@
       "integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
       "requires": {
         "browser-resolve": "1.11.2",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "is-builtin-module": "1.0.0"
       }
     },
@@ -8995,10 +9020,10 @@
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
       "integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-jest": "21.2.0",
         "babel-plugin-istanbul": "4.1.6",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "convert-source-map": "1.5.1",
         "graceful-fs": "4.1.11",
         "jest-config": "21.2.1",
@@ -9041,7 +9066,7 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
       "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "jest-diff": "21.2.1",
         "jest-matcher-utils": "21.2.1",
         "mkdirp": "0.5.1",
@@ -9055,7 +9080,7 @@
       "integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
       "requires": {
         "callsites": "2.0.0",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "graceful-fs": "4.1.11",
         "jest-message-util": "21.2.1",
         "jest-mock": "21.2.0",
@@ -9068,7 +9093,7 @@
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "jest-get-type": "21.2.0",
         "leven": "2.1.0",
         "pretty-format": "21.2.1"
@@ -9119,9 +9144,9 @@
         "babel-preset-es2015": "6.24.1",
         "babel-preset-stage-1": "6.24.1",
         "babel-register": "6.26.0",
-        "babylon": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.46",
         "colors": "1.1.2",
-        "flow-parser": "0.70.0",
+        "flow-parser": "0.71.0",
         "lodash": "4.15.0",
         "micromatch": "2.3.11",
         "neo-async": "2.5.1",
@@ -9133,9 +9158,9 @@
       },
       "dependencies": {
         "babylon": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+          "version": "7.0.0-beta.46",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+          "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
         },
         "write-file-atomic": {
           "version": "1.3.4",
@@ -9585,9 +9610,9 @@
       "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
     },
     "lodash-es": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
-      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -9753,7 +9778,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "requires": {
-        "chalk": "2.4.0"
+        "chalk": "2.4.1"
       }
     },
     "log-update": {
@@ -9795,9 +9820,13 @@
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
     },
     "loglevelnext": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.4.tgz",
-      "integrity": "sha512-V3N6LAJAiGwa/zjtvmgs2tyeiCJ23bGNhxXN8R+v7k6TNlSlTz40mIyZYdmO762eBnEFymn0Mhha+WuAhnwMBg=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
+      "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
+      "requires": {
+        "es6-symbol": "3.1.1",
+        "object.assign": "4.1.0"
+      }
     },
     "lolex": {
       "version": "2.3.2",
@@ -9964,7 +9993,7 @@
       "requires": {
         "commondir": "1.0.1",
         "deep-extend": "0.4.2",
-        "ejs": "2.5.8",
+        "ejs": "2.5.9",
         "glob": "7.1.2",
         "globby": "6.1.0",
         "mkdirp": "0.5.1",
@@ -9975,9 +10004,9 @@
       },
       "dependencies": {
         "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
         },
         "clone-stats": {
           "version": "1.0.0",
@@ -9994,7 +10023,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "requires": {
-            "clone": "2.1.2",
+            "clone": "2.1.1",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
             "cloneable-readable": "1.1.2",
@@ -10521,9 +10550,9 @@
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
     },
     "nise": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
-      "integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
+      "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
@@ -10629,7 +10658,7 @@
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.1",
         "string_decoder": "1.1.1",
-        "timers-browserify": "2.0.7",
+        "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
@@ -10648,9 +10677,9 @@
       }
     },
     "node-sass": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.8.3.tgz",
-      "integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
       "requires": {
         "async-foreach": "0.1.3",
         "chalk": "1.1.3",
@@ -11082,15 +11111,15 @@
       "integrity": "sha1-KhZgU8ye+wlWUGPn/Td8yKywNBw="
     },
     "office-ui-fabric-react": {
-      "version": "5.82.1",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.82.1.tgz",
-      "integrity": "sha512-ChqMfWuUWir7Xlt4szC5ysOwJwz9Ja67+j3w4PsHz94YVZDyLRexuLw5ALvNDlhF0OtIlONNdte5lv74HDcpMg==",
+      "version": "5.91.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.91.0.tgz",
+      "integrity": "sha512-dpUwLm4sB8qH22gz6PfIEtafsNf1DlMHchTtSL8xxZEshIwu4e7/cXbX9bh407nKQaypDW7WMXclPLtTmfweOQ==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.7.50",
+        "@microsoft/load-themed-styles": "1.7.54",
         "@uifabric/icons": "5.7.1",
-        "@uifabric/merge-styles": "5.15.1",
-        "@uifabric/styling": "5.23.1",
-        "@uifabric/utilities": "5.24.0",
+        "@uifabric/merge-styles": "5.17.0",
+        "@uifabric/styling": "5.27.0",
+        "@uifabric/utilities": "5.29.0",
         "prop-types": "15.6.1",
         "tslib": "1.9.0"
       }
@@ -11425,7 +11454,7 @@
         "browserify-aes": "1.2.0",
         "create-hash": "1.2.0",
         "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "pbkdf2": "3.0.16"
       }
     },
     "parse-glob": {
@@ -11526,14 +11555,14 @@
       }
     },
     "pbkdf2": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+      "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "requires": {
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
         "sha.js": "2.4.11"
       }
     },
@@ -11608,7 +11637,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
       "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "source-map": "0.6.1",
         "supports-color": "5.4.0"
       }
@@ -12372,7 +12401,7 @@
         "caniuse-api": "1.6.1",
         "postcss": "5.2.18",
         "postcss-selector-parser": "2.2.3",
-        "vendors": "1.0.1"
+        "vendors": "1.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12386,7 +12415,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
             "caniuse-db": "1.0.30000830",
-            "electron-to-chromium": "1.3.42"
+            "electron-to-chromium": "1.3.44"
           }
         },
         "chalk": {
@@ -13663,7 +13692,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
@@ -13672,7 +13701,7 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
         "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
@@ -13798,7 +13827,7 @@
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "requires": {
             "ansi-escapes": "3.1.0",
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
             "external-editor": "2.2.0",
@@ -13822,9 +13851,9 @@
               }
             },
             "chalk": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-              "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+              "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "requires": {
                 "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
@@ -13978,9 +14007,9 @@
       }
     },
     "react-html-attributes": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.1.tgz",
-      "integrity": "sha1-l7XscQ2miDNZjIvm+JrENiFoQKU=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.2.tgz",
+      "integrity": "sha1-DSzPE0/Hmy01Q4N9wVkdMre5A/k=",
       "requires": {
         "html-element-attributes": "1.3.1"
       }
@@ -14012,13 +14041,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.3.2.tgz",
       "integrity": "sha512-ybEM7YOr4yBgFd6w8dJqwxegqZGJNBZl6U27HnGKuTZmDvVrD5quWOK/wAnMywiZzW+Qsk+l4X2c70+thp/A8Q=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz",
+      "integrity": "sha512-pbZOSMVVkvppW7XRn9fcHK5OgEDnYLwMva7P6TgS44/SN9uGGjfh3Z1c8tomO+y4IsHQ6Fsz2EGwmE7sMeNZgQ=="
+    },
     "react-modal": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.3.2.tgz",
-      "integrity": "sha512-DLrmPG9PyXWSNA2ve1LttnNRE9Umy3u3awFeK+72dLOksLM+EoTg8Z2h/i/DV3O8ZGvnEhacjAVXdZuRDGvaag==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.4.4.tgz",
+      "integrity": "sha512-5VYNvy301Z0xxGBQhPmDdzOcyEkUG8sU7bpRsAPI4OHgEUkbBFrpjzs/ocNI0m824/lOqTxddXzwgmDJXx3s3Q==",
       "requires": {
         "exenv": "1.2.2",
         "prop-types": "15.6.1",
+        "react-lifecycles-compat": "3.0.2",
         "warning": "3.0.0"
       }
     },
@@ -14102,7 +14137,7 @@
         "prop-types": "15.6.1",
         "radium": "0.19.6",
         "shallowequal": "0.2.2",
-        "velocity-react": "1.4.0"
+        "velocity-react": "1.4.1"
       }
     },
     "read-chunk": {
@@ -14111,7 +14146,7 @@
       "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
       "requires": {
         "pify": "3.0.0",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "read-pkg": {
@@ -14142,7 +14177,7 @@
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
@@ -14249,7 +14284,7 @@
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
         "lodash": "4.15.0",
-        "lodash-es": "4.17.8",
+        "lodash-es": "4.17.10",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
       },
@@ -14484,7 +14519,7 @@
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
         "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
@@ -14629,22 +14664,12 @@
       }
     },
     "ripemd160": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "2.0.2",
+        "hash-base": "3.0.4",
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "hash-base": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-          "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        }
       }
     },
     "rst-selector-parser": {
@@ -14699,9 +14724,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -15300,6 +15325,11 @@
             "ms": "0.7.1"
           }
         },
+        "eventemitter3": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+          "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+        },
         "form-data": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
@@ -15336,6 +15366,15 @@
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-proxy": {
+          "version": "1.16.2",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+          "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+          "requires": {
+            "eventemitter3": "1.2.0",
+            "requires-port": "1.0.0"
+          }
         },
         "http-signature": {
           "version": "1.1.1",
@@ -15415,9 +15454,9 @@
       }
     },
     "screener-storybook": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/screener-storybook/-/screener-storybook-0.12.5.tgz",
-      "integrity": "sha1-B+L579ZC+fs9K9B/PVJGGnoQnQw=",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/screener-storybook/-/screener-storybook-0.12.6.tgz",
+      "integrity": "sha1-T/IcIkErBdFbzvqc/Aryw5HFbNE=",
       "requires": {
         "bluebird": "3.4.7",
         "colors": "1.1.2",
@@ -15425,13 +15464,13 @@
         "get-port": "3.2.0",
         "joi": "10.0.6",
         "jsdom": "11.7.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "prop-types": "15.6.1",
         "react": "15.6.2",
         "react-dom": "15.4.2",
         "request": "2.81.0",
         "requestretry": "1.12.3",
-        "screener-runner": "0.9.1"
+        "screener-runner": "0.9.2"
       },
       "dependencies": {
         "acorn": {
@@ -15540,10 +15579,24 @@
             "ms": "0.7.1"
           }
         },
+        "eventemitter3": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+          "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+        },
         "har-schema": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
           "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+        },
+        "http-proxy": {
+          "version": "1.16.2",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+          "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+          "requires": {
+            "eventemitter3": "1.2.0",
+            "requires-port": "1.0.0"
+          }
         },
         "joi": {
           "version": "10.0.6",
@@ -15584,7 +15637,7 @@
             "webidl-conversions": "4.0.2",
             "whatwg-encoding": "1.0.3",
             "whatwg-mimetype": "2.1.0",
-            "whatwg-url": "6.4.0",
+            "whatwg-url": "6.4.1",
             "ws": "4.1.0",
             "xml-name-validator": "3.0.0"
           },
@@ -15611,7 +15664,7 @@
                 "oauth-sign": "0.8.2",
                 "performance-now": "2.1.0",
                 "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "stringstream": "0.0.5",
                 "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.6.0",
@@ -15621,9 +15674,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "ms": {
           "version": "0.7.1",
@@ -15700,7 +15753,7 @@
             "oauth-sign": "0.8.2",
             "performance-now": "0.2.0",
             "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
@@ -15770,9 +15823,9 @@
           }
         },
         "screener-runner": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.9.1.tgz",
-          "integrity": "sha1-+k9X6DbU0+zo8yld/9te49Cs4BM=",
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.9.2.tgz",
+          "integrity": "sha1-fSvgN3uQ3Qv6auc85RUA2F+NZUo=",
           "requires": {
             "bluebird": "3.4.7",
             "colors": "1.1.2",
@@ -15932,9 +15985,9 @@
           }
         },
         "whatwg-url": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-          "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+          "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
           "requires": {
             "lodash.sortby": "4.7.0",
             "tr46": "1.0.1",
@@ -16021,9 +16074,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
-      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+      "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
     },
     "serve-favicon": {
       "version": "2.5.0",
@@ -16041,6 +16094,11 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         }
       }
     },
@@ -16126,7 +16184,7 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "shallow-clone": {
@@ -16207,7 +16265,7 @@
         "diff": "3.5.0",
         "lodash.get": "4.4.2",
         "lolex": "2.3.2",
-        "nise": "1.3.2",
+        "nise": "1.3.3",
         "supports-color": "5.4.0",
         "type-detect": "4.0.8"
       }
@@ -16364,7 +16422,7 @@
         "faye-websocket": "0.11.1",
         "inherits": "2.0.3",
         "json3": "3.3.2",
-        "url-parse": "1.3.0"
+        "url-parse": "1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -16431,7 +16489,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "requires": {
-        "atob": "2.1.0",
+        "atob": "2.1.1",
         "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
@@ -16502,7 +16560,7 @@
         "debug": "2.6.9",
         "handle-thing": "1.2.5",
         "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "select-hose": "2.0.0",
         "spdy-transport": "2.1.0"
       },
@@ -16527,7 +16585,7 @@
         "hpack.js": "2.1.6",
         "obuf": "1.1.2",
         "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "wbuf": "1.7.3"
       },
       "dependencies": {
@@ -16570,7 +16628,7 @@
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
       "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "static-extend": {
@@ -16678,7 +16736,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "string-hash": {
@@ -17319,9 +17377,9 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "timers-browserify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.7.tgz",
-      "integrity": "sha512-U7DtjfsHeYjNAyEz4MdCLGZMY3ySyHIgZZp6ba9uxZlMRMiK5yTHUYc2XfGQHKFgxGcmvBF2jafoNtQYvlDpOw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "requires": {
         "setimmediate": "1.0.5"
       }
@@ -17483,15 +17541,15 @@
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-21.2.4.tgz",
       "integrity": "sha512-Plk49Us+DcncpQcC8fhYwDUdhW96QB0Dv02etOLhzq+2HAvXfrEUys3teZ/BeyQ+r1rHxfGdNj4dB0Q5msZR3g==",
       "requires": {
-        "babel-core": "6.26.0",
+        "babel-core": "6.26.3",
         "babel-plugin-istanbul": "4.1.6",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
         "babel-preset-jest": "21.2.0",
         "cpx": "1.5.0",
         "fs-extra": "4.0.3",
         "jest-config": "21.2.1",
         "pkg-dir": "2.0.0",
-        "source-map-support": "0.5.4",
+        "source-map-support": "0.5.5",
         "yargs": "10.1.2"
       },
       "dependencies": {
@@ -17501,9 +17559,9 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "cliui": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -17529,10 +17587,11 @@
           }
         },
         "source-map-support": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
-          "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
+          "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
           "requires": {
+            "buffer-from": "1.0.0",
             "source-map": "0.6.1"
           }
         },
@@ -17549,7 +17608,7 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
           "requires": {
-            "cliui": "4.0.0",
+            "cliui": "4.1.0",
             "decamelize": "1.2.0",
             "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
@@ -17578,7 +17637,7 @@
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-4.2.0.tgz",
       "integrity": "sha512-EvnwgbEUklPQK82OiZS0NDrG0ZoH91+zef8PFXSOZocSQ5jklQyvAM84Id20UxjVdXVIzMgFu+vlKCQomfq27A==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "enhanced-resolve": "4.0.0",
         "loader-utils": "1.1.0",
         "micromatch": "3.1.10",
@@ -17855,7 +17914,7 @@
       "requires": {
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "commander": "2.15.1",
         "diff": "3.5.0",
         "glob": "7.1.2",
@@ -17864,7 +17923,7 @@
         "resolve": "1.7.1",
         "semver": "5.5.0",
         "tslib": "1.9.0",
-        "tsutils": "2.26.1"
+        "tsutils": "2.26.2"
       }
     },
     "tslint-microsoft-contrib": {
@@ -17872,7 +17931,7 @@
       "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.3.tgz",
       "integrity": "sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==",
       "requires": {
-        "tsutils": "2.26.1"
+        "tsutils": "2.26.2"
       }
     },
     "tslint-react": {
@@ -17880,13 +17939,13 @@
       "resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.5.1.tgz",
       "integrity": "sha512-ndS/iOOGrasATcf5YU3JxoIwPGVykjrKhzmlVsRdT1xzl/RbNg9n627rtAGbCjkQepyiaQYgxWQT5G/qUpQCaA==",
       "requires": {
-        "tsutils": "2.26.1"
+        "tsutils": "2.26.2"
       }
     },
     "tsutils": {
-      "version": "2.26.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.1.tgz",
-      "integrity": "sha512-bnm9bcjOqOr1UljleL94wVCDlpa6KjfGaTkefeLch4GRafgDkROxPizbB/FxTEdI++5JqhxczRy/Qub0syNqZA==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
+      "integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
       "requires": {
         "tslib": "1.9.0"
       }
@@ -17901,7 +17960,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "type-check": {
@@ -17963,14 +18022,14 @@
       }
     },
     "uglifyjs-webpack-plugin": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.4.tgz",
-      "integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz",
+      "integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
       "requires": {
         "cacache": "10.0.4",
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.4.5",
-        "serialize-javascript": "1.4.0",
+        "serialize-javascript": "1.5.0",
         "source-map": "0.6.1",
         "uglify-es": "3.3.9",
         "webpack-sources": "1.1.0",
@@ -18115,9 +18174,9 @@
       "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
     },
     "upath": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-      "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
+      "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww=="
     },
     "upper-case": {
       "version": "1.1.3",
@@ -18186,18 +18245,18 @@
       }
     },
     "url-parse": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.3.0.tgz",
-      "integrity": "sha512-zPvPA3T7P6M+0iNsgX+iAcAz4GshKrowtQBHHc/28tVsBc8jK7VRCNX+2GEcoE6zDB6XqXhcyiUWPVZY6C70Cg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+      "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
       "requires": {
-        "querystringify": "1.0.0",
+        "querystringify": "2.0.0",
         "requires-port": "1.0.0"
       },
       "dependencies": {
         "querystringify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+          "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
         }
       }
     },
@@ -18301,27 +18360,27 @@
       "integrity": "sha512-VJ3csMz5zP1ifkbBlsNYpxnoWkPHfVRQ8tUongS78W5DxSGHB68pjYHDTgUYBkVM7P/HpYdVukgVUFcxjr1gGg=="
     },
     "velocity-react": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.4.0.tgz",
-      "integrity": "sha512-DUb+uCIjv9PboB0GprUxHE5oWij5sm40qRZmpRgZMcBBd0g3T97q/hHafxoTzM5g2ZI5GUA5kQF98oONOXxwiQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/velocity-react/-/velocity-react-1.4.1.tgz",
+      "integrity": "sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==",
       "requires": {
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "prop-types": "15.6.1",
         "react-transition-group": "2.3.1",
         "velocity-animate": "1.5.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
     "vendors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
-      "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
+      "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
     },
     "verror": {
       "version": "1.10.0",
@@ -18421,9 +18480,9 @@
       }
     },
     "watchpack": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
-      "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "requires": {
         "chokidar": "2.0.3",
         "graceful-fs": "4.1.11",
@@ -18491,7 +18550,7 @@
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.4"
+            "upath": "1.0.5"
           }
         },
         "debug": {
@@ -18784,7 +18843,7 @@
         "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.5.0",
+        "watchpack": "1.6.0",
         "webpack-sources": "1.1.0",
         "yargs": "8.0.2"
       },
@@ -19000,7 +19059,7 @@
             "babel-register": "6.26.0",
             "babylon": "6.18.0",
             "colors": "1.1.2",
-            "flow-parser": "0.70.0",
+            "flow-parser": "0.71.0",
             "lodash": "4.15.0",
             "micromatch": "2.3.11",
             "node-dir": "0.1.8",
@@ -19041,13 +19100,13 @@
       "requires": {
         "acorn": "5.5.3",
         "bfj-node4": "5.3.1",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "commander": "2.15.1",
-        "ejs": "2.5.8",
+        "ejs": "2.5.9",
         "express": "4.16.3",
         "filesize": "3.6.1",
         "gzip-size": "4.1.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "mkdirp": "0.5.1",
         "opener": "1.4.3",
         "ws": "4.1.0"
@@ -19068,18 +19127,18 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
     "webpack-cli": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.14.tgz",
-      "integrity": "sha512-gRoWaxSi2JWiYsn1QgOTb6ENwIeSvN1YExZ+kJ0STsTZK7bWPElW+BBBv1UnTbvcPC3v7E17mK8hlFX8DOYSGw==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.15.tgz",
+      "integrity": "sha512-bjNeIUO51D4OsmZ5ufzcpzVoacjxfWNfeBZKYL3jc+EMfCME3TyfdCPSUoKiOnebQChfupQuIRpAnx7L4l3Hew==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "cross-spawn": "6.0.5",
         "diff": "3.5.0",
         "enhanced-resolve": "4.0.0",
@@ -19093,7 +19152,7 @@
         "jscodeshift": "0.5.0",
         "listr": "0.13.0",
         "loader-utils": "1.1.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "log-symbols": "2.2.0",
         "mkdirp": "0.5.1",
         "p-each-series": "1.0.0",
@@ -19118,9 +19177,9 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "cliui": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -19145,12 +19204,12 @@
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "requires": {
             "ansi-escapes": "3.1.0",
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
             "external-editor": "2.2.0",
             "figures": "2.0.0",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
             "rxjs": "5.5.10",
@@ -19160,9 +19219,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -19177,7 +19236,7 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "requires": {
-            "cliui": "4.0.0",
+            "cliui": "4.1.0",
             "decamelize": "1.2.0",
             "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
@@ -19317,7 +19376,7 @@
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.4"
+            "upath": "1.0.5"
           }
         },
         "expand-brackets": {
@@ -19489,9 +19548,9 @@
           "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
           "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
           "requires": {
-            "http-proxy": "1.16.2",
+            "http-proxy": "1.17.0",
             "is-glob": "3.1.0",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "micromatch": "2.3.11"
           },
           "dependencies": {
@@ -19662,9 +19721,9 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "micromatch": {
           "version": "3.1.10",
@@ -19709,9 +19768,9 @@
       }
     },
     "webpack-hot-middleware": {
-      "version": "2.21.2",
-      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.21.2.tgz",
-      "integrity": "sha512-N5c80o31E0COFJV8HRjiX3hJetDOwQ2Ajt5TTORKA9diOimhFtmaZKSfO3pQKMeQngb7I4TUnNDroJiUzPFhKQ==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.22.1.tgz",
+      "integrity": "sha512-wbjnvcc3HOPKRE/L0KmTv2MrByfLFOJlVFNKo5Svxy+1plR/bMIMYQDgB4pUOzJXhiBLU7Clp6P1SSzS89iKxA==",
       "requires": {
         "ansi-html": "0.0.7",
         "html-entities": "1.2.1",
@@ -19724,9 +19783,9 @@
       "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
       "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "log-symbols": "2.2.0",
-        "loglevelnext": "1.0.4",
+        "loglevelnext": "1.0.5",
         "uuid": "3.2.1"
       }
     },
@@ -19754,7 +19813,7 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": "0.4.11",
+        "http-parser-js": "0.4.12",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -19968,7 +20027,7 @@
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "requires": {
         "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "xml-name-validator": {
@@ -20141,7 +20200,7 @@
       "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
       "integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
       "requires": {
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "debug": "3.1.0",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
@@ -20149,7 +20208,7 @@
         "grouped-queue": "0.3.3",
         "inquirer": "3.3.0",
         "is-scoped": "1.0.0",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "log-symbols": "2.2.0",
         "mem-fs": "1.1.3",
         "text-table": "0.2.0",
@@ -20172,12 +20231,12 @@
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "requires": {
             "ansi-escapes": "3.1.0",
-            "chalk": "2.4.0",
+            "chalk": "2.4.1",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
             "external-editor": "2.2.0",
             "figures": "2.0.0",
-            "lodash": "4.17.5",
+            "lodash": "4.17.10",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
             "rx-lite": "4.0.8",
@@ -20188,9 +20247,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -20208,7 +20267,7 @@
       "integrity": "sha512-Sgvz3MAkOpEIobcpW3rjEl6bOTNnl8SkibP9z7hYKfIGIlw0QDC2k0MAeXvyE2pLqc2M0Duql+6R7/W9GrJojg==",
       "requires": {
         "async": "2.6.0",
-        "chalk": "2.4.0",
+        "chalk": "2.4.1",
         "cli-table": "0.3.1",
         "cross-spawn": "5.1.0",
         "dargs": "5.1.0",
@@ -20219,7 +20278,7 @@
         "find-up": "2.1.0",
         "github-username": "4.1.0",
         "istextorbinary": "2.2.1",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "make-dir": "1.2.0",
         "mem-fs-editor": "3.0.2",
         "minimist": "1.2.0",
@@ -20246,9 +20305,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "parse-json": {
           "version": "4.0.0",

--- a/rush.json
+++ b/rush.json
@@ -105,6 +105,11 @@
       "shouldPublish": false
     },
     {
+      "packageName": "test-bundles",
+      "projectFolder": "apps/test-bundles",
+      "shouldPublish": false
+    },
+    {
       "packageName": "office-ui-fabric-react-tslint",
       "projectFolder": "packages/office-ui-fabric-react-tslint",
       "shouldPublish": false

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -49,8 +49,224 @@
   },
   "bundlesize": [
     {
-      "path": "../apps/test-bundle-button/dist/test-bundle-button.min.js",
-      "maxSize": "47.6 kB"
+      "path": "../apps/test-bundles/dist/ActivityItem.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Breadcrumb.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Button.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Calendar.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Callout.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Check.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Checkbox.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/ChoiceGroup.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/ColorPicker.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/ComboBox.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/CommandBar.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/ContextualMenu.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/DatePicker.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/DetailsList.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Dialog.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/DocumentCard.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Dropdown.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Fabric.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Facepile.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/FocusTrapZone.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/FocusZone.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/GroupedList.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/HoverCard.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Icon.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Image.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Label.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Layer.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Link.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/List.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/MessageBar.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/MarqueeSelection.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Nav.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/OverflowSet.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Overlay.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Panel.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Pickers.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Persona.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/PersonaCoin.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Pivot.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/ProgressIndicator.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Rating.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/ResizeGroup.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/ScrollablePane.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/SearchBox.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Slider.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/SpinButton.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Spinner.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Sticky.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Styling.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/SwatchColorPicker.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/TeachingBubble.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/TextField.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Toggle.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Tooltip.min.js",
+      "maxSize": "30.0 kB"
+    },
+    {
+      "path": "../apps/test-bundles/dist/Utilities.min.js",
+      "maxSize": "30.0 kB"
     }
   ]
 }

--- a/scripts/tasks/webpack.js
+++ b/scripts/tasks/webpack.js
@@ -78,5 +78,6 @@ function getFileSize(size) {
   } else {
     sizeString = (Math.round(1000 * size / 1024) / 1000) + ' KB'
   }
-  return chalk.cyan(sizeString);
+  // return chalk.cyan(sizeString);
+  return size;
 }


### PR DESCRIPTION
This change adds bundle size locks not just for the button bundle, but each individual one.

This will help understand the impact of the changes and preemptively catch bad import problems which pull more content than they expected.

This will also help us understand the impact that tree shaking has!
