### PR TITLE
add window.document check before calling loadStyles to avoid rn errors

### DIFF
--- a/scripts/tasks/sass.js
+++ b/scripts/tasks/sass.js
@@ -74,7 +74,7 @@ module.exports = function (options) {
     const source = [
       `/* tslint:disable */`,
       `import { loadStyles } from \'@microsoft/load-themed-styles\';`,
-      `loadStyles(${JSON.stringify(splitStyles(css))});`
+      `window.document && loadStyles(${JSON.stringify(splitStyles(css))});`
     ];
 
     const map = _fileNameToClassMap[fileName];


### PR DESCRIPTION
Add window.document check before calling loadStyles to avoid react native errors. Sometimes we want to import a file in a react native project that has an import to a .sass (even if we don't use it), and it breaks the react native app execution. loadStyles -> measure -> applyThemableStyles -> registerStyles fails when it tries to insert a stylesheet on document (which does not exist in react native). Open to other suggestions @ThomasMichon 

