### PR TITLE
Refactor String.prototype.includes in favor of String.prototype.indexOf for IE compatibility

### DIFF
--- a/common/changes/@uifabric/example-app-base/keco-ie-string-includes_2018-04-30-21-50.json
+++ b/common/changes/@uifabric/example-app-base/keco-ie-string-includes_2018-04-30-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Refactors String.prototype.includes usage in favor of  String.prototype.indexOf for IE compat.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "keco@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -369,9 +369,9 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
     if (this.props.componentUrl) {
       mdUrl = `${this.props.componentUrl}/docs/${componentName}${section}.md`;
       // Replace /tree/ or /blob/ with /edit/ to get straight to GitHub editor.
-      if (mdUrl!.includes('/tree/')) {
+      if (mdUrl!.indexOf('/tree/') !== -1) {
         mdUrl = mdUrl!.replace('/tree/', '/edit/');
-      } else if (mdUrl!.includes('/blob/')) {
+      } else if (mdUrl!.indexOf('/blob/') !== -1) {
         mdUrl = mdUrl!.replace('/blob/', '/edit/');
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4712
- [x] Include a change request file using `$ npm run change`

#### Description of changes

I ran into this going back to look at a bug with IE & ContextualMenu component.

In local development mode the example pages using `ComponentPage` break in IE11 (and below) due to our usage of [String.prototype.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes) which IE doesn't support ([caniuse](https://caniuse.com/#feat=es6-string-includes)). This fix refactors those calls to the IE compatible [String.prototype.indexOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf).

#### Focus areas to test

1. Pull down this PR and run `npm run _rushBuild`
1. Once linked, run `npm start` to run the local dev site
1. Navigate to a component page such as http://localhost:4322/#/examples/contextmenu in IE11
1. Note that the console no longer has a script error re: `String.prototype.includes`. Compare with `master`

#### Forward Thinking

Have we considered [polyfilling](https://www.npmjs.com/package/string.prototype.includes) methods like this or guarding against them in some way as part of CI or transpilation? Otherwise it will be tricky to catch them manually, some will undoubtedly slip thru cc: @dzearing 

I think we also have an instance of `Array.prototype.includes` & IE compat issues in DateMath.ts:

https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts#L191