### PR TITLE
Fix icon imports

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-icon-imports_2018-06-02-19-38.json
+++ b/common/changes/office-ui-fabric-react/fix-icon-imports_2018-06-02-19-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Icons top level import was exporting a file path, should be exporting a package path.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/Icons.ts
+++ b/packages/office-ui-fabric-react/src/Icons.ts
@@ -1,1 +1,1 @@
-export * from '@uifabric/icons/lib/index';
+export * from '@uifabric/icons';

--- a/packages/office-ui-fabric-react/src/demo/index.tsx
+++ b/packages/office-ui-fabric-react/src/demo/index.tsx
@@ -9,7 +9,7 @@ import { ComponentPage, IAppLink, IAppLinkGroup } from '@uifabric/example-app-ba
 import './index.scss';
 import './ColorStyles.scss';
 
-import { initializeIcons } from '@uifabric/icons/lib/index';
+import { initializeIcons } from '@uifabric/icons';
 
 initializeIcons();
 


### PR DESCRIPTION
All top level import files which export external package content should be exporting by package name, and not by file path within package. This allows node.js to resolve the package by the `main` entry, which points to commonjs, while webpack can use the `module` entry which points to es6.

Fixing the Icons export that we missed.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5069)

