### PR TITLE
Fixes duplicate reading of suggestions on people picker

### DIFF
--- a/common/changes/office-ui-fabric-react/rebeba-suggestions-alert_2018-05-03-22-40.json
+++ b/common/changes/office-ui-fabric-react/rebeba-suggestions-alert_2018-05-03-22-40.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Puts additional alert on selected suggestions behind a prop",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/rebeba-suggestions-alert_2018-05-03-22-40.json
+++ b/common/changes/office-ui-fabric-react/rebeba-suggestions-alert_2018-05-03-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Puts additional alert on selected suggestions behind a prop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rebeba@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -175,9 +175,14 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     } = this.props;
 
     const currentIndex = this.suggestionStore.currentIndex;
-    const selectedSuggestion = currentIndex > -1 ? this.suggestionStore.getSuggestionAtIndex(this.suggestionStore.currentIndex) : undefined;
-    const selectedSuggestionAlert = selectedSuggestion ? selectedSuggestion.ariaLabel : undefined;
     const activeDescendant = currentIndex > -1 ? 'sug-' + currentIndex : undefined;
+
+    let selectedSuggestionAlert = undefined;
+    if (this.props.enableSelectedSuggestionAlert) {
+      const selectedSuggestion = currentIndex > -1 ? this.suggestionStore.getSuggestionAtIndex(this.suggestionStore.currentIndex) : undefined;
+      const selectedSuggestionAlertText = selectedSuggestion ? selectedSuggestion.ariaLabel : undefined;
+      selectedSuggestionAlert = (<div className={ styles.screenReaderOnly } role='alert' id='selected-suggestion-alert' aria-live='assertive'>{ selectedSuggestionAlertText } </div>);
+    }
 
     return (
       <div
@@ -192,7 +197,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           direction={ FocusZoneDirection.bidirectional }
           isInnerZoneKeystroke={ this._isFocusZoneInnerKeystroke }
         >
-          <div className={ styles.screenReaderOnly } role='alert' id='selected-suggestion-alert' aria-live='assertive'>{ selectedSuggestionAlert } </div>
+          { selectedSuggestionAlert }
           <SelectionZone selection={ this.selection } selectionMode={ SelectionMode.multiple }>
             <div className={ css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused) } role={ 'list' }>
               { this.renderItems() }

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -137,7 +137,8 @@ export interface IBasePickerProps<T> extends React.Props<any> {
   onDismiss?: (ev?: any, selectedItem?: T) => void;
   /**
    * Adds an additional alert for the currently selected suggestion. This prop should be set to true for IE11 and below, as it
-   * enables proper screen reader behavior for each suggestion. It should not be set for modern browsers (Edge, Chrome).
+   * enables proper screen reader behavior for each suggestion (since aria-activedescendant does not work with IE11).
+   * It should not be set for modern browsers (Edge, Chrome).
    * @default false
    */
   enableSelectedSuggestionAlert?: boolean;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -135,6 +135,12 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    * A callback to override the default behavior of adding the selected suggestion on dismiss.
    */
   onDismiss?: (ev?: any, selectedItem?: T) => void;
+  /**
+   * Adds an additional alert for the currently selected suggestion. This prop should be set to true for IE11 and below, as it
+   * enables proper screen reader behavior for each suggestion. It should not be set for modern browsers (Edge, Chrome).
+   * @default false
+   */
+  enableSelectedSuggestionAlert?: boolean;
 }
 
 export interface IBasePickerSuggestionsProps {

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -193,13 +193,14 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
               { footerTitle(this.props) }
             </div>) : (null)
         }
-        { (!isLoading && !isSearching && suggestions && suggestions.length > 0 && suggestionsAvailableAlertText) ?
-          (<span
-            role='alert'
+        {
+          (<span role='alert' aria-live='polite'
             className={ css('ms-Suggestions-suggestionsAvailable', styles.suggestionsAvailable) }
           >
-            { suggestionsAvailableAlertText }
-          </span>) : (null)
+            { (!isLoading && !isSearching && suggestions && suggestions.length > 0 && suggestionsAvailableAlertText) ?
+              suggestionsAvailableAlertText : null
+            }
+          </span>)
         }
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -194,7 +194,9 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
             </div>) : (null)
         }
         {
-          (<span role='alert' aria-live='polite'
+          (<span
+            role='alert'
+            aria-live='polite'
             className={ css('ms-Suggestions-suggestionsAvailable', styles.suggestionsAvailable) }
           >
             { (!isLoading && !isSearching && suggestions && suggestions.length > 0 && suggestionsAvailableAlertText) ?

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -1601,6 +1601,11 @@ exports[`Suggestions renders a list properly 1`] = `
       </div>
     </div>
   </div>
+  <span
+    aria-live="polite"
+    className="ms-Suggestions-suggestionsAvailable"
+    role="alert"
+  />
 </div>
 `;
 
@@ -3205,5 +3210,10 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
       </div>
     </div>
   </div>
+  <span
+    aria-live="polite"
+    className="ms-Suggestions-suggestionsAvailable"
+    role="alert"
+  />
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -16,14 +16,6 @@ exports[`Pickers BasePicker renders BasePicker correctly 1`] = `
     role="presentation"
   >
     <div
-      aria-live="assertive"
-      className={undefined}
-      id="selected-suggestion-alert"
-      role="alert"
-    >
-       
-    </div>
-    <div
       className="ms-SelectionZone"
       onClick={[Function]}
       onContextMenu={[Function]}
@@ -82,14 +74,6 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
     onMouseDownCapture={[Function]}
     role="presentation"
   >
-    <div
-      aria-live="assertive"
-      className={undefined}
-      id="selected-suggestion-alert"
-      role="alert"
-    >
-       
-    </div>
     <div
       className="ms-SelectionZone"
       onClick={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4764 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Puts the additional alert that was added in this PR (https://github.com/OfficeDev/office-ui-fabric-react/pull/2944) behind a prop. This alert was originally added to enable Narrator to read the selected suggestion in IE11 - however, the alert squashes suggestionsAvailableAlertText in other browsers and also results in duplicate reading of each selected suggestion. 

Since Fabric doesn't have browser detection, putting it behind a prop allows consumers of the PeoplePicker component to specify when the additional alert should be read based off of the browser.

#### Focus areas to test

Toggle T/F of the prop in PeoplePicker.Types.Example.tsx for "NormalPeoplePicker" and try with Narrator on in Edge, Chrome, and IE. When the prop is set to true, you will hear each suggestion announced in IE on keyboarding, and multiple readings of each suggestion in Chrome/ Edge. When the prop is set to false, you will hear each suggestion announced once in Chrome/ Edge and the suggestion not announced at all in IE.
