### PR TITLE
Replace includes with indexOf in component page

### DIFF
--- a/common/changes/@uifabric/example-app-base/hotfix-fix-componentpage-in-ie_2018-05-03-19-07.json
+++ b/common/changes/@uifabric/example-app-base/hotfix-fix-componentpage-in-ie_2018-05-03-19-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Fix bug in IE by replacing includes() with indexOf()",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -369,9 +369,9 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
     if (this.props.componentUrl) {
       mdUrl = `${this.props.componentUrl}/docs/${componentName}${section}.md`;
       // Replace /tree/ or /blob/ with /edit/ to get straight to GitHub editor.
-      if (mdUrl!.includes('/tree/')) {
+      if (mdUrl!.indexOf('/tree/') > -1) {
         mdUrl = mdUrl!.replace('/tree/', '/edit/');
-      } else if (mdUrl!.includes('/blob/')) {
+      } else if (mdUrl!.indexOf('/blob/') > -1) {
         mdUrl = mdUrl!.replace('/blob/', '/edit/');
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

I introduced a bug in component page by using `includes()` instead of `indexOf()` so the component pages wouldn't render in IE.