### PR TITLE
 Link: Changed display to inline-block 

### DIFF
--- a/common/changes/office-ui-fabric-react/magellan-linkInlineBlock_2018-05-23-20-27.json
+++ b/common/changes/office-ui-fabric-react/magellan-linkInlineBlock_2018-05-23-20-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Link: Changed to inline-block to fix line break outline",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "law@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -24,13 +24,13 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
       getFocusStyle(theme),
       {
         color: semanticColors.link,
+        display: 'inline-block',
       },
       isButton && {
         background: 'none',
         backgroundColor: 'transparent',
         border: 'none',
         cursor: 'pointer',
-        display: 'inline',
         fontSize: 'inherit',
         margin: 0,
         overflow: 'inherit',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #4883
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There is a issue with how the outline renders on inline elements that are broken across lines.
![multiline anchor element](https://user-images.githubusercontent.com/6496608/40442276-fee18c64-5e77-11e8-8787-51d8a4638b41.png)

This change adds `display: inline-block` to the anchor element links. This is currently how button links are rendered. This forces the link to never be split across line breaks.
![multiline anchor inline-block](https://user-images.githubusercontent.com/6496608/40445160-34b5ab92-5e80-11e8-8be6-8e67c35a6160.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/4968)

