### PR TITLE
ComboBox: Deprecate 'value' prop

### DIFF
--- a/common/changes/office-ui-fabric-react/jagore-deprecate-combobox-value_2018-05-11-17-57.json
+++ b/common/changes/office-ui-fabric-react/jagore-deprecate-combobox-value_2018-05-11-17-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Deprecate ComboBox's value prop in favor of new text prop.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.deprecated.test.tsx
@@ -1,0 +1,491 @@
+import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
+import { mount, ReactWrapper } from 'enzyme';
+import * as renderer from 'react-test-renderer';
+import * as WarnUtil from '@uifabric/utilities/lib/warn';
+import { KeyCodes } from '../../Utilities';
+
+import { ComboBox } from './ComboBox';
+import { IComboBox, IComboBoxOption } from './ComboBox.types';
+import { SelectableOptionMenuItemType } from '../../utilities/selectableOption/SelectableOption.types';
+import { expectOne, expectMissing } from '../../common/testUtilities';
+
+const DEFAULT_OPTIONS: IComboBoxOption[] = [
+  { key: '1', text: '1' },
+  { key: '2', text: '2' },
+  { key: '3', text: '3' }
+];
+
+const DEFAULT_OPTIONS2: IComboBoxOption[] = [
+  { key: '1', text: 'One' },
+  { key: '2', text: 'Foo' },
+  { key: '3', text: 'Bar' }
+];
+const DEFAULT_OPTIONS3: IComboBoxOption[] = [
+  { key: '0', text: 'Zero', itemType: SelectableOptionMenuItemType.Header },
+  { key: '1', text: 'One' },
+  { key: '2', text: 'Foo' },
+  { key: '3', text: 'Bar' }
+];
+
+describe('ComboBox', () => {
+  beforeAll(() => {
+    // Prevent warn deprecations from failing test
+    jest.spyOn(WarnUtil, 'warnDeprecations').mockImplementation(() => { /** no impl **/ });
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('Renders ComboBox correctly', () => {
+    const createNodeMock = (el: React.ReactElement<{}>) => {
+      return {
+        __events__: {}
+      };
+    };
+    const component = renderer.create(
+      <ComboBox
+        options={ DEFAULT_OPTIONS }
+        value={ 'testValue' }
+      />,
+      { createNodeMock }
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders a ComboBox with a Keytip correctly', () => {
+    const keytipProps = {
+      content: 'A',
+      keySequences: ['a']
+    };
+    const createNodeMock = (el: React.ReactElement<{}>) => {
+      return {
+        __events__: {}
+      };
+    };
+    const component = renderer.create(
+      <ComboBox options={ DEFAULT_OPTIONS } keytipProps={ keytipProps } />,
+      { createNodeMock }
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Can flip between enabled and disabled.', () => {
+    let wrapper = mount(
+      <ComboBox
+        disabled={ false }
+        label='testgroup'
+        options={ DEFAULT_OPTIONS }
+      />);
+
+    expectMissing(wrapper, '.ms-ComboBox.is-disabled');
+    expectOne(wrapper, '[data-is-interactable=true]');
+
+    wrapper = mount(
+      <ComboBox
+        disabled={ true }
+        label='testgroup'
+        options={ DEFAULT_OPTIONS }
+      />);
+
+    expectOne(wrapper, '.ms-ComboBox.is-disabled');
+    expectOne(wrapper, '[data-is-interactable=false]');
+  });
+
+  it('Renders no selected item in default case', () => {
+
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        options={ DEFAULT_OPTIONS }
+      />);
+
+    expect(wrapper.find('input[role="combobox"]').text()).toEqual('');
+  });
+
+  it('Renders a selected item in uncontrolled case', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS }
+      />);
+    const comboBoxRoot = wrapper.find('.ms-ComboBox');
+    const inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any> = comboBoxRoot.find('input');
+
+    expect(inputElement.props().value).toEqual('1');
+  });
+
+  it('Renders a selected item in controlled case', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        selectedKey='1'
+        options={ DEFAULT_OPTIONS }
+      />);
+    const comboBoxRoot = wrapper.find('.ms-ComboBox');
+    const inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any> = comboBoxRoot.find('input');
+
+    expect(inputElement.props().value).toEqual('1');
+  });
+
+  it('New options are not automatically added when allowFreeform on in controlled case', () => {
+    let comboBoxRoot;
+    let inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any>;
+    let comboBoxComponent: any;
+    const returnUndefined = (): undefined => {
+      return;
+    };
+    const setRef = (ref: IComboBox): void => {
+      comboBoxComponent = ref;
+    };
+
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        options={ DEFAULT_OPTIONS }
+        allowFreeform={ true }
+        onChanged={ returnUndefined }
+        componentRef={ setRef }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+    inputElement = comboBoxRoot.find('input');
+    inputElement.simulate('input', { target: { value: 'f' } });
+    inputElement.simulate('keydown', { which: KeyCodes.enter });
+    expect((comboBoxComponent as React.Component<any, any>).state.currentOptions.length).toEqual(DEFAULT_OPTIONS.length);
+  });
+
+  it('New options are automatically added when allowFreeform on in uncontrolled case', () => {
+    let comboBoxRoot;
+    let inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any>;
+    let comboBoxComponent: any;
+    const setRef = (ref: IComboBox): void => {
+      comboBoxComponent = ref;
+    };
+
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        options={ DEFAULT_OPTIONS }
+        allowFreeform={ true }
+        componentRef={ setRef }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+    inputElement = comboBoxRoot.find('input');
+    inputElement.simulate('input', { target: { value: 'f' } });
+    inputElement.simulate('keydown', { which: KeyCodes.enter });
+    const currentOptions = (comboBoxComponent as React.Component<any, any>).state.currentOptions;
+    expect(currentOptions.length).toEqual(DEFAULT_OPTIONS.length + 1);
+    expect(currentOptions[currentOptions.length - 1].text).toEqual('f');
+  });
+
+  it('Renders a default value with options', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        value='1'
+        options={ DEFAULT_OPTIONS }
+      />);
+    const comboBoxRoot = wrapper.find('.ms-ComboBox');
+    const inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any> = comboBoxRoot.find('input');
+
+    expect(inputElement.props().value).toEqual('1');
+  });
+
+  it('Renders a default value with no options', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        options={ [] }
+        value='1'
+      />);
+    const comboBoxRoot = wrapper.find('.ms-ComboBox');
+    const inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any> = comboBoxRoot.find('input');
+
+    expect(inputElement.props().value).toEqual('1');
+  });
+
+  it('Can change items in uncontrolled case', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS }
+      />);
+
+    // Manually assign `offsetParent` and `scrollIntoView` since it doesn't exist without DOM
+    const el = document.createElement('div') as Element;
+    el.scrollIntoView = () => null;
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', { get: () => el });
+
+    const buttonElement = wrapper.find('button');
+    buttonElement.simulate('click');
+    const secondItemElement: Element = wrapper.getDOMNode().ownerDocument.querySelector('.ms-ComboBox-option[data-index="1"]')!;
+
+    ReactTestUtils.Simulate.click(secondItemElement);
+
+    wrapper.update();
+
+    const inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any> = wrapper.find('input');
+    expect(inputElement.props().value).toEqual('2');
+  });
+
+  it('Can insert text in uncontrolled case with autoComplete and allowFreeform on', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        autoComplete='on'
+        allowFreeform={ true }
+      />);
+
+    wrapper.find('input').simulate('input', { target: { value: 'f' } });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Foo');
+  });
+
+  it('Can insert text in uncontrolled case with autoComplete on and allowFreeform off', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        autoComplete='on'
+        allowFreeform={ false }
+      />);
+
+    wrapper.find('input').simulate('input', { target: { value: 'f' } });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Foo');
+  });
+
+  it('Can insert text in uncontrolled case with autoComplete off and allowFreeform on', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        autoComplete='off'
+        allowFreeform={ true }
+      />);
+    wrapper.find('input').simulate('input', { target: { value: 'f' } });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('f');
+  });
+
+  it('Can insert text in uncontrolled case with autoComplete and allowFreeform off', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        autoComplete='off'
+        allowFreeform={ false }
+      />);
+    wrapper.find('input').simulate('keydown', { which: 'f' });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
+  it('Can change selected option with keyboard', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.down });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Foo');
+  });
+
+  it('Can change selected option with keyboard, looping from top to bottom', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.up });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Bar');
+  });
+
+  it('Can change selected option with keyboard, looping from bottom to top', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='3'
+        options={ DEFAULT_OPTIONS2 }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.down });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
+  it('Can change selected option with keyboard, looping from top to bottom', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS3 }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.up });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Bar');
+  });
+
+  it('Cannot insert text while disabled', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        disabled={ true }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.a });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
+  it('Cannot change selected option with keyboard while disabled', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        disabled={ true }
+      />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.down });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
+  it('Cannot expand the menu when clicking on the input while disabled', () => {
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        disabled={ true }
+      />);
+    wrapper.find('input').simulate('click');
+    expect(wrapper.find('.is-opened').length).toEqual(0);
+  });
+
+  it('Cannot expand the menu when clicking on the button while disabled', () => {
+    let comboBoxRoot;
+    let buttonElement;
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        disabled={ true }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+    buttonElement = comboBoxRoot.find('button');
+    buttonElement.simulate('click');
+    expect(comboBoxRoot.find('.is-opened').length).toEqual(0);
+  });
+
+  it('Call onMenuOpened when clicking on the button', () => {
+    let comboBoxRoot;
+    let buttonElement;
+    const returnUndefined = jest.fn();
+
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        onMenuOpen={ returnUndefined }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+    buttonElement = comboBoxRoot.find('button');
+    buttonElement.simulate('click');
+    expect(returnUndefined.mock.calls.length).toBe(1);
+  });
+
+  it('Call onMenuOpened when touch start on the input', () => {
+    let comboBoxRoot;
+    let inputElement;
+    const returnUndefined = jest.fn();
+
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        defaultSelectedKey='1'
+        options={ DEFAULT_OPTIONS2 }
+        onMenuOpen={ returnUndefined }
+        allowFreeform={ true }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+
+    inputElement = comboBoxRoot.find('input');
+
+    // in a normal scenario, when we do a touchstart we would also cause a
+    // click event to fire. This doesn't happen in the simulator so we're
+    // manually adding this in.
+    inputElement.simulate('touchstart');
+    inputElement.simulate('click');
+
+    expect(wrapper.find('.is-open').length).toEqual(1);
+  });
+
+  it('Can type a complete option with autocomplete and allowFreeform on and submit it', () => {
+    let updatedOption;
+    let updatedIndex;
+    let executionCount = 0;
+    const initialOption = { key: '1', text: 'Text' };
+
+    let comboBoxRoot;
+    let inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any>;
+    const wrapper = mount(
+      <ComboBox
+        label='testgroup'
+        options={ [initialOption] }
+        autoComplete='on'
+        allowFreeform={ true }
+        // tslint:disable-next-line:jsx-no-lambda
+        onChanged={ (option?: IComboBoxOption, index?: number) => {
+          updatedOption = option;
+          updatedIndex = index;
+          executionCount++;
+        } }
+      />);
+    comboBoxRoot = wrapper.find('.ms-ComboBox');
+    inputElement = comboBoxRoot.find('input');
+    inputElement.simulate('input', { target: { value: 't' } });
+    inputElement.simulate('input', { target: { value: 'e' } });
+    inputElement.simulate('input', { target: { value: 'x' } });
+    inputElement.simulate('input', { target: { value: 't' } });
+    inputElement.simulate('keydown', { which: KeyCodes.enter });
+    expect(executionCount).toEqual(1);
+    expect(updatedOption).toEqual(initialOption);
+    expect(updatedIndex).toEqual(0);
+
+    wrapper.update();
+    expect(wrapper.find('.ms-ComboBox input').props().value).toEqual('Text');
+  });
+
+  it('merges callout classNames', () => {
+    ReactTestUtils.renderIntoDocument<ComboBox>(
+      <ComboBox
+        options={ DEFAULT_OPTIONS }
+        calloutProps={ { className: 'foo' } }
+      />
+    );
+
+    setTimeout(() => {
+      const callout = document.querySelector('.ms-Callout') as HTMLElement;
+      expect(callout).toBeDefined();
+      expect(callout.classList.contains('ms-ComboBox-callout')).toBeTruthy();
+      expect(callout.classList.contains('foo')).toBeTruthy();
+    }, 0);
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -35,7 +35,10 @@ describe('ComboBox', () => {
       };
     };
     const component = renderer.create(
-      <ComboBox options={ DEFAULT_OPTIONS } />,
+      <ComboBox
+        options={ DEFAULT_OPTIONS }
+        text={ 'testValue' }
+      />,
       { createNodeMock }
     );
     const tree = component.toJSON();
@@ -173,7 +176,7 @@ describe('ComboBox', () => {
     const wrapper = mount(
       <ComboBox
         label='testgroup'
-        value='1'
+        text='1'
         options={ DEFAULT_OPTIONS }
       />);
     const comboBoxRoot = wrapper.find('.ms-ComboBox');
@@ -187,7 +190,7 @@ describe('ComboBox', () => {
       <ComboBox
         label='testgroup'
         options={ [] }
-        value='1'
+        text='1'
       />);
     const comboBoxRoot = wrapper.find('.ms-ComboBox');
     const inputElement: ReactWrapper<React.InputHTMLAttributes<any>, any> = comboBoxRoot.find('input');

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -174,10 +174,13 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     this._warnMutuallyExclusive({
       'defaultSelectedKey': 'selectedKey',
+      'text': 'defaultSelectedKey',
       'value': 'defaultSelectedKey',
       'selectedKey': 'value',
       'dropdownWidth': 'useComboBoxAsMenuWidth',
     });
+
+    this._warnDeprecations({ 'value': 'text' });
 
     this._id = props.id || getId('ComboBox');
 
@@ -217,6 +220,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     // Update the selectedIndex and currentOptions state if
     // the selectedKey, value, or options have changed
     if (newProps.selectedKey !== this.props.selectedKey ||
+      newProps.text !== this.props.text ||
       newProps.value !== this.props.value ||
       newProps.options !== this.props.options) {
       const selectedKeys: string[] | number[] = this._getSelectedKeys(undefined, newProps.selectedKey);
@@ -232,6 +236,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   public componentDidUpdate(prevProps: IComboBoxProps, prevState: IComboBoxState) {
     const {
       allowFreeform,
+      text,
       value,
       onMenuOpen,
       onMenuDismissed
@@ -274,7 +279,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     if (this._focusInputAfterClose && (prevState.isOpen && !isOpen ||
       (focused &&
         ((!isOpen && !this.props.multiSelect && prevState.selectedIndices && selectedIndices && prevState.selectedIndices[0] !== selectedIndices[0]) ||
-          !allowFreeform || value !== prevProps.value)
+          !allowFreeform || text !== prevProps.text || value !== prevProps.value)
       ))) {
       this._select();
     }
@@ -497,6 +502,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    */
   private _getVisibleValue = (): string | undefined => {
     const {
+      text,
       value,
       allowFreeform,
       autoComplete
@@ -515,6 +521,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     // If the user passed is a value prop, use that
     // unless we are open and have a valid current pending index
+    if (!(isOpen && currentPendingIndexValid) && (text && !currentPendingValue)) {
+      return text;
+    }
+
     if (!(isOpen && currentPendingIndexValid) && (value && !currentPendingValue)) {
       return value;
     }
@@ -1333,10 +1343,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       this.setState({
         suggestedDisplayValue: currentOptions[selectedIndex].text
       });
-    } else if (this.props.value) {
+    } else if (this.props.text || this.props.value) {
       // If we had a value initially, restore it
       this.setState({
-        suggestedDisplayValue: this.props.value
+        suggestedDisplayValue: this.props.text || this.props.value
       });
     }
   }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -180,7 +180,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
 
   /**
    * Value to show in the input, does not have to map to a combobox option
-   * @deprecated Use 'text' instead.
+   * @deprecated Use `text` instead.
    */
   value?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -98,7 +98,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   /**
    * Value to show in the input, does not have to map to a combobox option
    */
-  value?: string;
+  text?: string;
 
   /**
    * The IconProps to use for the button aspect of the combobox
@@ -177,6 +177,12 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * Optional keytip for this combo box
    */
   keytipProps?: IKeytipProps;
+
+  /**
+   * Value to show in the input, does not have to map to a combobox option
+   * @deprecated Use 'text' instead.
+   */
+  value?: string;
 }
 
 export interface IComboBoxStyles {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.deprecated.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`ComboBox Renders ComboBox correctly 1`] = `
 <div
   autoComplete="on"
   className="ms-ComboBox-container "
+  value="testValue"
 >
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -242,7 +242,7 @@ export class ComboBoxBasicExample extends React.Component<{}, {
             options={ options }
             onChanged={ this._onChanged }
             onResolveOptions={ this._getOptions }
-            value={ value && value }
+            text={ value && value }
             onRenderOption={ this._onRenderFontOption }
             // tslint:disable:jsx-no-lambda
             onFocus={ () => console.log('onFocus called') }


### PR DESCRIPTION

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4772
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Deprecate ComboBox's 'value' prop in favor of new 'text' prop. Replace all usages in codebase.

#### Focus areas to test

ComboBox's use of value and text props.
