### PR TITLE
Prevent TooltipHost from mutating calloutProps property.

### DIFF
--- a/common/changes/office-ui-fabric-react/jagore-fix-tooltip-mutation_2018-05-02-18-04.json
+++ b/common/changes/office-ui-fabric-react/jagore-fix-tooltip-mutation_2018-05-02-18-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix TooltipHost mutation of calloutProps.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.test.tsx
@@ -79,4 +79,37 @@ describe('TooltipHost', () => {
       expect(tooltip.prop(key)).toEqual(tooltipProps[key]);
     });
   });
+
+  it('does not mutate calloutProps', () => {
+    const calloutProps: ICalloutProps = {
+      isBeakVisible: false,
+      beakWidth: 0,
+      gapSpace: 10,
+      setInitialFocus: false,
+      doNotLayer: true
+    };
+    const content = 'test content';
+    let onTooltipToggleCalled = false;
+
+    const calloutPropsBefore = assign({}, calloutProps);
+
+    const component = mount(
+      <TooltipHost
+        calloutProps={ calloutProps }
+        content={ content }
+        onTooltipToggle={
+          () => {
+            onTooltipToggleCalled = true;
+            return null;
+          }
+        }
+      />
+    );
+
+    // simulate mouse enter to trigger use of calloutProps
+    component.find('div').simulate('mouseenter');
+
+    expect(onTooltipToggleCalled).toEqual(true);
+    expect(calloutPropsBefore).toEqual(calloutProps);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -82,10 +82,11 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
             targetElement={ this._getTargetElement() }
             directionalHint={ directionalHint }
             directionalHintForRTL={ directionalHintForRTL }
-            calloutProps={ assign(calloutProps, {
-              onMouseEnter: this._onTooltipMouseEnter,
-              onMouseLeave: this._onTooltipMouseLeave
-            }) }
+            calloutProps={ assign({},
+              calloutProps, {
+                onMouseEnter: this._onTooltipMouseEnter,
+                onMouseLeave: this._onTooltipMouseLeave
+              }) }
             onMouseEnter={ this._onTooltipMouseEnter }
             onMouseLeave={ this._onTooltipMouseLeave }
             { ...getNativeProps(this.props, divProperties) }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4715 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix object mutation in TooltipHost.

#### Focus areas to test

N/A
