### PR TITLE
Revisited the Multi-select Combo box initial state selection fix

### DIFF
--- a/common/changes/office-ui-fabric-react/ap-dev_2018-05-16-09-35.json
+++ b/common/changes/office-ui-fabric-react/ap-dev_2018-05-16-09-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Revisited the Multi-select Combo box initial state selection fix",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "asish2k14@outlook.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -804,7 +804,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         return;
       }
       if (this.props.multiSelect) {
-        option.selected = !option.selected;
+        // Setting the initial state of option.selected in Multi-select combobox by checking the selectedIndices array and overriding the undefined issue
+        option.selected = option.selected !== undefined ? !option.selected : (selectedIndices.indexOf(index) < 0);
         if (option.selected && selectedIndices.indexOf(index) < 0) {
           selectedIndices.push(index);
         } else if (!option.selected && selectedIndices.indexOf(index) >= 0) {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4689
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixing the Combobox issue with setting option.selected using selectedindices array with undefined check

#### Focus areas to test

File changes in file at \office-ui-fabric-react\packages\office-ui-fabric-react\src\components\ComboBox\ComboBox.tsx at line 808
[ap-dev_2018-05-16-09-35.zip](https://github.com/OfficeDev/office-ui-fabric-react/files/2008452/ap-dev_2018-05-16-09-35.zip)