### PR TITLE
6.0 - removed deprecated `icon` prop from IContextualMenuItem

### DIFF
--- a/6.0_RELEASE_NOTES.md
+++ b/6.0_RELEASE_NOTES.md
@@ -31,6 +31,7 @@ changes.
 * Selection utility: getSelectedIndices is now a mandatory member of the `ISelection` interface.
 * CommandBar: Interface improvements.
 * ContextualMenu: Remove onMenuDismssed from props.
+* ContextualMenu: Removed deprecated (back in v0.69.0 of OUFR) `icon` prop from `IContextualMenuItem`. Use `iconProps: { iconName: 'SomeIcon' }` instead.
 * Toggle: Interface improvements.
 * Label: Interface improvements.
 

--- a/common/changes/office-ui-fabric-react/6_0_contextualMenuProps.json
+++ b/common/changes/office-ui-fabric-react/6_0_contextualMenuProps.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Remove deprecated since v0.69 `icon` prop of ContextualMenu component.",
+      "type": "major"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -49,12 +49,12 @@ describe('Button', () => {
             {
               key: 'emailMessage',
               name: 'Email message',
-              icon: 'Mail'
+              iconProps: { iconName: 'Mail' }
             },
             {
               key: 'calendarEvent',
               name: 'Calendar event',
-              icon: 'Calendar'
+              iconProps: { iconName: 'Calendar' }
             }
           ]
         } }
