### PR TITLE
Fix DetailsList accessibility and add more ARIA hooks

### DIFF
--- a/common/changes/office-ui-fabric-react/details-accessibility_2018-06-01-20-15.json
+++ b/common/changes/office-ui-fabric-react/details-accessibility_2018-06-01-20-15.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fix Details List accessibility issues: header states and table scanning",
+      "comment": "DetailsList: adjusting aria labels and exporting more ariaLabels in `IColumn` to allow for better narrator reading and table scanning.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/details-accessibility_2018-06-01-20-15.json
+++ b/common/changes/office-ui-fabric-react/details-accessibility_2018-06-01-20-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Details List accessibility issues: header states and table scanning",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -161,7 +161,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
               ) }
               aria-labelledby={ `${this._id}-check` }
               onClick={ this._onSelectAllClicked }
-              aria-colindex={ 0 }
+              aria-colindex={ 1 }
               role='columnheader'
             >
               {
@@ -225,7 +225,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                   role='columnheader'
                   aria-sort={ column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none' }
                   aria-disabled={ column.columnActionsMode === ColumnActionsMode.disabled }
-                  aria-colindex={ (showCheckbox ? 1 : 0) + columnIndex }
+                  aria-colindex={ (showCheckbox ? 2 : 1) + columnIndex }
                   className={ css(
                     'ms-DetailsHeader-cell',
                     styles.cell,
@@ -273,19 +273,28 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
                           </span>
 
                           { column.isFiltered && (
-                            <Icon className={ styles.nearIcon } iconName='Filter' />
+                            <Icon ariaLabel={ column.filterAriaLabel } className={ styles.nearIcon } iconName='Filter' />
                           ) }
 
                           { column.isSorted && (
-                            <Icon className={ css(styles.nearIcon, styles.sortIcon) } iconName={ column.isSortedDescending ? 'SortDown' : 'SortUp' } />
+                            <Icon
+                              ariaLabel={
+                                column.isSortedDescending ?
+                                  column.sortDescendingAriaLabel :
+                                  column.sortAscendingAriaLabel
+                              }
+                              className={ css(styles.nearIcon, styles.sortIcon) }
+                              iconName={ column.isSortedDescending ? 'SortDown' : 'SortUp' }
+                            />
                           ) }
 
                           { column.isGrouped && (
-                            <Icon className={ styles.nearIcon } iconName='GroupedDescending' />
+                            <Icon ariaLabel={ column.groupAriaLabel } className={ styles.nearIcon } iconName='GroupedDescending' />
                           ) }
 
                           { column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
                             <Icon
+                              aria-hidden={ true }
                               className={ css('ms-DetailsHeader-filterChevron', styles.filterChevron) }
                               iconName='ChevronDown'
                             />

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -389,6 +389,23 @@ export interface IColumn {
   * If set, will add additional LTR padding-right to column and cells.
   */
   isPadded?: boolean;
+
+  /**
+   * ARIA label for the sort order of this column when sorted ascending.
+   */
+  sortAscendingAriaLabel?: string;
+  /**
+   * ARIA label for the sort order of this column when sorted descending.
+   */
+  sortDescendingAriaLabel?: string;
+  /**
+   * ARIA label for the status of this column when grouped.
+   */
+  groupAriaLabel?: string;
+  /**
+   * ARIA label for the status of this column when filtered.
+   */
+  filterAriaLabel?: string;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.tsx
@@ -263,7 +263,7 @@ export class DetailsRow extends BaseComponent<IDetailsRowProps, IDetailsRowState
         { showCheckbox && (
           <div
             role='gridcell'
-            aria-colindex={ 0 }
+            aria-colindex={ 1 }
             data-selection-toggle={ true }
             className={ css('ms-DetailsRow-cell', 'ms-DetailsRow-cellCheck', checkStyles.owner, styles.cell, styles.checkCell, checkboxCellClassName) }
           >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -47,7 +47,7 @@ export class DetailsRowFields extends BaseComponent<IDetailsRowFieldsProps, IDet
           <div
             key={ columnIndex }
             role={ column.isRowHeader ? 'rowheader' : 'gridcell' }
-            aria-colindex={ columnIndex + columnStartIndex }
+            aria-colindex={ columnIndex + columnStartIndex + 1 }
             className={ css('ms-DetailsRow-cell', styles.cell, column.className,
               column.isMultiline && 'is-multiline',
               column.isRowHeader && styles.isRowHeader,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`DetailsHeader can render 1`] = `
   role="row"
 >
   <div
-    aria-colindex={0}
+    aria-colindex={1}
     aria-labelledby="header0-check"
     className="ms-DetailsHeader-cell ms-DetailsHeader-cellIsCheck"
     onClick={[Function]}
@@ -130,7 +130,7 @@ exports[`DetailsHeader can render 1`] = `
     </span>
   </div>
   <div
-    aria-colindex={1}
+    aria-colindex={2}
     aria-disabled={false}
     aria-sort="none"
     className="ms-DetailsHeader-cell is-actionable undefined"
@@ -178,7 +178,7 @@ exports[`DetailsHeader can render 1`] = `
     role="button"
   />
   <div
-    aria-colindex={2}
+    aria-colindex={3}
     aria-disabled={false}
     aria-sort="none"
     className="ms-DetailsHeader-cell is-actionable undefined"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`DetailsList renders List correctly 1`] = `
           role="row"
         >
           <div
-            aria-colindex={0}
+            aria-colindex={1}
             aria-labelledby="header0-check"
             className="ms-DetailsHeader-cell ms-DetailsHeader-cellIsCheck"
             onClick={[Function]}
@@ -156,7 +156,7 @@ exports[`DetailsList renders List correctly 1`] = `
             </span>
           </div>
           <div
-            aria-colindex={1}
+            aria-colindex={2}
             aria-disabled={false}
             aria-sort="none"
             className="ms-DetailsHeader-cell is-actionable undefined"


### PR DESCRIPTION
The `DetailsList` recently lost the ability to use Narrator's table scan (Ctrl+Alt+Arrows) to navigate all cells in  the list. This change fixes the `aria-colindex` to start at `1` instead of `0`.
This change also adds more ARIA labels to the status indicators in `DetailsHeader` columns, so they can be read off by a screen reader.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5066)

