### PR TITLE
Use require.resolve logic in builds & watch .js files from node_modules

### DIFF
--- a/apps/fabric-website/config/pre-copy.json
+++ b/apps/fabric-website/config/pre-copy.json
@@ -1,7 +1,7 @@
 {
   "copyTo": {
     "lib": [
-      "src/**/*.json"
+      "./src/**/*.json"
     ]
   }
 }

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -8,7 +8,7 @@ const diagramStyles: any = require('./GetStartedPage.diagram.module.scss');
 import * as stylesImport from './GetStartedPage.module.scss';
 const styles: any = stylesImport;
 const pageStyles: any = require('../PageStyles.module.scss');
-const corePackageData = require('../../../node_modules/office-ui-fabric-core/package.json');
+const corePackageData = require('office-ui-fabric-core/package.json');
 const corePackageVersion: string = corePackageData && corePackageData.version || '9.2.0';
 
 export class GetStartedPage extends React.Component<any, any> {

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -3,8 +3,8 @@ import { css } from 'office-ui-fabric-react/lib/Utilities';
 import * as stylesImport from './HomePage.module.scss';
 const styles: any = stylesImport;
 
-const corePackageData = require('../../../node_modules/office-ui-fabric-core/package.json');
-const reactPackageData = require('../../../node_modules/office-ui-fabric-react/package.json');
+const corePackageData = require('office-ui-fabric-core/package.json');
+const reactPackageData = require('office-ui-fabric-react/package.json');
 
 export class HomePage extends React.Component<any, any> {
   public render(): JSX.Element {

--- a/apps/fabric-website/src/pages/Styles/IconsPage/IconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/IconsPage/IconsPage.tsx
@@ -7,7 +7,7 @@ import * as stylesImport from './IconsPage.module.scss';
 const styles: any = stylesImport;
 const pageStyles: any = require('../../PageStyles.module.scss');
 
-const iconData = require('../../../../node_modules/office-ui-fabric-core/src/data/icons.json');
+const iconData = require('office-ui-fabric-core/src/data/icons.json');
 
 export class IconsPage extends React.Component<any, any> {
   public render(): JSX.Element {

--- a/common/changes/@uifabric/fabric-website/fixbuild_2018-05-26-05-50.json
+++ b/common/changes/@uifabric/fabric-website/fixbuild_2018-05-26-05-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Use require.resolve logic in builds & watch .js files from node_modules",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fixbuild_2018-05-26-05-50.json
+++ b/common/changes/office-ui-fabric-react/fixbuild_2018-05-26-05-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Use require.resolve logic in builds & watch .js files from node_modules",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/config/pre-copy.json
+++ b/packages/office-ui-fabric-react/config/pre-copy.json
@@ -1,17 +1,17 @@
 {
   "copyTo": {
     "dist": [
-      "index.html"
+      "./index.html"
     ],
     "dist/sass": [
-      "node_modules/office-ui-fabric-core/dist/sass/**/*",
-      "src/common/_highContrast.scss",
-      "src/common/_i18n.scss",
-      "src/common/_semanticSlots.scss",
-      "src/common/_themeOverrides.scss"
+      "office-ui-fabric-core/dist/sass/**/*",
+      "./src/common/_highContrast.scss",
+      "./src/common/_i18n.scss",
+      "./src/common/_semanticSlots.scss",
+      "./src/common/_themeOverrides.scss"
     ],
     "dist/css": [
-      "node_modules/office-ui-fabric-core/dist/css/**/*"
+      "office-ui-fabric-core/dist/css/**/*"
     ]
   }
 }

--- a/scripts/require-resolve-cwd.js
+++ b/scripts/require-resolve-cwd.js
@@ -1,3 +1,3 @@
 module.exports = function (request) {
-  return require.resolve(request, { paths: process.cwd() });
+  return require.resolve(request, { paths: [process.cwd()] });
 }

--- a/scripts/require-resolve-cwd.js
+++ b/scripts/require-resolve-cwd.js
@@ -1,0 +1,3 @@
+module.exports = function (request) {
+  return require.resolve(request, { paths: process.cwd() });
+}

--- a/scripts/tasks/copy.js
+++ b/scripts/tasks/copy.js
@@ -1,6 +1,8 @@
 const path = require('path');
 
 function expandSourcePath(pattern) {
+  const requireResolveCwd = require('../require-resolve-cwd');
+
   if (!pattern) {
     return null;
   }
@@ -15,9 +17,7 @@ function expandSourcePath(pattern) {
   const packageName = pattern[0] == '@' ? `${splitPattern[0]}/${splitPattern[1]}` : splitPattern[0];
 
   try {
-    const resolvedPackageJson = require.resolve(`${packageName}/package.json`, {
-      paths: [process.cwd()]
-    });
+    const resolvedPackageJson = requireResolveCwd(`${packageName}/package.json`);
 
     if (!resolvedPackageJson) {
       // returns pattern if the packageName didn't contain a package.json (not really a package)

--- a/scripts/tasks/copy.js
+++ b/scripts/tasks/copy.js
@@ -1,10 +1,5 @@
-// @ts-check
 const path = require('path');
 
-/**
- * Handles resolve like require.resolve but respects the glob patterns
- * @param {string} pattern
- */
 function expandSourcePath(pattern) {
   if (!pattern) {
     return null;
@@ -18,14 +13,21 @@ function expandSourcePath(pattern) {
   // tries to resolve the packages, handling scoped packages
   const splitPattern = pattern.split('/');
   const packageName = pattern[0] == '@' ? `${splitPattern[0]}/${splitPattern[1]}` : splitPattern[0];
-  const resolvedPackageJson = require.resolve(`${packageName}/package.json`);
 
-  if (!resolvedPackageJson) {
-    // returns pattern if the packageName didn't contain a package.json (not really a package)
-    return pattern;
+  try {
+    const resolvedPackageJson = require.resolve(`${packageName}/package.json`, {
+      paths: [process.cwd()]
+    });
+
+    if (!resolvedPackageJson) {
+      // returns pattern if the packageName didn't contain a package.json (not really a package)
+      return pattern;
+    }
+
+    return pattern.replace(packageName, path.dirname(resolvedPackageJson));
+  } catch (e) {
+    console.error(e);
   }
-
-  return pattern.replace(packageName, path.dirname(resolvedPackageJson));
 }
 
 module.exports = function (options) {

--- a/scripts/tasks/jest-resources.js
+++ b/scripts/tasks/jest-resources.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const merge = require('./merge');
-const requireResolveCwd = require('../require-resolve-cwd');
 
 const styleMockPath =
   module.exports = {
@@ -13,13 +12,13 @@ const styleMockPath =
     createConfig: (customConfig) => merge(
       {
         moduleNameMapper: {
-          'ts-jest': requireResolveCwd('ts-jest'),
+          'ts-jest': require.resolve('ts-jest'),
           '\\.(scss)$': path.resolve(__dirname, 'jest-style-mock.js'),
           'KeyCodes': path.resolve(__dirname, 'jest-mock.js')
         },
 
         'transform': {
-          '.(ts|tsx)': requireResolveCwd('ts-jest/preprocessor.js')
+          '.(ts|tsx)': require.resolve('ts-jest/preprocessor.js')
         },
 
         'reporters': [

--- a/scripts/tasks/jest-resources.js
+++ b/scripts/tasks/jest-resources.js
@@ -12,13 +12,13 @@ const styleMockPath =
     createConfig: (customConfig) => merge(
       {
         moduleNameMapper: {
-          'ts-jest': path.resolve(__dirname, '../node_modules/ts-jest'),
+          'ts-jest': require.resolve('ts-jest'),
           '\\.(scss)$': path.resolve(__dirname, 'jest-style-mock.js'),
           'KeyCodes': path.resolve(__dirname, 'jest-mock.js')
         },
 
         'transform': {
-          '.(ts|tsx)': path.resolve(__dirname, '../node_modules/ts-jest/preprocessor.js')
+          '.(ts|tsx)': require.resolve('ts-jest/preprocessor.js')
         },
 
         'reporters': [

--- a/scripts/tasks/jest-resources.js
+++ b/scripts/tasks/jest-resources.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const merge = require('./merge');
+const requireResolveCwd = require('../require-resolve-cwd');
 
 const styleMockPath =
   module.exports = {
@@ -12,13 +13,13 @@ const styleMockPath =
     createConfig: (customConfig) => merge(
       {
         moduleNameMapper: {
-          'ts-jest': require.resolve('ts-jest'),
+          'ts-jest': requireResolveCwd('ts-jest'),
           '\\.(scss)$': path.resolve(__dirname, 'jest-style-mock.js'),
           'KeyCodes': path.resolve(__dirname, 'jest-mock.js')
         },
 
         'transform': {
-          '.(ts|tsx)': require.resolve('ts-jest/preprocessor.js')
+          '.(ts|tsx)': requireResolveCwd('ts-jest/preprocessor.js')
         },
 
         'reporters': [

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -3,11 +3,12 @@ module.exports = function (options) {
   const fs = require('fs');
   const execSync = require('../exec-sync');
   const findConfig = require('../find-config');
+  const requireResolveCwd = require('../require-resolve-cwd');
 
   const jestConfigPath = findConfig('jest.config.js');
 
   if (fs.existsSync(jestConfigPath)) {
-    const jestPath = require.resolve('jest/bin/jest');
+    const jestPath = requireResolveCwd('jest/bin/jest');
     const customArgs = options && options.argv ? options.argv.slice(3).join(' ') : '';
 
     const args = [

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -3,12 +3,11 @@ module.exports = function (options) {
   const fs = require('fs');
   const execSync = require('../exec-sync');
   const findConfig = require('../find-config');
-  const requireResolveCwd = require('../require-resolve-cwd');
 
   const jestConfigPath = findConfig('jest.config.js');
 
   if (fs.existsSync(jestConfigPath)) {
-    const jestPath = requireResolveCwd('jest/bin/jest');
+    const jestPath = require.resolve('jest/bin/jest');
     const customArgs = options && options.argv ? options.argv.slice(3).join(' ') : '';
 
     const args = [

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -7,7 +7,7 @@ module.exports = function (options) {
   const jestConfigPath = findConfig('jest.config.js');
 
   if (fs.existsSync(jestConfigPath)) {
-    const jestPath = path.resolve(__dirname, '../node_modules/jest/bin/jest');
+    const jestPath = require.resolve('jest/bin/jest');
     const customArgs = options && options.argv ? options.argv.slice(3).join(' ') : '';
 
     const args = [

--- a/scripts/tasks/sass.js
+++ b/scripts/tasks/sass.js
@@ -86,11 +86,23 @@ module.exports = function (options) {
     return source.join('\n');
   }
 
+  /**
+   * @param {string} url
+   * @param {string} prev
+   * @param {Function} done
+   */
   function patchSassUrl(url, prev, done) {
     let newUrl = url;
 
     if (url[0] === '~') {
-      newUrl = path.resolve(process.cwd(), 'node_modules', url.substr(1));
+      let packageUrl = url.substr(1) + (url.endsWith('.scss') ? '' : '.scss');
+
+      try {
+        newUrl = require.resolve(packageUrl);
+      } catch (e) {
+        // try again with a private reference
+        newUrl = require.resolve(path.join(path.dirname(packageUrl), `_${path.basename(packageUrl)}`));
+      }
     }
     else if (url === 'stdin') {
       newUrl = '';

--- a/scripts/tasks/sass.js
+++ b/scripts/tasks/sass.js
@@ -88,11 +88,13 @@ module.exports = function (options) {
   }
 
   function requireResolvePackageUrl(packageUrl) {
+    const fullName = packageUrl + (packageUrl.endsWith('.scss') ? '' : '.scss');
+
     try {
-      return requireResolveCwd(packageUrl);
+      return requireResolveCwd(fullName);
     } catch (e) {
       // try again with a private reference
-      return requireResolveCwd(path.join(path.dirname(packageUrl), `_${path.basename(packageUrl)}`));
+      return requireResolveCwd(path.join(path.dirname(fullName), `_${path.basename(fullName)}`));
     }
   }
 
@@ -100,7 +102,7 @@ module.exports = function (options) {
     let newUrl = url;
 
     if (url[0] === '~') {
-      newUrl = requireResolvePackageUrl(url.substr(1) + (url.endsWith('.scss') ? '' : '.scss'));
+      newUrl = requireResolvePackageUrl(url.substr(1));
     }
     else if (url === 'stdin') {
       newUrl = '';

--- a/scripts/tasks/sass.js
+++ b/scripts/tasks/sass.js
@@ -1,6 +1,7 @@
 module.exports = function (options) {
   const glob = require('glob');
   const path = require('path');
+  const requireResolveCwd = require('../require-resolve-cwd');
 
   const _fileNameToClassMap = {};
 
@@ -88,14 +89,10 @@ module.exports = function (options) {
 
   function requireResolvePackageUrl(packageUrl) {
     try {
-      return require.resolve(packageUrl, {
-        paths: [process.cwd()]
-      });
+      return requireResolveCwd(packageUrl);
     } catch (e) {
       // try again with a private reference
-      return require.resolve(path.join(path.dirname(packageUrl), `_${path.basename(packageUrl)}`), {
-        paths: [process.cwd()]
-      });
+      return requireResolveCwd(path.join(path.dirname(packageUrl), `_${path.basename(packageUrl)}`));
     }
   }
 
@@ -103,7 +100,7 @@ module.exports = function (options) {
     let newUrl = url;
 
     if (url[0] === '~') {
-      newUrl = requireResolve(url.substr(1) + (url.endsWith('.scss') ? '' : '.scss'));
+      newUrl = requireResolvePackageUrl(url.substr(1) + (url.endsWith('.scss') ? '' : '.scss'));
     }
     else if (url === 'stdin') {
       newUrl = '';

--- a/scripts/tasks/sass.js
+++ b/scripts/tasks/sass.js
@@ -86,23 +86,24 @@ module.exports = function (options) {
     return source.join('\n');
   }
 
-  /**
-   * @param {string} url
-   * @param {string} prev
-   * @param {Function} done
-   */
+  function requireResolvePackageUrl(packageUrl) {
+    try {
+      return require.resolve(packageUrl, {
+        paths: [process.cwd()]
+      });
+    } catch (e) {
+      // try again with a private reference
+      return require.resolve(path.join(path.dirname(packageUrl), `_${path.basename(packageUrl)}`), {
+        paths: [process.cwd()]
+      });
+    }
+  }
+
   function patchSassUrl(url, prev, done) {
     let newUrl = url;
 
     if (url[0] === '~') {
-      let packageUrl = url.substr(1) + (url.endsWith('.scss') ? '' : '.scss');
-
-      try {
-        newUrl = require.resolve(packageUrl);
-      } catch (e) {
-        // try again with a private reference
-        newUrl = require.resolve(path.join(path.dirname(packageUrl), `_${path.basename(packageUrl)}`));
-      }
+      newUrl = requireResolve(url.substr(1) + (url.endsWith('.scss') ? '' : '.scss'));
     }
     else if (url === 'stdin') {
       newUrl = '';

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -1,8 +1,7 @@
 module.exports = function (options) {
-  const requireResolveCwd = require('../require-resolve-cwd');
   const path = require('path');
   const execSync = require('../exec-sync');
-  const typescriptPath = 'node ' + requireResolveCwd('typescript/lib/tsc');
+  const typescriptPath = 'node ' + require.resolve('typescript/lib/tsc');
   const libPath = path.resolve(process.cwd(), 'lib');
   const srcPath = path.resolve(process.cwd(), 'src');
   const extraParams = '--pretty' + (options.isProduction ? ` --inlineSources --sourceRoot ${path.relative(libPath, srcPath)}` : '');

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -1,7 +1,7 @@
 module.exports = function (options) {
   const path = require('path');
   const execSync = require('../exec-sync');
-  const typescriptPath = 'node ' + path.resolve(__dirname, '../node_modules/typescript/lib/tsc');
+  const typescriptPath = 'node ' + require.resolve('typescript/lib/tsc');
   const libPath = path.resolve(process.cwd(), 'lib');
   const srcPath = path.resolve(process.cwd(), 'src');
   const extraParams = '--pretty' + (options.isProduction ? ` --inlineSources --sourceRoot ${path.relative(libPath, srcPath)}` : '');

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -1,7 +1,8 @@
 module.exports = function (options) {
+  const requireResolveCwd = require('../require-resolve-cwd');
   const path = require('path');
   const execSync = require('../exec-sync');
-  const typescriptPath = 'node ' + require.resolve('typescript/lib/tsc');
+  const typescriptPath = 'node ' + requireResolveCwd('typescript/lib/tsc');
   const libPath = path.resolve(process.cwd(), 'lib');
   const srcPath = path.resolve(process.cwd(), 'src');
   const extraParams = '--pretty' + (options.isProduction ? ` --inlineSources --sourceRoot ${path.relative(libPath, srcPath)}` : '');

--- a/scripts/tasks/tslint.js
+++ b/scripts/tasks/tslint.js
@@ -1,12 +1,13 @@
 module.exports = function (options) {
+  const requireResolveCwd = require('../require-resolve-cwd');
   const execSync = require('../exec-sync');
   const path = require('path');
   const fs = require('fs');
-  const msCustomRulesMain = require.resolve('tslint-microsoft-contrib');
+  const msCustomRulesMain = requireResolveCwd('tslint-microsoft-contrib');
   const rulesPath = path.dirname(msCustomRulesMain);
   const projectPath = path.resolve(process.cwd(), 'tsconfig.json');
   const sourcePath = path.resolve(process.cwd(), 'src/**/*.ts*');
-  const tslintPath = 'node ' + require.resolve('tslint/lib/tslint-cli');
+  const tslintPath = 'node ' + requireResolveCwd('tslint/lib/tslint-cli');
 
   execSync(`${tslintPath} --project ${projectPath} -t stylish -r ${rulesPath}`);
 };

--- a/scripts/tasks/tslint.js
+++ b/scripts/tasks/tslint.js
@@ -6,7 +6,7 @@ module.exports = function (options) {
   const rulesPath = path.dirname(msCustomRulesMain);
   const projectPath = path.resolve(process.cwd(), 'tsconfig.json');
   const sourcePath = path.resolve(process.cwd(), 'src/**/*.ts*');
-  const tslintPath = 'node ' + path.resolve(__dirname, '../node_modules/tslint/lib/tslint-cli');
+  const tslintPath = 'node ' + require.resolve('tslint/lib/tslint-cli');
 
   execSync(`${tslintPath} --project ${projectPath} -t stylish -r ${rulesPath}`);
 };

--- a/scripts/tasks/tslint.js
+++ b/scripts/tasks/tslint.js
@@ -1,13 +1,12 @@
 module.exports = function (options) {
-  const requireResolveCwd = require('../require-resolve-cwd');
   const execSync = require('../exec-sync');
   const path = require('path');
   const fs = require('fs');
-  const msCustomRulesMain = requireResolveCwd('tslint-microsoft-contrib');
+  const msCustomRulesMain = require.resolve('tslint-microsoft-contrib');
   const rulesPath = path.dirname(msCustomRulesMain);
   const projectPath = path.resolve(process.cwd(), 'tsconfig.json');
   const sourcePath = path.resolve(process.cwd(), 'src/**/*.ts*');
-  const tslintPath = 'node ' + requireResolveCwd('tslint/lib/tslint-cli');
+  const tslintPath = 'node ' + require.resolve('tslint/lib/tslint-cli');
 
   execSync(`${tslintPath} --project ${projectPath} -t stylish -r ${rulesPath}`);
 };

--- a/scripts/tasks/webpack-resources.js
+++ b/scripts/tasks/webpack-resources.js
@@ -13,7 +13,6 @@ module.exports = {
 
     const resolveLoader = {
       modules: [
-        path.resolve(__dirname, '../../node_modules'),
         path.resolve(__dirname, '../node_modules'),
         path.resolve(process.cwd(), 'node_modules')
       ]

--- a/scripts/tasks/webpack-resources.js
+++ b/scripts/tasks/webpack-resources.js
@@ -13,6 +13,7 @@ module.exports = {
 
     const resolveLoader = {
       modules: [
+        path.resolve(__dirname, '../../node_modules'),
         path.resolve(__dirname, '../node_modules'),
         path.resolve(process.cwd(), 'node_modules')
       ]
@@ -148,10 +149,6 @@ module.exports = {
 
         plugins: [
           new WebpackNotifierPlugin(),
-          new webpack.WatchIgnorePlugin([
-            /\.js$/,
-            /\.d\.ts$/
-          ]),
           new ForkTsCheckerWebpackPlugin()
         ]
       },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Lots of the scripts in the build tasks are doing so with a lot of assumptions on where the node_modules will end up. This change restores the use of the require.resolve logic. Several of the scripts deps have to be done by using require.resolve from scripts while others like copy & sass tasks have to use a "cwd" version.

Another issue addressed here is address `npm start` along with a dependent package. All this is needed to split up demo from components in a follow up PR.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5007)

