### PR TITLE
Edit link to customize experiments/Nav component and show more/less link to  toggle hidden nav links

### DIFF
--- a/common/changes/@uifabric/experiments/master_2018-05-02-19-53.json
+++ b/common/changes/@uifabric/experiments/master_2018-05-02-19-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Edit link to customize experiments/Nav component and show more/less link to toggle hidden nav links",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "sikrishn@microsoft.com"
+}

--- a/packages/experiments/src/components/Nav/Nav.tsx
+++ b/packages/experiments/src/components/Nav/Nav.tsx
@@ -1,12 +1,12 @@
 ﻿/* tslint:disable */
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/components/FocusZone';
-import { INavLinkGroup } from 'office-ui-fabric-react/lib/components/Nav';
-import { INavState } from 'office-ui-fabric-react/lib/components/Nav/Nav.base';
 import { AnimationClassNames } from 'office-ui-fabric-react/lib/Styling';
 import * as React from 'react';
 import {
   INavProps,
+  INavState,
   INavLink,
+  INavLinkGroup,
   INavStyleProps,
   INavStyles
 } from './Nav.types';
@@ -98,19 +98,26 @@ class NavComponent extends NavBase {
     const isChildLinkSelected = this.isChildLinkSelected(link);
     const hasChildren = !!link.links && link.links.length > 0;
     const isSelected = (isLinkSelected && !hasChildren) || (isChildLinkSelected && !link.isExpanded);
-    const { getStyles } = this.props;
+    const {
+      getStyles,
+      showMore,
+      onShowMoreLinkClicked,
+      dataHint
+    } = this.props;
     const classNames = getClassNames(getStyles!, { isSelected, nestingLevel });
+    const linkText = this.getLinkText(link, showMore);
+    const onClickHandler = link.isShowMoreLink && onShowMoreLinkClicked ? onShowMoreLinkClicked : this._onLinkClicked.bind(this, link);
 
     return (
       <NavLink
         id={ link.key }
-        content={ link.name }
+        content={ linkText }
         href={ link.url }
         target={ link.target }
-        onClick={ this._onLinkClicked.bind(this, link) }
-        dataHint={ this.props.dataHint }
+        onClick={ onClickHandler }
+        dataHint={ dataHint }
         dataValue={ link.key }
-        ariaLabel={ link.name }
+        ariaLabel={ linkText }
         role="menu"
         rootClassName={ classNames.navItemRoot }
         leftIconName={ leftIconName }
@@ -126,11 +133,13 @@ class NavComponent extends NavBase {
       return null;
     }
 
+    const linkText = this.getLinkText(link, this.props.showMore);
+
     return (
       <li
         role='listitem'
         key={ link.key || linkIndex }
-        title={ link.name }>
+        title={ linkText }>
         {
           this._renderCompositeLink(link, linkIndex, nestingLevel)
         }
@@ -155,11 +164,22 @@ class NavComponent extends NavBase {
       return null;
     }
 
+    const {
+      enableCustomization,
+      showMore
+    } = this.props;
+
     return (
       <ul role='list'>
         {
           links.map((link: INavLink, linkIndex: number) => {
-            return this._renderLink(link, linkIndex, nestingLevel);
+            if (enableCustomization && link.isHidden && !showMore) {
+              // "Show more" overrides isHidden property
+              return null;
+            }
+            else {
+              return this._renderLink(link, linkIndex, nestingLevel);
+            }
           })
         }
       </ul>
@@ -171,21 +191,32 @@ class NavComponent extends NavBase {
       return null;
     }
 
-    const { getStyles } = this.props;
+    const {
+      getStyles,
+      enableCustomization
+    } = this.props;
+
+    // skip customization group if customization is not enabled
+    if (!enableCustomization && group.isCustomizationGroup) {
+      return null;
+    }
+
     const classNames = getClassNames(getStyles!, {});
 
     return (
       <div key={ groupIndex }>
         {
-          groupIndex > 0 && group.name ?
+          groupIndex > 0 ?
             <div className={ classNames.navGroupSeparatorRoot }>
               <div className={ classNames.navGroupSeparatorHrLine }>
                 {
-                  <span className={ classNames.navGroupSeparatorGroupName }>
-                    {
-                      group.name
-                    }
-                  </span>
+                  group.name ?
+                    <span className={ classNames.navGroupSeparatorGroupName }>
+                      {
+                        group.name
+                      }
+                    </span>
+                    : null
                 }
               </div>
             </div> : null

--- a/packages/experiments/src/components/Nav/Nav.types.ts
+++ b/packages/experiments/src/components/Nav/Nav.types.ts
@@ -36,19 +36,39 @@ export interface INavProps {
   navScrollerId?: string;
 
   /**
-   * Call to provide customized styling that will layer on top of the variant rules
+   * (Optional) Call to provide customized styling that will layer on top of the variant rules
    */
   getStyles?: IStyleFunction<INavStyleProps, INavStyles>;
 
   /**
-   * Used for telemetry
+   * (Optional) Used for telemetry
    */
   dataHint?: string;
+
+  /**
+   * (Optional) When enabled
+   * 1. Links will consider isHidden property to show/hide itself.
+   * 2. There will be a customization group with show more/less link to show/hide hidden links.
+   * 3. There will also be an edit nav link button. This is for the partner to implement the UX which
+   * will customize the isHidden property of the nav link (possibly through a flyout and refresh the Nav component).
+   */
+  enableCustomization?: boolean;
+
+  /**
+   * Used to override isHidden property of the Nav link when the "Show More" link is clicked
+   */
+  showMore?: boolean;
 
   /**
    * (Optional) callback for the parent component when the nav component is toggled between expanded and collapsed state
    */
   onNavCollapsedCallback?(isCollapsed: boolean): void;
+
+  /**
+   * (Optional) callback for the Nav and SlimNav component when the "Show more" / "Show less" nav link is clicked.
+   * The state "showMore" stays in the parent NavToggler component to keep show more/less state of Nav and SlimNav component in sync.
+   */
+  onShowMoreLinkClicked?(ev: React.MouseEvent<HTMLElement>): void;
 }
 
 export interface INavState extends INavState {
@@ -56,11 +76,41 @@ export interface INavState extends INavState {
    * Used to toggle the nav component between expanded and collapsed state.
    */
   isNavCollapsed?: boolean;
+
+  /**
+   * Used to override isHidden property of the Nav link when the "Show More" link is clicked
+   */
+  showMore?: boolean;
 }
 
 export interface INavLink extends INavLink {
-  /* used to adjust the floating nav when the scrollbar appears */
+  /**
+   * (Optional) Used to adjust the floating nav when the scrollbar appears
+   */
   scrollTop?: number;
+
+  /**
+   * (Optional) Show / hide the nav link
+   */
+  isHidden?: boolean;
+
+  /**
+   * (Optional) Localized "Show more" nav link text.
+   */
+  showMoreText?: string;
+
+  /**
+   * (Optional) To identify whether this link is show more/less and
+   * provide internal implementation to show/hide nav links based on isHidden property.
+   */
+  isShowMoreLink?: boolean;
+}
+
+export interface INavLinkGroup extends INavLinkGroup {
+  /**
+   * (Optional) Used to identify whether the nav group is for customization or not.
+   */
+  isCustomizationGroup?: boolean;
 }
 
 export interface INavStyleProps {

--- a/packages/experiments/src/components/Nav/NavBase.tsx
+++ b/packages/experiments/src/components/Nav/NavBase.tsx
@@ -1,7 +1,6 @@
 /* tslint:disable */
-import { INavLink, INavProps } from './Nav.types';
+import { INavLink, INavProps, INavState } from './Nav.types';
 import { INav } from 'office-ui-fabric-react/lib/components/Nav';
-import { INavState } from 'office-ui-fabric-react/lib/components/Nav/Nav.base';
 import * as React from 'react';
 /* tslint:enable */
 
@@ -51,5 +50,18 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     // check if the link or any of the child link is selected
     return link.key === selectedKey ||
       (includeChildren && this.isChildLinkSelected(link));
+  }
+
+  protected getLinkText(link: INavLink, showMore?: boolean): string | undefined {
+    if (!link) {
+      return undefined;
+    }
+
+    if (link.isShowMoreLink && !showMore && link.showMoreText) {
+      // if the link is show more/less link, based on the showMore state; return "Show more" localized text
+      return link.showMoreText;
+    }
+
+    return link.name;
   }
 }

--- a/packages/experiments/src/components/Nav/NavToggler.tsx
+++ b/packages/experiments/src/components/Nav/NavToggler.tsx
@@ -24,8 +24,11 @@ class NavTogglerComponent extends React.Component<INavProps, INavState> {
     super(props);
 
     this.state = {
-      isNavCollapsed: props.isNavCollapsed ? props.isNavCollapsed : false
+      isNavCollapsed: props.isNavCollapsed ? props.isNavCollapsed : false,
+      showMore: props.showMore ? props.showMore : false
     };
+
+    this._onShowMoreLinkClicked = this._onShowMoreLinkClicked.bind(this);
   }
 
   public render() {
@@ -33,9 +36,13 @@ class NavTogglerComponent extends React.Component<INavProps, INavState> {
       return null;
     }
 
-    const isCollapsed = this.state.isNavCollapsed;
+    const {
+      isNavCollapsed,
+      showMore
+    } = this.state;
+
     const { getStyles } = this.props;
-    const classNames = getClassNames(getStyles!, { isCollapsed });
+    const classNames = getClassNames(getStyles!, { isCollapsed: isNavCollapsed });
 
     return (
       <div className={ classNames.root }>
@@ -43,17 +50,23 @@ class NavTogglerComponent extends React.Component<INavProps, INavState> {
           this._renderExpandCollapseNavItem()
         }
         {
-          isCollapsed ?
+          isNavCollapsed ?
             <SlimNav
               groups={ this.props.groups }
               selectedKey={ this.props.selectedKey }
               navScrollerId={ this.props.navScrollerId }
-              dataHint={ this.props.dataHint } />
+              dataHint={ this.props.dataHint }
+              enableCustomization={ this.props.enableCustomization }
+              showMore={ showMore }
+              onShowMoreLinkClicked={ this._onShowMoreLinkClicked } />
             :
             <Nav
               groups={ this.props.groups }
               selectedKey={ this.props.selectedKey }
-              dataHint={ this.props.dataHint } />
+              dataHint={ this.props.dataHint }
+              enableCustomization={ this.props.enableCustomization }
+              showMore={ showMore }
+              onShowMoreLinkClicked={ this._onShowMoreLinkClicked } />
         }
       </div>
     );
@@ -70,7 +83,7 @@ class NavTogglerComponent extends React.Component<INavProps, INavState> {
 
       return {
         isNavCollapsed: isNavCollapsed
-      } as INavState;
+      };
     });
   }
 
@@ -91,6 +104,17 @@ class NavTogglerComponent extends React.Component<INavProps, INavState> {
         iconClassName={ classNames.navItemIconColumn }>
       </NavLink>
     );
+  }
+
+  private _onShowMoreLinkClicked(ev: React.MouseEvent<HTMLElement>): void {
+    this.setState((prevState: INavState) => {
+      return {
+        showMore: !prevState.showMore
+      };
+    });
+
+    ev.preventDefault();
+    ev.stopPropagation();
   }
 }
 

--- a/packages/experiments/src/components/Nav/examples/Nav.Example.tsx
+++ b/packages/experiments/src/components/Nav/examples/Nav.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { INavLinkGroup } from 'office-ui-fabric-react/lib/components/Nav';
+import { INavLinkGroup } from '../Nav.types';
 import { NavToggler } from '../NavToggler';
 
 export class NavExample extends React.Component<{}, {}> {
@@ -19,7 +19,7 @@ export class NavExample extends React.Component<{}, {}> {
               { name: 'News - test with long name to show ellipse', url: 'http://msn.com', target: '_blank', key: 'key3' }
             ]
           },
-          { name: 'Documents', url: 'http://example.com', key: 'key4', icon: 'Document' },
+          { name: 'Documents', url: 'http://example.com', key: 'key4', icon: 'Document', isHidden: true },
           { name: 'Pages', url: 'http://msn.com', target: '_blank', key: 'key5', icon: 'Page' },
           {
             name: 'Notebook - test with long name to show ellipse',
@@ -50,13 +50,24 @@ export class NavExample extends React.Component<{}, {}> {
             icon: 'DietPlanNotebook'
           },
         ]
+      },
+      {
+        links: [
+          { name: 'Edit', url: '#', onClick: this._onEditClick, icon: 'Edit', key: 'key13' },
+          { name: 'Show less', showMoreText: 'Show more', url: '#', isShowMoreLink: true, icon: 'More', key: 'key14' },
+        ],
+        isCustomizationGroup: true
       }
     ];
 
     return (
       <div>
-        <NavToggler groups={ navLinkGroups } dataHint='LeftNav' />
+        <NavToggler groups={ navLinkGroups } dataHint='LeftNav' enableCustomization={ true } />
       </div>
     );
+  }
+
+  private _onEditClick(): void {
+    alert('open edit nav view / flyout');
   }
 }


### PR DESCRIPTION
Adding an ability to toggle nav links visibility based on isHidden property by Show more/less link.
Adding edit nav link as a placeholder to implement the view which will customize isHidden property.

Refer the screenshot below: "Documents" nav link is hidden by default and shown when the "Show more" link is clicked

![image](https://user-images.githubusercontent.com/12967315/39546380-118c65ac-4e09-11e8-923a-d867e0c1ee15.png)

![image](https://user-images.githubusercontent.com/12967315/39546393-1cb18714-4e09-11e8-80fc-4e01eb5bd0c0.png)

![image](https://user-images.githubusercontent.com/12967315/39546209-75fe906a-4e08-11e8-8f8a-d6b274ac1925.png)

![image](https://user-images.githubusercontent.com/12967315/39546224-8178156a-4e08-11e8-86e3-bebe21e21f36.png)

