### PR TITLE
Remove hover and pressed background colors

### DIFF
--- a/common/changes/office-ui-fabric-react/revert-Iconbutton-bg-changes_2018-05-17-20-13.json
+++ b/common/changes/office-ui-fabric-react/revert-Iconbutton-bg-changes_2018-05-17-20-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Revert IconButton hover/pressed background color change.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -485,7 +485,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
                     color: #004578;
                   }
                   &:active {
-                    background-color: #eaeaea;
+                    background-color: #c8c8c8;
                     color: #0078d4;
                   }
                   &:hover:active {
@@ -1204,7 +1204,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
                     color: #004578;
                   }
                   &:active {
-                    background-color: #eaeaea;
+                    background-color: #c8c8c8;
                     color: #0078d4;
                   }
                   &:hover:active {
@@ -1571,7 +1571,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 5 1`] = `
                     color: #004578;
                   }
                   &:active {
-                    background-color: #eaeaea;
+                    background-color: #c8c8c8;
                     color: #0078d4;
                   }
                   &:hover:active {
@@ -1778,7 +1778,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 6 1`] = `
                     color: #004578;
                   }
                   &:active {
-                    background-color: #eaeaea;
+                    background-color: #c8c8c8;
                     color: #0078d4;
                   }
                   &:hover:active {

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.styles.ts
@@ -29,7 +29,6 @@ export const getStyles = memoizeFunction((
 
     rootHovered: {
       color: palette.themeDarker,
-      backgroundColor: semanticColors.buttonBackground,
       selectors: {
         [HighContrastSelector]: {
           borderColor: 'Highlight',
@@ -40,7 +39,6 @@ export const getStyles = memoizeFunction((
 
     rootPressed: {
       color: palette.themePrimary,
-      backgroundColor: semanticColors.buttonBackgroundHovered,
     },
 
     rootExpanded: {

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.deprecated.test.tsx.snap
@@ -595,7 +595,6 @@ exports[`Button renders IconButton correctly 1`] = `
         top: -2px;
       }
       &:hover {
-        background-color: #f4f4f4;
         color: #004578;
       }
       @media screen and (-ms-high-contrast: active){&:hover {
@@ -603,7 +602,6 @@ exports[`Button renders IconButton correctly 1`] = `
         color: Highlight;
       }
       &:active {
-        background-color: #eaeaea;
         color: #0078d4;
       }
   data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -595,7 +595,6 @@ exports[`Button renders IconButton correctly 1`] = `
         top: -2px;
       }
       &:hover {
-        background-color: #f4f4f4;
         color: #004578;
       }
       @media screen and (-ms-high-contrast: active){&:hover {
@@ -603,7 +602,6 @@ exports[`Button renders IconButton correctly 1`] = `
         color: Highlight;
       }
       &:active {
-        background-color: #eaeaea;
         color: #0078d4;
       }
   data-is-focusable={true}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4888 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Revert the added background colors on IconButton for hover/pressed state.
