### PR TITLE
Issue#4832: Break BaseButton Types hard dependency from class ContextualMenu

### DIFF
--- a/common/changes/office-ui-fabric-react/pchandoria-contextualMenu-fix_2018-05-11-00-54.json
+++ b/common/changes/office-ui-fabric-react/pchandoria-contextualMenu-fix_2018-05-11-00-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Breaking BaseButton Types dependency from ContextualMenu class",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pramod.chandoria@hotmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -488,7 +488,7 @@ export interface IContextualMenuItem {
   inactive?: boolean;
 }
 
-export interface IContextualMenuSection extends React.Props<ContextualMenu> {
+export interface IContextualMenuSection extends React.Props<any> {
 
   /**
    * The items to include inside the section.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ContextualMenu } from './ContextualMenu';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { FocusZoneDirection, IFocusZoneProps } from '../../FocusZone';
 import { IIconProps } from '../Icon/Icon.types';
@@ -29,7 +28,7 @@ export interface IContextualMenu {
 
 }
 
-export interface IContextualMenuProps extends React.Props<ContextualMenu>, IWithResponsiveModeState {
+export interface IContextualMenuProps extends React.Props<any>, IWithResponsiveModeState {
   /**
    * Optional callback to access the IContextualMenu interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -28,6 +28,9 @@ export interface IContextualMenu {
 
 }
 
+/**
+ * React.Props is deprecated and we're removing it in 6.0. Usage of 'any' should go away with it.
+ */
 export interface IContextualMenuProps extends React.Props<any>, IWithResponsiveModeState {
   /**
    * Optional callback to access the IContextualMenu interface. Use this instead of ref for accessing
@@ -488,6 +491,9 @@ export interface IContextualMenuItem {
   inactive?: boolean;
 }
 
+/**
+ * React.Props is deprecated and we're removing it in 6.0. Usage of 'any' should go away with it.
+ */
 export interface IContextualMenuSection extends React.Props<any> {
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Fixes #4832 

#### Description of changes

In an effort to reduce bundle size on critical path rendering, we are trying to defer what is not required upfront. One such control from Fabric for us is ContextualMenu, which is required for edit scenario mostly. However What we learned is we cannot chunk this from core because we need BaseButton and It has hard dependency on IContextualMenuProps. Which is fine.
Unfortunately IContextualMenuProps have hard dependency on ContextualMenu which is not fine.
export interface IContextualMenuProps extends React.Props, IWithResponsiveModeState {
#### Focus areas to test

This is not supposed to change any runtime behavior as change is in typing only