@@ -258,12 +258,12 @@ describe('Button', () => {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }
@@ -286,12 +286,12 @@ describe('Button', () => {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }
@@ -319,12 +319,12 @@ describe('Button', () => {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }
@@ -350,12 +350,12 @@ describe('Button', () => {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }
@@ -377,12 +377,12 @@ describe('Button', () => {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }
@@ -406,12 +406,12 @@ describe('Button', () => {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }
@@ -439,12 +439,12 @@ describe('Button', () => {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }
@@ -470,12 +470,12 @@ describe('Button', () => {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }
@@ -518,12 +518,12 @@ describe('Button', () => {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }
@@ -547,12 +547,12 @@ describe('Button', () => {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }
@@ -585,12 +585,12 @@ describe('Button', () => {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }
@@ -620,12 +620,12 @@ describe('Button', () => {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Command.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Command.Example.tsx
@@ -19,12 +19,12 @@ export class ButtonCommandExample extends React.Component<IButtonProps, {}> {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.CommandBar.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.CommandBar.Example.tsx
@@ -19,12 +19,12 @@ export class ButtonCommandBarExample extends React.Component<IButtonProps, {}> {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -21,12 +21,12 @@ export class ButtonContextualMenuExample extends React.Component<IButtonProps, {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 },
               ],
               directionalHintFixed: true

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -39,12 +39,12 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }
@@ -66,12 +66,12 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }
@@ -94,12 +94,12 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }
@@ -121,12 +121,12 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
                 {
                   key: 'emailMessage',
                   name: 'Email message',
-                  icon: 'Mail'
+                  iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
                   name: 'Calendar event',
-                  icon: 'Calendar'
+                  iconProps: { iconName: 'Calendar' }
                 }
               ]
             } }
@@ -160,12 +160,12 @@ export class ButtonSplitCustomExample extends React.Component<IButtonProps> {
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -206,7 +206,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
     function itemsHaveIcons(contextualMenuItems: IContextualMenuItem[]): boolean {
       for (const item of contextualMenuItems) {
-        if (!!item.icon || !!item.iconProps) {
+        if (!!item.iconProps) {
           return true;
         }
 
@@ -657,7 +657,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _getIconProps(item: IContextualMenuItem): IIconProps {
     const iconProps: IIconProps = item.iconProps ? item.iconProps : {
-      iconName: item.icon
+      iconName: 'None'
     };
     return iconProps;
   }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -348,7 +348,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
 
   private _renderMenuItem(item: IContextualMenuItem, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean): React.ReactNode {
     const renderedItems: React.ReactNode[] = [];
-    const iconProps = this._getIconProps(item);
+    const iconProps = item.iconProps || { iconName: 'None' };
     // We only send a dividerClassName when the item to be rendered is a divider. For all other cases, the default divider style is used.
     const dividerClassName = item.itemType === ContextualMenuItemType.Divider ? item.className : undefined;
     const subMenuIconClassName = item.submenuIconProps ? item.submenuIconProps.className : '';
@@ -653,13 +653,6 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         onTap={ this._onPointerAndTouchEvent }
       />
     );
-  }
-
-  private _getIconProps(item: IContextualMenuItem): IIconProps {
-    const iconProps: IIconProps = item.iconProps ? item.iconProps : {
-      iconName: 'None'
-    };
-    return iconProps;
   }
 
   private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -278,12 +278,6 @@ export interface IContextualMenuItem {
   submenuIconProps?: IIconProps;
 
   /**
-   * Deprecated at v0.69.0 and will no longer exist after 1.0 use IconProps instead.
-   * @deprecated
-   */
-  icon?: string;
-
-  /**
    * Whether the menu item is disabled
    * @defaultvalue false
    */

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
@@ -11,7 +11,6 @@ const renderItemIcon = (props: IContextualMenuItemProps) => {
     classNames
   } = props;
 
-  // Only present to allow continued use of item.icon which is deprecated.
   const { iconProps } = item;
 
   if (!hasIcons) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
@@ -12,7 +12,7 @@ const renderItemIcon = (props: IContextualMenuItemProps) => {
   } = props;
 
   // Only present to allow continued use of item.icon which is deprecated.
-  const { iconProps, icon } = item;
+  const { iconProps } = item;
 
   if (!hasIcons) {
     return null;
@@ -24,11 +24,7 @@ const renderItemIcon = (props: IContextualMenuItemProps) => {
     );
   }
 
-  if (iconProps) {
-    return <Icon { ...iconProps } className={ classNames.icon } />;
-  }
-
-  return <Icon iconName={ icon } className={ classNames.icon } />;
+  return <Icon { ...iconProps } className={ classNames.icon } />;
 };
 
 const renderCheckMarkIcon = ({ onCheckmarkClick, item, classNames }: IContextualMenuItemProps) => {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuSplitButton.tsx
@@ -103,7 +103,6 @@ export class ContextualMenuSplitButton extends BaseComponent<IContextualMenuSpli
       canCheck: item.canCheck,
       isChecked: item.isChecked,
       checked: item.checked,
-      icon: item.icon,
       iconProps: item.iconProps,
       'data-is-focusable': false,
       'aria-hidden': true

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuSplitButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuSplitButton.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`ContextualMenuSplitButton creates a normal split button renders the con
     className="splitPrimary"
     data-is-focusable={false}
     disabled={undefined}
-    icon={undefined}
     name={undefined}
     role="menuitem"
   >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -235,19 +235,19 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       {
         key: 'addRow',
         name: 'Insert row',
-        icon: 'Add',
+        iconProps: { iconName: 'Add' },
         onClick: this._onAddRow
       },
       {
         key: 'deleteRow',
         name: 'Delete row',
-        icon: 'Delete',
+        iconProps: { iconName: 'Delete' },
         onClick: this._onDeleteRow
       },
       {
         key: 'configure',
         name: 'Configure',
-        icon: 'Settings',
+        iconProps: { iconName: 'Settings' },
         subMenuProps: {
           items: [
             {
@@ -396,7 +396,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       {
         key: 'aToZ',
         name: 'A to Z',
-        icon: 'SortUp',
+        iconProps: { iconName: 'SortUp' },
         canCheck: true,
         checked: column.isSorted && !column.isSortedDescending,
         onClick: () => this._onSortColumn(column.key, false)
@@ -404,7 +404,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       {
         key: 'zToA',
         name: 'Z to A',
-        icon: 'SortDown',
+        iconProps: { iconName: 'SortDown' },
         canCheck: true,
         checked: column.isSorted && column.isSortedDescending,
         onClick: () => this._onSortColumn(column.key, true)
@@ -414,7 +414,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       items.push({
         key: 'groupBy',
         name: 'Group By ' + column.name,
-        icon: 'GroupedDescending',
+        iconProps: { iconName: 'GroupedDescending' },
         canCheck: true,
         checked: column.isGrouped,
         onClick: () => this._onGroupByColumn(column)

--- a/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Tabbable.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Tabbable.Example.tsx
@@ -27,12 +27,12 @@ export const FocusZoneTabbableExample = () => (
               {
                 key: 'emailMessage',
                 name: 'Email message',
-                icon: 'Mail'
+                iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
                 name: 'Calendar event',
-                icon: 'Calendar'
+                iconProps: { iconName: 'Calendar' }
               }
             ]
           } }

--- a/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx
@@ -196,7 +196,7 @@ export class SelectionBasicExample extends React.Component<{}, ISelectionBasicEx
       {
         key: 'selectAll',
         name: 'Select All',
-        icon: 'CheckMark',
+        iconProps: { iconName: 'CheckMark' },
         onClick: this._onToggleSelectAll
       },
       {


### PR DESCRIPTION
#### Description of changes
In 6.0, the new CommandBar no longer uses the deprecated `icon` prop. This PR removes the deprecated prop and fixes the fact that a lot of Fabric example code and unit tests were still using the deprecated prop.


