### PR TITLE
Issue#4832: Break ContextualMenu Types hard dependency from class ContextualMenu

### DIFF
--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -488,7 +488,7 @@ export interface IContextualMenuItem {
   inactive?: boolean;
 }
 
-export interface IContextualMenuSection extends React.Props<ContextualMenu> {
+export interface IContextualMenuSection extends React.Props<any> {
 
   /**
    * The items to include inside the section.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ContextualMenu } from './ContextualMenu';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { FocusZoneDirection, IFocusZoneProps } from '../../FocusZone';
 import { IIconProps } from '../Icon/Icon.types';
@@ -29,7 +28,7 @@ export interface IContextualMenu {
 
 }
 
-export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWithResponsiveModeState {
+export interface IContextualMenuProps extends React.Props<any>, IWithResponsiveModeState {
   /**
    * Optional callback to access the IContextualMenu interface. Use this instead of ref for accessing
    * the public methods and properties of the component.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Fixes #4832 

#### Description of changes

In an effort to reduce bundle size on critical path rendering, we are trying to defer what is not required upfront.  One such control from Fabric for us is ContextualMenu, which is required for edit scenario mostly. However What we learned is we cannot chunk this from core because we need BaseButton and It has hard dependency on IContextualMenuProps. Which is fine.
Unfortunately IContextualMenuProps have hard dependency on ContextualMenu which is not fine.

export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWithResponsiveModeState {

#### Focus areas to test

This is not supposed to change any runtime behavior as change is in typing only