### PR TITLE
Toggle: porting high contrast hover state to 6.0 branch

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -87,6 +87,15 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
               {
                 borderColor: pillBorderHoveredColor
               }
+            ],
+            ':hover .ms-Toggle-thumb': [
+              {
+                selectors: {
+                  [HighContrastSelector]: {
+                    borderColor: 'Highlight'
+                  }
+                }
+              }
             ]
           }
         },
@@ -101,7 +110,12 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
               ':hover': [
                 {
                   backgroundColor: pillCheckedHoveredBackground,
-                  borderColor: 'transparent'
+                  borderColor: 'transparent',
+                  selectors: {
+                    [HighContrastSelector]: {
+                      backgroundColor: 'Highlight'
+                    }
+                  }
                 }
               ],
               [HighContrastSelector]: {

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -90,6 +90,9 @@ exports[`Toggle renders toggle correctly 1`] = `
           &:hover {
             border-color: #212121;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+            border-color: Highlight;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

This change was made here: https://github.com/OfficeDev/office-ui-fabric-react/pull/4728

Just porting it over to 6.0 per @cliffkoh 's request.

#### Focus areas to test

(optional)
