### PR TITLE
Enabling focus on people picker remove button and creating support for format strings

### DIFF
--- a/common/changes/office-ui-fabric-react/rebeba-people-picker-remove-button_2018-05-08-21-51.json
+++ b/common/changes/office-ui-fabric-react/rebeba-people-picker-remove-button_2018-05-08-21-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes issue where focus could not move to \"Remove button\" on selected people picker items",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rebeba@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -9,6 +9,7 @@ import {
 import { IFocusZone, FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { Callout, DirectionalHint } from '../../Callout';
 import { Selection, SelectionZone, SelectionMode } from '../../utilities/selection/index';
+import { format } from '../../utilities/string/StringHelper';
 import { Suggestions } from './Suggestions/Suggestions';
 import { ISuggestionsProps } from './Suggestions/Suggestions.types';
 import { SuggestionsController } from './Suggestions/SuggestionsController';
@@ -273,7 +274,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
       onRemoveItem: () => this.removeItem(item),
       disabled: disabled,
       onItemChange: this.onItemChange,
-      removeButtonAriaLabel: removeButtonAriaLabel
+      removeButtonAriaLabel: format(removeButtonAriaLabel, item.primaryText)
     }));
   }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -23,6 +23,7 @@ const styles: any = stylesImport;
 export interface IBasePickerState {
   items?: any;
   suggestedDisplayValue?: string;
+  removedItemAlertText?: string;
   moreSuggestionsAvailable?: boolean;
   isFocused?: boolean;
   isSearching?: boolean;
@@ -194,6 +195,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           isInnerZoneKeystroke={ this._isFocusZoneInnerKeystroke }
         >
           <div className={ styles.screenReaderOnly } role='alert' id='selected-suggestion-alert' aria-live='assertive'>{ selectedSuggestionAlert } </div>
+          <div className={ styles.screenReaderOnly } role='alert' id='suggestion-removed-alert' aria-live='assertive'>{ this.state.removedItemAlertText }</div>
           <SelectionZone selection={ this.selection } selectionMode={ SelectionMode.multiple }>
             <div className={ css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused) } role={ 'list' }>
               { this.renderItems() }
@@ -635,6 +637,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     if (index >= 0) {
       const newItems: T[] = items.slice(0, index).concat(items.slice(index + 1));
       this._updateSelectedItems(newItems);
+      this.setState({ removedItemAlertText: format(this.props.singularItemRemovalText, items[index].primaryText) });
     }
   }
 
@@ -645,6 +648,11 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     const index: number = items.indexOf(firstItemToRemove);
 
     this._updateSelectedItems(newItems, index);
+    if (itemsToRemove.length === 1) {
+      this.setState({ removedItemAlertText: format(this.props.singularItemRemovalText, firstItemToRemove.primaryText) });
+    } else {
+      this.setState({ removedItemAlertText: format(this.props.pluralItemRemovalText, itemsToRemove.length) });
+    }
   }
 
   // This is protected because we may expect the backspace key to work differently in a different kind of picker.

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -114,7 +114,9 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    */
   createGenericItem?: (input: string, ValidationState: ValidationState) => ISuggestionModel<T> | T;
   /**
-   * Aria label for the "X" button in the selected item component.
+   * Aria label for the "X" button in the selected item component.If a format string (for example, "Remove {0}")
+   * is provided, then the primary text of the selected item will be used to fill the string. In this example,
+   * if the selected item is Annie Lindqvest, then the completed aria label would be "Remove Annie Lindqvest".
    * @default ''
    */
   removeButtonAriaLabel?: string;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -114,12 +114,22 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    */
   createGenericItem?: (input: string, ValidationState: ValidationState) => ISuggestionModel<T> | T;
   /**
-   * Aria label for the "X" button in the selected item component.If a format string (for example, "Remove {0}")
+   * Aria label for the "X" button in the selected item component. If a format string (for example, "Remove {0}")
    * is provided, then the primary text of the selected item will be used to fill the string. In this example,
    * if the selected item is Annie Lindqvest, then the completed aria label would be "Remove Annie Lindqvest".
    * @default ''
    */
   removeButtonAriaLabel?: string;
