### PR TITLE
CommandBar example: fix link color on website

### DIFF
--- a/common/changes/office-ui-fabric-react/commandbar-link-style_2018-05-24-17-43.json
+++ b/common/changes/office-ui-fabric-react/commandbar-link-style_2018-05-24-17-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar Example: More specific selector for text color to override the link styles we get from msgraph on the website.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Example.scss
@@ -35,15 +35,19 @@
 
 /* Require update when office-ui-fabric-react changes to CSS modules */
 .button {
-    &:global.ms-Button {
-        height: 40px;
-        min-width: 28px;
-        padding: 0 5px;
-    }
+  &:global.ms-Button {
+      height: 40px;
+      min-width: 28px;
+      padding: 0 5px;
+  }
 
-    &:hover {
-      background: initial;
-    }
+  &:hover {
+    background: initial;
+  }
+}
+
+:global(.ms-CommandBarItem-commandText) {
+  color: $ms-color-neutralPrimary;
 }
 
 .darkerBG {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The website has global styles coming from msgraph overriding our link styles. We hope to find a way to resolve the global style issue, but this is works for now.

This is causing the following bug for CommandBar with links:
![image](https://user-images.githubusercontent.com/16619843/40502429-c9065638-5f3f-11e8-8ac1-b162013c5f03.png)

With this fix:
![image](https://user-images.githubusercontent.com/16619843/40502442-d74e5146-5f3f-11e8-8a7c-5d70026f7b91.png)


#### Focus areas to test

(optional)
