### PR TITLE
SplitButton: Add aria-roledescription

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-SplitButtonAddAriaRoleDescription_2018-06-01-18-07.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-SplitButtonAddAriaRoleDescription_2018-06-01-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SplitButton: Hook up aria-roledesrition to splitButtons so that they can leverage that markup if it gets passed in to the component.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jspurlin-SplitButtonAddAriaRoleDescription_2018-06-01-18-07.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-SplitButtonAddAriaRoleDescription_2018-06-01-18-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "SplitButton: Hook up aria-roledesrition to splitButtons so that they can leverage that markup if it gets passed in to the component.",
+      "comment": "SplitButton: Hook up aria-roledescription to splitButtons so that they can leverage that markup if it gets passed in to the component.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -541,6 +541,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
             data-is-focusable={ true }
             onClick={ !disabled && !primaryDisabled ? this._onSplitButtonPrimaryClick : undefined }
             tabIndex={ !disabled ? 0 : undefined }
+            aria-roledescription={ buttonProps['aria-roledescription'] }
           >
             <span
               style={ { 'display': 'flex' } }

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Split.Example.tsx
@@ -33,6 +33,7 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
             onClick={ alertClicked }
             split={ true }
             splitButtonAriaLabel={ 'See 2 sample options' }
+            aria-roledescription={ 'split button' }
             style={ { height: '35px' } }
             menuProps={ {
               items: [
@@ -60,6 +61,7 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
             text='Create account'
             onClick={ alertClicked }
             split={ true }
+            aria-roledescription={ 'split button' }
             style={ { height: '35px' } }
             menuProps={ {
               items: [
@@ -88,6 +90,7 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
             text='Create account'
             onClick={ alertClicked }
             split={ true }
+            aria-roledescription={ 'split button' }
             style={ { height: '35px' } }
             menuProps={ {
               items: [
@@ -115,6 +118,7 @@ export class ButtonSplitExample extends React.Component<IButtonProps> {
             text='Create account'
             onClick={ alertClicked }
             split={ true }
+            aria-roledescription={ 'split button' }
             style={ { height: '35px' } }
             menuProps={ {
               items: [
@@ -154,6 +158,7 @@ export class ButtonSplitCustomExample extends React.Component<IButtonProps> {
           text='Create account'
           onClick={ alertClicked }
           split={ true }
+          aria-roledescription={ 'split button' }
           styles={ customSplitButtonStyles }
           menuProps={ {
             items: [

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -79,6 +79,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
             onTouchStart={ this._onTouchStart }
             tabIndex={ 0 }
             data-is-focusable={ true }
+            aria-roledescription={ item['aria-roledescription'] }
           >
             { this._renderSplitPrimaryButton(item, classNames, index, hasCheckmarks!, hasIcons!) }
             { this._renderSplitDivider(item) }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.deprecated.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`ContextualMenuSplitButton creates a normal split button renders the con
   aria-haspopup={true}
   aria-label={undefined}
   aria-posinset={1}
+  aria-roledescription={undefined}
   aria-setsize={1}
   className="splitContainer"
   data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`ContextualMenuSplitButton creates a normal split button renders the con
   aria-haspopup={true}
   aria-label={undefined}
   aria-posinset={1}
+  aria-roledescription={undefined}
   aria-setsize={1}
   className="splitContainer"
   data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -85,6 +85,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
                 key: 'shareSplit',
                 onClick: () => alert('Split buttons!'),
                 split: true,
+                'aria-roledescription': 'split button',
                 subMenuProps: {
                   items: [
                     {


### PR DESCRIPTION
#### Pull request checklist

- Addresses an existing issue: Fixes #0000
- Include a change request file using `$ npm run change`
- Microsoft Alias (if you have one): jspurlin

#### Description of changes
With aria 1.1 there's an aria-roledescription (see: https://www.w3.org/TR/wai-aria-1.1/#aria-roledescription) which is there to help the user understand what a component is. Buttons (and any other componet that uses htmlProperties) can use it. The splitButton is built up slightly differently and needs it explicitly defined.

There's no harm if the attribute is not there and there's no harm if a screen reader does not read that content, it just gives the user a better chance to understand the components if an AT conveys that information

#### Focus areas to test
Verified that splitButtons top level and within menus can now get aria-roledescription and it reads out great in Edge/Narrator. Verified that not having the attribute does nothing and that normal buttons can also define this property if they so choose.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5062)

