### PR TITLE
SpinButton: Remove browser autocomplete (seen in Edge)

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-SpinButtonFixAutocomplete_2018-05-03-15-51.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-SpinButtonFixAutocomplete_2018-05-03-15-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SpinButton: Remove browser autocomplete",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -205,6 +205,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
                 onInput={ this._onInputChange }
                 className={ classNames.input }
                 type='text'
+                autoComplete='off'
                 role='spinbutton'
                 aria-labelledby={ label && this._labelId }
                 aria-valuenow={ !isNaN(Number(value)) ? Number(value) : undefined }

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
       aria-valuemin={0}
       aria-valuenow={0}
       aria-valuetext={undefined}
+      autoComplete="off"
       className=
           ms-spinButton-input
           {


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes
When attempting to type and spin a spinButton the autocomplete menu would appear in edge.
The PR makes it so that does not happen.

FYI, here's what it looked like before (obscured some text, on purpose):
![spinbuttonautocomplete](https://user-images.githubusercontent.com/7033561/39588243-443703b6-4eb0-11e8-9da0-2e0aa983d90c.png)



#### Focus areas to test
Verified that the autocomplete dropdown does not appear