### PR TITLE
Breaking Change: Mark ISelection#getSelectedIndices as non-optional

### DIFF
--- a/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
@@ -27,7 +27,7 @@ export interface ISelection {
   // Read selection methods.
 
   getSelection(): IObjectWithKey[];
-  getSelectedIndices?(): number[]; // TODO make non-optional on next breaking change
+  getSelectedIndices(): number[]; // TODO make non-optional on next breaking change
   getSelectedCount(): number;
   isRangeSelected(fromIndex: number, count: number): boolean;
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
@@ -27,7 +27,7 @@ export interface ISelection {
   // Read selection methods.
 
   getSelection(): IObjectWithKey[];
-  getSelectedIndices(): number[]; // TODO make non-optional on next breaking change
+  getSelectedIndices(): number[];
   getSelectedCount(): number;
   isRangeSelected(fromIndex: number, count: number): boolean;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4558
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Attempts to address _part of_ the above linked [Issue](https://github.com/OfficeDev/office-ui-fabric-react/issues/4558). There's a comment to make `ISelection#getSelectedIndices` non-optional next breaking-change, which I've done in this PR. This seems like it should go into `6.0` then as that's the next breaking-change semver.

I'm not convinced this fixes the original issue nor that it exists... the complaint from TS compiler there seems to be that the function can return `null`. But looking at the _only_ implementation of this function it always returns an array:

https://github.com/OfficeDev/office-ui-fabric-react/blob/1b37f96dd2d0ba2a86e0d963242671ead9ed082b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts#L203

**Note:** I haven't seen the TS compiler complain myself which makes sense given the above code.

This should probably be incorporated into a `major` release if we merge since it could break those that implement `ISelection`. The only other occurrence in lib code is guarded against the function being `undefined` is here:

https://github.com/OfficeDev/office-ui-fabric-react/blob/1b37f96dd2d0ba2a86e0d963242671ead9ed082b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx#L245

If we still want this, should I target a different branch for merge, haven't been involved in a major release yet cc: @dzearing or whomever for guidance.

#### Focus areas to test

1. Ensure that the lib still compiles (it should) via TS
1. Ensure that the implementer of `ISelection`, `MarqueeSelection` still works as expected via the examples page when running locally.
1. Check that I didn't miss any other references to `ISelection#getSelectedIndices`

**Side-note:** `MarqueeSelection` is pretty rad 😄 