### PR TITLE
ContextualMenu: Deprecate 'name' prop

### DIFF
--- a/6.0_RELEASE_NOTES.md
+++ b/6.0_RELEASE_NOTES.md
@@ -130,6 +130,7 @@ changes.
 * CommandBar: Supports custom styling and button aliasing.
 * CommandBar: Add aria label and change to single tab stop.
 * CommandBarButton: Fixed high contrast hover state. (#4738)
+* ContextualMenu: Deprecate 'name' prop in favor of more consistent 'text' prop. (#4862)
 * DetailsList: `fieldName` is now an optional field of `IColumn`. [32bc5dc]
 * Label: Supports custom styling and aliased root. (#4745)
 * Toggle: Supports custom styling and aliased root. (#4745)

--- a/apps/vr-tests/src/stories/Button.stories.tsx
+++ b/apps/vr-tests/src/stories/Button.stories.tsx
@@ -21,14 +21,14 @@ const commandProps: IButtonProps = {
     items: [
       {
         key: 'emailMessage',
-        name: 'Email message',
+        text: 'Email message',
         iconProps: {
           iconName: 'Mail'
         }
       },
       {
         key: 'calendarEvent',
-        name: 'Calendar event',
+        text: 'Calendar event',
         iconProps: {
           iconName: 'Calendar'
         }
@@ -53,12 +53,12 @@ storiesOf('Button Default', module)
       { story() }
     </Screener>
   ))
-  .add('Root', () => (<DefaultButton {...baseProps} />))
-  .add('Disabled', () => (<DefaultButton {...baseProps} disabled={ true } />))
-  .add('Checked', () => (<DefaultButton {...baseProps} checked={ true } />))
-  .add('Primary', () => (<DefaultButton {...baseProps} primary={ true } />))
-  .add('Primary Disabled', () => (<DefaultButton {...baseProps} primary={ true } disabled={ true } />))
-  .add('Primary Checked', () => (<DefaultButton {...baseProps} primary={ true } checked={ true } />));
+  .add('Root', () => (<DefaultButton { ...baseProps } />))
+  .add('Disabled', () => (<DefaultButton { ...baseProps } disabled={ true } />))
+  .add('Checked', () => (<DefaultButton { ...baseProps } checked={ true } />))
+  .add('Primary', () => (<DefaultButton { ...baseProps } primary={ true } />))
+  .add('Primary Disabled', () => (<DefaultButton { ...baseProps } primary={ true } disabled={ true } />))
+  .add('Primary Checked', () => (<DefaultButton { ...baseProps } primary={ true } checked={ true } />));
 
 storiesOf('Button Action', module)
   .addDecorator(FabricDecorator)
@@ -76,9 +76,9 @@ storiesOf('Button Action', module)
       { story() }
     </Screener>
   ))
-  .add('Root', () => (<ActionButton {...baseProps} />))
-  .add('Disabled', () => (<ActionButton {...baseProps} disabled={ true } />))
-  .add('Checked', () => (<ActionButton {...baseProps} checked={ true } />));
+  .add('Root', () => (<ActionButton { ...baseProps } />))
+  .add('Disabled', () => (<ActionButton { ...baseProps } disabled={ true } />))
+  .add('Checked', () => (<ActionButton { ...baseProps } checked={ true } />));
 
 storiesOf('Button Compound', module)
   .addDecorator(FabricDecorator)
@@ -96,12 +96,12 @@ storiesOf('Button Compound', module)
       { story() }
     </Screener>
   ))
-  .add('Root', () => (<CompoundButton {...baseProps} />))
-  .add('Disabled', () => (<CompoundButton {...baseProps} disabled={ true } />))
-  .add('Checked', () => (<CompoundButton {...baseProps} checked={ true } />))
-  .add('Primary', () => (<CompoundButton {...baseProps} primary={ true } />))
-  .add('Primary Disabled', () => (<CompoundButton {...baseProps} primary={ true } disabled={ true } />))
-  .add('Primary Checked', () => (<CompoundButton {...baseProps} primary={ true } checked={ true } />));
+  .add('Root', () => (<CompoundButton { ...baseProps } />))
+  .add('Disabled', () => (<CompoundButton { ...baseProps } disabled={ true } />))
+  .add('Checked', () => (<CompoundButton { ...baseProps } checked={ true } />))
+  .add('Primary', () => (<CompoundButton { ...baseProps } primary={ true } />))
+  .add('Primary Disabled', () => (<CompoundButton { ...baseProps } primary={ true } disabled={ true } />))
+  .add('Primary Checked', () => (<CompoundButton { ...baseProps } primary={ true } checked={ true } />));
 
 storiesOf('Button Command', module)
   // tslint:disable-next-line:jsx-ban-props
@@ -124,9 +124,9 @@ storiesOf('Button Command', module)
       { story() }
     </Screener>
   ))
-  .add('Root', () => (<CommandBarButton {...commandProps} />))
-  .add('Disabled', () => (<CommandBarButton {...commandProps} disabled={ true } />))
-  .add('Checked', () => (<CommandBarButton {...commandProps} checked={ true } />));
+  .add('Root', () => (<CommandBarButton { ...commandProps } />))
+  .add('Disabled', () => (<CommandBarButton { ...commandProps } disabled={ true } />))
+  .add('Checked', () => (<CommandBarButton { ...commandProps } checked={ true } />));
 
 storiesOf('Button Split', module)
   .addDecorator(FabricDecoratorTall)
@@ -153,12 +153,12 @@ storiesOf('Button Split', module)
       { story() }
     </Screener>
   ))
-  .add('Root', () => (<DefaultButton {...commandProps} split={ true } />))
-  .add('Disabled', () => (<DefaultButton {...commandProps} disabled={ true } split={ true } />))
-  .add('Checked', () => (<DefaultButton {...commandProps} checked={ true } split={ true } />))
-  .add('Primary', () => (<DefaultButton {...commandProps} primary={ true } split={ true } />))
-  .add('Primary Disabled', () => (<DefaultButton {...commandProps} primary={ true } disabled={ true } split={ true } />))
-  .add('Primary Checked', () => (<DefaultButton {...commandProps} primary={ true } checked={ true } split={ true } />));
+  .add('Root', () => (<DefaultButton { ...commandProps } split={ true } />))
+  .add('Disabled', () => (<DefaultButton { ...commandProps } disabled={ true } split={ true } />))
+  .add('Checked', () => (<DefaultButton { ...commandProps } checked={ true } split={ true } />))
+  .add('Primary', () => (<DefaultButton { ...commandProps } primary={ true } split={ true } />))
+  .add('Primary Disabled', () => (<DefaultButton { ...commandProps } primary={ true } disabled={ true } split={ true } />))
+  .add('Primary Checked', () => (<DefaultButton { ...commandProps } primary={ true } checked={ true } split={ true } />));
 
 storiesOf('Button Special Scenarios', module)
   .addDecorator(FabricDecorator)
