### PR TITLE
Fix contextualmenu timeout

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-contextualmenu-timeout_2018-05-14-14-41.json
+++ b/common/changes/office-ui-fabric-react/fix-contextualmenu-timeout_2018-05-14-14-41.json
@@ -1,0 +1,12 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment":
+        "Ensure subMenuHoverDelay is respected by the ContextualMenu for expanding and dismissing submenus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naal@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -739,7 +739,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
         });
         this._onItemSubMenuExpand(item, targetElement);
         this._enterTimerId = undefined;
-      }, NavigationIdleDelay);
+      }, timeoutDuration);
     } else {
       this._enterTimerId = this._async.setTimeout(() => {
         this._onSubMenuDismiss(ev);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4859
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Ensure ContextualMenu uses the subMenuHoverDelay prop if it has been provided as the timeout for expanding and dismissing submenus, instead of always using the default NavigationIdleDelay.


