### PR TITLE
Add functions to ContextualMenuItem to open and close menus on command

### DIFF
--- a/common/changes/office-ui-fabric-react/keyou-contextual-menu-item-functions_2018-05-02-18-14.json
+++ b/common/changes/office-ui-fabric-react/keyou-contextual-menu-item-functions_2018-05-02-18-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add ContextualMenuItem functions to open and close menus",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { Promise } from 'es6-promise';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import {
-  KeyCodes
+  KeyCodes,
+  createRef
 } from '../../Utilities';
 import { FocusZoneDirection } from '../../FocusZone';
 
 import { ContextualMenu, canAnyMenuItemsCheck } from './ContextualMenu';
 import { IContextualMenuItem, ContextualMenuItemType } from './ContextualMenu.types';
+import { IContextualMenuRenderItem } from './ContextualMenuItem.types';
 import { LayerBase as Layer } from '../Layer/Layer.base';
 
 describe('ContextualMenu', () => {
@@ -821,6 +823,63 @@ describe('ContextualMenu', () => {
         }];
 
       expect(canAnyMenuItemsCheck(items)).toEqual(true);
+    });
+  });
+
+  describe('IContextualMenuRenderItem function tests', () => {
+    const contextualItem = createRef<IContextualMenuRenderItem>();
+    let menuDismissed: boolean;
+    const onDismiss = (ev?: any, dismissAll?: boolean) => { menuDismissed = true; };
+
+    beforeEach(() => {
+      menuDismissed = false;
+      const menu: IContextualMenuItem[] = [
+        {
+          name: 'Test1',
+          key: 'Test1',
+          renderItemComponentRef: contextualItem,
+          subMenuProps: {
+            items: [
+              {
+                name: 'Test2',
+                key: 'Test2',
+                className: 'SubMenuClass'
+              },
+              {
+                name: 'Test3',
+                key: 'Test3',
+                className: 'SubMenuClass'
+              }
+            ],
+          }
+        }
+      ];
+
+      ReactTestUtils.renderIntoDocument<ContextualMenu>(
+        <ContextualMenu
+          onDismiss={ onDismiss }
+          items={ menu }
+        />
+      );
+    });
+
+    it('openSubMenu will open the item`s submenu if present', () => {
+      contextualItem.value!.openSubMenu();
+      expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
+    });
+
+    it('dismissSubMenu will close the item`s submenu if present', () => {
+      // Open the submenu with a click
+      const menuItem = document.querySelector('button.ms-ContextualMenu-link') as HTMLButtonElement;
+      ReactTestUtils.Simulate.click(menuItem);
+      expect(document.querySelector('.SubMenuClass')).not.toEqual(null);
+      contextualItem.value!.dismissSubMenu();
+      expect(document.querySelector('.SubMenuClass')).toEqual(null);
+    });
+
+    it('dismissMenu will close the item`s menu', () => {
+      contextualItem.value!.dismissMenu();
+      expect(menuDismissed).toEqual(true);
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -24,7 +24,8 @@ import {
   getFirstFocusable,
   getLastFocusable,
   css,
-  shouldWrapFocus
+  shouldWrapFocus,
+  createRef
 } from '../../Utilities';
 import { hasSubmenu, getIsChecked, isItemDisabled } from '../../utilities/contextualMenu/index';
 import { withResponsiveMode, ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
@@ -499,6 +500,10 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     const itemHasSubmenu = hasSubmenu(item);
     const nativeProps = getNativeProps(item, anchorProperties);
     const disabled = isItemDisabled(item);
+    const anchorRef = createRef<HTMLAnchorElement>();
+    const openSubMenu = this._onItemSubMenuExpand.bind(this);
+    const dismissSubMenu = this._onSubMenuDismiss.bind(this);
+    const dismissMenu = this.dismiss.bind(this, undefined);
 
     return (
       <div>
@@ -511,6 +516,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
             <a
               { ...nativeProps }
               { ...keytipAttributes }
+              ref={ anchorRef }
               href={ item.href }
               target={ item.target }
               rel={ anchorRel }
@@ -534,6 +540,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                 index={ index }
                 onCheckmarkClick={ hasCheckmarks ? this._onItemClick : undefined }
                 hasIcons={ hasIcons }
+                componentRef={ item.renderItemComponentRef }
+                openSubMenu={ openSubMenu }
+                dismissSubMenu={ dismissSubMenu }
+                dismissMenu={ dismissMenu }
+                subMenuTargetRef={ anchorRef }
               />
             </a>
           ) }
@@ -599,6 +610,10 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         hasMenu: true
       };
     }
+    const btnRef = createRef<HTMLButtonElement>();
+    const openSubMenu = this._onItemSubMenuExpand.bind(this);
+    const dismissSubMenu = this._onSubMenuDismiss.bind(this);
+    const dismissMenu = this.dismiss.bind(this, undefined);
 
     return (
       <KeytipData
@@ -608,6 +623,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       >
         { (keytipAttributes: any): JSX.Element => (
           <button
+            ref={ btnRef }
             { ...buttonNativeProperties as React.ButtonHTMLAttributes<HTMLButtonElement> }
             { ...itemButtonProperties as React.ButtonHTMLAttributes<HTMLButtonElement> }
             { ...keytipAttributes }
@@ -618,6 +634,11 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
               index={ index }
               onCheckmarkClick={ hasCheckmarks ? this._onItemClick : undefined }
               hasIcons={ hasIcons }
+              componentRef={ item.renderItemComponentRef }
+              openSubMenu={ openSubMenu }
+              dismissSubMenu={ dismissSubMenu }
+              dismissMenu={ dismissMenu }
+              subMenuTargetRef={ btnRef }
             />
           </button>
         ) }
@@ -634,6 +655,10 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
     hasCheckmarks?: boolean,
     hasIcons?: boolean): JSX.Element {
     const { contextualMenuItemAs } = this.props;
+
+    const openSubMenu = this._onItemSubMenuExpand.bind(this);
+    const dismissSubMenu = this._onSubMenuDismiss.bind(this);
+    const dismissMenu = this.dismiss.bind(this, undefined);
 
     return (
       <ContextualMenuSplitButton
@@ -653,6 +678,10 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         onItemClick={ this._onItemClick }
         onItemClickBase={ this._onItemClickBase }
         onItemKeyDown={ this._onItemKeyDown }
+        openSubMenu={ openSubMenu }
+        dismissSubMenu={ dismissSubMenu }
+        dismissMenu={ dismissMenu }
+        componentRef={ item.renderItemComponentRef }
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -15,7 +15,7 @@ import { IWithResponsiveModeState } from '../../utilities/decorators/withRespons
 import { IContextualMenuClassNames, IMenuItemClassNames } from './ContextualMenu.classNames';
 export { DirectionalHint } from '../../common/DirectionalHint';
 import { IVerticalDividerClassNames } from '../Divider/VerticalDivider.types';
-import { IContextualMenuItemProps } from './ContextualMenuItem.types';
+import { IContextualMenuItemProps, IContextualMenuRenderItem } from './ContextualMenuItem.types';
 import { IKeytipProps } from '../../Keytip';
 
 export enum ContextualMenuItemType {
@@ -463,6 +463,12 @@ export interface IContextualMenuItem {
   keytipProps?: IKeytipProps;
 
   /**
+   * Optional callback to access the IContextualMenuRenderItem interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  renderItemComponentRef?: (component: IContextualMenuRenderItem | null) => void;
+
+  /**
    * Any additional properties to use when custom rendering menu items.
    */
   [propertyName: string]: any;
@@ -471,7 +477,6 @@ export interface IContextualMenuItem {
    * Optional prop to make an item readonly which is disabled but visitable by keyboard, will apply aria-readonly and some styling. Not supported by all components
    */
   inactive?: boolean;
-
 }
 
 export interface IContextualMenuSection extends React.Props<ContextualMenu> {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
@@ -1,85 +1,108 @@
 import * as React from 'react';
 import { hasSubmenu, getIsChecked } from '../../utilities/contextualMenu/index';
-import { getRTL } from '../../Utilities';
+import { BaseComponent, getRTL } from '../../Utilities';
 import { Icon } from '../../Icon';
 import { IContextualMenuItemProps } from './ContextualMenuItem.types';
 
-const renderItemIcon = (props: IContextualMenuItemProps) => {
-  const {
-    item,
-    hasIcons,
-    classNames
-  } = props;
+export class ContextualMenuItem extends BaseComponent<IContextualMenuItemProps, {}> {
+  public render() {
+    const { item, classNames } = this.props;
 
-  // Only present to allow continued use of item.icon which is deprecated.
-  const { iconProps, icon } = item;
+    return (
+      <div
+        className={
+          item.split ? classNames.linkContentMenu : classNames.linkContent
+        }
+      >
+        { this.renderCheckMarkIcon(this.props) }
+        { this.renderItemIcon(this.props) }
+        { this.renderItemName(this.props) }
+        { this.renderSubMenuIcon(this.props) }
+      </div>
+    );
+  }
 
-  if (!hasIcons) {
+  public openSubMenu = (): void => {
+    const { item, openSubMenu, subMenuTargetRef } = this.props;
+    if (hasSubmenu(item) && openSubMenu && subMenuTargetRef && subMenuTargetRef.current) {
+      openSubMenu(item, subMenuTargetRef.current);
+    }
+  }
+
+  public dismissSubMenu = (): void => {
+    const { item, dismissSubMenu } = this.props;
+    if (hasSubmenu(item) && dismissSubMenu) {
+      dismissSubMenu();
+    }
+  }
+
+  public dismissMenu = (dismissAll?: boolean): void => {
+    const { dismissMenu } = this.props;
+    if (dismissMenu) {
+      dismissMenu(dismissAll);
+    }
+  }
+
+  private renderItemIcon = (props: IContextualMenuItemProps) => {
+    const {
+      item,
+      hasIcons,
+      classNames
+    } = props;
+
+    // Only present to allow continued use of item.icon which is deprecated.
+    const { iconProps, icon } = item;
+
+    if (!hasIcons) {
+      return null;
+    }
+
+    if (item.onRenderIcon) {
+      return (
+        item.onRenderIcon(props)
+      );
+    }
+
+    if (iconProps) {
+      return <Icon { ...iconProps } className={ classNames.icon } />;
+    }
+
+    return <Icon iconName={ icon } className={ classNames.icon } />;
+  }
+
+  private renderCheckMarkIcon = ({ onCheckmarkClick, item, classNames }: IContextualMenuItemProps) => {
+    const isItemChecked = getIsChecked(item);
+    if (onCheckmarkClick) {
+      const onClick = (e: React.MouseEvent<HTMLElement>) => onCheckmarkClick(item, e);
+
+      return (
+        <Icon
+          iconName={ isItemChecked ? 'CheckMark' : '' }
+          className={ classNames.checkmarkIcon }
+          onClick={ onClick }
+        />
+      );
+    }
     return null;
   }
 
-  if (item.onRenderIcon) {
-    return (
-      item.onRenderIcon(props)
-    );
+  private renderItemName = ({ item, classNames }: IContextualMenuItemProps) => {
+    if (item.name) {
+      return <span className={ classNames.label }>{ item.name }</span>;
+    }
+    return null;
   }
 
-  if (iconProps) {
-    return <Icon { ...iconProps } className={ classNames.icon } />;
+  private renderSubMenuIcon = ({ item, classNames }: IContextualMenuItemProps) => {
+    if (hasSubmenu(item)) {
+      return (
+        <Icon
+          iconName={ getRTL() ? 'ChevronLeft' : 'ChevronRight' }
+          { ...item.submenuIconProps }
+          className={ classNames.subMenuIcon }
+        />
+      );
+    }
+    return null;
   }
-
-  return <Icon iconName={ icon } className={ classNames.icon } />;
-};
-
-const renderCheckMarkIcon = ({ onCheckmarkClick, item, classNames }: IContextualMenuItemProps) => {
-  const isItemChecked = getIsChecked(item);
-  if (onCheckmarkClick) {
-    const onClick = (e: React.MouseEvent<HTMLElement>) => onCheckmarkClick(item, e);
-
-    return (
-      <Icon
-        iconName={ isItemChecked ? 'CheckMark' : '' }
-        className={ classNames.checkmarkIcon }
-        onClick={ onClick }
-      />
-    );
-  }
-  return null;
-};
-
-const renderItemName = ({ item, classNames }: IContextualMenuItemProps) => {
-  if (item.name) {
-    return <span className={ classNames.label }>{ item.name }</span>;
-  }
-  return null;
-};
-
-const renderSubMenuIcon = ({ item, classNames }: IContextualMenuItemProps) => {
-  if (hasSubmenu(item)) {
-    return (
-      <Icon
-        iconName={ getRTL() ? 'ChevronLeft' : 'ChevronRight' }
-        { ...item.submenuIconProps }
-        className={ classNames.subMenuIcon }
-      />
-    );
-  }
-  return null;
-};
-
-export const ContextualMenuItem: React.StatelessComponent<IContextualMenuItemProps> = (props) => {
-  const { item, classNames } = props;
-
-  return (
-    <div
-      className={
-        item.split ? classNames.linkContentMenu : classNames.linkContent
-      }
-    >
-      { renderCheckMarkIcon(props) }
-      { renderItemIcon(props) }
-      { renderItemName(props) }
-      { renderSubMenuIcon(props) }
-    </div>
-  );
-};
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.types.ts
@@ -1,8 +1,31 @@
 import { IContextualMenuItem } from './ContextualMenu.types';
 import { IMenuItemClassNames } from './ContextualMenu.classNames';
+import { RefObject } from '../../Utilities';
 
-export interface IContextualMenuItemProps
-  extends React.HTMLAttributes<IContextualMenuItemProps> {
+export interface IContextualMenuRenderItem {
+  /**
+   * Function to open this item's subMenu, if present.
+   */
+  openSubMenu: () => void;
+
+  /**
+   * Function to close this item's subMenu, if present.
+   */
+  dismissSubMenu: () => void;
+
+  /**
+   * Dismiss the menu this item belongs to.
+   */
+  dismissMenu: (dismissAll?: boolean) => void;
+}
+
+export interface IContextualMenuItemProps extends React.HTMLAttributes<IContextualMenuItemProps> {
+
+  /**
+   * Optional callback to access the IContextualMenuRenderItem interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: (component: IContextualMenuRenderItem | null) => void;
 
   /**
    * The item to display
@@ -28,4 +51,25 @@ export interface IContextualMenuItemProps
    * Click handler for the checkmark
    */
   onCheckmarkClick?: ((item: IContextualMenuItem, ev: React.MouseEvent<HTMLElement>) => void);
+
+  /**
+   * This prop will get set by ContextualMenu and can be called to open this item's subMenu, if present.
+   */
+  openSubMenu?: (item: IContextualMenuItem, target: HTMLElement) => void;
+
+  /**
+   * This prop will get set by ContextualMenu and can be called to close this item's subMenu, if present.
+   */
+  dismissSubMenu?: () => void;
+
+  /**
+   * This prop will get set by ContextualMenu and can be called to close the menu this item belongs to.
+   * If dismissAll is true, all menus will be closed.
+   */
+  dismissMenu?: (dismissAll?: boolean) => void;
+
+  /**
+   * This prop will get set by ContextualMenu, will be the target to attach the submenu to when openSubMenu is triggered.
+   */
+  subMenuTargetRef?: RefObject<HTMLElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuSplitButton.tsx
@@ -13,7 +13,7 @@ import {
 } from './ContextualMenu.classNames';
 import { ContextualMenuItem } from './ContextualMenuItem';
 import { KeytipData } from '../../KeytipData';
-import { getIsChecked, isItemDisabled } from '../../utilities/contextualMenu/index';
+import { getIsChecked, isItemDisabled, hasSubmenu } from '../../utilities/contextualMenu/index';
 import { VerticalDivider } from '../../Divider';
 import { IContextualMenuSplitButtonProps } from './ContextualMenuSplitButton.types';
 
@@ -72,6 +72,24 @@ export class ContextualMenuSplitButton extends BaseComponent<IContextualMenuSpli
         ) }
       </KeytipData>
     );
+  }
+
+  public openSubMenu = (): void => {
+    if (hasSubmenu(this.props.item) && this.props.openSubMenu && this._splitButton) {
+      this.props.openSubMenu(this.props.item, this._splitButton);
+    }
+  }
+
+  public dismissSubMenu = (): void => {
+    if (hasSubmenu(this.props.item) && this.props.dismissSubMenu) {
+      this.props.dismissSubMenu();
+    }
+  }
+
+  public dismissMenu = (dismissAll?: boolean): void => {
+    if (this.props.dismissMenu) {
+      this.props.dismissMenu(dismissAll);
+    }
   }
 
   private _renderSplitPrimaryButton(item: IContextualMenuItem, classNames: IMenuItemClassNames, index: number, hasCheckmarks: boolean, hasIcons: boolean) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuSplitButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuSplitButton.types.ts
@@ -102,7 +102,7 @@ export interface IContextualMenuSplitButtonProps extends React.Props<IContextual
   dismissSubMenu?: () => void;
 
   /**
-   * This props will get set by ContextualMenu and can be called to close the menu this item belongs to.
+   * This prop will get set by ContextualMenu and can be called to close the menu this item belongs to.
    * If dismissAll is true, all menus will be closed.
    */
   dismissMenu?: (dismissAll?: boolean) => void;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuSplitButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuSplitButton.types.ts
@@ -1,15 +1,14 @@
 
-import { IContextualMenuItem } from '../../ContextualMenu';
+import { IContextualMenuItem, IContextualMenuRenderItem } from '../../ContextualMenu';
 import { IMenuItemClassNames } from './ContextualMenu.classNames';
 import { IContextualMenuItemProps } from './ContextualMenuItem.types';
-import { ContextualMenuSplitButton } from './ContextualMenuSplitButton';
 
 export interface IContextualMenuSplitButtonProps extends React.Props<IContextualMenuItem> {
   /**
    * Optional callback to access the ContextualmenuSplitButton interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: (component: ContextualMenuSplitButton | null) => void;
+  componentRef?: (component: IContextualMenuRenderItem | null) => void;
 
   /**
    * The item that is used to render the split button.
@@ -91,4 +90,20 @@ export interface IContextualMenuSplitButtonProps extends React.Props<IContextual
    * Callback for keyboard events on the split button.
    */
   onItemKeyDown?: (item: IContextualMenuItem, ev: React.KeyboardEvent<HTMLElement>) => void;
+
+  /**
+   * This prop will get set by ContextualMenu and can be called to open this item's subMenu, if present.
+   */
+  openSubMenu?: (item: any, target: HTMLElement) => void;
+
+  /**
+   * This prop will get set by ContextualMenu and can be called to close this item's subMenu, if present.
+   */
+  dismissSubMenu?: () => void;
+
+  /**
+   * This props will get set by ContextualMenu and can be called to close the menu this item belongs to.
+   * If dismissAll is true, all menus will be closed.
+   */
+  dismissMenu?: (dismissAll?: boolean) => void;
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuItem.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ContextMenuItemChildren when a checkmark icon renders the component wit
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Unknown
+  Symbol(enzyme.__unrendered__): <ContextualMenuItem
     classNames={
       Object {
         "checkmarkIcon": "checkmarkIcon",
@@ -129,7 +129,7 @@ exports[`ContextMenuItemChildren when it has a sub menu renders the menu icon 1`
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Unknown
+  Symbol(enzyme.__unrendered__): <ContextualMenuItem
     classNames={
       Object {
         "checkmarkIcon": "checkmarkIcon",
@@ -275,7 +275,7 @@ exports[`ContextMenuItemChildren when it has icons when it doesnt have iconProps
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Unknown
+  Symbol(enzyme.__unrendered__): <ContextualMenuItem
     classNames={
       Object {
         "checkmarkIcon": "checkmarkIcon",
@@ -392,7 +392,7 @@ exports[`ContextMenuItemChildren when it has icons when it has iconProps renders
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Unknown
+  Symbol(enzyme.__unrendered__): <ContextualMenuItem
     classNames={
       Object {
         "checkmarkIcon": "checkmarkIcon",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

This work is related to keytips. It gives a way for a developer, given a ref to a contextual menu item, to open and close its menus on command instead of mocking a click or keypress. They are similar to the functions added to BaseButton (openMenu and dismissMenu). The functions added are:

- **openSubMenu()** - opens an item's subMenu, if it has one
- **dismissSubMenu()** - closes an item's subMenu, if it has one
- **dismissMenu(dismissAll?: boolean)** - closes the menu this ContextualMenuItem lives in, or all menus if dismissAll is true. The dismissAll parameter is dependent on the developer's implementation of onDismiss (which is how it's always been)

For ContextualMenuItem, these functions will call optional props that are assigned by ContextualMenu. The openSubMenu prop function requires a target to attach the subMenu to; this is also assigned in ContextualMenu by passing down a ref to the container element (the anchor in _renderAnchorMenuItem and the button in _renderButtonItem)

ContextualMenuSplitButton also uses this interface and has access to these functions. It does not need to take in a ref for openSubMenu because the containing div (this._splitButton) already has a ref and is what the subMenu should attach to

Part of the change requires ContextualMenuItem to become a BaseComponent to take advantage of componentRef

#### Focus areas to test

Wrote unit tests and tested manually
