### PR TITLE
StickyPane: fix Array.from in Ie (#4982)

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-stickypane-ie_2018-05-24-23-33.json
+++ b/common/changes/office-ui-fabric-react/fix-stickypane-ie_2018-05-24-23-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "StickyPane: Replaced Array.From since it is not supported in IE",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -112,9 +112,10 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
           this.updateStickyRefHeights();
         } else {
           // Else if mutation occurs in scrollable region, then find sticky it belongs to and force update
-          const stickyList = Array.from(this._stickies).filter((sticky) => {
-            if (this.root) {
-              return this.root.contains(mutation[0].target);
+          const stickyList: Sticky[] = [];
+          this._stickies.forEach((sticky) => {
+            if (sticky.root && sticky.root.contains(mutation[0].target)) {
+              stickyList.push(sticky);
             }
           });
           if (stickyList.length) {
@@ -320,17 +321,20 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     } else {
       // If stickyContentToAdd isn't a child element of target container, then append
       if (!stickyContainer.contains(stickyContentToAdd)) {
-        const stickyChildrenElements = Array.from(stickyContainer.children);
+        const stickyChildrenElements: Element[] = [].slice.call(stickyContainer.children);
 
+        const stickyList: Sticky[] = [];
         // Get stickies.  Filter by canStickyTop/Bottom, then sort by distance from top, and then
         // filter by elements that are in the stickyContainer already.
-        const stickyListSorted = Array.from(this._stickies).filter((item) => {
-          if (stickyContainer === this.stickyAbove) {
-            return item.canStickyTop;
-          } else {
-            return item.canStickyBottom;
+        this._stickies.forEach((stickyItem) => {
+          if (stickyContainer === this.stickyAbove && sticky.canStickyTop) {
+            stickyList.push(stickyItem);
+          } else if (sticky.canStickyBottom) {
+            stickyList.push(stickyItem);
           }
-        }).sort((a, b) => {
+        });
+
+        const stickyListSorted = stickyList.sort((a, b) => {
           return a.distanceFromTop - b.distanceFromTop;
         }).filter((item) => {
           const stickyContent = (stickyContainer === this.stickyAbove) ? item.stickyContentTop : item.stickyContentBottom;


### PR DESCRIPTION
* Replaced Array.From in sticky pane since it's not supported in IE

* adding change file

* adding missing semi colon:

* Fix Lint

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5000)

