### PR TITLE
Textfield number

### DIFF
--- a/common/changes/office-ui-fabric-react/textfield-number_2018-05-01-21-24.json
+++ b/common/changes/office-ui-fabric-react/textfield-number_2018-05-01-21-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField can now render the numeric value 0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -132,6 +132,32 @@ describe('TextField', () => {
     expect(inputDOM.disabled).toEqual(true);
   });
 
+  it('should render a value of 0 when given the number 0', () => {
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <TextField
+        value={ 0 as any }
+      />
+    );
+
+    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+
+    // Assert on the input element.
+    expect(inputDOM.value).toEqual('0');
+  });
+
+  it('should render a default value of 0 when given the number 0', () => {
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <TextField
+        defaultValue={ 0 as any }
+      />
+    );
+
+    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+
+    // Assert on the input element.
+    expect(inputDOM.defaultValue).toEqual('0');
+  });
+
   describe('error message', () => {
     const errorMessage = 'The string is too long, should not exceed 3 characters.';
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -74,7 +74,13 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     this._id = getId('TextField');
     this._descriptionId = getId('TextFieldDescription');
 
-    this._latestValue = props.value || props.defaultValue || '';
+    if (props.value !== undefined) {
+      this._latestValue = props.value;
+    } else if (props.defaultValue !== undefined) {
+      this._latestValue = props.defaultValue;
+    } else {
+      this._latestValue = '';
+    }
 
     this.state = {
       value: this._latestValue,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4019 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The TextField component explicitly checks that props.value and props.defaultValue are undefined rather than falsy. This allows TextField to render a value or defaultValue of the number 0.

#### Focus areas to test

(optional)
