### PR TITLE
Jest merge-styles serialization fix for animation-name

### DIFF
--- a/common/changes/@uifabric/jest-serializer-merge-styles/jest-serialize-fix_2018-05-20-16-54.json
+++ b/common/changes/@uifabric/jest-serializer-merge-styles/jest-serialize-fix_2018-05-20-16-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/jest-serializer-merge-styles",
+      "comment": "The `animation-name` values reference class names which should be expanded if there is a comma delimited list of them.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/jest-serializer-merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jest-serialize-fix_2018-05-20-16-54.json
+++ b/common/changes/office-ui-fabric-react/jest-serialize-fix_2018-05-20-16-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/jest-serializer-merge-styles/src/index.test.tsx
+++ b/packages/jest-serializer-merge-styles/src/index.test.tsx
@@ -63,9 +63,12 @@ describe('print', () => {
       from: { opacity: 0 },
       to: { opacity: 1 }
     });
-
+    const leftInClassName = keyframes({
+      from: { left: -100 },
+      to: { left: 0 }
+    });
     const className = mergeStyles({
-      animationName: fadeInClassName
+      animationName: `${fadeInClassName},${leftInClassName}`
     });
 
     expect(
@@ -78,7 +81,12 @@ describe('print', () => {
       '',
       '',
       indent('{'),
-      indent('  animation-name: keyframes from{opacity:0;}to{opacity:1;};'),
+      indent(
+        '  ' +
+        'animation-name: ' +
+        'keyframes from{opacity:0;}to{opacity:1;} ' +
+        'keyframes from{left:-100px;}to{left:0px;};'
+      ),
       indent('}'),
     ].join('\n'));
   });

--- a/packages/jest-serializer-merge-styles/src/index.ts
+++ b/packages/jest-serializer-merge-styles/src/index.ts
@@ -51,7 +51,13 @@ function _serializeRules(rules: string[], indent: (val: string) => string): stri
       insertedRules.split(';').sort().forEach((rule: string) => {
         if (rule) {
           const [name, value] = rule.split(':');
-          const valueParts = value.split(/[ ,]+/);
+          let delimiter: string | RegExp = ' ';
+
+          if (name === 'animation-name') {
+            delimiter = /[ ,]+/;
+          }
+
+          const valueParts = value.split(delimiter);
           let result: string[] = [];
 
           for (const part of valueParts) {

--- a/packages/jest-serializer-merge-styles/src/index.ts
+++ b/packages/jest-serializer-merge-styles/src/index.ts
@@ -8,7 +8,6 @@ export function print(
   const classNames = [];
   const rules = [];
   const parts = val.split(' ');
-
   for (const part of parts) {
     const ruleSet = Stylesheet.getInstance().insertedRulesFromClassName(part);
 
@@ -52,7 +51,7 @@ function _serializeRules(rules: string[], indent: (val: string) => string): stri
       insertedRules.split(';').sort().forEach((rule: string) => {
         if (rule) {
           const [name, value] = rule.split(':');
-          const valueParts = value.split(' ');
+          const valueParts = value.split(/[ ,]+/);
           let result: string[] = [];
 
           for (const part of valueParts) {

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Nav renders Nav correctly 1`] = `
             {
               animation-duration: 0.367s;
               animation-fill-mode: both;
-              animation-name: css-33,css-46;
+              animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(0,-20px,0);}to{transform:translate3d(0,0,0);};
               animation-timing-function: cubic-bezier(.1,.9,.2,1);
               display: block;
               margin-bottom: 40px;


### PR DESCRIPTION
When `animation-name` includes a comma delimited list of `keyframes` generated animation class names, they should independently expand correctly. Currently they are spit out unexpanded in the jest snapshot.

