### PR TITLE
Make primaryDisabled work for contextual menu items

### DIFF
--- a/common/changes/office-ui-fabric-react/chrisgo-primaryDisabledFix_2018-05-14-19-28.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-primaryDisabledFix_2018-05-14-19-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix bug where primaryDisabled is not respected on contextual menu items",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "1581488+christiango@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -82,6 +82,7 @@ export const getItemClassNames = memoizeFunction((
   dividerClassName?: string,
   iconClassName?: string,
   subMenuClassName?: string,
+  primaryDisabled?: boolean
 ): IMenuItemClassNames => {
 
   const styles = getMenuItemStyles(theme);
@@ -128,11 +129,11 @@ export const getItemClassNames = memoizeFunction((
         'is-checked',
         styles.rootChecked
       ],
-      disabled && [
+      (disabled || primaryDisabled) && [
         'is-disabled',
         styles.rootDisabled
       ],
-      !disabled && !checked && [{
+      !(disabled || primaryDisabled) && !checked && [{
         selectors: {
           ':hover': styles.rootHovered,
           ':active': styles.rootPressed,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -361,7 +361,8 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       item.className,
       dividerClassName,
       iconProps.className,
-      subMenuIconClassName
+      subMenuIconClassName,
+      item.primaryDisabled
     );
 
     if (item.name === '-') {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -407,7 +407,8 @@ export interface IContextualMenuItem {
     itemClassName?: string,
     dividerClassName?: string,
     iconClassName?: string,
-    subMenuClassName?: string) => IMenuItemClassNames;
+    subMenuClassName?: string,
+    primaryDisabled?: boolean) => IMenuItemClassNames;
 
   /**
   * Method to provide the classnames to style the Vertical Divider of a split button inside a menu. Default value is the getVerticalDividerClassnames func defined in ContextualMenu.classnames

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuPage.tsx
@@ -72,7 +72,7 @@ export class ContextualMenuPage extends React.Component<IComponentDemoPageProps,
               <ContextualMenuSectionExample />
             </ExampleCard>
             <ExampleCard
-              title='ContextualMenu with checkable menu items and toggable split button'
+              title='ContextualMenu with checkable menu items and toggleable split button'
               code={ ContextualMenuCheckmarksExampleCode }
             >
               <ContextualMenuCheckmarksExample />

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
@@ -7,7 +7,7 @@ export interface IContextualMenuMultiselectExampleState {
   selection?: { [key: string]: boolean };
 }
 
-const keys: string[] = ['newItem', 'share', 'mobile', 'enablePrint', 'enableMusic', 'newSub', 'emailMessage', 'calendarEvent', 'disabledNewSub', 'disabledEmailMessage', 'disabledCalendarEvent', 'splitButtonSubMenuLeftDirection', 'emailMessageLeft', 'calendarEventLeft'];
+const keys: string[] = ['newItem', 'share', 'mobile', 'enablePrint', 'enableMusic', 'newSub', 'emailMessage', 'calendarEvent', 'disabledNewSub', 'disabledEmailMessage', 'disabledCalendarEvent', 'splitButtonSubMenuLeftDirection', 'emailMessageLeft', 'calendarEventLeft', 'disabledPrimarySplit'];
 
 export class ContextualMenuCheckmarksExample extends React.Component<{}, IContextualMenuMultiselectExampleState> {
 
@@ -161,6 +161,26 @@ export class ContextualMenuCheckmarksExample extends React.Component<{}, IContex
                   isChecked: selection![keys[11]],
                   split: true,
                   onClick: this._onToggleSelect,
+                },
+                {
+                  key: keys[12],
+                  iconProps: {
+                    iconName: 'MusicInCollectionFill'
+                  },
+                  subMenuProps: {
+                    items: [
+                      {
+                        key: keys[12],
+                        name: 'Email message',
+                        canCheck: true,
+                        isChecked: selection![keys[12]],
+                        onClick: this._onToggleSelect
+                      }
+                    ],
+                  },
+                  name: 'Split Button Disabled Primary',
+                  split: true,
+                  primaryDisabled: true
                 },
               ]
           }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
We support rendering split buttons in menus. Sometimes it is desired to have the primary action of a split button disabled, but still have the menu launcher active. This is achieved using the "primaryDisabled" prop on contextual menu item. 

However, this does not currently work today:
![image](https://user-images.githubusercontent.com/1581488/40018959-ad5a5526-5772-11e8-9289-b30c528289e4.png)

This is because the classnames are already resolved by the time we render the ContextualMenuSplitButton. The fix here is to pass in the primaryDisabled to getClassNames.
