### PR TITLE
Addressing Issue #4685 - TextField error message flickering using onGetErrorMessage

### DIFF
--- a/common/changes/office-ui-fabric-react/textfield-errorfix-4685_2018-05-01-19-20.json
+++ b/common/changes/office-ui-fabric-react/textfield-errorfix-4685_2018-05-01-19-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "In the TextField component, The code setting the 'errorMessage' state to an empty string in the _onInputChange member function was removed do to causing the message to flicker.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -406,8 +406,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     this._latestValue = value;
 
     this.setState({
-      value: value,
-      errorMessage: ''
+      value: value
     } as ITextFieldState,
       () => {
         this._adjustInputHeight();


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4685 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In the TextField component, The code setting the 'errorMessage' state to an empty string in the _onInputChange member function was removed due to causing the message to flicker.

![ezgif-5-1876562c92](https://user-images.githubusercontent.com/3977969/39490304-4e5a638e-4d3d-11e8-82a9-4112f8a9d08b.gif)
