### PR TITLE
Adding option for focus on tags in disabled picker

### DIFF
--- a/common/changes/office-ui-fabric-react/focusTagItemOnDisabledPicker_2018-05-10-06-48.json
+++ b/common/changes/office-ui-fabric-react/focusTagItemOnDisabledPicker_2018-05-10-06-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added an addtional prop in IPickerItemProps for allowing focus on tagItem when picker is disabled",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "veloiya@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/PickerItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PickerItem.types.ts
@@ -12,5 +12,4 @@ export interface IPickerItemProps<T> extends React.AllHTMLAttributes<HTMLElement
   onItemChange?: (item: T, index: number) => void;
   key?: string | number;
   removeButtonAriaLabel?: string;
-  enableTagFocusInDisabledPicker?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/PickerItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PickerItem.types.ts
@@ -12,4 +12,5 @@ export interface IPickerItemProps<T> extends React.AllHTMLAttributes<HTMLElement
   onItemChange?: (item: T, index: number) => void;
   key?: string | number;
   removeButtonAriaLabel?: string;
+  enableTagFocusInDisabledPicker?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
@@ -8,7 +8,11 @@ import { ITag } from './TagPicker';
 import * as stylesImport from './TagItem.scss';
 const styles: any = stylesImport;
 
-export const TagItem = (props: IPickerItemProps<ITag>) => (
+export interface ITagItemProps extends IPickerItemProps<ITag> {
+  enableTagFocusInDisabledPicker?: boolean;
+}
+
+export const TagItem = (props: ITagItemProps) => (
   <div
     className={ css('ms-TagItem',
       styles.root,

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
@@ -17,7 +17,7 @@ export const TagItem = (props: IPickerItemProps<ITag>) => (
     role={ 'listitem' }
     key={ props.index }
     data-selection-index={ props.index }
-    data-is-focusable={ !props.disabled && true }
+    data-is-focusable={ (props.enableTagFocusInDisabledPicker || !props.disabled) && true }
   >
     <span className={ css('ms-TagItem-text', styles.tagItemText) } aria-label={ props.children as string }>{ props.children }</span>
     { !props.disabled &&

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.tsx
@@ -6,8 +6,7 @@ import {
 /* tslint:enable */
 import { BasePicker } from '../BasePicker';
 import { IBasePickerProps } from '../BasePicker.types';
-import { TagItem } from './TagItem';
-import { IPickerItemProps } from '../PickerItem.types';
+import { TagItem, ITagItemProps } from './TagItem';
 import * as stylesImport from './TagItem.scss';
 const styles: any = stylesImport;
 
@@ -21,7 +20,7 @@ export interface ITagPickerProps extends IBasePickerProps<ITag> {
 
 export class TagPicker extends BasePicker<ITag, ITagPickerProps> {
   protected static defaultProps = {
-    onRenderItem: (props: IPickerItemProps<ITag>) => { return <TagItem { ...props }>{ props.item.name }</TagItem>; },
+    onRenderItem: (props: ITagItemProps) => { return <TagItem { ...props }>{ props.item.name }</TagItem>; },
     onRenderSuggestionsItem: (props: ITag) => <div className={ css('ms-TagItem-TextOverflow', styles.tagItemTextOverflow) }> { props.name } </div>
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4822
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Added an additional optional prop for allowing focus on tagitem when the picker is disabled.

#### Focus areas to test
1. Focus behavior of tags when picker is enabled should not change.
2. Focus behavior of tags when picker is disabled and this prop is not set should not change. It must not allow focus on tags.
3. Focus behavior of tags when picker is disabled and this prop is set. It should allow focus on tags.