### PR TITLE
Experiments/Nav component: Enable auto expand until the next manual expand disables the auto expand

### DIFF
--- a/common/changes/@uifabric/experiments/AutoExpandFix_2018-05-25-18-31.json
+++ b/common/changes/@uifabric/experiments/AutoExpandFix_2018-05-25-18-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Experiments/Nav component: Enable auto expand until the next manual expand disables the auto expand",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "sikrishn@microsoft.com"
+}

--- a/packages/experiments/src/components/Nav/Nav.tsx
+++ b/packages/experiments/src/components/Nav/Nav.tsx
@@ -149,6 +149,9 @@ class NavComponent extends NavBase {
     // if allowed, auto expand if the child is selected
     link.isExpanded = link.disableAutoExpand ? link.isExpanded : isChildLinkSelected;
 
+    // enable auto expand until the next manual expand disables the auto expand
+    link.disableAutoExpand = false;
+
     return (
       <li
         role='listitem'


### PR DESCRIPTION
Focus areas to test

1. Pass selectedKey to the NavToggler component to expand the nav item
2. Manually Collapse the same nav item (internal state to auto expand based on key is disabled for that key, fixed that in this PR)
3. Pass the same selectedKey to the NavToggler component, this PR will reset the internal state to auto expand the nav item
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/4996)

