### PR TITLE
CommandBar: Fixed undefined farItems in ComputeCacheKey

### DIFF
--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -208,7 +208,8 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     return <OverflowButtonType aria-posinset={ this._setSize } aria-setsize={ this._setSize } { ...overflowProps as IButtonProps } />;
   }
 
-  private _computeCacheKey(primaryItems: ICommandBarItemProps[], farItems: ICommandBarItemProps[], overflow: boolean): string {
+  private _computeCacheKey(data: ICommandBarData): string {
+    const { primaryItems, farItems = [], overflowItems } = data;
     const returnKey = (acc: string, current: ICommandBarItemProps): string => {
       const { cacheKey = current.key } = current;
       return acc + cacheKey;
@@ -216,7 +217,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
     const primaryKey = primaryItems.reduce(returnKey, '');
     const farKey = farItems.reduce(returnKey, '');
-    const overflowKey = overflow ? 'overflow' : '';
+    const overflowKey = !!overflowItems.length ? 'overflow' : '';
 
     return [primaryKey, farKey, overflowKey].join(' ');
   }
@@ -236,7 +237,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
       const newData = this._setAriaPosinset({ ...data, primaryItems, overflowItems });
 
-      cacheKey = this._computeCacheKey(newData.primaryItems, newData.farItems!, !!newData.overflowItems.length);
+      cacheKey = this._computeCacheKey(newData);
 
       if (onDataReduced) {
         onDataReduced(movedItem);
@@ -250,7 +251,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   private _onGrowData = (data: ICommandBarData): ICommandBarData | undefined => {
     const { shiftOnReduce, onDataGrown } = this.props;
-    const { minimumOverflowItems, farItems } = data;
+    const { minimumOverflowItems } = data;
     let { primaryItems, overflowItems, cacheKey } = data;
     const movedItem = overflowItems[0];
 
@@ -263,7 +264,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       primaryItems = shiftOnReduce ? [movedItem, ...primaryItems] : [...primaryItems, movedItem];
 
       const newData = this._setAriaPosinset({ ...data, primaryItems, overflowItems });
-      cacheKey = this._computeCacheKey(primaryItems, farItems!, !!overflowItems.length);
+      cacheKey = this._computeCacheKey(newData);
 
       if (onDataGrown) {
         onDataGrown(movedItem);

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/data.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/data.ts
@@ -43,7 +43,7 @@ export const items = [
     iconProps: {
       iconName: 'Share',
     },
-    onClick: () => { return; }
+    onClick: () => console.log('Share')
   },
   {
     key: 'download',
@@ -51,7 +51,7 @@ export const items = [
     iconProps: {
       iconName: 'Download',
     },
-    onClick: () => { return; }
+    onClick: () => console.log('Download')
   }
 ];
 
@@ -86,7 +86,7 @@ export const farItems = [
     iconProps: {
       iconName: 'SortLines',
     },
-    onClick: () => { return; }
+    onClick: () => console.log('Sort')
   },
   {
     key: 'tile',
@@ -95,7 +95,7 @@ export const farItems = [
       iconName: 'Tiles',
     },
     iconOnly: true,
-    onClick: () => { return; }
+    onClick: () => console.log('Tiles')
   },
   {
     key: 'info',
@@ -104,6 +104,6 @@ export const farItems = [
       iconName: 'Info',
     },
     iconOnly: true,
-    onClick: () => { return; }
+    onClick: () => console.log('Info')
   }
 ];


### PR DESCRIPTION
Fixed issue in computeCacheKey when no far items are passed into the component

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/4953)

