### PR TITLE
Website: Fix mobile nav / interaction bug

### DIFF
--- a/apps/fabric-website/src/components/App/App.scss
+++ b/apps/fabric-website/src/components/App/App.scss
@@ -80,4 +80,8 @@
   .App {
     padding: 0;
   }
+
+  .App-nav {
+    display: none;
+  }
 }

--- a/common/changes/@uifabric/fabric-website/mobile-nav-fix_2018-05-16-21-55.json
+++ b/common/changes/@uifabric/fabric-website/mobile-nav-fix_2018-05-16-21-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Get rid of App-nav container in mobile, it was blocking interation.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "lynam.emily@gmail.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Somewhere between deprecating our own mobile nav when we adopted the UHF and implementing left nav scroll for desktop web, we left a div on in mobile that was blocking navigation and interaction with some components.

Hiding App-nav in mobile mode should fix this.

#### Focus areas to test

(optional)
