### PR TITLE
SelectionZone: Add optional 'data-selection-auto-select' property

### DIFF
--- a/common/changes/office-ui-fabric-react/nested-auto-select_2018-05-16-21-22.json
+++ b/common/changes/office-ui-fabric-react/nested-auto-select_2018-05-16-21-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SelectionZone: Add optional `data-selection-auto-select` property allowing nested link and button selections to proapagate to parent.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -31,6 +31,7 @@ import {
 // If you click index 8
 //    The anchor and focus are set to 8.
 
+const SELECTION_AUTO_SELECT = 'data-selection-auto-select';
 const SELECTION_DISABLED_ATTRIBUTE_NAME = 'data-selection-disabled';
 const SELECTION_INDEX_ATTRIBUTE_NAME = 'data-selection-index';
 const SELECTION_TOGGLE_ATTRIBUTE_NAME = 'data-selection-toggle';
@@ -197,7 +198,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         } else if (target === itemRoot && !this._isShiftPressed && !this._isCtrlPressed) {
           this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;
-        } else if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {
+        } else if ((target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') &&
+          !this._hasAttribute(target, SELECTION_AUTO_SELECT)) {
           return;
         }
       }
@@ -241,7 +243,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         } else if (target === itemRoot) {
           this._onItemSurfaceClick(ev, index);
           break;
-        } else if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {
+        } else if ((target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') &&
+          !this._hasAttribute(target, SELECTION_AUTO_SELECT)) {
           return;
         }
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4866
- [x] Include a change request file using `$ npm run change`

#### Description of changes

SelectionZone: Add optional 'data-selection-auto-select' property allowing nested link and button selections to propagate to parent.
