### PR TITLE
Fixes expanding sub contextual menu issue

### DIFF
--- a/common/changes/office-ui-fabric-react/rebeba-contextual-menu-keyboarding_2018-05-10-21-00.json
+++ b/common/changes/office-ui-fabric-react/rebeba-contextual-menu-keyboarding_2018-05-10-21-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes issue where expanding sub menu via arrow keys was broken, and adds aria label of \"menu\" to item when keyboarded",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rebeba@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -293,6 +293,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
                 handleTabKey={ FocusZoneTabbableElements.all }
               >
                 <ul
+                  role={ shouldFocusOnContainer ? undefined : 'menu' }
                   className={ this._classNames.list }
                   onKeyDown={ this._onKeyDown }
                 >

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -807,14 +807,9 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
   }
 
   private _onItemKeyDown = (item: any, ev: React.KeyboardEvent<HTMLElement>): void => {
-    let openKey;
-    if (item.split) {
-      openKey = getRTL() ? KeyCodes.left : KeyCodes.right;
-    } else {
-      openKey = KeyCodes.enter;
-    }
+    const openKey = getRTL() ? KeyCodes.left : KeyCodes.right;
 
-    if (ev.which === openKey && !item.disabled) {
+    if ((ev.which === openKey || ev.which === KeyCodes.enter) && !item.disabled) {
       this.setState({
         expandedByMouseClick: false
       });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4838
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes issue where arrowing didn't work to open sub menus, also adds label 'menu' to contextual menu when opened via keyboarding.
