### PR TITLE
CommandBarButton: High contrast hover states

### DIFF
--- a/common/changes/office-ui-fabric-react/commandBar-hc-hover_2018-05-02-17-29.json
+++ b/common/changes/office-ui-fabric-react/commandBar-hc-hover_2018-05-02-17-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBarButton: High contrast hover state.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/experiments/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -117,6 +117,9 @@ exports[`CommandBar renders commands correctly 1`] = `
                   background-color: #eaeaea;
                   color: #212121;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
                 &:active {
                   background-color: #dadada;
                   color: #000000;
@@ -228,6 +231,9 @@ exports[`CommandBar renders commands correctly 1`] = `
                 &:hover {
                   background-color: #eaeaea;
                   color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
                 }
                 &:active {
                   background-color: #dadada;

--- a/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
@@ -47,7 +47,12 @@ export const getStyles = memoizeFunction((
 
     rootHovered: {
       backgroundColor: theme.palette.neutralLight,
-      color: theme.palette.neutralDark
+      color: theme.palette.neutralDark,
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'Highlight'
+        }
+      }
     },
 
     rootPressed: {

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -176,6 +176,9 @@ exports[`Button renders CommandBarButton correctly 1`] = `
         background-color: #eaeaea;
         color: #212121;
       }
+      @media screen and (-ms-high-contrast: active){&:hover {
+        color: Highlight;
+      }
       &:active {
         background-color: #dadada;
         color: #000000;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -119,6 +119,9 @@ exports[`CommandBar renders commands correctly 1`] = `
                   background-color: #eaeaea;
                   color: #212121;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
                 &:active {
                   background-color: #dadada;
                   color: #000000;
@@ -233,6 +236,9 @@ exports[`CommandBar renders commands correctly 1`] = `
                 &:hover {
                   background-color: #eaeaea;
                   color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
                 }
                 &:active {
                   background-color: #dadada;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Ported this over to be merged into new_6.0 instead of master from here:
https://github.com/OfficeDev/office-ui-fabric-react/pull/4728

New is hovered on, Upload is a link (that's why it's green):
![image](https://user-images.githubusercontent.com/16619843/39539271-09f6a038-4df4-11e8-928b-ae51d71c3451.png)


#### Focus areas to test

(optional)
