### PR TITLE
Progressindicator aria props

### DIFF
--- a/common/changes/office-ui-fabric-react/progressindicator-aria-props_2018-05-15-18-45.json
+++ b/common/changes/office-ui-fabric-react/progressindicator-aria-props_2018-05-15-18-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix misuse of aria props on ProgressIndicator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "iancra@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
@@ -106,6 +106,10 @@ export class ProgressIndicatorBase extends BaseComponent<IProgressIndicatorProps
       transition: (percentComplete !== undefined && percentComplete < ZERO_THRESHOLD) ? 'none' : undefined,
     };
 
+    const ariaValueMin = percentComplete !== undefined ? 0 : undefined;
+    const ariaValueMax = percentComplete !== undefined ? 100 : undefined;
+    const ariaValueNow = percentComplete !== undefined ? Math.floor(percentComplete!) : undefined;
+
     return (
       <div className={ classNames.itemProgress }>
         <div className={ classNames.progressTrack } />
@@ -113,9 +117,9 @@ export class ProgressIndicatorBase extends BaseComponent<IProgressIndicatorProps
           className={ classNames.progressBar }
           style={ progressBarStyles }
           role='progressbar'
-          aria-valuemin={ 0 }
-          aria-valuemax={ 100 }
-          aria-valuenow={ Math.floor(percentComplete!) }
+          aria-valuemin={ ariaValueMin }
+          aria-valuemax={ ariaValueMax }
+          aria-valuenow={ ariaValueNow }
           aria-valuetext={ ariaValueText }
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -141,9 +141,9 @@ exports[`ProgressIndicator renders React content 1`] = `
           }
     />
     <div
-      aria-valuemax={100}
-      aria-valuemin={0}
-      aria-valuenow={NaN}
+      aria-valuemax={undefined}
+      aria-valuemin={undefined}
+      aria-valuenow={undefined}
       aria-valuetext={undefined}
       className=
           ms-ProgressIndicator-progressBar
@@ -235,9 +235,9 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
           }
     />
     <div
-      aria-valuemax={100}
-      aria-valuemin={0}
-      aria-valuenow={NaN}
+      aria-valuemax={undefined}
+      aria-valuemin={undefined}
+      aria-valuenow={undefined}
       aria-valuetext={undefined}
       className=
           ms-ProgressIndicator-progressBar
@@ -312,9 +312,9 @@ exports[`ProgressIndicator renders with no label or description 1`] = `
           }
     />
     <div
-      aria-valuemax={100}
-      aria-valuemin={0}
-      aria-valuenow={NaN}
+      aria-valuemax={undefined}
+      aria-valuemin={undefined}
+      aria-valuenow={undefined}
       aria-valuetext={undefined}
       className=
           ms-ProgressIndicator-progressBar


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4871 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

ProgressIndicator has some aria props to describe the % completed. When using the indeterminate indicator, these should not be applied. Checking `percentComplete` before setting these props.

#### Focus areas to test

ProgressIndicator
