### PR TITLE
Addressing issue #4068 - Textfield component does not honour aria-describedBy when getErrorMessage is also provided as a prop

### DIFF
--- a/common/changes/office-ui-fabric-react/textfield-ariadesc-4068_2018-05-16-17-57.json
+++ b/common/changes/office-ui-fabric-react/textfield-ariadesc-4068_2018-05-16-17-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added support in textfield for aria-describedby native prop",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jescla@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -370,7 +370,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         onInput={ this._onInputChange }
         onChange={ this._onInputChange }
         className={ this._getTextElementClassName() }
-        aria-describedby={ this._isDescriptionAvailable ? this._descriptionId : this.props["aria-describedby"] }
+        aria-describedby={ this._isDescriptionAvailable ? this._descriptionId : this.props['aria-describedby'] }
         aria-invalid={ !!this.state.errorMessage }
         aria-label={ this.props.ariaLabel }
         onFocus={ this._onFocus }
@@ -393,7 +393,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         onChange={ this._onInputChange }
         className={ this._getTextElementClassName() }
         aria-label={ this.props.ariaLabel }
-        aria-describedby={ this._isDescriptionAvailable ? this._descriptionId : this.props["aria-describedby"] }
+        aria-describedby={ this._isDescriptionAvailable ? this._descriptionId : this.props['aria-describedby'] }
         aria-invalid={ !!this.state.errorMessage }
         onFocus={ this._onFocus }
         onBlur={ this._onBlur }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -370,7 +370,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         onInput={ this._onInputChange }
         onChange={ this._onInputChange }
         className={ this._getTextElementClassName() }
-        aria-describedby={ this._isDescriptionAvailable ? this._descriptionId : undefined }
+        aria-describedby={ this._isDescriptionAvailable ? this._descriptionId : this.props["aria-describedby"] }
         aria-invalid={ !!this.state.errorMessage }
         aria-label={ this.props.ariaLabel }
         onFocus={ this._onFocus }
@@ -393,7 +393,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         onChange={ this._onInputChange }
         className={ this._getTextElementClassName() }
         aria-label={ this.props.ariaLabel }
-        aria-describedby={ this._isDescriptionAvailable ? this._descriptionId : undefined }
+        aria-describedby={ this._isDescriptionAvailable ? this._descriptionId : this.props["aria-describedby"] }
         aria-invalid={ !!this.state.errorMessage }
         onFocus={ this._onFocus }
         onBlur={ this._onBlur }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4068 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updated **TextField** component to add support for `aria-describedby` native prop, by adding fallback that checks if native `aria-describedby` is set if no `description` or `error message` is defined.