### PR TITLE
Keytip: Minor improvements to behavior

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-KeytipUpdates_2018-05-04-01-48.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-KeytipUpdates_2018-05-04-01-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Keytips: Minor update to improve behavior",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -622,7 +622,7 @@ exports[`Button renders IconButton correctly 1`] = `
 
 exports[`Button renders a DefaultButton with a keytip correctly 1`] = `
 <button
-  aria-describedby=" ktp-layer-id ktp-aria-separator-id ktp-a"
+  aria-describedby=" ktp-layer-id ktp-a"
   aria-label={undefined}
   aria-labelledby={null}
   aria-pressed={undefined}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -386,7 +386,7 @@ exports[`ComboBox renders a ComboBox with a Keytip correctly 1`] = `
     <input
       aria-activedescendant={undefined}
       aria-autocomplete="both"
-      aria-describedby="ComboBox4-option ktp-layer-id ktp-aria-separator-id ktp-a"
+      aria-describedby="ComboBox4-option ktp-layer-id ktp-a"
       aria-disabled={undefined}
       aria-expanded={false}
       aria-label={undefined}

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -374,6 +374,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
       case 'Alt':
         // ALT puts focus in the browser bar, so it should not be used as a key for keytips.
         // It can be used as a modifier
+        // new changes
         break;
       case 'Tab':
       case 'Enter':

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -374,7 +374,6 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
       case 'Alt':
         // ALT puts focus in the browser bar, so it should not be used as a key for keytips.
         // It can be used as a modifier
-        // new changes
         break;
       case 'Tab':
       case 'Enter':

--- a/packages/office-ui-fabric-react/src/utilities/keytips/KeytipConstants.ts
+++ b/packages/office-ui-fabric-react/src/utilities/keytips/KeytipConstants.ts
@@ -5,7 +5,6 @@ export const DATAKTP_TARGET = 'data-ktp-target';
 export const DATAKTP_EXECUTE_TARGET = 'data-ktp-execute-target';
 export const KTP_LAYER_ID = 'ktp-layer-id';
 export const KTP_ARIA_SEPARATOR = ', ';
-export const KTP_ARIA_SEPARATOR_ID = 'ktp-aria-separator-id';
 
 // Events
 export namespace KeytipEvents {

--- a/packages/office-ui-fabric-react/src/utilities/keytips/KeytipManager.ts
+++ b/packages/office-ui-fabric-react/src/utilities/keytips/KeytipManager.ts
@@ -23,6 +23,10 @@ export class KeytipManager {
   public keytips: IUniqueKeytip[] = [];
   public persistedKeytips: IUniqueKeytip[] = [];
 
+  // This is (and should be) updated and kept in sync
+  // with the inKeytipMode in KeytipLayer.
+  public inKeytipMode = false;
+
   /**
    * Static function to get singleton KeytipManager instance
    *

--- a/packages/office-ui-fabric-react/src/utilities/keytips/KeytipUtils.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/keytips/KeytipUtils.test.ts
@@ -3,7 +3,7 @@ import {
   mergeOverflows,
   getAriaDescribedBy
 } from './KeytipUtils';
-import { KTP_FULL_PREFIX, KTP_SEPARATOR, KTP_LAYER_ID, KTP_ARIA_SEPARATOR_ID } from './KeytipConstants';
+import { KTP_FULL_PREFIX, KTP_SEPARATOR, KTP_LAYER_ID } from './KeytipConstants';
 import { arraysEqual } from '../../Utilities';
 
 describe('KeytipUtils', () => {
@@ -61,27 +61,25 @@ describe('KeytipUtils', () => {
     it('for one singular key sequence', () => {
       const keySequence: string[] = ['b'];
       const ariaDescribedBy = getAriaDescribedBy(keySequence);
-      expect(ariaDescribedBy).toEqual(' ' + KTP_LAYER_ID + ' ' + KTP_ARIA_SEPARATOR_ID + ' ' + sequencesToID(keySequence));
+      expect(ariaDescribedBy).toEqual(' ' + KTP_LAYER_ID + ' ' + sequencesToID(keySequence));
     });
 
     it('for one complex key sequence', () => {
       const keySequence: string[] = ['bc'];
       const ariaDescribedBy = getAriaDescribedBy(keySequence);
-      expect(ariaDescribedBy).toEqual(' ' + KTP_LAYER_ID + ' ' + KTP_ARIA_SEPARATOR_ID + ' ' + sequencesToID(keySequence));
+      expect(ariaDescribedBy).toEqual(' ' + KTP_LAYER_ID + ' ' + sequencesToID(keySequence));
     });
 
     it('for multiple singular key sequences', () => {
       const keySequences: string[] = ['b', 'c'];
       const ariaDescribedBy = getAriaDescribedBy(keySequences);
-      expect(ariaDescribedBy).toEqual(' ' + KTP_LAYER_ID +
-        ' ' + KTP_ARIA_SEPARATOR_ID + ' ' + sequencesToID(keySequences));
+      expect(ariaDescribedBy).toEqual(' ' + KTP_LAYER_ID + ' ' + sequencesToID(keySequences));
     });
 
     it('for multiple complex key sequences', () => {
       const keySequences: string[] = ['an', 'cb'];
       const ariaDescribedBy = getAriaDescribedBy(keySequences);
-      expect(ariaDescribedBy).toEqual(' ' + KTP_LAYER_ID +
-        ' ' + KTP_ARIA_SEPARATOR_ID + ' ' + sequencesToID(keySequences));
+      expect(ariaDescribedBy).toEqual(' ' + KTP_LAYER_ID + ' ' + sequencesToID(keySequences));
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/utilities/keytips/KeytipUtils.ts
+++ b/packages/office-ui-fabric-react/src/utilities/keytips/KeytipUtils.ts
@@ -3,8 +3,7 @@ import {
   KTP_PREFIX,
   DATAKTP_TARGET,
   DATAKTP_EXECUTE_TARGET,
-  KTP_LAYER_ID,
-  KTP_ARIA_SEPARATOR_ID
+  KTP_LAYER_ID
 } from './KeytipConstants';
 import { addElementAtIndex } from '../../Utilities';
 
@@ -68,5 +67,5 @@ export function getAriaDescribedBy(keySequences: string[]): string {
     return describedby;
   }
 
-  return describedby + ' ' + KTP_ARIA_SEPARATOR_ID + ' ' + sequencesToID(keySequences);
+  return describedby + ' ' + sequencesToID(keySequences);
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes
This change covers a few minor improvement to keytips which were not included in the initial checkin:
* Add the ability to query the KeytipManager to see if it is currently in keytip mode
* Made arrow keys exit keytip mode (this is always the case)
* Combine the initial sequence and the comma span to simplify the DOM and code since the comma always (and only) came after the initial sequence

#### Focus areas to test
Verified tests are passing and keytips are getting read out as expected
