### PR TITLE
SelectionZone: Fix 'select-on-click' behavior to be opt-out for buttons

### DIFF
--- a/common/changes/office-ui-fabric-react/auto-select_2018-05-17-18-34.json
+++ b/common/changes/office-ui-fabric-react/auto-select_2018-05-17-18-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add data-selection-select behavior to make elements select rows before taking action",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
@@ -18,6 +18,8 @@ let _invoke0: Element;
 let _toggle0: Element;
 let _surface1: Element;
 let _toggle1: Element;
+let _noSelect1: Element;
+let _select1: Element;
 let _toggle2: Element;
 let _surface3: Element;
 
@@ -31,6 +33,7 @@ function _initializeSelection(selectionMode = SelectionMode.multiple): void {
     <SelectionZone
       selection={ _selection }
       selectionMode={ selectionMode }
+      disableAutoSelectOnInputElements={ true }
       // tslint:disable-next-line:jsx-no-lambda
       onItemInvoked={ (item: IObjectWithKey) => { _onItemInvokeCalled++; _lastItemInvoked = item; } }
     >
@@ -45,6 +48,8 @@ function _initializeSelection(selectionMode = SelectionMode.multiple): void {
       <div id='surface1' data-selection-index='1'>
         <button id='toggle1' data-selection-toggle={ true }>Toggle</button>
         <button id='invoke1' data-selection-invoke={ true }>Invoke</button>
+        <button id='noSelect1'>No Select</button>
+        <button id='select1' data-selection-select={ true }>Select First</button>
       </div>
 
       <div id='invoke2' data-selection-index='2' data-selection-invoke={ true }>
@@ -63,6 +68,8 @@ function _initializeSelection(selectionMode = SelectionMode.multiple): void {
   _toggle0 = _componentElement.querySelector('#toggle0')!;
   _surface1 = _componentElement.querySelector('#surface1')!;
   _toggle1 = _componentElement.querySelector('#toggle1')!;
+  _noSelect1 = _componentElement.querySelector('#noSelect1')!;
+  _select1 = _componentElement.querySelector('#select1')!;
   _toggle2 = _componentElement.querySelector('#toggle2')!;
   _surface3 = _componentElement.querySelector('#surface3')!;
 
@@ -227,6 +234,16 @@ describe('SelectionZone', () => {
     ReactTestUtils.Simulate.mouseDown(_invoke0);
     expect(_selection.isIndexSelected(0)).toEqual(false);
     expect(_onItemInvokeCalled).toEqual(0);
+  });
+
+  it('does not select an item when a button is clicked', () => {
+    ReactTestUtils.Simulate.mouseDown(_noSelect1);
+    expect(_selection.isIndexSelected(1)).toEqual(false);
+  });
+
+  it('select an item when a button is clicked that has data-selection-select', () => {
+    ReactTestUtils.Simulate.mouseDown(_select1);
+    expect(_selection.isIndexSelected(1)).toEqual(true);
   });
 });
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -51,6 +51,7 @@ export interface ISelectionZoneProps extends React.Props<SelectionZone> {
   layout?: {};
   selectionMode?: SelectionMode;
   selectionPreservedOnEmptyClick?: boolean;
+  disableAutoSelectOnInputElements?: boolean;
   enterModalOnTouch?: boolean;
   isSelectedOnFocus?: boolean;
   onItemInvoked?: (item?: IObjectWithKey, index?: number, ev?: Event) => void;
@@ -199,7 +200,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
           && !this._isShiftPressed && !this._isCtrlPressed) {
           this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;
-        } else if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {
+        } else if (this.props.disableAutoSelectOnInputElements &&
+          (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT')) {
           return;
         }
       }

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -36,6 +36,7 @@ const SELECTION_INDEX_ATTRIBUTE_NAME = 'data-selection-index';
 const SELECTION_TOGGLE_ATTRIBUTE_NAME = 'data-selection-toggle';
 const SELECTION_INVOKE_ATTRIBUTE_NAME = 'data-selection-invoke';
 const SELECTALL_TOGGLE_ALL_ATTRIBUTE_NAME = 'data-selection-all-toggle';
+const SELECTION_SELECT_ATTRIBUTE_NAME = 'data-selection-select';
 
 export interface ISelectionZone {
   ignoreNextFocus: () => void;
@@ -194,7 +195,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
           break;
         } else if (this._hasAttribute(target, SELECTION_INVOKE_ATTRIBUTE_NAME)) {
           break;
-        } else if (target === itemRoot && !this._isShiftPressed && !this._isCtrlPressed) {
+        } else if ((target === itemRoot || this._hasAttribute(target, SELECTION_SELECT_ATTRIBUTE_NAME))
+          && !this._isShiftPressed && !this._isCtrlPressed) {
           this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;
         } else if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {

--- a/packages/office-ui-fabric-react/src/utilities/selection/docs/SelectionOverview.md
+++ b/packages/office-ui-fabric-react/src/utilities/selection/docs/SelectionOverview.md
@@ -13,3 +13,4 @@ Available attributes:
 - **data-selection-toggle:** this boolean flag would be set on the element which should handle toggles.This could be a checkbox or a div.
 - **data-selection-toggle-all:** this boolean flag indicates that clicking it should toggle all selection.
 - **data-selection-disabled:** allows a branch of the DOM to be marked to ignore input events that alter selections.
+- **data-selection-select:** allows a branch of the DOM to ensure that the current item is selected upon interaction

--- a/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Basic.Example.tsx
@@ -52,6 +52,8 @@ export class SelectionItemExample extends React.Component<ISelectionItemExampleP
         <span className='ms-SelectionItemExample-name'>
           { item.name }
         </span>
+        <a className='ms-SelectionItemExample-link' href='https://bing.com' target='_blank'>Link that avoids selection</a>
+        <a className='ms-SelectionItemExample-link' data-selection-select={ true } href='https://bing.com' target='_blank'>Link that selects first</a>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Example.scss
+++ b/packages/office-ui-fabric-react/src/utilities/selection/examples/Selection.Example.scss
@@ -16,6 +16,19 @@
     background: #EEE;
   }
 
+  .ms-SelectionItemExample-link {
+    display: inline-block;
+    overflow: hidden;
+    height: 36px;
+    cursor: default;
+    padding: 8px;
+    box-sizing: border-box;
+    vertical-align: top;
+    background: none;
+    background-color: transparent;
+    border: none;
+  }
+
   .ms-SelectionItemExample-name {
     display: inline-block;
     overflow: hidden;


### PR DESCRIPTION
### Overview

A previous PR, #4544, caused a breaking change in the behavior of `SelectionZone`, because teams were relying on the select-on-mouse-down behavior before input elements were clicked within selectable regions.

This PR fixes that issue by putting the 'disable-auto-select' behavior behind a prop, and then adds a per-element `data-selection-select` attribute to enable the auto-select-on-mousedown for target elements if that prop is also set.

Added unit tests and documentations for the new behaviors, with examples.