### PR TITLE
BaseButton: Allow Alt + Down on menu buttons to open the menu

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-05-08-02-09.json
+++ b/common/changes/office-ui-fabric-react/master_2018-05-08-02-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BaseButton: Allow Alt + Down on menu buttons to open the menu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -685,6 +685,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     } else if (this.props.menuProps) {
       return ev.which === KeyCodes.down && (ev.altKey || ev.metaKey);
     }
+    return false;
   }
 
   private _onMenuClick = (ev: React.MouseEvent<HTMLDivElement | HTMLAnchorElement>) => {

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -639,6 +639,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       ev.preventDefault();
       ev.stopPropagation();
     }
+
+    // Note: When enter is pressed, we will let the event continue to propagate
+    // to trigger the onClick event on the button
   }
 
   private _onTouchStart: () => void = () => {

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -450,7 +450,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
   private _openMenu = (shouldFocusOnContainer?: boolean): void => {
     if (this.props.menuProps) {
-      const menuProps = {...this.props.menuProps, shouldFocusOnContainer: shouldFocusOnContainer };
+      const menuProps = { ...this.props.menuProps, shouldFocusOnContainer: shouldFocusOnContainer };
       if (this.props.persistMenu) {
         menuProps.hidden = false;
       }
@@ -679,12 +679,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   private _isValidMenuOpenKey(ev: React.KeyboardEvent<HTMLDivElement | HTMLAnchorElement | HTMLButtonElement>): boolean {
     if (this.props.menuTriggerKeyCode) {
       return ev.which === this.props.menuTriggerKeyCode;
-    } else {
-      if (this._isSplitButton) {
-        return ev.which === KeyCodes.down && (ev.altKey || ev.metaKey);
-      } else {
-        return ev.which === KeyCodes.enter;
-      }
+    } else if (this.props.menuProps) {
+      return ev.which === KeyCodes.down && (ev.altKey || ev.metaKey);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -639,9 +639,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       ev.preventDefault();
       ev.stopPropagation();
     }
-
-    // Note: When enter is pressed, we will let the event continue to propagate
-    // to trigger the onClick event on the button
   }
 
   private _onTouchStart: () => void = () => {
@@ -685,6 +682,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     } else if (this.props.menuProps) {
       return ev.which === KeyCodes.down && (ev.altKey || ev.metaKey);
     }
+
+    // Note: When enter is pressed, we will let the event continue to propagate
+    // to trigger the onClick event on the button
     return false;
   }
 


### PR DESCRIPTION
#### Description of changes

For a menu button, alt + down will no longer open the menu. I've changed the code that restricted that behavior to not just split buttons, but to any buttons that haves a menu (split button + menu buttons)

#### Focus areas to test

I tested behaviors on both Menu Buttons and Split Buttons.

The Split Button behavior remained consistent where alt + down will put focus on the first item in the menu and clicking will put focus on the container

The Menu buttons will open the menu with both alt + down or enter and focus is put on the first item in the list. Clicking will put the focus on the menu container.