### PR TITLE
Fixes focus issue for contextual menus

### DIFF
--- a/common/changes/office-ui-fabric-react/rebeba-contextual-menu-focus_2018-05-02-21-23.json
+++ b/common/changes/office-ui-fabric-react/rebeba-contextual-menu-focus_2018-05-02-21-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes issue where focus isn't displayed correctly on the contextual menu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rebeba@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -612,9 +612,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     if (!ev.defaultPrevented) {
       const menuProps = this.props.menuProps;
       if (menuProps) {
-        // When Edge + Narrator are used together, pressing "Enter" on a button fires this method and not
-        // _onMenuKeyDown. Checking ev.nativeEvent.detail differentiates between a real click event and a
-        // keypress event.
+        // When Edge + Narrator are used together (regardless of if the button is in a form or not), pressing
+        // "Enter" fires this method and not _onMenuKeyDown. Checking ev.nativeEvent.detail differentiates
+        // between a real click event and a keypress event.
         menuProps.shouldFocusOnContainer = (ev.nativeEvent.detail !== 0);
       }
       this.setState({ menuProps: menuProps });

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -612,7 +612,10 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     if (!ev.defaultPrevented) {
       const menuProps = this.props.menuProps;
       if (menuProps) {
-        menuProps.shouldFocusOnContainer = true;
+        // When Edge + Narrator are used together, pressing "Enter" on a button fires this method and not
+        // _onMenuKeyDown. Checking ev.nativeEvent.detail differentiates between a real click event and a
+        // keypress event.
+        menuProps.shouldFocusOnContainer = (ev.nativeEvent.detail !== 0);
       }
       this.setState({ menuProps: menuProps });
       this._onToggleMenu();

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -568,12 +568,17 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       this.props.onKeyDown(ev);
     }
 
