### PR TITLE
Fix index import

### DIFF
--- a/common/changes/office-ui-fabric-react/no-index_2018-05-09-17-33.json
+++ b/common/changes/office-ui-fabric-react/no-index_2018-05-09-17-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix index import",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -28,7 +28,7 @@ import { withResponsiveMode, ResponsiveMode } from '../../utilities/decorators/w
 import { Callout } from '../../Callout';
 import { IIconProps } from '../../Icon';
 import { ContextualMenuItem } from './ContextualMenuItem';
-import { ContextualMenuSplitButton, ContextualMenuButton, ContextualMenuAnchor } from './ContextualMenuItemWrapper';
+import { ContextualMenuSplitButton, ContextualMenuButton, ContextualMenuAnchor } from './ContextualMenuItemWrapper/index';
 
 export interface IContextualMenuState {
   expandedMenuItemKey?: string;


### PR DESCRIPTION
Yet again, fixing an implicit `/index` import which breaks AMD-style builds.