### PR TITLE
[6.0.0] Fix icon package manually

### DIFF
--- a/common/changes/@uifabric/file-type-icons/6_0_react_minbar.json
+++ b/common/changes/@uifabric/file-type-icons/6_0_react_minbar.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@uifabric/file-type-icons",
       "comment": "Minimum React version is now 16.3.2.",
-      "type": "major"
+      "type": "minor"
     }
   ],
   "packageName": "@uifabric/file-type-icons",

--- a/common/changes/@uifabric/icons/6_0_noop.json
+++ b/common/changes/@uifabric/icons/6_0_noop.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/6_0_button.json
+++ b/common/changes/office-ui-fabric-react/6_0_button.json
@@ -12,7 +12,7 @@
     },
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Command Bar component has been replaced with the one from the experiments package.",
+      "comment": "CommandBar component has been replaced with the one from the experiments package.",
       "type": "major"
     }
   ],

--- a/packages/icons/src/iconAliases.ts
+++ b/packages/icons/src/iconAliases.ts
@@ -1,4 +1,6 @@
-import { registerIconAlias } from '@uifabric/styling/lib-commonjs/index';
+import { registerIconAlias } from '@uifabric/styling';
 
-registerIconAlias('trash', 'delete');
-registerIconAlias('onedrive', 'onedrivelogo');
+export const registerIconAliases = () => {
+  registerIconAlias('trash', 'delete');
+  registerIconAlias('onedrive', 'onedrivelogo');
+}

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -16,7 +16,8 @@ import { initializeIcons as i8 } from './fabric-icons-8';
 import { initializeIcons as i9 } from './fabric-icons-9';
 
 import { IIconOptions } from '@uifabric/styling';
-import './iconAliases';
+import { registerIconAliases } from './iconAliases';
+
 const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/icons/';
 
 export function initializeIcons(
@@ -26,6 +27,8 @@ export function initializeIcons(
   [i, i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14].forEach(
     (initialize: (url: string, options?: IIconOptions) => void) => initialize(baseUrl, options)
   );
+
+  registerIconAliases();
 }
 
 export { IconNames } from './IconNames';


### PR DESCRIPTION
This change has been made upstream but was not previously on the 6.0 branch. 
If not changed, this will cause iconAliases to be dropped in Webpack 4's tree shaking.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5028)

