### PR TITLE
Experiments: Fix Fluent theme color names

### DIFF
--- a/common/changes/@uifabric/experiments/miwhea-fluent-fix-color-names_2018-05-10-15-43.json
+++ b/common/changes/@uifabric/experiments/miwhea-fluent-fix-color-names_2018-05-10-15-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fix Fluent palette color names",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "mike@mikewheaton.ca"
+}

--- a/packages/experiments/src/components/fluent/theme/FluentTheme.ts
+++ b/packages/experiments/src/components/fluent/theme/FluentTheme.ts
@@ -4,17 +4,17 @@ import { GrayColors } from './FluentColors';
 const FluentTheme: ITheme = createTheme({
   palette: {
     black: GrayColors.black,
-    neutralDark: GrayColors.GrayColors190,
-    neutralPrimary: GrayColors.GrayColors160,
-    neutralPrimaryAlt: GrayColors.GrayColors150,
-    neutralSecondary: GrayColors.GrayColors130,
-    neutralTertiary: GrayColors.GrayColors90,
-    neutralTertiaryAlt: GrayColors.GrayColors60,
-    neutralQuaternary: GrayColors.GrayColors50,
-    neutralQuaternaryAlt: GrayColors.GrayColors40,
-    neutralLight: GrayColors.GrayColors30,
-    neutralLighter: GrayColors.GrayColors20,
-    neutralLighterAlt: GrayColors.GrayColors10,
+    neutralDark: GrayColors.gray190,
+    neutralPrimary: GrayColors.gray160,
+    neutralPrimaryAlt: GrayColors.gray150,
+    neutralSecondary: GrayColors.gray130,
+    neutralTertiary: GrayColors.gray90,
+    neutralTertiaryAlt: GrayColors.gray60,
+    neutralQuaternary: GrayColors.gray50,
+    neutralQuaternaryAlt: GrayColors.gray40,
+    neutralLight: GrayColors.gray30,
+    neutralLighter: GrayColors.gray20,
+    neutralLighterAlt: GrayColors.gray10,
     white: GrayColors.white
   }
 });

--- a/packages/experiments/src/components/fluent/theme/FluentThemePage.tsx
+++ b/packages/experiments/src/components/fluent/theme/FluentThemePage.tsx
@@ -6,7 +6,7 @@ import {
 } from '@uifabric/example-app-base';
 
 import { FluentThemeBasicExample } from './examples/FluentTheme.Basic.Example';
-import FluentTheme from './FluentTheme';
+
 const FluentThemeBasicExampleCode =
   require('!raw-loader!@uifabric/experiments/src/components/fluent/theme/examples/FluentTheme.Basic.Example.tsx') as string;
 

--- a/packages/experiments/src/components/fluent/theme/FluentThemePage.tsx
+++ b/packages/experiments/src/components/fluent/theme/FluentThemePage.tsx
@@ -5,7 +5,8 @@ import {
   ExampleCard
 } from '@uifabric/example-app-base';
 
-import { FluentThemeBasicExample } from '@uifabric/experiments/lib/components/fluent/theme/examples/FluentTheme.Basic.Example';
+import { FluentThemeBasicExample } from './examples/FluentTheme.Basic.Example';
+import FluentTheme from './FluentTheme';
 const FluentThemeBasicExampleCode =
   require('!raw-loader!@uifabric/experiments/src/components/fluent/theme/examples/FluentTheme.Basic.Example.tsx') as string;
 
@@ -14,6 +15,9 @@ export class FluentThemePage extends React.Component<
   {}
   > {
   public render(): JSX.Element {
+
+    console.log(FluentTheme.palette);
+
     return (
       <ComponentPage
         title='Fluent Theme'

--- a/packages/experiments/src/components/fluent/theme/FluentThemePage.tsx
+++ b/packages/experiments/src/components/fluent/theme/FluentThemePage.tsx
@@ -15,9 +15,6 @@ export class FluentThemePage extends React.Component<
   {}
   > {
   public render(): JSX.Element {
-
-    console.log(FluentTheme.palette);
-
     return (
       <ComponentPage
         title='Fluent Theme'


### PR DESCRIPTION
In a [previous PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/4761/files#diff-502a92752dcf6396962fa55c5a61c290) I checked in color names that look to have been broken by a find-replace run amok. I've fixed them here and verified that the theme is being applied correctly.