### PR TITLE
fixing webpack config to allow rush build to complete on a small VM

### DIFF
--- a/scripts/tasks/webpack-resources.js
+++ b/scripts/tasks/webpack-resources.js
@@ -29,7 +29,7 @@ module.exports = {
       ]
     };
 
-    const devtool = 'source-map';
+    const devtool = 'cheap-module-source-map';
     const configs = [];
 
     if (!onlyProduction) {
@@ -176,6 +176,11 @@ function getPlugins(
         reportFilename: bundleName + '.stats.html',
         openAnalyzer: false,
         generateStatsFile: true,
+        statsOptions: {
+          source: false,
+          reasons: false,
+          chunks: false,
+        },
         statsFilename: bundleName + '.stats.json',
         logLevel: 'warn'
       })


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
bundleanalyzerplugin is doing a lot of work to generate stats.json and in turn stalls on prod builds.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5037)