+  /**
+   * Text that is read after successful removal of selected item. If a format string is provided, then the
+   * primary text of the selected item will be used to fill the string.
+   */
+  singularItemRemovalText?: string;
+  /**
+   * Text that is read after successful removal of multiple selected items. If a format string is provided, then
+   * the number of items removed will be used to fill the string.
+   */
+  pluralItemRemovalText?: string;
   /**
    * A callback to process a selection after the user selects something from the picker. If the callback returns null,
    * the item will not be added to the picker.

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -14,7 +14,6 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
     item,
     onRemoveItem,
     index,
-    selected,
     removeButtonAriaLabel
   } = peoplePickerItemProps;
 
@@ -32,11 +31,8 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
       className={ css(
         'ms-PickerPersona-container',
         styles.personaContainer,
-        { ['is-selected ' + styles.personaContainerIsSelected]: selected },
         { ['is-invalid ' + styles.validationError]: item.ValidationState === ValidationState.warning }
       ) }
-      data-is-focusable={ true }
-      data-is-sub-focuszone={ true }
       data-selection-index={ index }
       role={ 'listitem' }
       aria-labelledby={ 'selectedItemPersona-' + itemId }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -167,6 +167,8 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         onRemoveSuggestion={ this._onRemoveSuggestion }
         onValidateInput={ this._validateInput }
         removeButtonAriaLabel={ 'Remove {0}' }
+        singularItemRemovalText={ 'Removed {0}' }
+        pluralItemRemovalText={ 'Removed {0} people' }
         inputProps={ {
           onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),
           onFocus: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onFocus called'),

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -166,7 +166,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         key={ 'normal' }
         onRemoveSuggestion={ this._onRemoveSuggestion }
         onValidateInput={ this._validateInput }
-        removeButtonAriaLabel={ 'Remove' }
+        removeButtonAriaLabel={ 'Remove {0}' }
         inputProps={ {
           onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),
           onFocus: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onFocus called'),
@@ -256,7 +256,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         className={ 'ms-PeoplePicker' }
         onRemoveSuggestion={ this._onRemoveSuggestion }
         onValidateInput={ this._validateInput }
-        removeButtonAriaLabel={ 'Remove' }
+        removeButtonAriaLabel={ 'Remove {0}' }
         onItemSelected={ this._onItemSelected }
         inputProps={ {
           onBlur: (ev: React.FocusEvent<HTMLInputElement>) => console.log('onBlur called'),

--- a/packages/office-ui-fabric-react/src/utilities/string/StringHelper.ts
+++ b/packages/office-ui-fabric-react/src/utilities/string/StringHelper.ts
@@ -1,0 +1,17 @@
+// Regex that finds {#} so it can be replaced by the arguments in string format
+const FORMAT_REGEX = /\{(\d+)\}/g;
+
+/**
+ * String Format is like C# string format. Usage Example: "hello {0}!".format("world")
+ * will return "hello world". Calling format on a string with less arguments than
+ * specified in the format will substitute "undefined"
+ */
+export function format(template: string | undefined, ...values: any[]): string {
+  if (template) {
+    return template.replace(FORMAT_REGEX, (match: string, valueIndex: any) => {
+      const value = values[valueIndex];
+      return value;
+    });
+  }
+  return '';
+}

--- a/packages/office-ui-fabric-react/src/utilities/string/StringHelper.ts
+++ b/packages/office-ui-fabric-react/src/utilities/string/StringHelper.ts
@@ -3,7 +3,7 @@ const FORMAT_REGEX = /\{(\d+)\}/g;
 
 /**
  * String Format is like C# string format. Usage Example: "hello {0}!".format("world")
- * will return "hello world". Calling format on a string with less arguments than
+ * will return "hello world!". Calling format on a string with less arguments than
  * specified in the format will substitute "undefined"
  */
 export function format(template: string | undefined, ...values: any[]): string {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4816 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

DO NOT REVIEW yet. I need to work with Ben to talk through the design of multi-selection.

Fixes issue where when using the <- button focus would go to the entire people picker item instead of just the remove button (the only part of the item that should be focusable). Now you can press <- and then "Enter" to remove an item. 

I talked with Ben Truelove about the design for selected items (since previously we would highlight the entire item blue), and the new behavior where we show a focus rect around just the x button is correct.

Also adds support for format strings, so we can have more descriptive aria labels than a generic label - i.e., so "Remove Annie Lindqvest" can be read instead of just "Remove".