### PR TITLE
Fix onitem click for contextual menu with anchor item

### DIFF
--- a/common/changes/office-ui-fabric-react/office-ui-fabric-react-5002_2018-05-26-00-58.json
+++ b/common/changes/office-ui-fabric-react/office-ui-fabric-react-5002_2018-05-26-00-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix passing onclick from props for contextual anchor item",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kabalas@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
@@ -8,12 +8,10 @@ describe('ContextualMenuButton', () => {
   describe('creates a normal button', () => {
     let menuItem: IContextualMenuItem;
     let menuClassNames: IMenuItemClassNames;
-    let itemOnClick: jest.Mock;
 
     beforeEach(() => {
       menuItem = { key: '123' };
       menuClassNames = getMenuItemClassNames();
-      itemOnClick = jest.fn();
     });
 
     it('renders the contextual menu split button correctly', () => {
@@ -24,7 +22,6 @@ describe('ContextualMenuButton', () => {
           index={ 0 }
           focusableElementIndex={ 0 }
           totalItemCount={ 1 }
-          onItemClick={ itemOnClick }
         />);
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
@@ -8,10 +8,12 @@ describe('ContextualMenuButton', () => {
   describe('creates a normal button', () => {
     let menuItem: IContextualMenuItem;
     let menuClassNames: IMenuItemClassNames;
+    let itemOnClick: () => void;
 
     beforeEach(() => {
       menuItem = { key: '123' };
       menuClassNames = getMenuItemClassNames();
+      itemOnClick = () => undefined;
     });
 
     it('renders the contextual menu split button correctly', () => {
@@ -22,6 +24,7 @@ describe('ContextualMenuButton', () => {
           index={ 0 }
           focusableElementIndex={ 0 }
           totalItemCount={ 1 }
+          onItemClick={ itemOnClick }
         />);
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
@@ -8,12 +8,12 @@ describe('ContextualMenuButton', () => {
   describe('creates a normal button', () => {
     let menuItem: IContextualMenuItem;
     let menuClassNames: IMenuItemClassNames;
-    let itemOnClick: () => void;
+    let itemOnClick: jest.Mock;
 
     beforeEach(() => {
       menuItem = { key: '123' };
       menuClassNames = getMenuItemClassNames();
-      itemOnClick = () => undefined;
+      itemOnClick = jest.fn();
     });
 
     it('renders the contextual menu split button correctly', () => {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
@@ -71,7 +71,7 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
               aria-setsize={ totalItemCount }
               aria-disabled={ isItemDisabled(item) }
               style={ item.style }
-              onClick={ this._onItemClick }
+              onClick={ onItemClick ? onItemClick.bind(this, item) : undefined }
               onMouseEnter={ this._onItemMouseEnter }
               onMouseLeave={ this._onItemMouseLeave }
               onKeyDown={ itemHasSubmenu ? this._onItemKeyDown : null }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
@@ -71,7 +71,7 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
               aria-setsize={ totalItemCount }
               aria-disabled={ isItemDisabled(item) }
               style={ item.style }
-              onClick={ onItemClick ? onItemClick.bind(this, item) : undefined }
+              onClick={ this._onItemClick }
               onMouseEnter={ this._onItemMouseEnter }
               onMouseLeave={ this._onItemMouseLeave }
               onKeyDown={ itemHasSubmenu ? this._onItemKeyDown : null }
@@ -96,5 +96,12 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
 
   protected _getSubmenuTarget = (): HTMLElement | undefined => {
     return this._anchor.current ? this._anchor.current : undefined;
+  }
+
+  protected _onItemClick = (ev: React.MouseEvent<HTMLElement>): void => {
+    const { item, onItemClick } = this.props;
+    if (onItemClick) {
+      onItemClick(item, ev);
+    }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -57,6 +57,16 @@ export class ContextualMenuBasicExample extends React.Component {
                 target: '_blank'
               },
               {
+                key: 'linkWithOnClick',
+                name: 'Link click',
+                href: 'http://bing.com',
+                onClick: (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+                  alert('Link clicked');
+                  ev.preventDefault();
+                },
+                target: '_blank'
+              },
+              {
                 key: 'disabled',
                 name: 'Disabled item',
                 disabled: true,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5002 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

With #4741 , the behavior of the context menu is regressed, If you have both onclick with preventdefault and href of the context menu item, href is now obeyed and onclick is never been called. This is because now _onItemClick from ContextualMenuItemWrapper is called instead from props.

With this change, the onclick is passed from props instead of baseclass.

#### Focus areas to test

(ContextualMenu)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5003)

