### PR TITLE
Fix Keytip offset workaround

### DIFF
--- a/apps/vr-tests/src/stories/Keytip.stories.tsx
+++ b/apps/vr-tests/src/stories/Keytip.stories.tsx
@@ -24,4 +24,5 @@ storiesOf('Keytip', module)
     </Screener>
   ))
   .add('Root', () => (<Keytip content={ 'A' } keySequences={ ['a'] } visible={ true } />))
-  .add('Disabled', () => (<Keytip content={ 'A' } keySequences={ ['a'] } visible={ true } disabled={ true } />));
+  .add('Disabled', () => (<Keytip content={ 'A' } keySequences={ ['a'] } visible={ true } disabled={ true } />))
+  .add('Offset', () => (<Keytip content={ 'A' } keySequences={ ['a'] } visible={ true } offset={ { x: 15, y: 15 } } />));

--- a/common/changes/office-ui-fabric-react/keyou-fix-keytip-offset_2018-05-04-23-38.json
+++ b/common/changes/office-ui-fabric-react/keyou-fix-keytip-offset_2018-05-04-23-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove keytip positioning workaround since Callout positioning was fixed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Keytip/Keytip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Keytip/Keytip.styles.ts
@@ -63,9 +63,7 @@ export const getCalloutOffsetStyles = (offset: IPoint): IStyleFunction<ICalloutC
     return mergeStyleSets(getCalloutStyles(props), {
       root: [{
         marginLeft: offset.x,
-        // Reverse the margin from the bottom so the callout positioning
-        // doesn't auto-correct it
-        marginBottom: -1 * offset.y
+        marginTop: offset.y
       }]
     });
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

There was a workaround done to get the Keytip 'offset' property to work by inverting the vertical offset and using marginBottom. The positioning code was recently changed and fixed this bug, so we can now use marginTop. This should have been caught by a screener test, which has now been added
