### PR TITLE
Add pointerup listener to exit keytip mode

### DIFF
--- a/common/changes/office-ui-fabric-react/keyou-keytip-pointer-dismiss_2018-05-31-20-28.json
+++ b/common/changes/office-ui-fabric-react/keyou-keytip-pointer-dismiss_2018-05-31-20-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add support for pointerup to dismiss keytips",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -146,6 +146,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
   public componentDidMount(): void {
     // Add window listeners
     this._events.on(window, 'mouseup', this._onDismiss, true /* useCapture */);
+    this._events.on(window, 'pointerup', this._onDismiss, true /* useCapture */);
     this._events.on(window, 'resize', this._onDismiss);
     this._events.on(window, 'keydown', this._onKeyDown, true /* useCapture */);
     this._events.on(window, 'keypress', this._onKeyPress, true /* useCapture */);
@@ -159,6 +160,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
   public componentWillUnmount(): void {
     // Remove window listeners
     this._events.off(window, 'mouseup', this._onDismiss, true /* useCapture */);
+    this._events.off(window, 'pointerup', this._onDismiss, true /* useCapture */);
     this._events.off(window, 'resize', this._onDismiss);
     this._events.off(window, 'keydown', this._onKeyDown, true /* useCapture */);
     this._events.off(window, 'keypress', this._onKeyPress, true /* useCapture */);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adding the pointerup event to the KeytipLayer listeners to allow it to exit keytip mode. This is added because in most cases a pointerup and mouseup event are both sent, but an app using keytips may have implemented logic to ignore the mouseup event if they're basing their code on pointer events (to avoid essentially duplicate events).

#### Focus areas to test

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5051)

