### PR TITLE
Mark Slider#ValuePosition enum as deprecated as it is unused.

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-deprec-unused-slider-enum_2018-05-07-20-05.json
+++ b/common/changes/office-ui-fabric-react/keco-deprec-unused-slider-enum_2018-05-07-20-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Mark Slider's ValuePosition enum as deprecated as it is unused.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
@@ -18,6 +18,9 @@ export interface ISliderState {
   renderedValue?: number;
 }
 
+/**
+ * @deprecated Unused. Do not use, will be removed in 6.0
+*/
 export enum ValuePosition {
   Previous = 0,
   Next = 1


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Not high priority, but while working on #4796, I noticed this enum was unused but exported and figured we might want to deprecate it and remove sometime in `6.x`.

#### Focus areas to test

Nowhere since its unused. Partners may be using it since its exported.
