### PR TITLE
Const enums are not being extracted during docgen

### DIFF
--- a/common/changes/@uifabric/example-app-base/parserfix_2018-05-16-21-17.json
+++ b/common/changes/@uifabric/example-app-base/parserfix_2018-05-16-21-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Fixed a bug in the documentation generator code that skipped const enums (parser)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "benw@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/parser/Parse.ts
+++ b/packages/example-app-base/src/utilities/parser/Parse.ts
@@ -28,7 +28,7 @@ export function parse(source: string, propsInterfaceOrEnumName?: string): IPrope
   let propertyType = (type: string) => type === 'interface' ? PropertyType.interface : PropertyType.enum;
 
   if (propsInterfaceOrEnumName) {
-    regex = new RegExp(`export (interface|enum) ${propsInterfaceOrEnumName}(?: extends .*?)? \\{(.*[\\r\\n]*)*?\\}`);
+    regex = new RegExp(`export (interface|(?:const )?enum) ${propsInterfaceOrEnumName}(?: extends .*?)? \\{(.*[\\r\\n]*)*?\\}`);
     let regexResult = regex.exec(source);
     if (regexResult && regexResult.length > 0) {
       parseInfo = _parseEnumOrInterface(regexResult);
@@ -40,7 +40,7 @@ export function parse(source: string, propsInterfaceOrEnumName?: string): IPrope
       }];
     }
   } else {
-    regex = new RegExp(`export (interface|enum) (\\S*?)(?: extends .*?)? \\{(.*[\\r\\n]*)*?\\}`, 'g');
+    regex = new RegExp(`export (interface|(?:const )?enum) (\\S*?)(?: extends .*?)? \\{(.*[\\r\\n]*)*?\\}`, 'g');
     let regexResult: RegExpExecArray | null;
     let results: Array<IProperty> = [];
     while ((regexResult = regex.exec(source)) !== null) {


### PR DESCRIPTION
Updated regex.

Checked that propertyNameSuffix and propertyType delegates return properly.  Verified documentation page for FocusZone now shows both enums in FocusZone.types.ts, not just one.