### PR TITLE
Restart stalebot: Wait until triage meetings are complete to merge.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 180
+daysUntilStale: 30
 
 # Number of days of inactivity before a stale Issue or Pull Request is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 60
+daysUntilClose: 14
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
@@ -25,8 +25,8 @@ staleLabel: no-recent-activity
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions to Fabric React!
-  
+  This issue has been automatically marked as stale because it has not activity for **30 days**. It will be closed if no further activity occurs **within 14 days of this comment**. Thank you for your contributions to Fabric React!
+
   [Why am I receiving this notification?](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/FAQ.md#q-why-do-i-get-the-stalebot-messages-why-is-my-issue-marked-as-stale)
 
 # Comment to post when removing the stale label.
@@ -36,7 +36,7 @@ markComment: >
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >
   This issue has been automatically closed because it has not had recent activity after being marked as stale. If you belive this issue is still a problem or should be reopened, please reopen it! Thank you for your contributions to Fabric React!
-  
+
   [Why am I receiving this notification?](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/FAQ.md#q-why-do-i-get-the-stalebot-messages-why-is-my-issue-marked-as-stale)
 
 # Limit the number of actions per hour, from 1-30. Default is 30

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 30
+daysUntilStale: 60
 
 # Number of days of inactivity before a stale Issue or Pull Request is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.


### PR DESCRIPTION
#### Description of changes

Back in the beginning of April, we turned stalebot waaaay down. This turns it back on.
