### PR TITLE
Fix pivot type comparing

### DIFF
--- a/common/changes/office-ui-fabric-react/fix_pivotTypeComparing_2018-05-03-11-36.json
+++ b/common/changes/office-ui-fabric-react/fix_pivotTypeComparing_2018-05-03-11-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fixes type comparing in Pivot",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "daniel.gut@gia.ch"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -212,7 +212,7 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
     this._keyToTabIds = {};
 
     React.Children.map(props.children, (child: any, index: number) => {
-      if (typeof child === 'object' && child.type === PivotItem) {
+      if (typeof child === 'object' && child.type.name === PivotItem.prototype.className) {
         const pivotItem = child as PivotItem;
         const itemKey = pivotItem.props.itemKey || index.toString();
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4249
- [x] Include a change request file using `$ npm run change`

#### Description of changes

changes the comparing of types for Pivot. The previous comparing can cause issues with HMR.

#### Focus areas to test

PivotItem in a Pivot
