### PR TITLE
Rename all getStyles to styles.

### DIFF
--- a/6.0_RELEASE_NOTES.md
+++ b/6.0_RELEASE_NOTES.md
@@ -106,8 +106,8 @@ changes.
 
 ## Breaking changes
 ### Components
-* All: `getStyles` were renamed to `styles` and now either takes in a style object
-  or a function.
+* All: Components with `getStyles` property had the property renamed to `styles`
+  which now either takes in a style object or a function. (#4844)
 * Checkbox: Replaced optional properties of the `ICheckboxStyles` interface,
   removed `getClassNames` from the `ICheckboxProps` interface, in favor of `styles`.
   (#4748)

--- a/6.0_RELEASE_NOTES.md
+++ b/6.0_RELEASE_NOTES.md
@@ -106,9 +106,11 @@ changes.
 
 ## Breaking changes
 ### Components
+* All: `getStyles` was renamed to `styles` and now either takes in a style object
+  or a function.
 * Checkbox: Replaced optional properties of the `ICheckboxStyles` interface,
-  removed `styles` and `getClassNames` from the `ICheckboxProps` interface, in
-  favor of `getStyles`. (#4748)
+  removed `getClassNames` from the `ICheckboxProps` interface, in favor of `styles`.
+  (#4748)
 * CommandBar: Moved experimental Command Bar into release.
 * ContextualMenu: Removed deprecated (back in v0.69.0 of OUFR) `icon` prop
   from `IContextualMenuItem`. Use `iconProps: { iconName: 'SomeIcon' }`

--- a/6.0_RELEASE_NOTES.md
+++ b/6.0_RELEASE_NOTES.md
@@ -106,7 +106,7 @@ changes.
 
 ## Breaking changes
 ### Components
-* All: `getStyles` was renamed to `styles` and now either takes in a style object
+* All: `getStyles` were renamed to `styles` and now either takes in a style object
   or a function.
 * Checkbox: Replaced optional properties of the `ICheckboxStyles` interface,
   removed `getClassNames` from the `ICheckboxProps` interface, in favor of `styles`.

--- a/packages/experiments/src/components/Nav/Nav.tsx
+++ b/packages/experiments/src/components/Nav/Nav.tsx
@@ -99,12 +99,12 @@ class NavComponent extends NavBase {
     const hasChildren = !!link.links && link.links.length > 0;
     const isSelected = (isLinkSelected && !hasChildren) || (isChildLinkSelected && !link.isExpanded);
     const {
-      getStyles,
+      styles,
       showMore,
       onShowMoreLinkClicked,
       dataHint
     } = this.props;
-    const classNames = getClassNames(getStyles!, { isSelected, nestingLevel });
+    const classNames = getClassNames(styles!, { isSelected, nestingLevel });
     const linkText = this.getLinkText(link, showMore);
     const onClickHandler = link.isShowMoreLink && onShowMoreLinkClicked ? onShowMoreLinkClicked : this._onLinkClicked.bind(this, link);
 
@@ -192,7 +192,7 @@ class NavComponent extends NavBase {
     }
 
     const {
-      getStyles,
+      styles,
       enableCustomization
     } = this.props;
 
@@ -201,7 +201,7 @@ class NavComponent extends NavBase {
       return null;
     }
 
-    const classNames = getClassNames(getStyles!, {});
+    const classNames = getClassNames(styles!, {});
 
     return (
       <div key={ groupIndex }>

--- a/packages/experiments/src/components/Nav/Nav.types.ts
+++ b/packages/experiments/src/components/Nav/Nav.types.ts
@@ -38,7 +38,7 @@ export interface INavProps {
   /**
    * (Optional) Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<INavStyleProps, INavStyles>;
+  styles?: IStyleFunctionOrObject<INavStyleProps, INavStyles>;
 
   /**
    * (Optional) Used for telemetry

--- a/packages/experiments/src/components/Nav/NavToggler.tsx
+++ b/packages/experiments/src/components/Nav/NavToggler.tsx
@@ -41,8 +41,8 @@ class NavTogglerComponent extends React.Component<INavProps, INavState> {
       showMore
     } = this.state;
 
-    const { getStyles } = this.props;
-    const classNames = getClassNames(getStyles!, { isCollapsed: isNavCollapsed });
+    const { styles } = this.props;
+    const classNames = getClassNames(styles!, { isCollapsed: isNavCollapsed });
 
     return (
       <div className={ classNames.root }>
@@ -89,8 +89,8 @@ class NavTogglerComponent extends React.Component<INavProps, INavState> {
 
   private _renderExpandCollapseNavItem(): React.ReactElement<{}> {
     const isNavCollapsed = this.state.isNavCollapsed;
-    const { getStyles } = this.props;
-    const classNames = getClassNames(getStyles!, {});
+    const { styles } = this.props;
+    const classNames = getClassNames(styles!, {});
 
     return (
       <NavLink

--- a/packages/experiments/src/components/Nav/SlimNav.tsx
+++ b/packages/experiments/src/components/Nav/SlimNav.tsx
@@ -110,11 +110,11 @@ class SlimNavComponent extends NavBase {
 
     const isSelected = nestingLevel > 0 && this.isLinkSelected(link, false /* includeChildren */);
     const {
-      getStyles,
+      styles,
       showMore,
       dataHint
     } = this.props;
-    const classNames = getClassNames(getStyles!, { isSelected, nestingLevel });
+    const classNames = getClassNames(styles!, { isSelected, nestingLevel });
     const linkText = this.getLinkText(link, showMore);
 
     return (
@@ -188,8 +188,8 @@ class SlimNavComponent extends NavBase {
     }
 
     const hasChildren = (!!link.links && link.links.length > 0);
-    const { getStyles } = this.props;
-    const classNames = getClassNames(getStyles!, { hasChildren, scrollTop: link.scrollTop });
+    const { styles } = this.props;
+    const classNames = getClassNames(styles!, { hasChildren, scrollTop: link.scrollTop });
 
     return (
       <div className={ classNames.navFloatingRoot }>
@@ -208,12 +208,12 @@ class SlimNavComponent extends NavBase {
     const isSelected = this.isLinkSelected(link, true /* includeChildren */);
     const hasChildren = (!!link.links && link.links.length > 0);
     const {
-      getStyles,
+      styles,
       showMore,
       onShowMoreLinkClicked,
       dataHint
     } = this.props;
-    const classNames = getClassNames(getStyles!, { isSelected, hasChildren });
+    const classNames = getClassNames(styles!, { isSelected, hasChildren });
     const linkText = this.getLinkText(link, showMore);
     const onClickHandler = link.isShowMoreLink && onShowMoreLinkClicked ? onShowMoreLinkClicked : this._onLinkClicked.bind(this, link);
 
@@ -277,7 +277,7 @@ class SlimNavComponent extends NavBase {
     }
 
     const {
-      getStyles,
+      styles,
       enableCustomization
     } = this.props;
 
@@ -286,7 +286,7 @@ class SlimNavComponent extends NavBase {
       return null;
     }
 
-    const classNames = getClassNames(getStyles!, {});
+    const classNames = getClassNames(styles!, {});
 
     return (
       <div key={ groupIndex }>

--- a/packages/experiments/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/experiments/src/components/Shimmer/Shimmer.base.tsx
@@ -33,7 +33,7 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, {}> {
 
   public render(): JSX.Element {
     const {
-      getStyles,
+      styles,
       width,
       lineElements,
       children,
@@ -45,7 +45,7 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, {}> {
 
     const rowHeight: number | undefined = lineElements ? findMaxElementHeight(lineElements) : undefined;
 
-    this._classNames = getClassNames(getStyles!, {
+    this._classNames = getClassNames(styles!, {
       width, rowHeight, isDataLoaded, isBaseStyle, widthInPercentage, widthInPixel
     });
 

--- a/packages/experiments/src/components/Shimmer/Shimmer.types.ts
+++ b/packages/experiments/src/components/Shimmer/Shimmer.types.ts
@@ -56,7 +56,7 @@ export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<IShimmerStyleProps, IShimmerStyles>;
+  styles?: IStyleFunctionOrObject<IShimmerStyleProps, IShimmerStyles>;
 }
 
 export interface IShimmerElement {

--- a/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.base.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.base.tsx
@@ -12,15 +12,15 @@ import {
 const getClassNames = classNamesFunction<IShimmerCircleStyleProps, IShimmerCircleStyles>();
 
 export class ShimmerCircleBase extends BaseComponent<IShimmerCircleProps, {}> {
-  private _classNames: {[key in keyof IShimmerCircleStyles]: string};
+  private _classNames: { [key in keyof IShimmerCircleStyles]: string };
 
   constructor(props: IShimmerCircleProps) {
     super(props);
   }
 
   public render(): JSX.Element {
-    const { height, getStyles, borderStyle } = this.props;
-    this._classNames = getClassNames(getStyles!, { height, borderStyle });
+    const { height, styles, borderStyle } = this.props;
+    this._classNames = getClassNames(styles!, { height, borderStyle });
 
     return (
       <div className={ this._classNames.root }>

--- a/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.types.ts
+++ b/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.types.ts
@@ -30,7 +30,7 @@ export interface IShimmerCircleProps extends React.AllHTMLAttributes<HTMLElement
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<IShimmerCircleStyleProps, IShimmerCircleStyles>;
+  styles?: IStyleFunctionOrObject<IShimmerCircleStyleProps, IShimmerCircleStyles>;
 }
 
 export interface IShimmerCircleStyleProps {

--- a/packages/experiments/src/components/Shimmer/ShimmerGap/ShimmerGap.base.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerGap/ShimmerGap.base.tsx
@@ -12,16 +12,16 @@ import {
 const getClassNames = classNamesFunction<IShimmerGapStyleProps, IShimmerGapStyles>();
 
 export class ShimmerGapBase extends BaseComponent<IShimmerGapProps, {}> {
-  private _classNames: {[key in keyof IShimmerGapStyles]: string};
+  private _classNames: { [key in keyof IShimmerGapStyles]: string };
 
   constructor(props: IShimmerGapProps) {
     super(props);
   }
 
   public render(): JSX.Element {
-    const { height, getStyles, widthInPercentage, widthInPixel, borderStyle } = this.props;
+    const { height, styles, widthInPercentage, widthInPixel, borderStyle } = this.props;
 
-    this._classNames = getClassNames(getStyles!, { height, widthInPixel, widthInPercentage, borderStyle });
+    this._classNames = getClassNames(styles!, { height, widthInPixel, widthInPercentage, borderStyle });
 
     return (
       <div className={ this._classNames.root } />

--- a/packages/experiments/src/components/Shimmer/ShimmerGap/ShimmerGap.types.ts
+++ b/packages/experiments/src/components/Shimmer/ShimmerGap/ShimmerGap.types.ts
@@ -42,7 +42,7 @@ export interface IShimmerGapProps extends React.AllHTMLAttributes<HTMLElement> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<IShimmerGapStyleProps, IShimmerGapStyles>;
+  styles?: IStyleFunctionOrObject<IShimmerGapStyleProps, IShimmerGapStyles>;
 }
 
 export interface IShimmerGapStyleProps {

--- a/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.base.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.base.tsx
@@ -19,9 +19,9 @@ export class ShimmerLineBase extends BaseComponent<IShimmerLineProps, {}> {
   }
 
   public render(): JSX.Element {
-    const { height, getStyles, widthInPercentage, widthInPixel, borderStyle } = this.props;
+    const { height, styles, widthInPercentage, widthInPixel, borderStyle } = this.props;
 
-    this._classNames = getClassNames(getStyles!, { height, widthInPixel, widthInPercentage, borderStyle });
+    this._classNames = getClassNames(styles!, { height, widthInPixel, widthInPercentage, borderStyle });
 
     return (
       <div className={ this._classNames.root } />

--- a/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.types.ts
+++ b/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.types.ts
@@ -42,7 +42,7 @@ export interface IShimmerLineProps extends React.AllHTMLAttributes<HTMLElement> 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<IShimmerLineStyleProps, IShimmerLineStyles>;
+  styles?: IStyleFunctionOrObject<IShimmerLineStyleProps, IShimmerLineStyles>;
 }
 
 export interface IShimmerLineStyleProps {

--- a/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.base.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.base.tsx
@@ -67,7 +67,7 @@ export class ShimmerTileBase extends BaseComponent<IShimmerTileProps, {}> {
 
   public render(): JSX.Element {
     const {
-      getStyles,
+      styles,
       contentSize = { width: 176, height: 171 },
       itemActivity = true,
       itemName = true,
@@ -103,7 +103,7 @@ export class ShimmerTileBase extends BaseComponent<IShimmerTileProps, {}> {
       }
     }
 
-    this._classNames = getClassNames(getStyles!, {});
+    this._classNames = getClassNames(styles!, {});
 
     return (
       <div

--- a/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.types.ts
+++ b/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.types.ts
@@ -49,7 +49,7 @@ export interface IShimmerTileProps extends React.AllHTMLAttributes<HTMLElement> 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<IShimmerTileStyleProps, IShimmerTileStyles>;
+  styles?: IStyleFunctionOrObject<IShimmerTileStyleProps, IShimmerTileStyles>;
 }
 
 export interface IShimmerTileStyleProps {

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -62,7 +62,7 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
       items,
       className,
       theme,
-      getStyles
+      styles
     } = this.props;
     const renderedItems = [...items];
     const renderedOverflowItems = renderedItems.splice(overflowIndex!, renderedItems.length - maxDisplayedItems!);
@@ -72,7 +72,7 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
       renderedOverflowItems
     };
 
-    this._classNames = getClassNames(getStyles, {
+    this._classNames = getClassNames(styles, {
       className,
       theme: theme!
     });

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -65,7 +65,7 @@ export interface IBreadcrumbProps extends React.Props<BreadcrumbBase> {
    */
   overflowIndex?: number;
 
-  getStyles?: IStyleFunctionOrObject<IBreadcrumbStyleProps, IBreadcrumbStyles>;
+  styles?: IStyleFunctionOrObject<IBreadcrumbStyleProps, IBreadcrumbStyles>;
   theme?: ITheme;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -181,7 +181,7 @@ export interface ICalloutProps {
   /**
    * Optional styles for the component.
    */
-  getStyles?: IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>;
+  styles?: IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>;
 
   /**
    * If specified, renders the Callout in a hidden state.

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -66,7 +66,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     directionalHint: DirectionalHint.bottomAutoEdge
   };
 
-  private _classNames: {[key in keyof ICalloutContentStyles]: string };
+  private _classNames: { [key in keyof ICalloutContentStyles]: string };
   private _didSetInitialFocus: boolean;
   private _hostElement = createRef<HTMLDivElement>();
   private _calloutElement = createRef<HTMLDivElement>();
@@ -149,7 +149,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
       target
     } = this.props;
     const {
-      getStyles,
+      styles,
       role,
       ariaLabel,
       ariaDescribedBy,
@@ -173,7 +173,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
 
     const beakVisible = isBeakVisible && (!!target);
     this._classNames = getClassNames(
-      getStyles!,
+      styles!,
       {
         theme: this.props.theme!,
         className,

--- a/packages/office-ui-fabric-react/src/components/Check/Check.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.types.ts
@@ -18,7 +18,7 @@ export interface ICheckProps extends React.Props<CheckBase> {
   /**
   * Call to provide customized styling that will layer on top of the variant rules
   */
-  getStyles?: IStyleFunctionOrObject<ICheckStyleProps, ICheckStyles>;
+  styles?: IStyleFunctionOrObject<ICheckStyleProps, ICheckStyles>;
 
   /**
    * Flag to always show the check icon. Not currently working.

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
@@ -30,7 +30,7 @@ export class CheckboxBase extends BaseComponent<ICheckboxProps, ICheckboxState> 
 
   private _checkBox = createRef<HTMLElement>();
   private _id: string;
-  private _classNames: {[key in keyof ICheckboxStyles]: string };
+  private _classNames: { [key in keyof ICheckboxStyles]: string };
 
   /**
    * Initialize a new instance of the TopHeaderV2
@@ -74,7 +74,7 @@ export class CheckboxBase extends BaseComponent<ICheckboxProps, ICheckboxState> 
       ariaLabel,
       ariaLabelledBy,
       ariaDescribedBy,
-      getStyles,
+      styles,
       onRenderLabel = this._onRenderLabel,
       checkmarkIconProps,
       ariaPositionInSet,
@@ -85,7 +85,7 @@ export class CheckboxBase extends BaseComponent<ICheckboxProps, ICheckboxState> 
     const isChecked = checked === undefined ? this.state.isChecked : checked;
     const isReversed = boxSide !== 'start' ? true : false;
 
-    this._classNames = getClassNames(getStyles!, {
+    this._classNames = getClassNames(styles!, {
       theme: theme!,
       className,
       disabled,

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
@@ -97,14 +97,14 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
   ariaPositionInSet?: number;
 
   /**
-  * The total size of the parent set (if in a set) for aria-setsize.
-  */
+   * The total size of the parent set (if in a set) for aria-setsize.
+   */
   ariaSetSize?: number;
 
   /**
-  * Call to provide customized styling that will layer on top of the variant rules.
-  */
-  getStyles?: IStyleFunctionOrObject<ICheckboxStyleProps, ICheckboxStyles>;
+   * Call to provide customized styling that will layer on top of the variant rules.
+   */
+  styles?: IStyleFunctionOrObject<ICheckboxStyleProps, ICheckboxStyles>;
 
   /**
    * Custom render function for the label.

--- a/packages/office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.ImplementationExamples.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.ImplementationExamples.tsx
@@ -44,7 +44,7 @@ export class CheckboxImplementationExamples extends React.Component<{}, ICheckbo
             onFocus: () => { console.log('Uncontrolled checkbox is focused'); },
             onBlur: () => { console.log('Uncontrolled checkbox is blured'); }
           } }
-          getStyles={ checkboxStyles }
+          styles={ checkboxStyles }
           ariaDescribedBy={ 'descriptionID' }
         />
         <label id='descriptionID' className='screenReaderOnly'>Uncontroller checkbox description</label>
@@ -53,13 +53,13 @@ export class CheckboxImplementationExamples extends React.Component<{}, ICheckbo
           label='Uncontrolled checkbox with defaultChecked true'
           defaultChecked={ true }
           onChange={ this._onCheckboxChange }
-          getStyles={ checkboxStyles }
+          styles={ checkboxStyles }
         />
 
         <Checkbox
           label='Disabled uncontrolled checkbox'
           disabled={ true }
-          getStyles={ checkboxStyles }
+          styles={ checkboxStyles }
         />
 
         <Checkbox
@@ -67,25 +67,25 @@ export class CheckboxImplementationExamples extends React.Component<{}, ICheckbo
           disabled={ true }
           defaultChecked={ true }
           onChange={ this._onCheckboxChange }
-          getStyles={ checkboxStyles }
+          styles={ checkboxStyles }
         />
 
         <Checkbox
           label='Controlled checkbox'
           checked={ isChecked }
           onChange={ this._onControlledCheckboxChange }
-          getStyles={ checkboxStyles }
+          styles={ checkboxStyles }
         />
 
         <Checkbox
           label='Checkbox rendered with boxSide "end"'
           boxSide='end'
-          getStyles={ checkboxStyles }
+          styles={ checkboxStyles }
         />
 
         <Checkbox
           label='Persona Checkbox'
-          getStyles={ checkboxStyles }
+          styles={ checkboxStyles }
           onRenderLabel={ this._renderPersonaLabel }
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
@@ -13,7 +13,7 @@ export interface ICoachmarkTypes extends React.Props<Coachmark> {
   /**
    * Get styles method.
    */
-  getStyles?: IStyleFunctionOrObject<ICoachmarkStyleProps, ICoachmarkStyles>;
+  styles?: IStyleFunctionOrObject<ICoachmarkStyleProps, ICoachmarkStyles>;
 
   /**
    * The target that the TeachingBubble should try to position itself based on.

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1115,7 +1115,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
               ariaLabel={ this._getPreviewText(item) }
               key={ item.key }
               data-index={ item.index }
-              getStyles={ checkboxStyles }
+              styles={ checkboxStyles }
               className={ 'ms-ComboBox-option' }
               data-is-focusable={ true }
               onChange={ this._onItemClick(item.index!) }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -67,7 +67,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       items,
       overflowItems,
       farItems,
-      getStyles,
+      styles,
       theme,
       onReduceData = this._onReduceData,
       onGrowData = this._onGrowData,
@@ -82,7 +82,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     };
 
     this._setAriaPosinset(commandBarData);
-    this._classNames = getClassNames(getStyles!, { theme: theme!, className });
+    this._classNames = getClassNames(styles!, { theme: theme!, className });
 
     return (
       <ResizeGroup

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -104,7 +104,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
   * Call to provide customized styling that will layer on top of the variant rules
   */
-  getStyles?: IStyleFunctionOrObject<ICommandBarStyleProps, ICommandBarStyles>;
+  styles?: IStyleFunctionOrObject<ICommandBarStyleProps, ICommandBarStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
@@ -74,7 +74,7 @@ export class DialogBase extends BaseComponent<IDialogProps, {}> {
       elementToFocusOnDismiss,
       firstFocusableSelector,
       forceFocusInsideTrap,
-      getStyles,
+      styles,
       hidden,
       ignoreExternalFocusing,
       isBlocking,
@@ -102,7 +102,7 @@ export class DialogBase extends BaseComponent<IDialogProps, {}> {
       ...this.props.dialogContentProps,
     };
 
-    const classNames = getClassNames(getStyles!, {
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       className: className || modalProps!.className,
       containerClassName: containerClassName || modalProps!.containerClassName,

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
@@ -23,7 +23,7 @@ export interface IDialogProps extends React.Props<DialogBase>, IWithResponsiveMo
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IDialogStyleProps, IDialogStyles>;
+  styles?: IStyleFunctionOrObject<IDialogStyleProps, IDialogStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -42,11 +42,11 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
       titleId,
       title,
       type,
-      getStyles,
+      styles,
       theme,
     } = this.props;
 
-    const classNames = getClassNames(getStyles!, {
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       className,
       isLargeHeader: type === DialogType.largeHeader,

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -19,7 +19,7 @@ export interface IDialogContentProps extends React.Props<DialogContentBase> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IDialogContentStyleProps, IDialogContentStyles>;
+  styles?: IStyleFunctionOrObject<IDialogContentStyleProps, IDialogContentStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.base.tsx
@@ -20,11 +20,11 @@ export class DialogFooterBase extends BaseComponent<IDialogFooterProps, {}> {
   public render(): JSX.Element {
     const {
       className,
-      getStyles,
+      styles,
       theme
     } = this.props;
 
-    this._classNames = getClassNames(getStyles!, {
+    this._classNames = getClassNames(styles!, {
       theme: theme!,
       className
     });

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.types.ts
@@ -12,7 +12,7 @@ export interface IDialogFooterProps extends React.Props<DialogFooterBase> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IDialogFooterStyleProps, IDialogFooterStyles>;
+  styles?: IStyleFunctionOrObject<IDialogFooterStyleProps, IDialogFooterStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
@@ -48,7 +48,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
     const previewPropsUsingIcon: IDocumentCardPreviewProps = {
       previewImages: [
         {
-          previewIconProps: { iconName: 'OpenFile', getStyles: { root: { fontSize: 42, color: '#ffffff' } } },
+          previewIconProps: { iconName: 'OpenFile', styles: { root: { fontSize: 42, color: '#ffffff' } } },
           width: 144
         }
       ]
@@ -57,7 +57,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
     const previewOutlookUsingIcon: IDocumentCardPreviewProps = {
       previewImages: [
         {
-          previewIconProps: { iconName: 'OutlookLogo', getStyles: { root: { fontSize: 42, color: '#0078d7' } } },
+          previewIconProps: { iconName: 'OutlookLogo', styles: { root: { fontSize: 42, color: '#0078d7' } } },
           previewIconContainerClass: 'ms-DocumentCardPreview-iconContainer2',
           width: 144
         }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -80,7 +80,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
     const previewPropsUsingIcon: IDocumentCardPreviewProps = {
       previewImages: [
         {
-          previewIconProps: { iconName: 'OpenFile', getStyles: { root: { fontSize: 42, color: '#ffffff' } } },
+          previewIconProps: { iconName: 'OpenFile', styles: { root: { fontSize: 42, color: '#ffffff' } } },
           width: 318,
           height: 196
         }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -543,7 +543,7 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
             checked={ isItemSelected }
             // Hover is being handled by focus styles
             // so clear out the explicit hover styles
-            getStyles={ checkboxStyles }
+            styles={ checkboxStyles }
           />
         )
     );

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
@@ -30,7 +30,7 @@ export class IconBase extends BaseComponent<IIconProps, IIconState> {
     const {
       ariaLabel,
       className,
-      getStyles,
+      styles,
       iconName,
       imageErrorAs,
     } = this.props;
@@ -38,7 +38,7 @@ export class IconBase extends BaseComponent<IIconProps, IIconState> {
     const isImage = this.props.iconType === IconType.image || this.props.iconType === IconType.Image;
     const { iconClassName, children } = this._getIconContent(iconName);
 
-    const classNames = getClassNames(getStyles, {
+    const classNames = getClassNames(styles, {
       className,
       iconClassName,
       isImage,

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.test.tsx
@@ -20,7 +20,7 @@ describe('Icon', () => {
     const component = renderer.create(
       <Icon
         iconName='Upload'
-        getStyles={ { root: 'root', imageContainer: 'imageContainer' } }
+        styles={ { root: 'root', imageContainer: 'imageContainer' } }
       />
     );
     expect(component.toJSON()).toMatchSnapshot();
@@ -33,7 +33,7 @@ describe('Icon', () => {
       <Icon
         className='className'
         iconName='Upload'
-        getStyles={ customStyles }
+        styles={ customStyles }
       />
     );
     expect(component.toJSON()).toMatchSnapshot();

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.types.ts
@@ -64,7 +64,7 @@ export interface IIconProps extends IBaseProps, React.HTMLAttributes<HTMLElement
   /**
    * Gets the styles for an Icon.
    */
-  getStyles?: IStyleFunctionOrObject<IIconStyleProps, IIconStyles>;
+  styles?: IStyleFunctionOrObject<IIconStyleProps, IIconStyles>;
 }
 
 export interface IIconStyleProps {

--- a/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
@@ -78,12 +78,12 @@ export class ImageBase extends BaseComponent<IImageProps, IImageState> {
       imageFit,
       role,
       maximizeFrame,
-      getStyles,
+      styles,
       theme
     } = this.props;
     const { loadState } = this.state;
     const coverStyle = this.props.coverStyle !== undefined ? this.props.coverStyle : this._coverStyle;
-    const classNames = getClassNames(getStyles!,
+    const classNames = getClassNames(styles!,
       {
         theme: theme!,
         className,

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -16,7 +16,7 @@ export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IImageStyleProps, IImageStyles>;
+  styles?: IStyleFunctionOrObject<IImageStyleProps, IImageStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/Keytip/Keytip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Keytip/Keytip.tsx
@@ -57,7 +57,7 @@ export class Keytip extends BaseComponent<IKeytipProps, {}> implements IKeytip {
         isBeakVisible={ false }
         doNotLayer={ true }
         minPagePadding={ 0 }
-        getStyles={ offset ? getCalloutOffsetStyles(offset) : getCalloutStyles }
+        styles={ offset ? getCalloutOffsetStyles(offset) : getCalloutStyles }
         preventDismissOnScroll={ true }
         target={ keytipTarget }
       >

--- a/packages/office-ui-fabric-react/src/components/Keytip/Keytip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Keytip/Keytip.types.ts
@@ -83,7 +83,7 @@ export interface IKeytipProps {
    *
    * @type {IStyleFunctionOrObject<IKeytipStyleProps, IKeytipStyles>}
    */
-  getStyles?: IStyleFunctionOrObject<IKeytipStyleProps, IKeytipStyles>;
+  styles?: IStyleFunctionOrObject<IKeytipStyleProps, IKeytipStyles>;
 
   /**
    * Offset x and y for the keytip, added from the top-left corner

--- a/packages/office-ui-fabric-react/src/components/Keytip/KeytipContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Keytip/KeytipContent.base.tsx
@@ -15,7 +15,7 @@ export class KeytipContentBase extends BaseComponent<IKeytipProps, {}> {
   public render(): JSX.Element {
     const {
       content,
-      getStyles,
+      styles,
       theme,
       disabled,
       visible
@@ -23,7 +23,7 @@ export class KeytipContentBase extends BaseComponent<IKeytipProps, {}> {
 
     const getClassNames = classNamesFunction<IKeytipStyleProps, IKeytipStyles>();
     const classNames = getClassNames(
-      getStyles!,
+      styles!,
       {
         theme: theme!,
         disabled,

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -126,7 +126,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
   public render(): JSX.Element {
     const {
       content,
-      getStyles
+      styles
     } = this.props;
 
     const {
@@ -135,11 +135,11 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
     } = this.state;
 
     this._classNames = getClassNames(
-      getStyles!
+      styles!
     );
 
     return (
-      <Layer getStyles={ getLayerStyles }>
+      <Layer styles={ getLayerStyles }>
         <span id={ KTP_LAYER_ID } className={ this._classNames.innerContent }>{ `${content}${KTP_ARIA_SEPARATOR}` }</span>
         { keytips && keytips.map((keytipProps: IKeytipProps, index: number) => {
           return (

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.types.ts
@@ -57,7 +57,7 @@ export interface IKeytipLayerProps extends React.Props<IKeytipLayer> {
   onEnterKeytipMode?: () => void;
 
   /**
-   * getStyles function for KeytipLayer
+   * (Optional) Call to provide customized styling.
    */
   styles?: IStyleFunctionOrObject<IKeytipLayerStyleProps, IKeytipLayerStyles>;
 }

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.types.ts
@@ -59,7 +59,7 @@ export interface IKeytipLayerProps extends React.Props<IKeytipLayer> {
   /**
    * getStyles function for KeytipLayer
    */
-  getStyles?: IStyleFunctionOrObject<IKeytipLayerStyleProps, IKeytipLayerStyles>;
+  styles?: IStyleFunctionOrObject<IKeytipLayerStyleProps, IKeytipLayerStyles>;
 }
 
 export interface IKeytipLayerStyles {

--- a/packages/office-ui-fabric-react/src/components/Label/Label.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.base.tsx
@@ -12,12 +12,12 @@ export class LabelBase extends BaseComponent<ILabelProps, {}> {
       children,
       className,
       disabled,
-      getStyles,
+      styles,
       required,
       theme
     } = this.props;
     const classNames = getClassNames(
-      getStyles,
+      styles,
       {
         className,
         disabled,

--- a/packages/office-ui-fabric-react/src/components/Label/Label.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.test.tsx
@@ -11,7 +11,7 @@ describe('Label', () => {
 
   it('renders a label', () => {
     const component = ReactTestUtils.renderIntoDocument(
-      <LabelBase getStyles={ getStyles }>test</LabelBase>
+      <LabelBase styles={ getStyles }>test</LabelBase>
     );
     const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance) as Element;
 
@@ -20,7 +20,7 @@ describe('Label', () => {
 
   it('renders label correctly', () => {
     const component = renderer.create(
-      <LabelBase getStyles={ getStyles }>test</LabelBase>
+      <LabelBase styles={ getStyles }>test</LabelBase>
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/office-ui-fabric-react/src/components/Label/Label.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.types.ts
@@ -41,7 +41,7 @@ export interface ILabelProps extends React.LabelHTMLAttributes<HTMLLabelElement>
   /**
    * Styles for the label.
    */
-  getStyles?: IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles>;
+  styles?: IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles>;
 }
 
 export interface ILabelStyles {

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
@@ -105,8 +105,8 @@ export class LayerBase extends BaseComponent<ILayerProps, {}> {
   }
 
   private _getClassNames() {
-    const { className, getStyles, theme } = this.props;
-    const classNames = getClassNames(getStyles!,
+    const { className, styles, theme } = this.props;
+    const classNames = getClassNames(styles!,
       {
         theme: theme!,
         className,

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.types.ts
@@ -17,7 +17,7 @@ export interface ILayerProps extends React.HTMLAttributes<HTMLDivElement | Layer
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<ILayerStyleProps, ILayerStyles>;
+  styles?: IStyleFunctionOrObject<ILayerStyleProps, ILayerStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/Layer/__snapshots__/Layer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Layer/__snapshots__/Layer.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Layer renders Layer correctly 1`] = `
 <StyledCustomizedLayer>
   <CustomizedLayer
-    getStyles={[Function]}
     onLayerDidMount={[Function]}
     onLayerWillUnmount={[Function]}
+    styles={[Function]}
   >
     <LayerBase
-      getStyles={[Function]}
       onLayerDidMount={[Function]}
       onLayerWillUnmount={[Function]}
+      styles={[Function]}
       theme={
         Object {
           "disableGlobalClassNames": false,

--- a/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
@@ -23,9 +23,9 @@ export class LinkBase extends BaseComponent<ILinkProps, any> implements ILink {
   private _link = createRef<HTMLAnchorElement | HTMLButtonElement | null>();
 
   public render(): JSX.Element {
-    const { disabled, children, className, href, theme, getStyles, keytipProps } = this.props;
+    const { disabled, children, className, href, theme, styles, keytipProps } = this.props;
 
-    const classNames = getClassNames(getStyles!, {
+    const classNames = getClassNames(styles!, {
       className,
       isButton: !href,
       isDisabled: disabled,

--- a/packages/office-ui-fabric-react/src/components/Link/Link.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.types.ts
@@ -28,7 +28,7 @@ export interface ILinkProps extends React.AllHTMLAttributes<HTMLAnchorElement | 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<ILinkStyleProps, ILinkStyles>;
+  styles?: IStyleFunctionOrObject<ILinkStyleProps, ILinkStyles>;
 
   /**
    * Theme (provided through customization.)

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -91,10 +91,10 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
   }
 
   public render(): JSX.Element {
-    const { rootProps, children, theme, className, getStyles } = this.props;
+    const { rootProps, children, theme, className, styles } = this.props;
     const { dragRect } = this.state;
 
-    const classNames = getClassNames(getStyles!, {
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       className
     });

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.types.ts
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.types.ts
@@ -59,7 +59,7 @@ export interface IMarqueeSelectionProps extends React.HTMLAttributes<HTMLDivElem
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunction<IMarqueeSelectionStyleProps, IMarqueeSelectionStyles>;
+  styles?: IStyleFunction<IMarqueeSelectionStyleProps, IMarqueeSelectionStyles>;
 }
 
 export interface IMarqueeSelectionStyleProps {

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/__snapshots__/MarqueeSelection.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/__snapshots__/MarqueeSelection.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`MarqueeSelection renders MarqueeSelection correctly 1`] = `
   }
 >
   <CustomizedMarqueeSelection
-    getStyles={[Function]}
     isEnabled={true}
     rootProps={Object {}}
     rootTagName="div"
@@ -46,9 +45,9 @@ exports[`MarqueeSelection renders MarqueeSelection correctly 1`] = `
         "mode": 2,
       }
     }
+    styles={[Function]}
   >
     <MarqueeSelectionBase
-      getStyles={[Function]}
       isEnabled={true}
       rootProps={Object {}}
       rootTagName="div"
@@ -71,6 +70,7 @@ exports[`MarqueeSelection renders MarqueeSelection correctly 1`] = `
           "mode": 2,
         }
       }
+      styles={[Function]}
       theme={
         Object {
           "disableGlobalClassNames": false,

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -89,7 +89,7 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
   }
 
   public render(): JSX.Element | null {
-    const { getStyles, groups, className, isOnTop, theme } = this.props;
+    const { styles, groups, className, isOnTop, theme } = this.props;
 
     if (!groups) {
       return null;
@@ -97,7 +97,7 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
 
     const groupElements: React.ReactElement<{}>[] = groups.map(this._renderGroup);
 
-    const classNames = getClassNames(getStyles!, { theme: theme!, className, isOnTop, groups });
+    const classNames = getClassNames(styles!, { theme: theme!, className, isOnTop, groups });
 
     return (
       <FocusZone direction={ FocusZoneDirection.vertical }>
@@ -117,20 +117,20 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
   }
 
   private _onRenderLink = (link: INavLink): JSX.Element => {
-    const { getStyles, groups, theme } = this.props;
-    const classNames = getClassNames(getStyles!, { theme: theme!, groups });
+    const { styles, groups, theme } = this.props;
+    const classNames = getClassNames(styles!, { theme: theme!, groups });
     return (<div className={ classNames.linkText }>{ link.name }</div>);
   }
 
   private _renderNavLink(link: INavLink, linkIndex: number, nestingLevel: number): JSX.Element {
     const {
-      getStyles,
+      styles,
       groups,
       theme,
       onRenderLink = this._onRenderLink
     } = this.props;
 
-    const classNames = getClassNames(getStyles!, {
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       isSelected: this._isLinkSelected(link),
       isButtonEntry: link.onClick && !link.forceAnchor,
@@ -160,8 +160,8 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
 
   private _renderCompositeLink(link: INavLink, linkIndex: number, nestingLevel: number): React.ReactElement<{}> {
     const divProps: React.HTMLProps<HTMLDivElement> = { ...getNativeProps(link, divProperties, ['onClick']) };
-    const { getStyles, groups, theme } = this.props;
-    const classNames = getClassNames(getStyles!, {
+    const { styles, groups, theme } = this.props;
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       isExpanded: !!link.isExpanded,
       isSelected: this._isLinkSelected(link),
@@ -195,8 +195,8 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
   }
 
   private _renderLink(link: INavLink, linkIndex: number, nestingLevel: number): React.ReactElement<{}> {
-    const { getStyles, groups, theme } = this.props;
-    const classNames = getClassNames(getStyles!, { theme: theme!, groups });
+    const { styles, groups, theme } = this.props;
+    const classNames = getClassNames(styles!, { theme: theme!, groups });
 
     return (
       <li key={ link.key || linkIndex } role='listitem' className={ classNames.navItem }>
@@ -213,8 +213,8 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
     const linkElements: React.ReactElement<{}>[] = links.map(
       (link: INavLink, linkIndex: number) => this._renderLink(link, linkIndex, nestingLevel));
 
-    const { getStyles, groups, theme } = this.props;
-    const classNames = getClassNames(getStyles!, { theme: theme!, groups });
+    const { styles, groups, theme } = this.props;
+    const classNames = getClassNames(styles!, { theme: theme!, groups });
 
     return (
       <ul role='list' className={ classNames.navItems }>
@@ -224,8 +224,8 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
   }
 
   private _renderGroup = (group: INavLinkGroup, groupIndex: number): React.ReactElement<{}> => {
-    const { getStyles, groups, theme } = this.props;
-    const classNames = getClassNames(getStyles!, {
+    const { styles, groups, theme } = this.props;
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       isGroup: true,
       isExpanded: !this.state.isGroupCollapsed![group.name!],

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -23,7 +23,7 @@ export interface INavProps {
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<INavStyleProps, INavStyles>;
+  styles?: IStyleFunctionOrObject<INavStyleProps, INavStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.base.tsx
@@ -32,12 +32,12 @@ export class OverlayBase extends BaseComponent<IOverlayProps, {}> {
       isDarkThemed: isDark,
       className,
       theme,
-      getStyles
+      styles
     } = this.props;
 
     const divProps = getNativeProps(this.props, divProperties);
 
-    const classNames = getClassNames(getStyles!, {
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       className,
       isDark,

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.types.ts
@@ -15,7 +15,7 @@ export interface IOverlayProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IOverlayStyleProps, IOverlayStyles>;
+  styles?: IStyleFunctionOrObject<IOverlayStyleProps, IOverlayStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
@@ -22,7 +22,7 @@ const getClassNames = classNamesFunction<IPersonaStyleProps, IPersonaStyles>();
 
 /**
  * Persona with no default styles.
- * [Use the `getStyles` API to add your own styles.](https://github.com/OfficeDev/office-ui-fabric-react/wiki/Styling)
+ * [Use the `styles` API to add your own styles.](https://github.com/OfficeDev/office-ui-fabric-react/wiki/Styling)
  */
 @customizable('Persona', ['theme'])
 export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
@@ -54,7 +54,7 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
       coinProps,
       showUnknownPersonaCoin,
       coinSize,
-      getStyles,
+      styles,
       imageAlt,
       imageInitials,
       imageShouldFadeIn,
@@ -89,7 +89,7 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
       size,
     };
 
-    const classNames = getClassNames(getStyles, {
+    const classNames = getClassNames(styles, {
       theme: theme!,
       className,
       showSecondaryText,

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -145,7 +145,7 @@ export interface IPersonaProps extends IPersonaSharedProps {
   /**
    * Call to provide customized styling that will layer on top of variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IPersonaStyleProps, IPersonaStyles>;
+  styles?: IStyleFunctionOrObject<IPersonaStyleProps, IPersonaStyles>;
 
   /**
    * Optional custom renderer for the primary text.
@@ -221,7 +221,7 @@ export interface IPersonaCoinProps extends IPersonaSharedProps {
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IPersonaCoinStyleProps, IPersonaCoinStyles>;
+  styles?: IStyleFunctionOrObject<IPersonaCoinStyleProps, IPersonaCoinStyles>;
 
   /**
    * Additional css class to apply to the PersonaCoin
@@ -270,7 +270,7 @@ export interface IPersonaPresenceProps extends IPersonaSharedProps {
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IPersonaPresenceStyleProps, IPersonaPresenceStyles>;
+  styles?: IStyleFunctionOrObject<IPersonaPresenceStyleProps, IPersonaPresenceStyles>;
 }
 
 export interface IPersonaPresenceStyleProps {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -82,7 +82,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
       coinProps,
       showUnknownPersonaCoin,
       coinSize,
-      getStyles,
+      styles,
       imageUrl,
       onRenderCoin = this._onRenderCoin,
       onRenderInitials = this._onRenderInitials,
@@ -102,7 +102,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
     };
 
     // Use getStyles from props, or fall back to getStyles from styles file.
-    const classNames = getClassNames(getStyles, {
+    const classNames = getClassNames(styles, {
       theme: theme!,
       className: (coinProps && coinProps.className) ? coinProps.className : className,
       size,
@@ -160,7 +160,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
   private _onRenderCoin = (props: IPersonaCoinProps): JSX.Element | null => {
     const {
       coinSize,
-      getStyles,
+      styles,
       imageUrl,
       imageAlt,
       imageShouldFadeIn,
@@ -171,7 +171,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
 
     const size = this.props.size as PersonaSize;
 
-    const classNames = getClassNames(getStyles, {
+    const classNames = getClassNames(styles, {
       theme: theme!,
       size,
       showUnknownPersonaCoin

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
@@ -35,7 +35,7 @@ export class PersonaPresenceBase extends BaseComponent<IPersonaPresenceProps, {}
   public render(): JSX.Element | null {
     const {
       coinSize,
-      getStyles, // Use getStyles from props.
+      styles, // Use getStyles from props.
       presence,
       theme,
     } = this.props;
@@ -50,7 +50,7 @@ export class PersonaPresenceBase extends BaseComponent<IPersonaPresenceProps, {}
     const coinSizeWithPresenceStyle = coinSize ? { width: presenceHeightWidth, height: presenceHeightWidth } : undefined;
 
     // Use getStyles from props, or fall back to getStyles from styles file.
-    const classNames = getClassNames(getStyles, {
+    const classNames = getClassNames(styles, {
       theme: theme!,
       presence,
       size: this.props.size,

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -21,7 +21,7 @@ export interface IPivotProps extends React.Props<PivotBase> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<IPivotStyleProps, IPivotStyles>;
+  styles?: IStyleFunctionOrObject<IPivotStyleProps, IPivotStyles>;
 
   /**
    * Theme provided by High-Order Component.

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
@@ -42,14 +42,14 @@ export class ProgressIndicatorBase extends BaseComponent<IProgressIndicatorProps
       barHeight,
       className,
       description,
-      getStyles,
+      styles,
       theme,
       title,
     } = this.props;
 
     let { label, percentComplete } = this.props;
 
-    const classNames = getClassNames(getStyles, {
+    const classNames = getClassNames(styles, {
       theme: theme!,
       className,
       barHeight,

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
@@ -16,7 +16,7 @@ export interface IProgressIndicatorProps extends React.Props<ProgressIndicatorBa
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<IProgressIndicatorStyleProps, IProgressIndicatorStyles>;
+  styles?: IStyleFunctionOrObject<IProgressIndicatorStyleProps, IProgressIndicatorStyles>;
 
   /**
    * Theme provided by High-Order Component.

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -86,7 +86,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
     const {
       disabled,
       getAriaLabel,
-      getStyles,
+      styles,
       max,
       rating,
       readOnly,
@@ -94,7 +94,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
       theme
     } = this.props;
 
-    this._classNames = getClassNames(getStyles!, {
+    this._classNames = getClassNames(styles!, {
       disabled,
       readOnly,
       theme: theme!

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.test.tsx
@@ -21,7 +21,7 @@ describe('Rating', () => {
     try {
       rating = ReactTestUtils.renderIntoDocument(
         <RatingBase
-          getStyles={ getStyles }
+          styles={ getStyles }
           rating={ 2 }
         />
       );
@@ -61,7 +61,7 @@ describe('Rating', () => {
     try {
       rating = ReactTestUtils.renderIntoDocument(
         <RatingBase
-          getStyles={ getStyles }
+          styles={ getStyles }
           rating={ 10 }
         />
       );
@@ -95,7 +95,7 @@ describe('Rating', () => {
     try {
       rating = ReactTestUtils.renderIntoDocument<RatingBase>(
         <RatingBase
-          getStyles={ getStyles }
+          styles={ getStyles }
           rating={ 2.5 }
         />
       );
@@ -127,7 +127,7 @@ describe('Rating', () => {
     try {
       choiceGroup = ReactTestUtils.renderIntoDocument<RatingBase>(
         <RatingBase
-          getStyles={ getStyles }
+          styles={ getStyles }
           disabled={ true }
         />
       );
@@ -152,7 +152,7 @@ describe('Rating', () => {
     try {
       choiceGroup = ReactTestUtils.renderIntoDocument<RatingBase>(
         <RatingBase
-          getStyles={ getStyles }
+          styles={ getStyles }
           readOnly={ true }
           rating={ 2 }
         />

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
@@ -81,7 +81,7 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<IRatingStyleProps, IRatingStyles>;
+  styles?: IStyleFunctionOrObject<IRatingStyleProps, IRatingStyles>;
 
   /**
    * Theme (provided through customization.)

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -307,10 +307,10 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
   }
 
   public render(): JSX.Element {
-    const { onRenderData, className, getStyles, theme } = this.props;
+    const { onRenderData, className, styles, theme } = this.props;
     const { dataToMeasure, renderedData } = this.state;
     const divProps = getNativeProps(this.props, divProperties, ['data']);
-    const classNames = getClassNames(getStyles!, { theme: theme!, className });
+    const classNames = getClassNames(styles!, { theme: theme!, className });
 
     return (
       <div { ...divProps } className={ classNames.root } ref={ this._root }>

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -20,7 +20,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IResizeGroupStyleProps, IResizeGroupStyles>;
+  styles?: IStyleFunctionOrObject<IResizeGroupStyleProps, IResizeGroupStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -164,9 +164,9 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   }
 
   public render(): JSX.Element {
-    const { className, theme, getStyles } = this.props;
+    const { className, theme, styles } = this.props;
     const { stickyTopHeight, stickyBottomHeight } = this.state;
-    const classNames = getClassNames(getStyles!,
+    const classNames = getClassNames(styles!,
       {
         theme: theme!,
         className

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -21,7 +21,7 @@ export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement |
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */
-  getStyles?: IStyleFunctionOrObject<IScrollablePaneStyleProps, IScrollablePaneStyles>;
+  styles?: IStyleFunctionOrObject<IScrollablePaneStyleProps, IScrollablePaneStyles>;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -63,7 +63,7 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
       className,
       disabled,
       underlined,
-      getStyles,
+      styles,
       labelText,
       theme,
       clearButtonProps,
@@ -72,7 +72,7 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
     const { value, hasFocus, id } = this.state;
     const placeholderValue = labelText === undefined ? placeholder : labelText;
 
-    const classNames = getClassNames(getStyles!, {
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       className,
       underlined,

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -102,7 +102,7 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<ISearchBoxStyleProps, ISearchBoxStyles>;
+  styles?: IStyleFunctionOrObject<ISearchBoxStyleProps, ISearchBoxStyles>;
 
   /**
    * Whether or not to animate the SearchBox icon on focus.

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.base.tsx
@@ -25,7 +25,7 @@ export class SpinnerBase extends BaseComponent<ISpinnerProps, any> {
       size,
       ariaLabel,
       ariaLive,
-      getStyles,
+      styles,
       label,
       theme,
       className
@@ -40,7 +40,7 @@ export class SpinnerBase extends BaseComponent<ISpinnerProps, any> {
       styleSize = type === SpinnerType.large ? SpinnerSize.large : SpinnerSize.medium;
     }
 
-    const classNames = getClassNames(getStyles!, {
+    const classNames = getClassNames(styles!, {
       theme: theme!,
       size: styleSize,
       className

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.types.ts
@@ -55,7 +55,7 @@ export interface ISpinnerProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<ISpinnerStyleProps, ISpinnerStyles>;
+  styles?: IStyleFunctionOrObject<ISpinnerStyleProps, ISpinnerStyles>;
 }
 
 export enum SpinnerSize {

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
@@ -28,7 +28,7 @@ export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCel
     selected: false,
   } as IColorPickerGridCellProps;
 
-  private _classNames: {[key in keyof IColorPickerGridCellStyles]: string };
+  private _classNames: { [key in keyof IColorPickerGridCellStyles]: string };
 
   public render(): JSX.Element {
     const {
@@ -36,7 +36,7 @@ export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCel
       id,
       selected,
       disabled,
-      getStyles,
+      styles,
       theme,
       circle,
       color,
@@ -51,7 +51,7 @@ export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCel
     } = this.props;
 
     this._classNames = getClassNames(
-      getStyles!,
+      styles!,
       {
         theme: theme!,
         disabled,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
@@ -67,7 +67,7 @@ export interface IColorPickerGridCellProps {
   /**
   * Optional styles for the component.
   */
-  getStyles?: IStyleFunctionOrObject<IColorPickerGridCellStyleProps, IColorPickerGridCellStyles>;
+  styles?: IStyleFunctionOrObject<IColorPickerGridCellStyleProps, IColorPickerGridCellStyles>;
 
   /**
    * Optional, mouseEnter handler.

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -99,11 +99,11 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
       shouldFocusCircularNavigate,
       className,
       doNotContainWithinFocusZone,
-      getStyles,
+      styles,
     } = this.props;
 
     const classNames = getClassNames(
-      getStyles!,
+      styles!,
       {
         theme: this.props.theme!,
         className,
@@ -126,7 +126,7 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
         onBlur={ this._onSwatchColorPickerBlur }
         theme={ this.props.theme! }
         // tslint:disable-next-line:jsx-no-lambda
-        getStyles={ (props) => ({
+        styles={ (props) => ({
           root: classNames.root,
           tableCell: classNames.tableCell,
           focusedContainer: classNames.focusedContainer
@@ -169,7 +169,7 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
         item={ item }
         id={ id }
         color={ item.color }
-        getStyles={ this.props.getColorGridCellStyles }
+        styles={ this.props.getColorGridCellStyles }
         disabled={ this.props.disabled }
         onClick={ this._onCellClick }
         onHover={ this._onGridCellHovered }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
@@ -28,7 +28,7 @@ describe('SwatchColorPicker', () => {
       <SwatchColorPickerBase
         colorCells={ DEFAULT_OPTIONS }
         columnCount={ 4 }
-        getStyles={ getStyles }
+        styles={ getStyles }
       />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
@@ -39,7 +39,7 @@ describe('SwatchColorPicker', () => {
       <SwatchColorPickerBase
         colorCells={ DEFAULT_OPTIONS }
         columnCount={ 4 }
-        getStyles={ getStyles }
+        styles={ getStyles }
       />);
 
     expectNodes(wrapper, '.ms-swatchColorPickerBodyContainer', 1);
@@ -50,7 +50,7 @@ describe('SwatchColorPicker', () => {
       <SwatchColorPickerBase
         colorCells={ DEFAULT_OPTIONS }
         columnCount={ 4 }
-        getStyles={ getStyles }
+        styles={ getStyles }
       />
     );
 
@@ -76,7 +76,7 @@ describe('SwatchColorPicker', () => {
         // tslint:disable-next-line:jsx-no-lambda
         onColorChanged={ (color) => eventFireCounter++ }
         columnCount={ 4 }
-        getStyles={ getStyles }
+        styles={ getStyles }
       />
     );
 
@@ -95,7 +95,7 @@ describe('SwatchColorPicker', () => {
         // tslint:disable-next-line:jsx-no-lambda
         onCellHovered={ (color) => eventFireCounter++ }
         columnCount={ 4 }
-        getStyles={ getStyles }
+        styles={ getStyles }
       />
     );
 
@@ -111,7 +111,7 @@ describe('SwatchColorPicker', () => {
         // tslint:disable-next-line:jsx-no-lambda
         onCellFocused={ (color) => eventFireCounter++ }
         columnCount={ 4 }
-        getStyles={ getStyles }
+        styles={ getStyles }
       />
     );
 

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -95,7 +95,7 @@ export interface ISwatchColorPickerProps {
   /**
    * Optional styles for the component.
    */
-  getStyles?: IStyleFunctionOrObject<ISwatchColorPickerStyleProps, ISwatchColorPickerStyles>;
+  styles?: IStyleFunctionOrObject<ISwatchColorPickerStyleProps, ISwatchColorPickerStyles>;
 
   /**
   * Optional styles for the component.

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -22,14 +22,14 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
   >
     <StyledCustomizedLayer>
       <CustomizedLayer
-        getStyles={[Function]}
         onLayerDidMount={[Function]}
         onLayerWillUnmount={[Function]}
+        styles={[Function]}
       >
         <LayerBase
-          getStyles={[Function]}
           onLayerDidMount={[Function]}
           onLayerWillUnmount={[Function]}
+          styles={[Function]}
           theme={
             Object {
               "disableGlobalClassNames": false,
@@ -460,11 +460,11 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
                       directionalHint={12}
                       doNotLayer={false}
                       gapSpace={0}
-                      getStyles={[Function]}
                       isBeakVisible={true}
                       minPagePadding={8}
                       preventDismissOnScroll={false}
                       setInitialFocus={true}
+                      styles={[Function]}
                     >
                       <CalloutContentBase
                         beakWidth={16}
@@ -472,11 +472,11 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
                         directionalHint={12}
                         doNotLayer={false}
                         gapSpace={0}
-                        getStyles={[Function]}
                         isBeakVisible={true}
                         minPagePadding={8}
                         preventDismissOnScroll={false}
                         setInitialFocus={true}
+                        styles={[Function]}
                         theme={
                           Object {
                             "disableGlobalClassNames": false,

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -68,14 +68,14 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
       offText,
       onAriaLabel,
       onText,
-      getStyles
+      styles
     } = this.props;
     const { checked } = this.state;
     const stateText = checked ? onText : offText;
     const ariaLabel = checked ? onAriaLabel : offAriaLabel;
     const toggleNativeProps = getNativeProps(this.props, inputProperties, ['defaultChecked']);
     const classNames = getClassNames(
-      getStyles!,
+      styles!,
       {
         theme: theme!,
         className,

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
@@ -13,7 +13,7 @@ describe('Toggle', () => {
   it('renders a label', () => {
     const component = ReactTestUtils.renderIntoDocument(
       <ToggleBase
-        getStyles={ getStyles }
+        styles={ getStyles }
         label='Label'
       />
     );
@@ -26,7 +26,7 @@ describe('Toggle', () => {
   it('renders toggle correctly', () => {
     const component = renderer.create(
       <ToggleBase
-        getStyles={ getStyles }
+        styles={ getStyles }
         label='Label'
       />
     );
@@ -37,7 +37,7 @@ describe('Toggle', () => {
   it('renders aria-label', () => {
     const component = ReactTestUtils.renderIntoDocument(
       <ToggleBase
-        getStyles={ getStyles }
+        styles={ getStyles }
         label='Label'
         offAriaLabel='offLabel'
       />
@@ -57,7 +57,7 @@ describe('Toggle', () => {
 
     ReactTestUtils.renderIntoDocument<React.ReactInstance>(
       <ToggleBase
-        getStyles={ getStyles }
+        styles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         componentRef={ ref => component = ref }
         label='Label'
@@ -77,7 +77,7 @@ describe('Toggle', () => {
 
     ReactTestUtils.renderIntoDocument(
       <ToggleBase
-        getStyles={ getStyles }
+        styles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         componentRef={ ref => component = ref }
         label='Label'
@@ -95,7 +95,7 @@ describe('Toggle', () => {
   it(`doesn't render a label element if none is provided`, () => {
     const component = ReactTestUtils.renderIntoDocument(
       <ToggleBase
-        getStyles={ getStyles }
+        styles={ getStyles }
         checked={ false }
       />
     );
@@ -120,7 +120,7 @@ describe('Toggle', () => {
         } }
       >
         <ToggleBase
-          getStyles={ getStyles }
+          styles={ getStyles }
           // tslint:disable-next-line:jsx-no-lambda
           componentRef={ ref => component = ref }
           label='Label'

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.types.ts
@@ -75,7 +75,7 @@ export interface IToggleProps extends React.HTMLAttributes<HTMLElement> {
   /**
    * Optional styles for the component.
    */
-  getStyles?: IStyleFunctionOrObject<IToggleStyleProps, IToggleStyles>;
+  styles?: IStyleFunctionOrObject<IToggleStyleProps, IToggleStyles>;
 
   /**
    * Optional keytip for this toggle

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
@@ -43,7 +43,7 @@ export class TooltipBase extends BaseComponent<ITooltipProps, any> {
       delay,
       directionalHint,
       directionalHintForRTL,
-      getStyles,
+      styles,
       id,
       maxWidth,
       onRenderContent = this._onRenderContent,
@@ -51,7 +51,7 @@ export class TooltipBase extends BaseComponent<ITooltipProps, any> {
       theme
     } = this.props;
 
-    this._classNames = getClassNames(getStyles!, {
+    this._classNames = getClassNames(styles!, {
       theme: theme!,
       className: className || (calloutProps && calloutProps.className),
       delay: delay!,

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
@@ -73,7 +73,7 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  getStyles?: IStyleFunctionOrObject<ITooltipStyleProps, ITooltipStyles>;
+  styles?: IStyleFunctionOrObject<ITooltipStyleProps, ITooltipStyles>;
 }
 
 export enum TooltipDelay {

--- a/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -225,14 +225,14 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
     >
       <StyledCustomizedLayer>
         <CustomizedLayer
-          getStyles={[Function]}
           onLayerDidMount={[Function]}
           onLayerWillUnmount={[Function]}
+          styles={[Function]}
         >
           <LayerBase
-            getStyles={[Function]}
             onLayerDidMount={[Function]}
             onLayerWillUnmount={[Function]}
+            styles={[Function]}
             theme={
               Object {
                 "disableGlobalClassNames": false,
@@ -662,22 +662,22 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
                         directionalHint={1}
                         doNotLayer={false}
                         gapSpace={0}
-                        getStyles={[Function]}
                         isBeakVisible={true}
                         minPagePadding={8}
                         preventDismissOnScroll={false}
                         setInitialFocus={true}
+                        styles={[Function]}
                       >
                         <CalloutContentBase
                           beakWidth={16}
                           directionalHint={1}
                           doNotLayer={false}
                           gapSpace={0}
-                          getStyles={[Function]}
                           isBeakVisible={true}
                           minPagePadding={8}
                           preventDismissOnScroll={false}
                           setInitialFocus={true}
+                          styles={[Function]}
                           theme={
                             Object {
                               "disableGlobalClassNames": false,

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -28,12 +28,12 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
       onRenderItem,
       positionInSet,
       setSize,
-      getStyles
+      styles
     } = this.props;
 
     const htmlProps = getNativeProps(this.props, htmlElementProperties, ['onBlur, aria-posinset, aria-setsize']);
 
-    const classNames = getClassNames(getStyles!, { theme: this.props.theme! });
+    const classNames = getClassNames(styles!, { theme: this.props.theme! });
 
     // Array to store the cells in the correct row index
     const rowsOfItems: any[][] = toMatrix(items, columnCount);

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.test.tsx
@@ -22,7 +22,7 @@ describe('Grid', () => {
       <GridBase
         items={ DEFAULT_ITEMS }
         columnCount={ 4 }
-        getStyles={ getStyles }
+        styles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         onRenderItem={ (item: any, index: number) => { return <DefaultButton role='gridcell'>item.text</DefaultButton>; } }
       />
@@ -38,7 +38,7 @@ describe('Grid', () => {
       <GridBase
         items={ DEFAULT_ITEMS }
         columnCount={ 2 }
-        getStyles={ getStyles }
+        styles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         onRenderItem={ (item: any, index: number) => { return <DefaultButton role='gridcell'>item.text</DefaultButton>; } }
       />
@@ -54,7 +54,7 @@ describe('Grid', () => {
       <GridBase
         items={ DEFAULT_ITEMS }
         columnCount={ 2 }
-        getStyles={ getStyles }
+        styles={ getStyles }
         // tslint:disable-next-line:jsx-no-lambda
         onRenderItem={ (item: any, index: number) => { return <DefaultButton role='gridcell'>item.text</DefaultButton>; } }
         positionInSet={ 1 }

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -38,7 +38,7 @@ export interface IGridProps {
 
   /**
    * Optional, class name for the FocusZone container for the grid
-   * @deprecated Use getStyles and IGridStyles to define a styling for the focus zone container with
+   * @deprecated Use styles and IGridStyles to define a styling for the focus zone container with
    * focusedContainer property.
    */
   containerClassName?: string;
@@ -66,7 +66,7 @@ export interface IGridProps {
   /**
    * Optional styles for the component.
    */
-  getStyles?: IStyleFunctionOrObject<IGridStyleProps, IGridStyles>;
+  styles?: IStyleFunctionOrObject<IGridStyleProps, IGridStyles>;
 }
 
 /**

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -5,7 +5,7 @@ import { IStyleFunction } from './IStyleFunction';
 export type IStyleFunctionOrObject<TStyleProps, TStyles> = IStyleFunction<TStyleProps, TStyles> | TStyles;
 
 export interface IPropsWithStyles<TStyleProps, TStyles> {
-  getStyles?: IStyleFunctionOrObject<TStyleProps, TStyles>;
+  styles?: IStyleFunctionOrObject<TStyleProps, TStyles>;
   subComponents?: {
     [key: string]: IStyleFunction<{}, {}>;
   };
@@ -41,10 +41,10 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
       styleProps: TStyleProps
     ) => concatStyleSets(
       getBaseStyles && getBaseStyles(styleProps),
-      componentProps && componentProps.getStyles && (
-        typeof componentProps.getStyles === 'function' ?
-          componentProps.getStyles(styleProps)
-          : componentProps.getStyles
+      componentProps && componentProps.styles && (
+        typeof componentProps.styles === 'function' ?
+          componentProps.styles(styleProps)
+          : componentProps.styles
       )
     );
     const additionalProps = getProps ? getProps(componentProps) : {};
@@ -53,7 +53,7 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
       <Component
         { ...additionalProps }
         { ...componentProps }
-        getStyles={ getStyles }
+        styles={ getStyles }
       />
     );
   }) as IWrappedComponent<TComponentProps>;


### PR DESCRIPTION
Now that `getStyles` takes in either a function or style object (#4830), rename `getStyles` to `styles` for a more natural/intuitive API surface.