### PR TITLE
ComboBox: Fix styling when navigating menu with single select

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxFixSelectedStylingSingleSelect_2018-05-29-20-33.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxFixSelectedStylingSingleSelect_2018-05-29-20-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Update styling so that the \"selected\" item does not get the \"selected\" look when navigating through the potential options.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -199,8 +199,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       currentOptions: this.props.options,
       currentPendingValueValidIndex: -1,
       currentPendingValue: '',
-      currentPendingValueValidIndexOnHover: HoverStatus.default,
-
+      currentPendingValueValidIndexOnHover: HoverStatus.default
     };
   }
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -199,7 +199,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       currentOptions: this.props.options,
       currentPendingValueValidIndex: -1,
       currentPendingValue: '',
-      currentPendingValueValidIndexOnHover: HoverStatus.default
+      currentPendingValueValidIndexOnHover: HoverStatus.default,
+
     };
   }
 
@@ -1177,7 +1178,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     }
 
     let idxOfSelectedIndex = -1;
-    if ((index !== undefined) && this.state.selectedIndices) {
+    if (this.props.multiSelect && (index !== undefined) && this.state.selectedIndices) {
       idxOfSelectedIndex = this.state.selectedIndices.indexOf(index);
     }
     return (idxOfSelectedIndex >= 0);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
The comboBox should not show a "selected" item other than the hovered/focused item. When the multiselect functionality was added a regression was introduced where the currently "selected" item could show the "selected" look even when it was not hovered/focused

The fix is to make sure we don't attempt to set a selected look if we are not multiselect and any other item has been hovered/focused

#### Focus areas to test
Verified that the hover/focus styling is behaving correctly again and multiselect was not affected

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5017)

