### PR TITLE
Fix Keytip example regression

### DIFF
--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.test.tsx
@@ -55,7 +55,7 @@ describe('ContextMenuItemChildren', () => {
       let wrapper: ShallowWrapper<IContextualMenuItemProps, {}>;
 
       beforeEach(() => {
-        menuItem = { key: '123', icon: 'itemIcon', name: 'menuItem' };
+        menuItem = { key: '123', iconProps: { iconName: 'itemIcon' }, name: 'menuItem' };
         menuClassNames = getMenuItemClassNames();
 
         wrapper = shallow(

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuItem.test.tsx.snap
@@ -413,7 +413,9 @@ ShallowWrapper {
     index={1}
     item={
       Object {
-        "icon": "itemIcon",
+        "iconProps": Object {
+          "iconName": "itemIcon",
+        },
         "key": "123",
         "name": "menuItem",
       }

--- a/packages/office-ui-fabric-react/src/components/Keytip/examples/Keytips.CommandBar.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Keytip/examples/Keytips.CommandBar.Example.tsx
@@ -28,14 +28,18 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
               {
                 key: 'commandBarItem1',
                 name: 'New',
-                icon: 'Add',
+                iconProps: {
+                  iconName: 'Add',
+                },
                 onClick: this._showModal,
                 keytipProps: keytipMap.CommandButton1Keytip
               },
               {
                 key: 'commandBarItem2',
                 name: 'Upload',
-                icon: 'Upload',
+                iconProps: {
+                  iconName: 'Upload',
+                },
                 onClick: this._showMessageBar,
                 keytipProps: keytipMap.CommandButton2Keytip
               }
@@ -46,21 +50,27 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
               {
                 key: 'farItem1',
                 name: 'Options',
-                icon: 'SortLines',
+                iconProps: {
+                  iconName: 'SortLines',
+                },
                 keytipProps: keytipMap.CommandButton3Keytip,
                 subMenuProps: {
                   items: [
                     {
                       key: 'emailMessage',
                       name: 'Send Email',
-                      icon: 'Mail',
+                      iconProps: {
+                        iconName: 'Mail',
+                      },
                       keytipProps: keytipMap.SubmenuKeytip1,
                       onClick: () => { console.log('test1'); }
                     },
                     {
                       key: 'calendarEvent',
                       name: 'Make Calendar Event',
-                      icon: 'Calendar',
+                      iconProps: {
+                        iconName: 'Calendar',
+                      },
                       keytipProps: keytipMap.SubmenuKeytip2,
                       onClick: () => { console.log('test2'); },
                       subMenuProps: {


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix Keytip example regression of icons not appearing due to CommandBar changes.

Convert deprecated icon prop usage to iconProps.

**Before**
![before](https://user-images.githubusercontent.com/26070760/39607359-669529a8-4eef-11e8-9d2f-1d3c5112d2e6.png)

**After**
![after](https://user-images.githubusercontent.com/26070760/39607365-6a8f5c40-4eef-11e8-8a19-232e79ace9b2.png)



#### Focus areas to test

n/a
