### PR TITLE
Experiments/Nav component: display "show more" link only if there is atleast one hidden link

### DIFF
--- a/common/changes/@uifabric/experiments/HideShowMore_2018-06-01-05-32.json
+++ b/common/changes/@uifabric/experiments/HideShowMore_2018-06-01-05-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Experiments/Nav component: display \"show more\" link only if there is atleast one hidden link",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "sikrishn@microsoft.com"
+}

--- a/packages/experiments/src/components/Nav/Nav.tsx
+++ b/packages/experiments/src/components/Nav/Nav.tsx
@@ -37,6 +37,10 @@ class NavComponent extends NavBase {
       return null;
     }
 
+    // reset the flag
+    // on render link, find if there is atleast one hidden link to display "Show more" link
+    this._hasAtleastOneHiddenLink = false;
+
     return (
       <nav role='navigation'>
         {
@@ -191,7 +195,14 @@ class NavComponent extends NavBase {
         {
           links.map((link: INavLink, linkIndex: number) => {
             if (enableCustomization && link.isHidden && !showMore) {
+              // atleast one link is hidden
+              this._hasAtleastOneHiddenLink = true;
+
               // "Show more" overrides isHidden property
+              return null;
+            }
+            else if (link.isShowMoreLink && !this._hasAtleastOneHiddenLink && !showMore) {
+              // there is no hidden link, hide "Show more" link
               return null;
             }
             else {

--- a/packages/experiments/src/components/Nav/NavBase.tsx
+++ b/packages/experiments/src/components/Nav/NavBase.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 /* tslint:enable */
 
 export class NavBase extends React.Component<INavProps, INavState> implements INav {
-  protected _hasAtleastOneHiddenLink: boolean = false;
+  protected _hasAtleastOneHiddenLink = false;
 
   constructor(props: INavProps) {
     super(props);

--- a/packages/experiments/src/components/Nav/NavBase.tsx
+++ b/packages/experiments/src/components/Nav/NavBase.tsx
@@ -5,6 +5,8 @@ import * as React from 'react';
 /* tslint:enable */
 
 export class NavBase extends React.Component<INavProps, INavState> implements INav {
+  protected _hasAtleastOneHiddenLink: boolean = false;
+
   constructor(props: INavProps) {
     super(props);
   }

--- a/packages/experiments/src/components/Nav/SlimNav.tsx
+++ b/packages/experiments/src/components/Nav/SlimNav.tsx
@@ -43,6 +43,10 @@ class SlimNavComponent extends NavBase {
       return null;
     }
 
+    // reset the flag
+    // on render link, find if there is atleast one hidden link to display "Show more" link
+    this._hasAtleastOneHiddenLink = false;
+
     return (
       <nav role='navigation'>
         {
@@ -309,7 +313,14 @@ class SlimNavComponent extends NavBase {
         {
           links.map((link: INavLink, linkIndex: number) => {
             if (enableCustomization && link.isHidden && !showMore) {
+              // atleast one link is hidden
+              this._hasAtleastOneHiddenLink = true;
+
               // "Show more" overrides isHidden property
+              return null;
+            }
+            else if (link.isShowMoreLink && !this._hasAtleastOneHiddenLink && !showMore) {
+              // there is no hidden link, hide "Show more" link
               return null;
             }
             else {


### PR DESCRIPTION
Description of changes

Experiments/Nav component: display \"show more\" link only if there is atleast one hidden link

Focus areas to test

Set isHidden property of all nav links to false and pass it through props, "Show more" link shouldn't display in both expanded and slim nav.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5057)

