### PR TITLE
Enable multiline to make Type and Default Value columns more readable.

### DIFF
--- a/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
+++ b/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
@@ -41,7 +41,8 @@ const DEFAULT_COLUMNS: IColumn[] = [
     minWidth: 130,
     maxWidth: 150,
     isCollapsable: false,
-    isResizable: true
+    isResizable: true,
+    isMultiline: true
   },
   {
     key: 'defaultValue',
@@ -50,7 +51,8 @@ const DEFAULT_COLUMNS: IColumn[] = [
     minWidth: 130,
     maxWidth: 150,
     isCollapsable: false,
-    isResizable: true
+    isResizable: true,
+    isMultiline: true
   }, {
     key: 'description',
     name: 'Description',


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4682
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

As described in issue, sometimes `Type` and `Default value` columns are not readable. This fix just enables multiline for those columns.

**Before**
![before](https://user-images.githubusercontent.com/26070760/39588740-3ca96890-4eb1-11e8-81cb-6fa67d02b439.png)

**After**
![after](https://user-images.githubusercontent.com/26070760/39588746-3f1a3370-4eb1-11e8-9f2d-dea6b39980a2.png)


#### Focus areas to test

n/a