### PR TITLE
Fix type of 'parent' passed to Async

### DIFF
--- a/common/changes/@uifabric/utilities/async-parent_2018-05-13-01-25.json
+++ b/common/changes/@uifabric/utilities/async-parent_2018-05-13-01-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Remove dependency on React from Async",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/utilities/src/Async.ts
+++ b/packages/utilities/src/Async.ts
@@ -16,12 +16,12 @@ export class Async {
   private _intervalIds: { [id: number]: boolean } | null = null;
   private _animationFrameIds: { [id: number]: boolean } | null = null;
   private _isDisposed: boolean;
-  private _parent: React.ReactNode | null;
+  private _parent: object | null;
   // tslint:disable-next-line:no-any
   private _onErrorHandler: ((e: any) => void) | undefined;
   private _noop: () => void;
   // tslint:disable-next-line:no-any
-  constructor(parent?: React.ReactNode, onError?: (e: any) => void) {
+  constructor(parent?: object, onError?: (e: any) => void) {
     this._isDisposed = false;
     this._parent = parent || null;
     this._onErrorHandler = onError;


### PR DESCRIPTION
For some reason `new Async(parent)` requires that `parent` be assignable to `React.ReactNode`. `parent` must instead always be of type `object`.