### PR TITLE
Improvements for auto-select opt-in mode

### DIFF
--- a/common/changes/office-ui-fabric-react/auto-select_2018-05-18-15-47.json
+++ b/common/changes/office-ui-fabric-react/auto-select_2018-05-18-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pass SelectionZone props through DetailsList and add alternate data-selection-auto-selection attribute name",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -277,6 +277,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       onColumnHeaderContextMenu,
       selectionMode,
       selectionPreservedOnEmptyClick,
+      selectionZoneProps,
       ariaLabel,
       ariaLabelForGrid,
       rowElementEventMap,
@@ -392,6 +393,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
                 onItemInvoked={ onItemInvoked }
                 onItemContextMenu={ onItemContextMenu }
                 enterModalOnTouch={ this.props.enterModalSelectionOnTouch }
+                { ...(selectionZoneProps || {}) }
               >
                 { groups ? (
                   <GroupedList

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { DetailsList } from './DetailsList';
 import {
   ISelection,
-  SelectionMode
+  SelectionMode,
+  ISelectionZoneProps
 } from '../../utilities/selection/index';
 import { IRenderFunction } from '../../Utilities';
 import {
@@ -91,6 +92,11 @@ export interface IDetailsListProps extends React.Props<DetailsList>, IWithViewpo
    * @default false
    **/
   selectionPreservedOnEmptyClick?: boolean;
+
+  /**
+   * Addition props to pass through to the selection zone created by default.
+   */
+  selectionZoneProps?: ISelectionZoneProps;
 
   /** Controls how the columns are adjusted. */
   layoutMode?: DetailsListLayoutMode;

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
@@ -241,8 +241,13 @@ describe('SelectionZone', () => {
     expect(_selection.isIndexSelected(1)).toEqual(false);
   });
 
-  it('select an item when a button is clicked that has data-selection-select', () => {
+  it('selects an item when a button is clicked that has data-selection-select', () => {
     ReactTestUtils.Simulate.mouseDown(_select1);
+    expect(_selection.isIndexSelected(1)).toEqual(true);
+  });
+
+  it('selects an item when a button is clicked that has data-selection-select', () => {
+    ReactTestUtils.Simulate.keyDown(_select1, { which: KeyCodes.enter });
     expect(_selection.isIndexSelected(1)).toEqual(true);
   });
 });

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -196,7 +196,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
           break;
         } else if (this._hasAttribute(target, SELECTION_INVOKE_ATTRIBUTE_NAME)) {
           break;
-        } else if ((target === itemRoot || this._hasAttribute(target, SELECTION_SELECT_ATTRIBUTE_NAME))
+        } else if (
+          (target === itemRoot || this._shouldAutoSelect(target))
           && !this._isShiftPressed && !this._isCtrlPressed) {
           this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;
@@ -376,6 +377,11 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
           // For toggle elements, assuming they are rendered as buttons, they will generate a click event,
           // so we can no-op for any keydowns in this case.
           break;
+        } else if (this._shouldAutoSelect(target)) {
+          // If the event went to an element which should trigger auto-select, select it and then let
+          // the default behavior kick in.
+          this._onInvokeMouseDown(ev, index);
+          break;
         } else if ((ev.which === KeyCodes.enter || ev.which === KeyCodes.space) &&
           (target.tagName === 'BUTTON' || target.tagName === 'A' || target.tagName === 'INPUT')) {
           return false;
@@ -441,7 +447,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   }
 
   private _onInvokeClick(ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, index: number): void {
-    const { selection, onItemInvoked } = this.props;
+    const {
+      selection,
+      onItemInvoked
+    } = this.props;
 
     if (onItemInvoked) {
       onItemInvoked(selection.getItems()[index], index, ev.nativeEvent);
@@ -538,6 +547,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
 
   private _getItemIndex(itemRoot: HTMLElement): number {
     return Number(itemRoot.getAttribute(SELECTION_INDEX_ATTRIBUTE_NAME));
+  }
+
+  private _shouldAutoSelect(element: HTMLElement): boolean {
+    return this._hasAttribute(element, SELECTION_SELECT_ATTRIBUTE_NAME);
   }
 
   private _hasAttribute(element: HTMLElement, attributeName: string): boolean {


### PR DESCRIPTION
### Overview

This change adds non-breaking improvements to #4907:

1. Pass `selectionZoneProps` through `DetailsList` to avoid having to pass each prop individually.
2. Add `data-selection-auto-select` as a preferred alias for `data-selection-select` to match original proposal in #4866.