### PR TITLE
Invoke correct onClick handler for select and collapse detailslist group

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-collapse-detailslist-ex_2018-05-07-21-15.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-collapse-detailslist-ex_2018-05-07-21-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix detailslist custom group header example by invoking correct onClick for select and collapse toggles.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
@@ -32,13 +32,13 @@ export class DetailsListCustomGroupHeadersExample extends React.Component {
                 <div className='DetailsListExample-customHeaderLinkSet'>
                   <Link
                     className='DetailsListExample-customHeaderLink'
-                    onClick={ this._onClick(props!) }
+                    onClick={ this._onToggleSelectGroup(props!) }
                   >
                     { props!.isSelected ? 'Remove selection' : 'Select group' }
                   </Link>
                   <Link
                     className='DetailsListExample-customHeaderLink'
-                    onClick={ this._onClick(props!) }
+                    onClick={ this._onToggleCollapse(props!) }
                   >
                     { props!.group!.isCollapsed ? 'Expand group' : 'Collapse group' }
                   </Link>
@@ -56,10 +56,15 @@ export class DetailsListCustomGroupHeadersExample extends React.Component {
     );
   }
 
-  private _onClick(props: IGroupDividerProps): () => void {
+  private _onToggleSelectGroup(props: IGroupDividerProps): () => void {
     return () => {
       props.onToggleSelectGroup!(props.group!);
     };
   }
 
+  private _onToggleCollapse(props: IGroupDividerProps): () => void {
+    return () => {
+      props!.onToggleCollapse!(props!.group!);
+    }
+  }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4781
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Discovered while I was working on https://github.com/OfficeDev/office-ui-fabric-react/pull/4727.

This PR separates the `onClick` handlers for the `<DetailsList/>` Custom Group Headers example to fix a regression where clicking on "Collapse / expand group" would invoke the un/select all logic. Was accidentally caused by the refactor in https://github.com/OfficeDev/office-ui-fabric-react/pull/2824.

#### Focus areas to test

- Run the solution locally
- Navigate to http://localhost:4322/#/examples/detailslist
- Scroll to the example: "Rendering custom group headers"
- Invoke both the `Select group` and `Collapse group` toggles and make sure they do what you'd expect.
- Compare with PROD.
