### PR TITLE
ContextualMenu: Make the menu always programmatically focusable

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ContextualMenuMakeFocusable_2018-05-18-00-58.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ContextualMenuMakeFocusable_2018-05-18-00-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Make the whole menu always programatically focusable",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -281,7 +281,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
             ref={ (host: HTMLDivElement) => this._host = host }
             id={ id }
             className={ this._classNames.container }
-            tabIndex={ shouldFocusOnContainer ? 0 : undefined }
+            tabIndex={ shouldFocusOnContainer ? 0 : -1 }
             onKeyDown={ this._onMenuKeyDown }
           >
             { title && <div className={ this._classNames.title } role='heading' aria-level={ 1 }> { title } </div> }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
There was a change recently to make the menu not have a tabindex if it was opened via keyboard. The problem with that is if you open a menu using keyboard (or Keytips), hover over an item and then mouseout of the menu the focus doesn't clear correctly.

This PR sets the tabindex to -1 if the menu was not launched via click so that the code can still programmatically put focus on the menu for the mouseout case

#### Focus areas to test
Verified that no existing behavior around launching the menu has changed but that now on mouseout the menu gets focused as expected