@@ -175,21 +175,21 @@ storiesOf('Button Special Scenarios', module)
 
   .add('primary with placeholder', () => (
     <div>
-      <DefaultButton {...baseProps} iconProps={ { iconName: '' } } primary={ true } />
+      <DefaultButton { ...baseProps } iconProps={ { iconName: '' } } primary={ true } />
       <br />
-      <DefaultButton {...baseProps} iconProps={ { iconName: 'Add' } } primary={ true } />
+      <DefaultButton { ...baseProps } iconProps={ { iconName: 'Add' } } primary={ true } />
     </div>
   ))
   .add('no flex shrink', () => (
     <div style={ { width: '300px' } }>
       <DefaultButton
-        {...baseProps }
+        { ...baseProps }
         iconProps={ { iconName: 'Add' } }
         menuIconProps={ {} }
         styles={ { root: { width: '100%' } } }
       />
       <DefaultButton
-        {...baseProps }
+        { ...baseProps }
         text='This is a much longer string of text in a constrained space'
         iconProps={ { iconName: 'Add' } }
         menuIconProps={ {} }

--- a/apps/vr-tests/src/stories/CommandBar.stories.tsx
+++ b/apps/vr-tests/src/stories/CommandBar.stories.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTall } from '../utilities';
-import { CommandBar } from 'office-ui-fabric-react';
+import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react';
 
-const items = [
+const items: ICommandBarItemProps[] = [
   {
     key: 'newItem',
-    name: 'New',
+    text: 'New',
     iconProps: {
       iconName: 'Add'
     },
@@ -16,14 +16,14 @@ const items = [
       items: [
         {
           key: 'emailMessage',
-          name: 'Email message',
+          text: 'Email message',
           iconProps: {
             iconName: 'Mail'
           }
         },
         {
           key: 'calendarEvent',
-          name: 'Calendar event',
+          text: 'Calendar event',
           iconProps: {
             iconName: 'Calendar'
           }
@@ -33,28 +33,28 @@ const items = [
   },
   {
     key: 'upload',
-    name: 'Upload',
+    text: 'Upload',
     iconProps: {
       iconName: 'Upload'
     }
   },
   {
     key: 'share',
-    name: 'Share',
+    text: 'Share',
     iconProps: {
       iconName: 'Share'
     }
   },
   {
     key: 'download',
-    name: 'Download',
+    text: 'Download',
     iconProps: {
       iconName: 'Download'
     }
   },
   {
     key: 'disabled',
-    name: 'Disabled...',
+    text: 'Disabled...',
     iconProps: {
       iconName: 'Cancel'
     },
@@ -62,24 +62,24 @@ const items = [
   }
 ];
 
-const farItems = [
+const farItems: ICommandBarItemProps[] = [
   {
     key: 'sort',
-    name: 'Sort',
+    text: 'Sort',
     iconProps: {
       iconName: 'SortLines'
     }
   },
   {
     key: 'tile',
-    name: 'Grid view',
+    text: 'Grid view',
     iconProps: {
       iconName: 'Tiles'
     }
   },
   {
     key: 'info',
-    name: 'Info',
+    text: 'Info',
     iconProps: {
       iconName: 'Info'
     }
@@ -117,7 +117,7 @@ storiesOf('CommandBar', module)
   ))
   .add('Icons only', () => (
     <CommandBar
-      items={ items.map(item => ({ ...item, name: '' })) }
-      farItems={ farItems.map(item => ({ ...item, name: '' })) }
+      items={ items.map(item => ({ ...item, text: '' })) }
+      farItems={ farItems.map(item => ({ ...item, text: '' })) }
     />
   ));

--- a/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
+++ b/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { ContextualMenu, ContextualMenuItemType } from 'office-ui-fabric-react';
+import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from 'office-ui-fabric-react';
 
-const items = [
+const items: IContextualMenuItem[] = [
   {
     key: 'newItem',
-    name: 'New'
+    text: 'New'
   },
   {
     key: 'divider_1',
@@ -16,35 +16,35 @@ const items = [
   },
   {
     key: 'rename',
-    name: 'Rename'
+    text: 'Rename'
   },
   {
     key: 'edit',
-    name: 'Edit'
+    text: 'Edit'
   },
   {
     key: 'properties',
-    name: 'Properties'
+    text: 'Properties'
   },
   {
     key: 'disabled',
-    name: 'Disabled item',
+    text: 'Disabled item',
     disabled: true
   },
   {
     key: 'isDisabled',
-    name: 'isDisabled item',
+    text: 'isDisabled item',
     isDisabled: true
   }
 ];
 
-const itemsWithIcons = [
+const itemsWithIcons: IContextualMenuItem[] = [
   {
     key: 'newItem',
     iconProps: {
       iconName: 'Add'
     },
-    name: 'New'
+    text: 'New'
   },
   {
     key: 'upload',
@@ -54,7 +54,7 @@ const itemsWithIcons = [
         color: 'salmon'
       }
     },
-    name: 'Upload',
+    text: 'Upload',
     title: 'Upload a file'
   },
   {
@@ -66,31 +66,31 @@ const itemsWithIcons = [
     iconProps: {
       iconName: 'Share'
     },
-    name: 'Share'
+    text: 'Share'
   },
   {
     key: 'print',
     iconProps: {
       iconName: 'Print'
     },
-    name: 'Print'
+    text: 'Print'
   },
   {
     key: 'music',
     iconProps: {
       iconName: 'MusicInCollectionFill'
     },
-    name: 'Music',
+    text: 'Music',
   }
 ];
 
-const itemsWithSecondaryText = [
+const itemsWithSecondaryText: IContextualMenuItem[] = [
   {
     key: 'Later Today',
     iconProps: {
       iconName: 'Clock'
     },
-    name: 'Later Today',
+    text: 'Later Today',
     secondaryText: '7:00 PM'
   },
   {
@@ -98,7 +98,7 @@ const itemsWithSecondaryText = [
     iconProps: {
       iconName: 'Coffeescript'
     },
-    name: 'Tomorrow',
+    text: 'Tomorrow',
     secondaryText: 'Thu. 8:00 AM'
   },
   {
@@ -106,7 +106,7 @@ const itemsWithSecondaryText = [
     iconProps: {
       iconName: 'Vacation'
     },
-    name: 'This Weekend',
+    text: 'This Weekend',
     secondaryText: 'Sat. 10:00 AM'
   },
   {
@@ -114,29 +114,29 @@ const itemsWithSecondaryText = [
     iconProps: {
       iconName: 'Suitcase'
     },
-    name: 'Next Week',
+    text: 'Next Week',
     secondaryText: 'Mon. 8:00 AM'
   }
 ];
 
-const itemsWithSubmenu = [
+const itemsWithSubmenu: IContextualMenuItem[] = [
   {
     key: 'newItem',
     subMenuProps: {
       items: [
         {
           key: 'emailMessage',
-          name: 'Email message',
+          text: 'Email message',
           title: 'Create an email'
         },
         {
           key: 'calendarEvent',
-          name: 'Calendar event',
+          text: 'Calendar event',
           title: 'Create a calendar event',
         }
       ],
     },
-    name: 'New'
+    text: 'New'
   },
   {
     key: 'share',
@@ -144,25 +144,25 @@ const itemsWithSubmenu = [
       items: [
         {
           key: 'sharetotwitter',
-          name: 'Share to Twitter',
+          text: 'Share to Twitter',
         },
         {
           key: 'sharetofacebook',
-          name: 'Share to Facebook',
+          text: 'Share to Facebook',
         },
         {
           key: 'sharetoemail',
-          name: 'Share to Email',
+          text: 'Share to Email',
           subMenuProps: {
             items: [
               {
                 key: 'sharetooutlook_1',
-                name: 'Share to Outlook',
+                text: 'Share to Outlook',
                 title: 'Share to Outlook',
               },
               {
                 key: 'sharetogmail_1',
-                name: 'Share to Gmail',
+                text: 'Share to Gmail',
                 title: 'Share to Gmail',
               }
             ],
@@ -170,11 +170,11 @@ const itemsWithSubmenu = [
         },
       ],
     },
-    name: 'Share'
+    text: 'Share'
   }
 ];
 
-const itemsWithHeaders = [
+const itemsWithHeaders: IContextualMenuItem[] = [
   {
     key: 'section',
     itemType: ContextualMenuItemType.Section,
@@ -185,11 +185,11 @@ const itemsWithHeaders = [
       items: [
         {
           key: 'newItem',
-          name: 'New',
+          text: 'New',
         },
         {
           key: 'deleteItem',
-          name: 'Delete',
+          text: 'Delete',
         }
       ]
     }
@@ -202,18 +202,18 @@ const itemsWithHeaders = [
       items: [
         {
           key: 'share',
-          name: 'Share'
+          text: 'Share'
         },
         {
           key: 'print',
-          name: 'Print'
+          text: 'Print'
         }
       ]
     }
   }
 ];
 
-const itemsWithSplitButtonSubmenu = [
+const itemsWithSplitButtonSubmenu: IContextualMenuItem[] = [
   {
     key: 'share',
     split: true,
@@ -222,27 +222,27 @@ const itemsWithSplitButtonSubmenu = [
       items: [
         {
           key: 'sharetotwitter',
-          name: 'Share to Twitter',
+          text: 'Share to Twitter',
         },
         {
           key: 'sharetofacebook',
-          name: 'Share to Facebook',
+          text: 'Share to Facebook',
         },
         {
           key: 'sharetoemail',
           split: true,
           onClick: () => { },
-          name: 'Share to Email',
+          text: 'Share to Email',
           subMenuProps: {
             items: [
               {
                 key: 'sharetooutlook_1',
-                name: 'Share to Outlook',
+                text: 'Share to Outlook',
                 title: 'Share to Outlook',
               },
               {
                 key: 'sharetogmail_1',
-                name: 'Share to Gmail',
+                text: 'Share to Gmail',
                 title: 'Share to Gmail',
               }
             ],
@@ -250,7 +250,7 @@ const itemsWithSplitButtonSubmenu = [
         },
       ],
     },
-    name: 'Share'
+    text: 'Share'
   }
 ];
 

--- a/common/changes/office-ui-fabric-react/6_0_deprecate_contextual_name.json
+++ b/common/changes/office-ui-fabric-react/6_0_deprecate_contextual_name.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Deprecate ContextualMenu's name prop in favor of new text prop.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -48,12 +48,12 @@ describe('Button', () => {
           items: [
             {
               key: 'emailMessage',
-              name: 'Email message',
+              text: 'Email message',
               iconProps: { iconName: 'Mail' }
             },
             {
               key: 'calendarEvent',
-              name: 'Calendar event',
+              text: 'Calendar event',
               iconProps: { iconName: 'Calendar' }
             }
           ]
@@ -207,7 +207,7 @@ describe('Button', () => {
 
       beforeAll(() => {
         const wrapper = ReactTestUtils.renderIntoDocument<any>(
-          <DefaultButton menuProps={ { items: [{ key: 'item', name: 'Item' }] } }>Hello</DefaultButton>
+          <DefaultButton menuProps={ { items: [{ key: 'item', text: 'Item' }] } }>Hello</DefaultButton>
         ) as DefaultButton;
         button = ReactTestUtils.findRenderedDOMComponentWithTag(wrapper, 'button');
       });
@@ -257,12 +257,12 @@ describe('Button', () => {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]
@@ -285,12 +285,12 @@ describe('Button', () => {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]
@@ -318,12 +318,12 @@ describe('Button', () => {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]
@@ -349,12 +349,12 @@ describe('Button', () => {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]
@@ -376,12 +376,12 @@ describe('Button', () => {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]
@@ -405,12 +405,12 @@ describe('Button', () => {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]
@@ -438,12 +438,12 @@ describe('Button', () => {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]
@@ -469,12 +469,12 @@ describe('Button', () => {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]
@@ -517,12 +517,12 @@ describe('Button', () => {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]
@@ -546,12 +546,12 @@ describe('Button', () => {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]
@@ -584,12 +584,12 @@ describe('Button', () => {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]
@@ -619,12 +619,12 @@ describe('Button', () => {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Command.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Command.Example.tsx
@@ -18,12 +18,12 @@ export class ButtonCommandExample extends React.Component<IButtonProps, {}> {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.CommandBar.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.CommandBar.Example.tsx
@@ -18,12 +18,12 @@ export class ButtonCommandBarExample extends React.Component<IButtonProps, {}> {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -20,12 +20,12 @@ export class ButtonContextualMenuExample extends React.Component<IButtonProps, {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 },
               ],

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -38,12 +38,12 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]
@@ -65,12 +65,12 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]
@@ -93,12 +93,12 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]
@@ -120,12 +120,12 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
               items: [
                 {
                   key: 'emailMessage',
-                  name: 'Email message',
+                  text: 'Email message',
                   iconProps: { iconName: 'Mail' }
                 },
                 {
                   key: 'calendarEvent',
-                  name: 'Calendar event',
+                  text: 'Calendar event',
                   iconProps: { iconName: 'Calendar' }
                 }
               ]
@@ -159,12 +159,12 @@ export class ButtonSplitCustomExample extends React.Component<IButtonProps> {
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -165,6 +165,8 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       buttonAs: CommandButtonType = CommandBarButton
     } = this.props;
 
+    const itemText = item.text || item.name;
+
     if (item.onRender) {
       // These are the top level items, there is no relevant menu dismissing function to
       // provide for the IContextualMenuItem onRender function. Pass in a no op function instead.
@@ -174,13 +176,13 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       ...item,
       styles: { root: { height: '100%' }, ...item.buttonStyles },
       className: css('ms-CommandBarItem-link', item.className),
-      text: !item.iconOnly ? item.name : '',
+      text: !item.iconOnly ? itemText : '',
       menuProps: item.subMenuProps,
     };
 
-    if (item.iconOnly && item.name !== undefined) {
+    if (item.iconOnly && itemText !== undefined) {
       return (
-        <TooltipHost content={ item.name } >
+        <TooltipHost content={ itemText } >
           <CommandButtonType { ...commandButtonProps as IButtonProps } />
         </TooltipHost>
       );

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.deprecated.test.tsx
@@ -23,8 +23,8 @@ describe('CommandBar', () => {
     expect(renderer.create(
       <CommandBar
         items={ [
-          { key: '1', text: 'asdf' },
-          { key: '2', text: 'asdf' }
+          { key: '1', name: 'asdf' },
+          { key: '2', name: 'asdf' }
         ] }
         className={ 'TestClassName' }
       />
@@ -34,13 +34,13 @@ describe('CommandBar', () => {
   it('adds the correct aria-setsize and -posinset attributes to the command bar items.', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         className: 'item1',
         subMenuProps: {
           items: [
             {
-              text: 'SubmenuText 1',
+              name: 'SubmenuText 1',
               key: 'SubmenuKey1',
               className: 'SubMenuClass'
             }
@@ -48,12 +48,12 @@ describe('CommandBar', () => {
         }
       },
       {
-        text: 'TestText 2',
+        name: 'TestText 2',
         key: 'TestKey2',
         className: 'item2',
       },
       {
-        text: 'TestText 3',
+        name: 'TestText 3',
         key: 'TestKey3',
         className: 'item3',
       },
@@ -80,13 +80,13 @@ describe('CommandBar', () => {
       <CommandBar
         items={ [
           {
-            text: 'TestText 1',
+            name: 'TestText 1',
             key: 'TestKey1',
             className: 'MenuItem',
             subMenuProps: {
               items: [
                 {
-                  text: 'SubmenuText 1',
+                  name: 'SubmenuText 1',
                   key: 'SubmenuKey1',
                   className: 'SubMenuClass'
                 }
@@ -111,12 +111,12 @@ describe('CommandBar', () => {
       <CommandBar
         items={ [
           {
-            text: 'TestText 1',
+            name: 'TestText 1',
             key: 'TestKey1',
             subMenuProps: {
               items: [
                 {
-                  text: 'SubmenuText 1',
+                  name: 'SubmenuText 1',
                   key: 'SubmenuKey1',
                   className: 'SubMenuClass'
                 }
@@ -153,12 +153,12 @@ describe('CommandBar', () => {
       <CommandBar
         items={ [
           {
-            text: 'TestText 1',
+            name: 'TestText 1',
             key: 'TestKey1',
             subMenuProps: {
               items: [
                 {
-                  text: 'SubmenuText 1',
+                  name: 'SubmenuText 1',
                   key: 'SubmenuKey1',
                   className: 'SubMenuClass'
                 }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
@@ -130,6 +130,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                 }
             data-is-focusable={true}
             disabled={undefined}
+            name="asdf"
             type="button"
           >
             <div
@@ -247,6 +248,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                 }
             data-is-focusable={true}
             disabled={undefined}
+            name="asdf"
             type="button"
           >
             <div

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.deprecated.test.tsx
@@ -24,10 +24,10 @@ describe('ContextualMenu', () => {
 
   it('does not have a scrollbar due to an overflowing icon', () => {
     const items: IContextualMenuItem[] = [
-      { text: 'TestText 1', key: 'TestKey1', canCheck: true, isChecked: true },
-      { text: 'TestText 2', key: 'TestKey2', canCheck: true, isChecked: true },
-      { text: 'TestText 3', key: 'TestKey3', canCheck: true, isChecked: true },
-      { text: 'TestText 4', key: 'TestKey4', canCheck: true, isChecked: true },
+      { name: 'TestText 1', key: 'TestKey1', canCheck: true, isChecked: true },
+      { name: 'TestText 2', key: 'TestKey2', canCheck: true, isChecked: true },
+      { name: 'TestText 3', key: 'TestKey3', canCheck: true, isChecked: true },
+      { name: 'TestText 4', key: 'TestKey4', canCheck: true, isChecked: true },
     ];
 
     ReactTestUtils.renderIntoDocument<ContextualMenu>(
@@ -43,10 +43,10 @@ describe('ContextualMenu', () => {
 
   it('closes on left arrow if it is a submenu', () => {
     const items: IContextualMenuItem[] = [
-      { text: 'TestText 1', key: 'TestKey1' },
-      { text: 'TestText 2', key: 'TestKey2' },
-      { text: 'TestText 3', key: 'TestKey3' },
-      { text: 'TestText 4', key: 'TestKey4' },
+      { name: 'TestText 1', key: 'TestKey1' },
+      { name: 'TestText 2', key: 'TestKey2' },
+      { name: 'TestText 3', key: 'TestKey3' },
+      { name: 'TestText 4', key: 'TestKey4' },
     ];
 
     let spyCalled = false;
@@ -68,10 +68,10 @@ describe('ContextualMenu', () => {
 
   it('does not close on left arrow if it is a submenu with horizontal arrowDirection', () => {
     const items: IContextualMenuItem[] = [
-      { text: 'TestText 1', key: 'TestKey1' },
-      { text: 'TestText 2', key: 'TestKey2' },
-      { text: 'TestText 3', key: 'TestKey3' },
-      { text: 'TestText 4', key: 'TestKey4' },
+      { name: 'TestText 1', key: 'TestKey1' },
+      { name: 'TestText 2', key: 'TestKey2' },
+      { name: 'TestText 3', key: 'TestKey3' },
+      { name: 'TestText 4', key: 'TestKey4' },
     ];
 
     let spyCalled = false;
@@ -94,10 +94,10 @@ describe('ContextualMenu', () => {
 
   it('does not close on left arrow if it is a submenu with bidirectional arrowDirection', () => {
     const items: IContextualMenuItem[] = [
-      { text: 'TestText 1', key: 'TestKey1' },
-      { text: 'TestText 2', key: 'TestKey2' },
-      { text: 'TestText 3', key: 'TestKey3' },
-      { text: 'TestText 4', key: 'TestKey4' },
+      { name: 'TestText 1', key: 'TestKey1' },
+      { name: 'TestText 2', key: 'TestKey2' },
+      { name: 'TestText 3', key: 'TestKey3' },
+      { name: 'TestText 4', key: 'TestKey4' },
     ];
 
     let spyCalled = false;
@@ -121,12 +121,12 @@ describe('ContextualMenu', () => {
   it('opens a submenu item on right arrow', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         subMenuProps: {
           items: [
             {
-              text: 'SubmenuText 1',
+              name: 'SubmenuText 1',
               key: 'SubmenuKey1',
               className: 'SubMenuClass'
             }
@@ -150,12 +150,12 @@ describe('ContextualMenu', () => {
   it('opens a submenu item on click', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         subMenuProps: {
           items: [
             {
-              text: 'SubmenuText 1',
+              name: 'SubmenuText 1',
               key: 'SubmenuKey1',
               className: 'SubMenuClass'
             }
@@ -180,14 +180,14 @@ describe('ContextualMenu', () => {
   it('opens a splitbutton submenu item on touch start', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         split: true,
         onClick: () => { alert('test'); },
         subMenuProps: {
           items: [
             {
-              text: 'SubmenuText 1',
+              name: 'SubmenuText 1',
               key: 'SubmenuKey1',
               className: 'SubMenuClass'
             }
@@ -202,7 +202,7 @@ describe('ContextualMenu', () => {
       />
     );
 
-    const menuItem = document.getElementsByTagName('button')[0] as HTMLButtonElement;
+    const menuItem = document.getElementsByName('TestText 1')[0] as HTMLButtonElement;
 
     // in a normal scenario, when we do a touchstart we would also cause a
     // click event to fire. This doesn't happen in the simulator so we're
@@ -217,13 +217,13 @@ describe('ContextualMenu', () => {
     const submenuId = 'testSubmenuId';
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         subMenuProps: {
           id: submenuId,
           items: [
             {
-              text: 'SubmenuText 1',
+              name: 'SubmenuText 1',
               key: 'SubmenuKey1',
               className: 'SubMenuClass'
             }
@@ -249,11 +249,11 @@ describe('ContextualMenu', () => {
   it('still works with deprecated IContextualMenuItem.items property', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         items: [
           {
-            text: 'SubmenuText 1',
+            name: 'SubmenuText 1',
             key: 'SubmenuKey1',
             className: 'SubMenuClass'
           }
@@ -276,16 +276,16 @@ describe('ContextualMenu', () => {
   it('can focus on disabled items', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
       },
       {
-        text: 'TestText 2',
+        name: 'TestText 2',
         key: 'TestKey2',
         disabled: true,
       },
       {
-        text: 'TestText 3',
+        name: 'TestText 3',
         key: 'TestKey3',
         isDisabled: true,
       },
@@ -321,12 +321,12 @@ describe('ContextualMenu', () => {
     ];
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         onClick: () => itemsClicked[0] = true
       },
       {
-        text: 'TestText 2',
+        name: 'TestText 2',
         key: 'TestKey2',
         disabled: true,
         onClick: () => {
@@ -335,7 +335,7 @@ describe('ContextualMenu', () => {
         }
       },
       {
-        text: 'TestText 3',
+        name: 'TestText 3',
         key: 'TestKey3',
         isDisabled: true,
         onClick: () => {
@@ -367,16 +367,16 @@ describe('ContextualMenu', () => {
   it('renders headers properly', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         itemType: ContextualMenuItemType.Header
       },
       {
-        text: 'TestText 2',
+        name: 'TestText 2',
         key: 'TestKey3'
       },
       {
-        text: 'TestText 3',
+        name: 'TestText 3',
         key: 'TestKey3',
         itemType: ContextualMenuItemType.Header
       }
@@ -404,7 +404,7 @@ describe('ContextualMenu', () => {
   it('renders sections properly', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         itemType: ContextualMenuItemType.Section,
         sectionProps: {
@@ -413,28 +413,28 @@ describe('ContextualMenu', () => {
           bottomDivider: true,
           items: [
             {
-              text: 'TestText 2',
+              name: 'TestText 2',
               key: 'TestKey2'
             },
             {
-              text: 'TestText 3',
+              name: 'TestText 3',
               key: 'TestKey3',
             }
           ]
         }
       }, {
-        text: 'TestText 4',
+        name: 'TestText 4',
         key: 'TestKey4',
         itemType: ContextualMenuItemType.Section,
         sectionProps: {
           key: 'Section1',
           items: [
             {
-              text: 'TestText 5',
+              name: 'TestText 5',
               key: 'TestKey5'
             },
             {
-              text: 'TestText 6',
+              name: 'TestText 6',
               key: 'TestKey6',
             }
           ]
@@ -466,31 +466,31 @@ describe('ContextualMenu', () => {
     beforeEach(() => {
       items = [
         {
-          text: 'TestText 1',
+          name: 'TestText 1',
           key: 'TestKey1',
           href: testUrl
         },
         {
-          text: 'TestText 2',
+          name: 'TestText 2',
           key: 'TestKey2',
           href: testUrl,
           target: '_blank'
         },
         {
-          text: 'TestText 3',
+          name: 'TestText 3',
           key: 'TestKey3',
           href: testUrl,
           target: '_blank',
           rel: 'test'
         },
         {
-          text: 'TestText 4',
+          name: 'TestText 4',
           key: 'TestKey4',
           href: testUrl,
           target: '_self',
         },
         {
-          text: 'TestText 5',
+          name: 'TestText 5',
           key: 'TestKey5',
           href: testUrl,
           rel: 'test'
@@ -559,12 +559,12 @@ describe('ContextualMenu', () => {
   it('correctly focuses the first element', (done) => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         className: 'testkey1'
       },
       {
-        text: 'TestText 2',
+        name: 'TestText 2',
         key: 'TestKey2'
       },
     ];
@@ -592,12 +592,12 @@ describe('ContextualMenu', () => {
   it('will not focus the first element when shouldFocusOnMount is false', (done) => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         className: 'testkey1'
       },
       {
-        text: 'TestText 2',
+        name: 'TestText 2',
         key: 'TestKey2'
       },
     ];
@@ -626,12 +626,12 @@ describe('ContextualMenu', () => {
   it('Hover correctly focuses the second element', (done) => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         className: 'testkey1'
       },
       {
-        text: 'TestText 2',
+        name: 'TestText 2',
         key: 'TestKey2',
         className: 'testkey2'
       },
@@ -668,7 +668,7 @@ describe('ContextualMenu', () => {
     ReactTestUtils.renderIntoDocument<ContextualMenu>(
       <ContextualMenu
         items={ [{
-          text: 'TestText 0',
+          name: 'TestText 0',
           key: 'TestKey0'
         }] }
         calloutProps={ { className: 'foo' } }
@@ -684,7 +684,7 @@ describe('ContextualMenu', () => {
   it('Contextual Menu submenu has chrevron icon even if submenu has no items', () => {
     const menuWithEmptySubMenu: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         subMenuProps: {
           items: []
@@ -712,7 +712,7 @@ describe('ContextualMenu', () => {
 
     const menuWithEmptySubMenu: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
         subMenuProps: {
           items: [],
@@ -737,11 +737,11 @@ describe('ContextualMenu', () => {
   it('calls the custom child renderer when the contextualMenuItemAs prop is provided', () => {
     const items: IContextualMenuItem[] = [
       {
-        text: 'TestText 1',
+        name: 'TestText 1',
         key: 'TestKey1',
       },
       {
-        text: 'TestText 2',
+        name: 'TestText 2',
         key: 'TestKey2',
       }
     ];
@@ -763,9 +763,9 @@ describe('ContextualMenu', () => {
   describe('canAnyMenuItemsCheck', () => {
     it('returns false when there are no checkable menu items', () => {
       const items: IContextualMenuItem[] = [
-        { text: 'Item 1', key: 'Item 1' },
-        { text: 'Item 2', key: 'Item 2' },
-        { text: 'Item 3', key: 'Item 3' }
+        { name: 'Item 1', key: 'Item 1' },
+        { name: 'Item 2', key: 'Item 2' },
+        { name: 'Item 3', key: 'Item 3' }
       ];
 
       expect(canAnyMenuItemsCheck(items)).toEqual(false);
@@ -773,9 +773,9 @@ describe('ContextualMenu', () => {
 
     it('returns true when there is at least one checkable menu item', () => {
       const items: IContextualMenuItem[] = [
-        { text: 'Item 1', key: 'Item 1' },
-        { text: 'Item 2', key: 'Item 2', canCheck: true },
-        { text: 'Item 3', key: 'Item 3' }
+        { name: 'Item 1', key: 'Item 1' },
+        { name: 'Item 2', key: 'Item 2', canCheck: true },
+        { name: 'Item 3', key: 'Item 3' }
       ];
 
       expect(canAnyMenuItemsCheck(items)).toEqual(true);
@@ -784,22 +784,22 @@ describe('ContextualMenu', () => {
     it('returns true when there is a menu section with an item that can check', () => {
       const items: IContextualMenuItem[] = [
         {
-          text: 'Item 1',
+          name: 'Item 1',
           key: 'Item 1'
         },
         {
-          text: 'Item 2',
+          name: 'Item 2',
           key: 'Item 2'
         },
         {
-          text: 'Item 3',
+          name: 'Item 3',
           key: 'Item 3',
           sectionProps: {
             key: 'Section1',
             items: [
-              { text: 'Item 1', key: 'Item 1' },
-              { text: 'Item 2', key: 'Item 2', canCheck: true },
-              { text: 'Item 3', key: 'Item 3' }
+              { name: 'Item 1', key: 'Item 1' },
+              { name: 'Item 2', key: 'Item 2', canCheck: true },
+              { name: 'Item 3', key: 'Item 3' }
             ]
           }
         }];
@@ -818,18 +818,18 @@ describe('ContextualMenu', () => {
         menuDismissed = false;
         const menu: IContextualMenuItem[] = [
           {
-            text: 'Test1',
+            name: 'Test1',
             key: 'Test1',
             componentRef: contextualItem,
             subMenuProps: {
               items: [
                 {
-                  text: 'Test2',
+                  name: 'Test2',
                   key: 'Test2',
                   className: 'SubMenuClass'
                 },
                 {
-                  text: 'Test3',
+                  name: 'Test3',
                   key: 'Test3',
                   className: 'SubMenuClass'
                 }
@@ -868,19 +868,19 @@ describe('ContextualMenu', () => {
         menuDismissed = false;
         const menu: IContextualMenuItem[] = [
           {
-            text: 'Test1',
+            name: 'Test1',
             key: 'Test1',
             componentRef: contextualItem,
             split: true,
             subMenuProps: {
               items: [
                 {
-                  text: 'Test2',
+                  name: 'Test2',
                   key: 'Test2',
                   className: 'SubMenuClass'
                 },
                 {
-                  text: 'Test3',
+                  name: 'Test3',
                   key: 'Test3',
                   className: 'SubMenuClass'
                 }
@@ -919,19 +919,19 @@ describe('ContextualMenu', () => {
         menuDismissed = false;
         const menu: IContextualMenuItem[] = [
           {
-            text: 'Test1',
+            name: 'Test1',
             key: 'Test1',
             componentRef: contextualItem,
             href: '#test',
             subMenuProps: {
               items: [
                 {
-                  text: 'Test2',
+                  name: 'Test2',
                   key: 'Test2',
                   className: 'SubMenuClass'
                 },
                 {
-                  text: 'Test3',
+                  name: 'Test3',
                   key: 'Test3',
                   className: 'SubMenuClass'
                 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -356,7 +356,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       subMenuIconClassName
     );
 
-    if (item.name === '-') {
+    if (item.text === '-' || item.name === '-') {
       item.itemType = ContextualMenuItemType.Divider;
     }
     switch (item.itemType) {
@@ -391,7 +391,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       const headerContextualMenuItem: IContextualMenuItem = {
         key: `section-${section.title}-title`,
         itemType: ContextualMenuItemType.Header,
-        name: section.title,
+        text: section.title,
       };
       headerItem = this._renderHeaderMenuItem(headerContextualMenuItem, menuClassNames, index, hasCheckmarks, hasIcons);
     }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -255,7 +255,7 @@ export interface IContextualMenuItem {
   /**
    * Text description for the menu item to display
    */
-  name?: string;
+  text?: string;
 
   /**
    * Seconday description for the menu item to display
@@ -444,6 +444,12 @@ export interface IContextualMenuItem {
    * Optional prop to make an item readonly which is disabled but visitable by keyboard, will apply aria-readonly and some styling. Not supported by all components
    */
   inactive?: boolean;
+
+  /**
+   * Text description for the menu item to display
+   * @deprecated Use 'text' instead.
+   */
+  name?: string;
 }
 
 export interface IContextualMenuSection extends React.Props<ContextualMenu> {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -447,7 +447,7 @@ export interface IContextualMenuItem {
 
   /**
    * Text description for the menu item to display
-   * @deprecated Use 'text' instead.
+   * @deprecated Use `text` instead.
    */
   name?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.deprecated.test.tsx
@@ -55,7 +55,7 @@ describe('ContextMenuItemChildren', () => {
       let wrapper: ShallowWrapper<IContextualMenuItemProps, {}>;
 
       beforeEach(() => {
-        menuItem = { key: '123', iconProps: { iconName: 'itemIcon' }, text: 'menuItem' };
+        menuItem = { key: '123', iconProps: { iconName: 'itemIcon' }, name: 'menuItem' };
         menuClassNames = getMenuItemClassNames();
 
         wrapper = shallow(

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.tsx
@@ -43,8 +43,8 @@ const renderCheckMarkIcon = ({ onCheckmarkClick, item, classNames }: IContextual
 };
 
 const renderItemName = ({ item, classNames }: IContextualMenuItemProps) => {
-  if (item.name) {
-    return <span className={ classNames.label }>{ item.name }</span>;
+  if (item.text || item.name) {
+    return <span className={ classNames.label }>{ item.text || item.name }</span>;
   }
   return null;
 };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.deprecated.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { IContextualMenuItem } from '../ContextualMenu.types';
+import { IMenuItemClassNames } from '../ContextualMenu.classNames';
+import { ContextualMenuAnchor } from './ContextualMenuAnchor';
+
+describe('ContextualMenuButton', () => {
+  describe('creates a normal button', () => {
+    let menuItem: IContextualMenuItem;
+    let menuClassNames: IMenuItemClassNames;
+
+    beforeEach(() => {
+      menuItem = { key: '123' };
+      menuClassNames = getMenuItemClassNames();
+    });
+
+    it('renders the contextual menu split button correctly', () => {
+      const component = renderer.create(
+        <ContextualMenuAnchor
+          item={ menuItem }
+          classNames={ menuClassNames }
+          index={ 0 }
+          focusableElementIndex={ 0 }
+          totalItemCount={ 1 }
+        />);
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});
+
+function getMenuItemClassNames(): IMenuItemClassNames {
+  return {
+    item: 'item',
+    divider: '---',
+    root: 'root',
+    linkContent: 'linkContent',
+    icon: 'icon',
+    checkmarkIcon: 'checkmarkIcon',
+    subMenuIcon: 'subMenuIcon',
+    label: 'label',
+    secondaryText: 'secondaryText',
+    splitContainer: 'splitContainer',
+    splitPrimary: 'splitPrimary',
+    splitMenu: 'splitMenu',
+    linkContentMenu: 'linkContentMenu',
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.deprecated.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { IContextualMenuItem } from '../ContextualMenu.types';
+import { IMenuItemClassNames } from '../ContextualMenu.classNames';
+import { ContextualMenuButton } from './ContextualMenuButton';
+
+describe('ContextualMenuButton', () => {
+  describe('creates a normal button', () => {
+    let menuItem: IContextualMenuItem;
+    let menuClassNames: IMenuItemClassNames;
+
+    beforeEach(() => {
+      menuItem = { key: '123' };
+      menuClassNames = getMenuItemClassNames();
+    });
+
+    it('renders the contextual menu split button correctly', () => {
+      const component = renderer.create(
+        <ContextualMenuButton
+          item={ menuItem }
+          classNames={ menuClassNames }
+          index={ 0 }
+          focusableElementIndex={ 0 }
+          totalItemCount={ 1 }
+        />);
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});
+
+function getMenuItemClassNames(): IMenuItemClassNames {
+  return {
+    item: 'item',
+    divider: '---',
+    root: 'root',
+    linkContent: 'linkContent',
+    icon: 'icon',
+    checkmarkIcon: 'checkmarkIcon',
+    subMenuIcon: 'subMenuIcon',
+    label: 'label',
+    secondaryText: 'secondaryText',
+    splitContainer: 'splitContainer',
+    splitPrimary: 'splitPrimary',
+    splitMenu: 'splitMenu',
+    linkContentMenu: 'linkContentMenu',
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -31,13 +31,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
     } = this.props;
 
     const subMenuId = this._getSubMenuId(item);
-    let ariaLabel = '';
-
-    if (item.ariaLabel) {
-      ariaLabel = item.ariaLabel;
-    } else if (item.name) {
-      ariaLabel = item.name;
-    }
+    const ariaLabel = item.ariaLabel || item.text || item.name || '';
 
     const isChecked: boolean | null | undefined = getIsChecked(item);
     const canCheck: boolean = isChecked !== null;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.deprecated.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { IContextualMenuItem } from '../ContextualMenu.types';
+import { IMenuItemClassNames } from '../ContextualMenu.classNames';
+import { ContextualMenuSplitButton } from './ContextualMenuSplitButton';
+
+describe('ContextualMenuSplitButton', () => {
+  describe('creates a normal split button', () => {
+    let menuItem: IContextualMenuItem;
+    let menuClassNames: IMenuItemClassNames;
+
+    beforeEach(() => {
+      menuItem = { key: '123' };
+      menuClassNames = getMenuItemClassNames();
+    });
+
+    it('renders the contextual menu split button correctly', () => {
+      const component = renderer.create(
+        <ContextualMenuSplitButton
+          item={ menuItem }
+          classNames={ menuClassNames }
+          index={ 0 }
+          focusableElementIndex={ 0 }
+          totalItemCount={ 1 }
+        />);
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});
+
+function getMenuItemClassNames(): IMenuItemClassNames {
+  return {
+    item: 'item',
+    divider: '---',
+    root: 'root',
+    linkContent: 'linkContent',
+    icon: 'icon',
+    checkmarkIcon: 'checkmarkIcon',
+    subMenuIcon: 'subMenuIcon',
+    label: 'label',
+    secondaryText: 'secondaryText',
+    splitContainer: 'splitContainer',
+    splitPrimary: 'splitPrimary',
+    splitMenu: 'splitMenu',
+    linkContentMenu: 'linkContentMenu',
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -111,6 +111,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
       key: item.key,
       disabled: isItemDisabled(item) || item.primaryDisabled,
       name: item.name,
+      text: item.text || item.name,
       className: classNames.splitPrimary,
       role: item.role || defaultRole,
       canCheck: item.canCheck,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuAnchor.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuAnchor.deprecated.test.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContextualMenuButton creates a normal button renders the contextual menu split button correctly 1`] = `
+<div>
+  <a
+    aria-disabled={false}
+    aria-expanded={undefined}
+    aria-haspopup={undefined}
+    aria-owns={undefined}
+    aria-posinset={1}
+    aria-setsize={1}
+    className="root"
+    href={undefined}
+    onClick={[Function]}
+    onKeyDown={null}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    rel={undefined}
+    role="menuitem"
+    style={undefined}
+    target={undefined}
+  >
+    <div
+      className="linkContent"
+    />
+  </a>
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.deprecated.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContextualMenuButton creates a normal button renders the contextual menu split button correctly 1`] = `
+<button
+  aria-checked={false}
+  aria-disabled={false}
+  aria-expanded={undefined}
+  aria-haspopup={undefined}
+  aria-label=""
+  aria-owns={undefined}
+  aria-posinset={1}
+  aria-setsize={1}
+  className="root"
+  href={undefined}
+  onClick={[Function]}
+  onKeyDown={null}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  role="menuitem"
+  style={undefined}
+  title={undefined}
+>
+  <div
+    className="linkContent"
+  />
+</button>
+`;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.deprecated.test.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContextualMenuSplitButton creates a normal split button renders the contextual menu split button correctly 1`] = `
+<div
+  aria-checked={undefined}
+  aria-describedby="undefined"
+  aria-disabled={false}
+  aria-haspopup={true}
+  aria-labelledby={undefined}
+  aria-posinset={1}
+  aria-setsize={1}
+  className="splitContainer"
+  data-is-focusable={true}
+  data-ktp-target={undefined}
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={undefined}
+  onMouseMove={[Function]}
+  onTouchStart={[Function]}
+  role="button"
+  tabIndex={0}
+>
+  <button
+    aria-hidden={true}
+    checked={undefined}
+    className="splitPrimary"
+    data-is-focusable={false}
+    disabled={undefined}
+    name={undefined}
+    role="menuitem"
+  >
+    <div
+      className="linkContent"
+    />
+  </button>
+  <span
+    className=
+
+        {
+          align-items: center;
+          display: inline-flex;
+          height: 100%;
+        }
+  >
+    <span
+      className=
+
+          {
+            background-color: #c8c8c8;
+            height: 16px;
+            width: 1px;
+          }
+    />
+  </span>
+  <button
+    aria-hidden={true}
+    className="splitMenu"
+    data-is-focusable={false}
+    data-ktp-execute-target={undefined}
+    disabled={false}
+    onClick={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={undefined}
+    onMouseMove={[Function]}
+  >
+    <div
+      className="linkContentMenu"
+    />
+  </button>
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuItem.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuItem.deprecated.test.tsx.snap
@@ -433,7 +433,7 @@ ShallowWrapper {
           "iconName": "itemIcon",
         },
         "key": "123",
-        "text": "menuItem",
+        "name": "menuItem",
       }
     }
   />,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -23,7 +23,7 @@ export class ContextualMenuBasicExample extends React.Component {
             items: [
               {
                 key: 'newItem',
-                name: 'New',
+                text: 'New',
                 onClick: () => console.log('New clicked')
               },
               {
@@ -32,33 +32,33 @@ export class ContextualMenuBasicExample extends React.Component {
               },
               {
                 key: 'rename',
-                name: 'Rename',
+                text: 'Rename',
                 onClick: () => console.log('Rename clicked')
               },
               {
                 key: 'edit',
-                name: 'Edit',
+                text: 'Edit',
                 onClick: () => console.log('Edit clicked')
               },
               {
                 key: 'properties',
-                name: 'Properties',
+                text: 'Properties',
                 onClick: () => console.log('Properties clicked')
               },
               {
                 key: 'linkNoTarget',
-                name: 'Link same window',
+                text: 'Link same window',
                 href: 'http://bing.com'
               },
               {
                 key: 'linkWithTarget',
-                name: 'Link new window',
+                text: 'Link new window',
                 href: 'http://bing.com',
                 target: '_blank'
               },
               {
                 key: 'disabled',
-                name: 'Disabled item',
+                text: 'Disabled item',
                 disabled: true,
                 onClick: () => console.error('Disabled item should not be clickable.')
               }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
@@ -35,21 +35,21 @@ export class ContextualMenuCheckmarksExample extends React.Component<{}, IContex
               [
                 {
                   key: keys[0],
-                  name: 'New',
+                  text: 'New',
                   canCheck: true,
                   isChecked: selection![keys[0]],
                   onClick: this._onToggleSelect
                 },
                 {
                   key: keys[1],
-                  name: 'Share',
+                  text: 'Share',
                   canCheck: true,
                   isChecked: selection![keys[1]],
                   onClick: this._onToggleSelect
                 },
                 {
                   key: keys[2],
-                  name: 'Mobile',
+                  text: 'Mobile',
                   canCheck: true,
                   isChecked: selection![keys[2]],
                   onClick: this._onToggleSelect
@@ -61,14 +61,14 @@ export class ContextualMenuCheckmarksExample extends React.Component<{}, IContex
 
                 {
                   key: keys[3],
-                  name: 'Print',
+                  text: 'Print',
                   canCheck: true,
                   isChecked: selection![keys[3]],
                   onClick: this._onToggleSelect
                 },
                 {
                   key: keys[4],
-                  name: 'Music',
+                  text: 'Music',
                   canCheck: true,
                   isChecked: selection![keys[4]],
                   onClick: this._onToggleSelect
@@ -82,21 +82,21 @@ export class ContextualMenuCheckmarksExample extends React.Component<{}, IContex
                     items: [
                       {
                         key: keys[6],
-                        name: 'Email message',
+                        text: 'Email message',
                         canCheck: true,
                         isChecked: selection![keys[6]],
                         onClick: this._onToggleSelect
                       },
                       {
                         key: keys[7],
-                        name: 'Calendar event',
+                        text: 'Calendar event',
                         canCheck: true,
                         isChecked: selection![keys[7]],
                         onClick: this._onToggleSelect
                       }
                     ],
                   },
-                  name: 'Split Button',
+                  text: 'Split Button',
                   canCheck: true,
                   isChecked: selection![keys[5]],
                   split: true,
@@ -111,21 +111,21 @@ export class ContextualMenuCheckmarksExample extends React.Component<{}, IContex
                     items: [
                       {
                         key: keys[9],
-                        name: 'Email message',
+                        text: 'Email message',
                         canCheck: true,
                         isChecked: selection![keys[9]],
                         onClick: this._onToggleSelect
                       },
                       {
                         key: keys[10],
-                        name: 'Calendar event',
+                        text: 'Calendar event',
                         canCheck: true,
                         isChecked: selection![keys[10]],
                         onClick: this._onToggleSelect
                       }
                     ],
                   },
-                  name: 'Split Button',
+                  text: 'Split Button',
                   canCheck: true,
                   isChecked: selection![keys[8]],
                   split: true,
@@ -142,21 +142,21 @@ export class ContextualMenuCheckmarksExample extends React.Component<{}, IContex
                     items: [
                       {
                         key: keys[12],
-                        name: 'Email message',
+                        text: 'Email message',
                         canCheck: true,
                         isChecked: selection![keys[12]],
                         onClick: this._onToggleSelect
                       },
                       {
                         key: keys[13],
-                        name: 'Calendar event',
+                        text: 'Calendar event',
                         canCheck: true,
                         isChecked: selection![keys[13]],
                         onClick: this._onToggleSelect
                       }
                     ],
                   },
-                  name: 'Split Button Left Menu',
+                  text: 'Split Button Left Menu',
                   canCheck: true,
                   isChecked: selection![keys[11]],
                   split: true,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuItem.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuItem.Example.tsx
@@ -24,7 +24,7 @@ export class ContextualMenuWithCustomMenuItemExample extends React.Component {
             items: [
               {
                 key: 'newItem',
-                name: 'New'
+                text: 'New'
               },
               {
                 key: 'divider_1',
@@ -32,23 +32,23 @@ export class ContextualMenuWithCustomMenuItemExample extends React.Component {
               },
               {
                 key: 'rename',
-                name: 'Rename'
+                text: 'Rename'
               },
               {
                 key: 'edit',
-                name: 'Edit'
+                text: 'Edit'
               },
               {
                 key: 'properties',
-                name: 'Properties'
+                text: 'Properties'
               },
               {
                 key: 'disabled',
-                name: 'Disabled item',
+                text: 'Disabled item',
                 disabled: true
               }
             ],
-            contextualMenuItemAs: (props: IContextualMenuItemProps) => <div>Custom rendered { props.item.name }</div>
+            contextualMenuItemAs: (props: IContextualMenuItemProps) => <div>Custom rendered { props.item.text }</div>
           } }
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
@@ -19,11 +19,11 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
               [
                 {
                   key: 'newItem',
-                  name: 'New'
+                  text: 'New'
                 },
                 {
                   key: 'upload',
-                  name: 'Upload'
+                  text: 'Upload'
                 },
                 {
                   key: 'divider_1',
@@ -31,96 +31,96 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
                 },
                 {
                   key: 'charm',
-                  name: 'Charm',
+                  text: 'Charm',
                   className: 'Charm-List',
                   subMenuProps: {
                     focusZoneProps: { direction: FocusZoneDirection.bidirectional },
                     items: [
                       {
                         key: 'none',
-                        name: 'None'
+                        text: 'None'
                       },
                       {
                         key: 'bulb',
-                        name: 'Lightbulb',
+                        text: 'Lightbulb',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'run',
-                        name: 'Running',
+                        text: 'Running',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'plane',
-                        name: 'Airplane',
+                        text: 'Airplane',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'page',
-                        name: 'Page',
+                        text: 'Page',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'cake',
-                        name: 'Cake',
+                        text: 'Cake',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'soccer',
-                        name: 'Soccer',
+                        text: 'Soccer',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'home',
-                        name: 'Home',
+                        text: 'Home',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'emoji',
-                        name: 'Emoji2',
+                        text: 'Emoji2',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'work',
-                        name: 'Work',
+                        text: 'Work',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'coffee',
-                        name: 'Coffee',
+                        text: 'Coffee',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'people',
-                        name: 'People',
+                        text: 'People',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'stopwatch',
-                        name: 'Stopwatch',
+                        text: 'Stopwatch',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'music',
-                        name: 'MusicInCollectionFill',
+                        text: 'MusicInCollectionFill',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'lock',
-                        name: 'Lock',
+                        text: 'Lock',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       }
@@ -129,12 +129,12 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
                 },
                 {
                   key: 'categories',
-                  name: 'Categorize',
+                  text: 'Categorize',
                   subMenuProps: {
                     items: [
                       {
                         key: 'categories',
-                        name: 'categories',
+                        text: 'categories',
                         categoryList: [
                           {
                             name: 'Personal',
@@ -169,11 +169,11 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
                       },
                       {
                         key: 'clear',
-                        name: 'Clear categories'
+                        text: 'Clear categories'
                       },
                       {
                         key: 'manage',
-                        name: 'Manage categories'
+                        text: 'Manage categories'
                       }
                     ]
                   },

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
@@ -19,11 +19,11 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
               [
                 {
                   key: 'newItem',
-                  name: 'New'
+                  text: 'New'
                 },
                 {
                   key: 'upload',
-                  name: 'Upload'
+                  text: 'Upload'
                 },
                 {
                   key: 'divider_1',
@@ -31,7 +31,7 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
                 },
                 {
                   key: 'charm',
-                  name: 'Charm',
+                  text: 'Charm',
                   className: 'Charm-List',
                   subMenuProps: {
                     focusZoneProps: {
@@ -41,96 +41,96 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
                     items: [
                       {
                         key: 'bulb',
-                        name: 'Lightbulb',
+                        text: 'Lightbulb',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'run',
-                        name: 'Running',
+                        text: 'Running',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'plane',
-                        name: 'Airplane',
+                        text: 'Airplane',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'page',
-                        name: 'Page',
+                        text: 'Page',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'cake',
-                        name: 'Cake',
+                        text: 'Cake',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'soccer',
-                        name: 'Soccer',
+                        text: 'Soccer',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'home',
-                        name: 'Home',
+                        text: 'Home',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'emoji',
-                        name: 'Emoji2',
+                        text: 'Emoji2',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'work',
-                        name: 'Work',
+                        text: 'Work',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'coffee',
-                        name: 'Coffee',
+                        text: 'Coffee',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'people',
-                        name: 'People',
+                        text: 'People',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'stopwatch',
-                        name: 'Stopwatch',
+                        text: 'Stopwatch',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'music',
-                        name: 'MusicInCollectionFill',
+                        text: 'MusicInCollectionFill',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'lock',
-                        name: 'Lock',
+                        text: 'Lock',
                         onRender: this._renderCharmMenuItem,
                         className: 'ms-ContextualMenu-customizationExample-item'
                       },
                       {
                         key: 'item3',
-                        name: 'Item 3',
+                        text: 'Item 3',
                         'data-no-horizontal-wrap': true
                       },
                       {
                         key: 'item4',
-                        name: 'Item 4',
+                        text: 'Item 4',
                         'data-no-horizontal-wrap': true
                       },
                     ]
@@ -138,12 +138,12 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
                 },
                 {
                   key: 'categories',
-                  name: 'Categorize',
+                  text: 'Categorize',
                   subMenuProps: {
                     items: [
                       {
                         key: 'categories',
-                        name: 'categories',
+                        text: 'categories',
                         categoryList: [
                           {
                             name: 'Personal',
@@ -178,11 +178,11 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
                       },
                       {
                         key: 'clear',
-                        name: 'Clear categories'
+                        text: 'Clear categories'
                       },
                       {
                         key: 'manage',
-                        name: 'Manage categories'
+                        text: 'Manage categories'
                       }
                     ]
                   },

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
@@ -101,7 +101,7 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
               items: [
                 {
                   key: 'newItem',
-                  name: 'New'
+                  text: 'New'
                 },
                 {
                   key: 'divider_1',
@@ -109,19 +109,19 @@ export class ContextualMenuDirectionalExample extends React.Component<{}, IConte
                 },
                 {
                   key: 'rename',
-                  name: 'Rename'
+                  text: 'Rename'
                 },
                 {
                   key: 'edit',
-                  name: 'Edit'
+                  text: 'Edit'
                 },
                 {
                   key: 'properties',
-                  name: 'Properties'
+                  text: 'Properties'
                 },
                 {
                   key: 'disabled',
-                  name: 'Disabled item',
+                  text: 'Disabled item',
                   disabled: true
                 }
               ]

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx
@@ -17,7 +17,7 @@ export class ContextualMenuHeaderExample extends React.Component<{}, {}> {
               {
                 key: 'Actions',
                 itemType: 2,
-                name: 'Actions'
+                text: 'Actions'
               },
               {
                 key: 'upload',
@@ -27,12 +27,12 @@ export class ContextualMenuHeaderExample extends React.Component<{}, {}> {
                     color: 'salmon'
                   }
                 },
-                name: 'Upload',
+                text: 'Upload',
                 title: 'Upload a file'
               },
               {
                 key: 'rename',
-                name: 'Rename'
+                text: 'Rename'
               },
               {
                 key: 'share',
@@ -43,46 +43,46 @@ export class ContextualMenuHeaderExample extends React.Component<{}, {}> {
                   items: [
                     {
                       key: 'sharetoemail',
-                      name: 'Share to Email',
+                      text: 'Share to Email',
                       iconProps: {
                         iconName: 'Mail'
                       },
                     },
                     {
                       key: 'sharetofacebook',
-                      name: 'Share to Facebook',
+                      text: 'Share to Facebook',
                     },
                     {
                       key: 'sharetotwitter',
-                      name: 'Share to Twitter',
+                      text: 'Share to Twitter',
                       iconProps: {
                         iconName: 'Share'
                       },
                     },
                   ],
                 },
-                name: 'Sharing'
+                text: 'Sharing'
               },
               {
                 key: 'navigation',
                 itemType: 2,
-                name: 'Navigation'
+                text: 'Navigation'
               },
               {
                 key: 'properties',
-                name: 'Properties'
+                text: 'Properties'
               },
               {
                 key: 'print',
                 iconProps: {
                   iconName: 'Print'
                 },
-                name: 'Print'
+                text: 'Print'
               },
 
               {
                 key: 'Bing',
-                name: 'Go to Bing',
+                text: 'Go to Bing',
                 href: 'http://www.bing.com'
               },
             ]

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
@@ -30,7 +30,7 @@ export class ContextualMenuIconExample extends React.Component<{}, { showCallout
             items: [
               {
                 key: 'openInWord',
-                name: 'Open in Word',
+                text: 'Open in Word',
                 onRenderIcon: (props: IContextualMenuItemProps) => {
                   return (
                     <span className={ styles.iconContainer }>
@@ -45,7 +45,7 @@ export class ContextualMenuIconExample extends React.Component<{}, { showCallout
                 iconProps: {
                   iconName: 'Add'
                 },
-                name: 'New'
+                text: 'New'
               },
               {
                 key: 'upload',
@@ -58,7 +58,7 @@ export class ContextualMenuIconExample extends React.Component<{}, { showCallout
                     color: 'salmon'
                   }
                 },
-                name: 'Upload (Click for popup)',
+                text: 'Upload (Click for popup)',
                 title: 'Upload a file'
               },
               {
@@ -70,21 +70,21 @@ export class ContextualMenuIconExample extends React.Component<{}, { showCallout
                 iconProps: {
                   iconName: 'Share'
                 },
-                name: 'Share'
+                text: 'Share'
               },
               {
                 key: 'print',
                 iconProps: {
                   iconName: 'Print'
                 },
-                name: 'Print'
+                text: 'Print'
               },
               {
                 key: 'music',
                 iconProps: {
                   iconName: 'MusicInCollectionFill'
                 },
-                name: 'Music',
+                text: 'Music',
               }
             ]
           }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.SecondaryText.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.SecondaryText.Example.tsx
@@ -24,7 +24,7 @@ export class ContextualMenuIconSecondaryTextExample extends React.Component<{}, 
                 iconProps: {
                   iconName: 'Clock'
                 },
-                name: 'Later Today',
+                text: 'Later Today',
                 secondaryText: '7:00 PM'
               },
               {
@@ -32,7 +32,7 @@ export class ContextualMenuIconSecondaryTextExample extends React.Component<{}, 
                 iconProps: {
                   iconName: 'Coffeescript'
                 },
-                name: 'Tomorrow',
+                text: 'Tomorrow',
                 secondaryText: 'Thu. 8:00 AM'
               },
               {
@@ -40,7 +40,7 @@ export class ContextualMenuIconSecondaryTextExample extends React.Component<{}, 
                 iconProps: {
                   iconName: 'Vacation'
                 },
-                name: 'This Weekend',
+                text: 'This Weekend',
                 secondaryText: 'Sat. 10:00 AM'
               },
               {
@@ -48,7 +48,7 @@ export class ContextualMenuIconSecondaryTextExample extends React.Component<{}, 
                 iconProps: {
                   iconName: 'Suitcase'
                 },
-                name: 'Next Week',
+                text: 'Next Week',
                 secondaryText: 'Mon. 8:00 AM'
               },
             ]

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx
@@ -27,23 +27,23 @@ export class ContextualMenuWithScrollBarExample extends React.Component<{}, {
             items: [
               {
                 key: 'newItem',
-                name: 'New'
+                text: 'New'
               },
               {
                 key: 'item 2',
-                name: 'Item with a very long label text'
+                text: 'Item with a very long label text'
               },
               {
                 key: 'edit',
-                name: 'Edit'
+                text: 'Edit'
               },
               {
                 key: 'properties',
-                name: 'Properties'
+                text: 'Properties'
               },
               {
                 key: 'disabled',
-                name: 'Disabled item',
+                text: 'Disabled item',
                 disabled: true
               }
             ],

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
@@ -13,62 +13,62 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
           text='Click for ContextualMenu'
           menuProps={ {
             items:
-            [
-              {
-                key: 'section',
-                itemType: ContextualMenuItemType.Section,
-                sectionProps: {
-                  topDivider: true,
-                  bottomDivider: true,
-                  title: 'Actions',
-                  items: [
-                    {
-                      key: 'newItem',
-                      name: 'New',
-                    },
-                    {
-                      key: 'deleteItem',
-                      name: 'Delete',
-                    }
-                  ]
+              [
+                {
+                  key: 'section',
+                  itemType: ContextualMenuItemType.Section,
+                  sectionProps: {
+                    topDivider: true,
+                    bottomDivider: true,
+                    title: 'Actions',
+                    items: [
+                      {
+                        key: 'newItem',
+                        text: 'New',
+                      },
+                      {
+                        key: 'deleteItem',
+                        text: 'Delete',
+                      }
+                    ]
+                  }
+                },
+                {
+                  key: 'section',
+                  itemType: ContextualMenuItemType.Section,
+                  sectionProps: {
+                    title: 'Social',
+                    items: [
+                      {
+                        key: 'share',
+                        text: 'Share'
+                      },
+                      {
+                        key: 'print',
+                        text: 'Print'
+                      },
+                      {
+                        key: 'music',
+                        text: 'Music',
+                      },
+                    ]
+                  }
+                },
+                {
+                  key: 'section',
+                  itemType: ContextualMenuItemType.Section,
+                  sectionProps: {
+                    title: 'Navigation',
+                    items: [
+                      {
+                        key: 'Bing',
+                        text: 'Go to Bing',
+                        href: 'http://www.bing.com'
+                      }
+                    ]
+                  }
                 }
-              },
-              {
-                key: 'section',
-                itemType: ContextualMenuItemType.Section,
-                sectionProps: {
-                  title: 'Social',
-                  items: [
-                    {
-                      key: 'share',
-                      name: 'Share'
-                    },
-                    {
-                      key: 'print',
-                      name: 'Print'
-                    },
-                    {
-                      key: 'music',
-                      name: 'Music',
-                    },
-                  ]
-                }
-              },
-              {
-                key: 'section',
-                itemType: ContextualMenuItemType.Section,
-                sectionProps: {
-                  title: 'Navigation',
-                  items: [
-                    {
-                      key: 'Bing',
-                      name: 'Go to Bing',
-                      href: 'http://www.bing.com'
-                    }
-                  ]
-                }
-              }
-            ]
+              ]
           }
           }
         />

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -34,18 +34,18 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
                   items: [
                     {
                       key: 'emailMessage',
-                      name: 'Email message',
+                      text: 'Email message',
                       title: 'Create an email'
                     },
                     {
                       key: 'calendarEvent',
-                      name: 'Calendar event',
+                      text: 'Calendar event',
                       title: 'Create a calendar event',
                     }
                   ],
                 },
                 href: 'https://bing.com',
-                name: 'New'
+                text: 'New'
               },
               {
                 key: 'share',
@@ -53,25 +53,25 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
                   items: [
                     {
                       key: 'sharetotwitter',
-                      name: 'Share to Twitter',
+                      text: 'Share to Twitter',
                     },
                     {
                       key: 'sharetofacebook',
-                      name: 'Share to Facebook',
+                      text: 'Share to Facebook',
                     },
                     {
                       key: 'sharetoemail',
-                      name: 'Share to Email',
+                      text: 'Share to Email',
                       subMenuProps: {
                         items: [
                           {
                             key: 'sharetooutlook_1',
-                            name: 'Share to Outlook',
+                            text: 'Share to Outlook',
                             title: 'Share to Outlook',
                           },
                           {
                             key: 'sharetogmail_1',
-                            name: 'Share to Gmail',
+                            text: 'Share to Gmail',
                             title: 'Share to Gmail',
                           }
                         ],
@@ -79,7 +79,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
                     },
                   ],
                 },
-                name: 'Share'
+                text: 'Share'
               },
               {
                 key: 'shareSplit',
@@ -89,25 +89,25 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
                   items: [
                     {
                       key: 'sharetotwittersplit',
-                      name: 'Share to Twitter',
+                      text: 'Share to Twitter',
                     },
                     {
                       key: 'sharetofacebooksplit',
-                      name: 'Share to Facebook',
+                      text: 'Share to Facebook',
                     },
                     {
                       key: 'sharetoemailsplit',
-                      name: 'Share to Email',
+                      text: 'Share to Email',
                       subMenuProps: {
                         items: [
                           {
                             key: 'sharetooutlooksplit_1',
-                            name: 'Share to Outlook',
+                            text: 'Share to Outlook',
                             title: 'Share to Outlook',
                           },
                           {
                             key: 'sharetogmailsplit_1',
-                            name: 'Share to Gmail',
+                            text: 'Share to Gmail',
                             title: 'Share to Gmail',
                           }
                         ],
@@ -115,7 +115,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
                     },
                   ],
                 },
-                name: 'Share w/ Split'
+                text: 'Share w/ Split'
               }
             ]
           }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -234,69 +234,69 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
     return [
       {
         key: 'addRow',
-        name: 'Insert row',
+        text: 'Insert row',
         iconProps: { iconName: 'Add' },
         onClick: this._onAddRow
       },
       {
         key: 'deleteRow',
-        name: 'Delete row',
+        text: 'Delete row',
         iconProps: { iconName: 'Delete' },
         onClick: this._onDeleteRow
       },
       {
         key: 'configure',
-        name: 'Configure',
+        text: 'Configure',
         iconProps: { iconName: 'Settings' },
         subMenuProps: {
           items: [
             {
               key: 'resizing',
-              name: 'Allow column resizing',
+              text: 'Allow column resizing',
               canCheck: true,
               checked: canResizeColumns,
               onClick: this._onToggleResizing
             },
             {
               key: 'headerVisible',
-              name: 'Is header visible',
+              text: 'Is header visible',
               canCheck: true,
               checked: isHeaderVisible,
               onClick: () => this.setState({ isHeaderVisible: !isHeaderVisible })
             },
             {
               key: 'lazyload',
-              name: 'Simulate async loading',
+              text: 'Simulate async loading',
               canCheck: true,
               checked: isLazyLoaded,
               onClick: this._onToggleLazyLoad
             },
             {
               key: 'dash',
-              name: '-'
+              text: '-'
             },
             {
               key: 'checkboxVisibility',
-              name: 'Checkbox visibility',
+              text: 'Checkbox visibility',
               subMenuProps: {
                 items: [
                   {
                     key: 'checkboxVisibility.always',
-                    name: 'Always',
+                    text: 'Always',
                     canCheck: true,
                     isChecked: checkboxVisibility === CheckboxVisibility.always,
                     onClick: () => this.setState({ checkboxVisibility: CheckboxVisibility.always })
                   },
                   {
                     key: 'checkboxVisibility.onHover',
-                    name: 'On hover',
+                    text: 'On hover',
                     canCheck: true,
                     isChecked: checkboxVisibility === CheckboxVisibility.onHover,
                     onClick: () => this.setState({ checkboxVisibility: CheckboxVisibility.onHover })
                   },
                   {
                     key: 'checkboxVisibility.hidden',
-                    name: 'Hidden',
+                    text: 'Hidden',
                     canCheck: true,
                     isChecked: checkboxVisibility === CheckboxVisibility.hidden,
                     onClick: () => this.setState({ checkboxVisibility: CheckboxVisibility.hidden })
@@ -306,12 +306,12 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
             },
             {
               key: 'layoutMode',
-              name: 'Layout mode',
+              text: 'Layout mode',
               subMenuProps: {
                 items: [
                   {
                     key: LayoutMode[LayoutMode.fixedColumns],
-                    name: 'Fixed columns',
+                    text: 'Fixed columns',
                     canCheck: true,
                     checked: layoutMode === LayoutMode.fixedColumns,
                     onClick: this._onLayoutChanged,
@@ -319,7 +319,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
                   },
                   {
                     key: LayoutMode[LayoutMode.justified],
-                    name: 'Justified columns',
+                    text: 'Justified columns',
                     canCheck: true,
                     checked: layoutMode === LayoutMode.justified,
                     onClick: this._onLayoutChanged,
@@ -330,12 +330,12 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
             },
             {
               key: 'selectionMode',
-              name: 'Selection mode',
+              text: 'Selection mode',
               subMenuProps: {
                 items: [
                   {
                     key: SelectionMode[SelectionMode.none],
-                    name: 'None',
+                    text: 'None',
                     canCheck: true,
                     checked: selectionMode === SelectionMode.none,
                     onClick: this._onSelectionChanged,
@@ -344,7 +344,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
                   },
                   {
                     key: SelectionMode[SelectionMode.single],
-                    name: 'Single select',
+                    text: 'Single select',
                     canCheck: true,
                     checked: selectionMode === SelectionMode.single,
                     onClick: this._onSelectionChanged,
@@ -352,7 +352,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
                   },
                   {
                     key: SelectionMode[SelectionMode.multiple],
-                    name: 'Multi select',
+                    text: 'Multi select',
                     canCheck: true,
                     checked: selectionMode === SelectionMode.multiple,
                     onClick: this._onSelectionChanged,
@@ -363,12 +363,12 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
             },
             {
               key: 'constrainMode',
-              name: 'Constrain mode',
+              text: 'Constrain mode',
               subMenuProps: {
                 items: [
                   {
                     key: ConstrainMode[ConstrainMode.unconstrained],
-                    name: 'Unconstrained',
+                    text: 'Unconstrained',
                     canCheck: true,
                     checked: constrainMode === ConstrainMode.unconstrained,
                     onClick: this._onConstrainModeChanged,
@@ -376,7 +376,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
                   },
                   {
                     key: ConstrainMode[ConstrainMode.horizontalConstrained],
-                    name: 'Horizontal constrained',
+                    text: 'Horizontal constrained',
                     canCheck: true,
                     checked: constrainMode === ConstrainMode.horizontalConstrained,
                     onClick: this._onConstrainModeChanged,

--- a/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Tabbable.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Tabbable.Example.tsx
@@ -26,12 +26,12 @@ export const FocusZoneTabbableExample = () => (
             items: [
               {
                 key: 'emailMessage',
-                name: 'Email message',
+                text: 'Email message',
                 iconProps: { iconName: 'Mail' }
               },
               {
                 key: 'calendarEvent',
-                name: 'Calendar event',
+                text: 'Calendar event',
                 iconProps: { iconName: 'Calendar' }
               }
             ]

--- a/packages/office-ui-fabric-react/src/components/Keytip/examples/Keytips.Button.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Keytip/examples/Keytips.Button.Example.tsx
@@ -43,12 +43,12 @@ export class KeytipsButtonExample extends React.Component<{}, IKeytipsButtonExam
             items: [
               {
                 key: 'buttonMenuItem1',
-                name: 'Menu Item 1',
+                text: 'Menu Item 1',
                 keytipProps: keytipMap.ButtonMenuItem1
               },
               {
                 key: 'buttonMenuItem2',
-                name: 'Menu Item 2',
+                text: 'Menu Item 2',
                 keytipProps: keytipMap.ButtonMenuItem2
               }
             ]
@@ -63,12 +63,12 @@ export class KeytipsButtonExample extends React.Component<{}, IKeytipsButtonExam
             items: [
               {
                 key: 'splitButtonMenuButton1',
-                name: 'Split Button Menu Item 1',
+                text: 'Split Button Menu Item 1',
                 keytipProps: keytipMap.SplitButtonMenuItem1
               },
               {
                 key: 'splitButtonMenuButton2',
-                name: 'Split Button Menu Item 2',
+                text: 'Split Button Menu Item 2',
                 keytipProps: keytipMap.SplitButtonMenuItem2
               }
             ]

--- a/packages/office-ui-fabric-react/src/components/Keytip/examples/Keytips.CommandBar.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Keytip/examples/Keytips.CommandBar.Example.tsx
@@ -27,7 +27,7 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
             [
               {
                 key: 'commandBarItem1',
-                name: 'New',
+                text: 'New',
                 iconProps: {
                   iconName: 'Add',
                 },
@@ -36,7 +36,7 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
               },
               {
                 key: 'commandBarItem2',
-                name: 'Upload',
+                text: 'Upload',
                 iconProps: {
                   iconName: 'Upload',
                 },
@@ -49,7 +49,7 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
             [
               {
                 key: 'farItem1',
-                name: 'Options',
+                text: 'Options',
                 iconProps: {
                   iconName: 'SortLines',
                 },
@@ -58,7 +58,7 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
                   items: [
                     {
                       key: 'emailMessage',
-                      name: 'Send Email',
+                      text: 'Send Email',
                       iconProps: {
                         iconName: 'Mail',
                       },
@@ -67,7 +67,7 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
                     },
                     {
                       key: 'calendarEvent',
-                      name: 'Make Calendar Event',
+                      text: 'Make Calendar Event',
                       iconProps: {
                         iconName: 'Calendar',
                       },
@@ -77,13 +77,13 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
                         items: [
                           {
                             key: 'testButton',
-                            name: 'Add to Outlook',
+                            text: 'Add to Outlook',
                             keytipProps: keytipMap.SubmenuKeytip3,
                             onClick: () => { console.log('test3'); }
                           },
                           {
                             key: 'testButton2',
-                            name: 'Go to Bing',
+                            text: 'Go to Bing',
                             keytipProps: keytipMap.SubmenuKeytip4,
                             href: 'http://www.bing.com',
                             target: '_blank'
@@ -93,18 +93,18 @@ export class KeytipsCommandBarExample extends React.Component<{}, IKeytipsComman
                     },
                     {
                       key: 'splitButtonTest',
-                      name: 'Other...',
+                      text: 'Other...',
                       split: true,
                       keytipProps: keytipMap.SubmenuKeytip5,
                       subMenuProps: {
                         items: [
                           {
                             key: 'splitButtonSubMenu1',
-                            name: 'Submenu Item w/o Keytip',
+                            text: 'Submenu Item w/o Keytip',
                           },
                           {
                             key: 'splitButtonSubMenu2',
-                            name: 'Submenu Item w/o Keytip'
+                            text: 'Submenu Item w/o Keytip'
                           }
                         ]
                       }

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -125,7 +125,7 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
     if (this.props.editMenuItemText && this.props.getEditingItemText) {
       menuItems.push({
         key: 'Edit',
-        name: this.props.editMenuItemText,
+        text: this.props.editMenuItemText,
         onClick: (ev: React.MouseEvent<HTMLElement>, menuItem: IContextualMenuItem) => {
           this._beginEditing(menuItem.data);
         },
@@ -137,7 +137,7 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
       menuItems.push(
         {
           key: 'Remove',
-          name: this.props.removeMenuItemText,
+          text: this.props.removeMenuItemText,
           onClick: (ev: React.MouseEvent<HTMLElement>, menuItem: IContextualMenuItem) => {
             this.removeItem(menuItem.data as ISelectedItemProps<IExtendedPersonaProps>);
           },
@@ -148,7 +148,7 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
     if (this.props.copyMenuItemText) {
       menuItems.push({
         key: 'Copy',
-        name: this.props.copyMenuItemText,
+        text: this.props.copyMenuItemText,
         onClick: (ev: React.MouseEvent<HTMLElement>, menuItem: IContextualMenuItem) => {
           if (this.props.onCopyItems) {
             (this.copyItems as (items: IExtendedPersonaProps[]) => void)([menuItem.data] as IExtendedPersonaProps[]);

--- a/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx
@@ -164,7 +164,7 @@ export class SelectionBasicExample extends React.Component<{}, ISelectionBasicEx
     return [
       {
         key: 'selectionMode',
-        name: 'Selection Mode',
+        text: 'Selection Mode',
         items: [
           {
             key: SelectionMode[SelectionMode.none],
@@ -195,13 +195,13 @@ export class SelectionBasicExample extends React.Component<{}, ISelectionBasicEx
       },
       {
         key: 'selectAll',
-        name: 'Select All',
+        text: 'Select All',
         iconProps: { iconName: 'CheckMark' },
         onClick: this._onToggleSelectAll
       },
       {
         key: 'allowCanSelect',
-        name: 'Choose selectable items',
+        text: 'Choose selectable items',
         items: [
           {
             key: 'all',


### PR DESCRIPTION

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4772
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Deprecate ContextualMenu's 'name' prop in favor of new 'text' prop. Replace all usages in codebase.

#### Focus areas to test

ContextMenu and CommandBar's usage of name and text props.
