### PR TITLE
Zhiliu/should virtualize fix

### DIFF
--- a/common/changes/office-ui-fabric-react/zhiliu-shouldVirtualizeFix_2018-05-15-06-07.json
+++ b/common/changes/office-ui-fabric-react/zhiliu-shouldVirtualizeFix_2018-05-15-06-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "shouldVirtualize takes incoming properties",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "zhiliu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -943,7 +943,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     const { renderedWindowsAhead, renderedWindowsBehind } = props;
     const { pages } = this.state;
     // when not in virtualize mode, we render all items without measurement to optimize page rendering perf
-    if (!this._shouldVirtualize()) {
+    if (!this._shouldVirtualize(props)) {
       return;
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
_shouldVirtualize() should takes incoming properties when calling from componentWillReceiveProps().
This fixes sharepoint document library scenario: when going from root folder to subfolder back and forth, every time when going back to root folder by clicking breadcrumb, list renders 30 rows more. It is because _shouldVirtualize() returns false by evaluating props of subfolder. But it should evaluate props of incoming root folder.  This caused perf issue of IE.

(give an overview)

#### Focus areas to test

(optional)
