### PR TITLE
Fluent theme: Fix imports to use relative paths

### DIFF
--- a/common/changes/@uifabric/experiments/miwhea-fluent-theme-update-imports_2018-05-09-20-02.json
+++ b/common/changes/@uifabric/experiments/miwhea-fluent-theme-update-imports_2018-05-09-20-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Update Fluent theme to use relative imports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "mike@mikewheaton.ca"
+}

--- a/packages/experiments/src/components/fluent/theme/FluentTheme.ts
+++ b/packages/experiments/src/components/fluent/theme/FluentTheme.ts
@@ -1,5 +1,5 @@
 import { createTheme, ITheme } from 'office-ui-fabric-react';
-import { GrayColors } from '@uifabric/experiments/lib/components/fluent/theme/FluentColors';
+import { GrayColors } from './FluentColors';
 
 const FluentTheme: ITheme = createTheme({
   palette: {

--- a/packages/experiments/src/components/fluent/theme/examples/FluentTheme.Basic.Example.tsx
+++ b/packages/experiments/src/components/fluent/theme/examples/FluentTheme.Basic.Example.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import { Link, Customizer, Breadcrumb } from 'office-ui-fabric-react';
-import FluentTheme from '@uifabric/experiments/lib/components/fluent/theme/FluentTheme';
+import FluentTheme from '../FluentTheme';
 
 export class FluentThemeBasicExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <div>
         <h2>Current theme</h2>
-        {this._renderComponents()}
+        { this._renderComponents() }
 
         <h2>Fluent theme</h2>
-        <Customizer settings={{ theme: FluentTheme }}>
-          {this._renderComponents()}
+        <Customizer settings={ { theme: FluentTheme } }>
+          { this._renderComponents() }
         </Customizer>
       </div>
     );
@@ -20,14 +20,14 @@ export class FluentThemeBasicExample extends React.Component<{}, {}> {
   private _renderComponents(): JSX.Element {
     return (
       <div>
-        <Link disabled={true}>Disabled link</Link>
+        <Link disabled={ true }>Disabled link</Link>
         <Breadcrumb
-          items={[
+          items={ [
             { text: 'Files', key: 'Files' },
             { text: 'This is folder 1', key: 'f1' },
             { text: 'This is folder 2', key: 'f2' },
             { text: 'This is folder 3', key: 'f3', isCurrentItem: true }
-          ]}
+          ] }
         />
       </div>
     );


### PR DESCRIPTION
I ran into an issue while testing the Fluent theme, where it seems values like `GrayColors.GrayColors190` are not being found, so it returns a theme where the grays are undefined. It looks like this is most likely being caused by importing colors from the package, instead of with a relative path.