### PR TITLE
Cleanup unneeded refs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
   - '8'
 script:
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
-  - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "true" ]; then
-      npm run checkchange;
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$TRAVIS_PULL_REQUEST, BRANCH=$BRANCH"
+  - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST != "false" ];
+    then npm run checkchange;
     fi
   - npm run buildfast
   - npm run bundlesize

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - '8'
 script:
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$TRAVIS_PULL_REQUEST, BRANCH=$BRANCH"
   - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST != "false" ];
     then npm run checkchange;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '8'
 script:
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
   - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "true" ]; then
       npm run checkchange;
     fi

--- a/apps/fabric-website/src/pages/Components/ActivityItemComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ActivityItemComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ActivityItemComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='ActivityItem' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/BreadcrumbComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/BreadcrumbComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class BreadcrumbComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Breadcrumb' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ButtonComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ButtonComponentPage.tsx
@@ -8,7 +8,7 @@ export class ButtonComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
 
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Button' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/CalendarComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/CalendarComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class CalendarComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Calendar' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/CalloutComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/CalloutComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class CalloutComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Callout' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/CheckboxComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/CheckboxComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class CheckboxComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Checkbox' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ChoiceGroupComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ChoiceGroupComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ChoiceGroupComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='ChoiceGroup' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/CoachmarkComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/CoachmarkComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class CoachmarkComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Coachmark' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ColorPickerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ColorPickerComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ColorPickerComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='ColorPicker' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ComboBoxComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ComboBoxComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ComboBoxComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='ComboBox' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/CommandBarComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/CommandBarComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class CommandBarComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='CommandBar' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ComponentUtilitiesPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ComponentUtilitiesPage.tsx
@@ -6,7 +6,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ComponentUtilitiesPage extends React.Component<IComponentPageProps, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Utilities' backgroundColor='#038387' />
           <h2 className='ComponentPage-subHeading'>Overview</h2>

--- a/apps/fabric-website/src/pages/Components/ContextualMenuComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ContextualMenuComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ContextualMenuComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='ContextualMenu' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/DatePickerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DatePickerComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class DatePickerComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='DatePicker' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/DetailsListComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DetailsListComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class DetailsListComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='DetailsList' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/DialogComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DialogComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class DialogComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Dialog' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/DocumentCardComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DocumentCardComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class DocumentCardComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='DocumentCard' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/DropdownComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DropdownComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class DropdownComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Dropdown' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/FacepileComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/FacepileComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class FacepileComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Facepile' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/FocusTrapZoneUtilityPage.tsx
+++ b/apps/fabric-website/src/pages/Components/FocusTrapZoneUtilityPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class FocusTrapZoneUtilityPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='FocusTrapZone' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/FocusZoneUtilityPage.tsx
+++ b/apps/fabric-website/src/pages/Components/FocusZoneUtilityPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class FocusZoneUtilityPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='FocusZone' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/GroupedListComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/GroupedListComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class GroupedListComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='GroupedList' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/HoverCardComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/HoverCardComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class HoverCardComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='HoverCard' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/IconComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/IconComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class IconComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Icon' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ImageComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ImageComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ImageComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Image' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/LabelComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/LabelComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class LabelComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Label' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/LayerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/LayerComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class LayerComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Layer' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/LinkComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/LinkComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class LinkComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Link' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ListComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ListComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ListComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='List' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/MarqueeSelectionUtilityPage.tsx
+++ b/apps/fabric-website/src/pages/Components/MarqueeSelectionUtilityPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class MarqueeSelectionUtilityPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='MarqueeSelection' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/MessageBarComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/MessageBarComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class MessageBarComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='MessageBar' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ModalComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ModalComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ModalComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Modal' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/NavComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/NavComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class NavComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Nav' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/OverflowSetComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/OverflowSetComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class OverflowSetComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='OverflowSet' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/OverlayComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/OverlayComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class OverlayComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Overlay' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/PanelComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PanelComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class PanelComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Panel' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/PeoplePickerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PeoplePickerComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class PeoplePickerComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='PeoplePicker' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/PersonaComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PersonaComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class PersonaComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Persona' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/PickersComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PickersComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class PickersComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Pickers' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/PivotComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/PivotComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class PivotComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Pivot' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ProgressIndicatorComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ProgressIndicatorComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ProgressIndicatorComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='ProgressIndicator' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/RatingComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/RatingComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class RatingComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Rating' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ResizeGroupComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ResizeGroupComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ResizeGroupComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='ResizeGroupPage' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ScrollablePaneComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ScrollablePaneComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ScrollablePaneComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='ScrollablePane' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/SearchBoxComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SearchBoxComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class SearchBoxComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='SearchBox' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/SelectionUtilityPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SelectionUtilityPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class SelectionUtilityPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Selection' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/SliderComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SliderComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class SliderComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Slider' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/SpinButtonComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SpinButtonComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class SpinButtonComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='SpinButton' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/SpinnerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SpinnerComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class SpinnerComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Spinner' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/SwatchColorPickerComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/SwatchColorPickerComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class SwatchColorPickerComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='SwatchColorPicker' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/TeachingBubbleComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/TeachingBubbleComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class TeachingBubbleComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='TeachingBubble' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/TextFieldComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/TextFieldComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class TextFieldComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='TextField' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ThemesUtilityPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ThemesUtilityPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ThemesUtilityPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Themes' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/ToggleComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ToggleComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class ToggleComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Toggle' backgroundColor='#038387'
             links={

--- a/apps/fabric-website/src/pages/Components/TooltipComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/TooltipComponentPage.tsx
@@ -7,7 +7,7 @@ const pageStyles: any = require('../PageStyles.module.scss');
 export class TooltipComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div ref='pageElement' className={ pageStyles.basePage }>
+      <div className={ pageStyles.basePage }>
         <ComponentPage>
           <PageHeader pageTitle='Tooltip' backgroundColor='#038387'
             links={

--- a/common/changes/@uifabric/fabric-website/cleanup-refs_2018-04-29-18-29.json
+++ b/common/changes/@uifabric/fabric-website/cleanup-refs_2018-04-29-18-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Removing unused refs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "dzearing@microsoft.com"
+}

--- a/ghdocs/BestPractices/ComponentDesign.md
+++ b/ghdocs/BestPractices/ComponentDesign.md
@@ -173,21 +173,7 @@ public render() {
 }
 ```
 
-Acceptable:
-```typescript
-private _root: HTMLElement;
-private _resolveRoot: (element: HTMLElement) => any;
-
-constructor() {
-  this._resolveRoot = (el: HTMLElement) => this._root = el;
-}
-
-public render() {
-  return <div ref={ this._resolveRoot } />
-}
-```
-
-Best, use createRef:
+Good:
 
 The `createRef` function in `lib/Utilities` is a polyfill for [React.createRef](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs). (When Fabric switches over to React 16, we'll use React.createRef instead)
 


### PR DESCRIPTION
This removes all of the string refs that I spotted. 

Note, I found that the "checkchange" task was not running because the travis.yml was using a `$TRAVIS_PULL_REQUEST == "true"` condition. The environment variable seems to have been changed from just being "true" to being the actual PR number, or false if not a PR. Changed the condition, builds should now once again fail if the PR does not include a change file.