-    if (!ev.defaultPrevented &&
-      this._isValidMenuOpenKey(ev)) {
+    if (!ev.defaultPrevented && this._isValidMenuOpenKey(ev)) {
       const { onMenuClick } = this.props;
       if (onMenuClick) {
         onMenuClick(ev, this);
       }
+
+      const menuProps = this.props.menuProps;
+      if (menuProps) {
+        menuProps.shouldFocusOnContainer = false;
+      }
+      this.setState({ menuProps: menuProps });
 
       this._onToggleMenu();
       ev.preventDefault();
@@ -590,7 +595,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     if (this.props.menuTriggerKeyCode) {
       return ev.which === this.props.menuTriggerKeyCode;
     } else {
-      return ev.which === KeyCodes.down && (ev.altKey || ev.metaKey);
+      if (this._isSplitButton) {
+        return ev.which === KeyCodes.down && (ev.altKey || ev.metaKey);
+      } else {
+        return ev.which === KeyCodes.enter;
+      }
     }
   }
 
@@ -601,6 +610,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     if (!ev.defaultPrevented) {
+      const menuProps = this.props.menuProps;
+      if (menuProps) {
+        menuProps.shouldFocusOnContainer = true;
+      }
+      this.setState({ menuProps: menuProps });
       this._onToggleMenu();
       ev.preventDefault();
       ev.stopPropagation();

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -194,6 +194,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       useTargetAsMinWidth,
       directionalHintFixed,
       shouldFocusOnMount,
+      shouldFocusOnContainer,
       title,
       theme,
       calloutProps,
@@ -277,11 +278,14 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
           hidden={ this.props.hidden }
         >
           <div
-            role='menu'
+            role={ shouldFocusOnContainer ? 'menu' : 'group' }
+            aria-label={ ariaLabel }
+            aria-labelledby={ labelElementId }
             style={ contextMenuStyle }
             ref={ (host: HTMLDivElement) => this._host = host }
             id={ id }
             className={ this._classNames.container }
+            tabIndex={ shouldFocusOnContainer ? 0 : undefined }
             onKeyDown={ this._onMenuKeyDown }
           >
             { title && <div className={ this._classNames.title } role='heading' aria-level={ 1 }> { title } </div> }
@@ -295,8 +299,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                 <ul
                   className={ this._classNames.list }
                   onKeyDown={ this._onKeyDown }
-                  aria-label={ ariaLabel }
-                  aria-labelledby={ labelElementId }
                 >
                   { items.map((item, index) => {
                     const menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -278,13 +278,10 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         >
           <div
             role='menu'
-            aria-label={ ariaLabel }
-            aria-labelledby={ labelElementId }
             style={ contextMenuStyle }
             ref={ (host: HTMLDivElement) => this._host = host }
             id={ id }
             className={ this._classNames.container }
-            tabIndex={ 0 }
             onKeyDown={ this._onMenuKeyDown }
           >
             { title && <div className={ this._classNames.title } role='heading' aria-level={ 1 }> { title } </div> }
@@ -296,9 +293,10 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                 handleTabKey={ FocusZoneTabbableElements.all }
               >
                 <ul
-                  role='presentation'
                   className={ this._classNames.list }
                   onKeyDown={ this._onKeyDown }
+                  aria-label={ ariaLabel }
+                  aria-labelledby={ labelElementId }
                 >
                   { items.map((item, index) => {
                     const menuItem = this._renderMenuItem(item, index, indexCorrection, totalItemCount, hasCheckmarks, hasIcons);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -278,7 +278,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
           hidden={ this.props.hidden }
         >
           <div
-            role={ shouldFocusOnContainer ? 'menu' : 'group' }
+            role={ shouldFocusOnContainer ? 'menu' : undefined }
             aria-label={ ariaLabel }
             aria-labelledby={ labelElementId }
             style={ contextMenuStyle }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -828,7 +828,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         this._onSubMenuDismiss(ev);
       } else { // This has a collapsed sub menu. Expand it.
         this.setState({
-          expandedByMouseClick: true
+          expandedByMouseClick: (ev.nativeEvent.detail !== 0)
         });
         this._onItemSubMenuExpand(item, target);
       }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -35,6 +35,7 @@ import { ContextualMenuSplitButton } from './ContextualMenuSplitButton';
 
 export interface IContextualMenuState {
   expandedMenuItemKey?: string;
+  expandedByMouseClick?: boolean;
   dismissedMenuItemKey?: string;
   contextualMenuItems?: IContextualMenuItem[];
   contextualMenuTarget?: Element;
@@ -786,6 +787,9 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       ev.stopPropagation();
       this._enterTimerId = this._async.setTimeout(() => {
         targetElement.focus();
+        this.setState({
+          expandedByMouseClick: true
+        });
         this._onItemSubMenuExpand(item, targetElement);
         this._enterTimerId = undefined;
       }, this._navigationIdleDelay);
@@ -823,6 +827,9 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       if (item.key === this.state.expandedMenuItemKey) { // This has an expanded sub menu. collapse it.
         this._onSubMenuDismiss(ev);
       } else { // This has a collapsed sub menu. Expand it.
+        this.setState({
+          expandedByMouseClick: true
+        });
         this._onItemSubMenuExpand(item, target);
       }
     }
@@ -852,9 +859,17 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   }
 
   private _onItemKeyDown = (item: any, ev: React.KeyboardEvent<HTMLElement>): void => {
-    const openKey = getRTL() ? KeyCodes.left : KeyCodes.right;
+    let openKey;
+    if (item.split) {
+      openKey = getRTL() ? KeyCodes.left : KeyCodes.right;
+    } else {
+      openKey = KeyCodes.enter;
+    }
 
     if (ev.which === openKey && !item.disabled) {
+      this.setState({
+        expandedByMouseClick: false
+      });
       this._onItemSubMenuExpand(item, ev.currentTarget as HTMLElement);
       ev.preventDefault();
     }
@@ -889,6 +904,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         isSubMenu: true,
         id: this.state.subMenuId,
         shouldFocusOnMount: true,
+        shouldFocusOnContainer: this.state.expandedByMouseClick,
         directionalHint: getRTL() ? DirectionalHint.leftTopEdge : DirectionalHint.rightTopEdge,
         className: this.props.className,
         gapSpace: 0,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -128,6 +128,12 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
   shouldFocusOnMount?: boolean;
 
   /**
+   * Whether to focus on the contextual menu container (as opposed to the first menu item).
+   * @default false
+   */
+  shouldFocusOnContainer?: boolean;
+
+  /**
    * Callback when the ContextualMenu tries to close. If dismissAll is true then all
    * submenus will be dismissed.
    */

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -129,7 +129,7 @@ export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWith
 
   /**
    * Whether to focus on the contextual menu container (as opposed to the first menu item).
-   * @default false
+   * @default null
    */
   shouldFocusOnContainer?: boolean;
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -20,6 +20,8 @@ export class ContextualMenuBasicExample extends React.Component {
           text='Click for ContextualMenu'
           menuProps={ {
             shouldFocusOnMount: true,
+            ariaLabel: 'Hi there Rebecca Ballantyne',
+            shouldFocusOnContainer: true,
             items: [
               {
                 key: 'newItem',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -21,7 +21,6 @@ export class ContextualMenuBasicExample extends React.Component {
           menuProps={ {
             shouldFocusOnMount: true,
             ariaLabel: 'Hi there Rebecca Ballantyne',
-            shouldFocusOnContainer: false,
             items: [
               {
                 key: 'newItem',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -21,7 +21,7 @@ export class ContextualMenuBasicExample extends React.Component {
           menuProps={ {
             shouldFocusOnMount: true,
             ariaLabel: 'Hi there Rebecca Ballantyne',
-            shouldFocusOnContainer: true,
+            shouldFocusOnContainer: false,
             items: [
               {
                 key: 'newItem',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -20,7 +20,6 @@ export class ContextualMenuBasicExample extends React.Component {
           text='Click for ContextualMenu'
           menuProps={ {
             shouldFocusOnMount: true,
-            ariaLabel: 'Hi there Rebecca Ballantyne',
             items: [
               {
                 key: 'newItem',


### PR DESCRIPTION
#### Pull request checklist

- [x ] Addresses an existing issue: Fixes #4717
- [x ] Include a change request file using `$ npm run change`

#### Description of changes

Prior to fix, when a contextual menu was opened, focus always went to the contextual menu container. 

The correct behavior (determined via discussion with Jeremy Spurlin/ Ben Truelove/ Chris Schlechty/ Jon Schectman/ Thomas Michon) is as follows:

- If user activates contextual menu via keyboarding (pressing enter on a button for example), focus should go to the first focusable menu item.


- If user activates contextual menu via mouse click, focus should go to the contextual menu container.

The following is a summary of changes to each file: 

- BaseButton.tsx: Pipes through to ContextualMenu via new param (shouldFocusOnContainer) how the menu was opened. Right now we disregard user input for "shouldFocusOnContainer" if contextual menu is created via menu params to button. I think that is actually desired behavior as it means we will enforce accessibility. Tweaked _isValidMenuOpenKey so that way "Enter" is considered the valid menu open key for non split button items. This means that on enter key press, _onMenuKeyDown will be executed instead of _onMenuClick.

- ContextualMenu.tsx: Responds to new param shouldFocusOnContainer, setting roles and tab indexes appropriately. Note that aria label is read regardless of if focus is put on container or first menu item. Added state expandedByMouseClick so that way the same focus behavior applies to sub-menus.

#### Focus areas to test

With Narrator on and off (in Edge), test contextual menus, activating via keyboard or via click. Observe different focus behaviors. 