### PR TITLE
FocusZone: Add the ability to stop focus from propagating outside the FocusZone

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-FocusZoneAddStopFocusPropagation_2018-05-09-12-17.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-FocusZoneAddStopFocusPropagation_2018-05-09-12-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: Add a prop to allow a FocusZone to not let focus events propagate outside of the FocusZone",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -192,7 +192,6 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
    */
   public focusElement(element: HTMLElement): boolean {
     const { onBeforeFocus } = this.props;
-    // const { onBeforeFocus, onActiveElementChanged } = this.props;
 
     if (onBeforeFocus && !onBeforeFocus(element)) {
       return false;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -211,7 +211,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   }
 
   private _onFocus = (ev: React.FocusEvent<HTMLElement>): void => {
-    const { doNotAllowFocusEventToPropagate } = this.props;
+    const { onActiveElementChanged, doNotAllowFocusEventToPropagate } = this.props;
 
     if (this._isImmediateDescendantOfZone(ev.target as HTMLElement)) {
       this._activeElement = ev.target as HTMLElement;
@@ -226,6 +226,10 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         }
         parentElement = getParent(parentElement, ALLOW_VIRTUAL_ELEMENTS) as HTMLElement;
       }
+    }
+
+    if (onActiveElementChanged) {
+      onActiveElementChanged(this._activeElement as HTMLElement, ev);
     }
 
     if (doNotAllowFocusEventToPropagate) {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -192,6 +192,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
    */
   public focusElement(element: HTMLElement): boolean {
     const { onBeforeFocus } = this.props;
+    // const { onBeforeFocus, onActiveElementChanged } = this.props;
 
     if (onBeforeFocus && !onBeforeFocus(element)) {
       return false;
@@ -210,7 +211,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
   }
 
   private _onFocus = (ev: React.FocusEvent<HTMLElement>): void => {
-    const { onActiveElementChanged } = this.props;
+    const { doNotAllowFocusEventToPropagate } = this.props;
 
     if (this._isImmediateDescendantOfZone(ev.target as HTMLElement)) {
       this._activeElement = ev.target as HTMLElement;
@@ -226,8 +227,9 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         parentElement = getParent(parentElement, ALLOW_VIRTUAL_ELEMENTS) as HTMLElement;
       }
     }
-    if (onActiveElementChanged) {
-      onActiveElementChanged(this._activeElement as HTMLElement, ev);
+
+    if (doNotAllowFocusEventToPropagate) {
+      ev.stopPropagation();
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
@@ -133,6 +133,8 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
    * @default false
    */
   checkForNoWrap?: boolean;
+
+  doNotAllowFocusEventToPropagate?: boolean;
 }
 
 export const enum FocusZoneTabbableElements {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
@@ -134,6 +134,9 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
    */
   checkForNoWrap?: boolean;
 
+  /**
+   * Whether the FocusZone should allow focus events to propagate past the FocusZone
+   */
   doNotAllowFocusEventToPropagate?: boolean;
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes
In react, focus bubbles but there might be times when you do not want the FocusZone to bubble outside of the FocusZone.

This PR makes it so that FocusZones can be created with the ability to not let focus propagate outside of the FocusZone 


#### Focus areas to test
Verified that existing behavior did not changed and the focus event does not propagate outside of the FocusZone if doNotAllowFocusEventToPropagate is true
