### PR TITLE
Callout: dismissal can now be done when you click on the documentElement

### DIFF
--- a/common/changes/office-ui-fabric-react/fixdismiss_2018-06-04-02-09.json
+++ b/common/changes/office-ui-fabric-react/fixdismiss_2018-06-04-02-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout: fix dismissing events to attach to the documentElement, not body.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -287,8 +287,8 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     this._async.setTimeout(() => {
       this._events.on(this._targetWindow, 'scroll', this._dismissOnScroll, true);
       this._events.on(this._targetWindow, 'resize', this.dismiss, true);
-      this._events.on(this._targetWindow.document.body, 'focus', this._dismissOnLostFocus, true);
-      this._events.on(this._targetWindow.document.body, 'click', this._dismissOnLostFocus, true);
+      this._events.on(this._targetWindow.document.documentElement, 'focus', this._dismissOnLostFocus, true);
+      this._events.on(this._targetWindow.document.documentElement, 'click', this._dismissOnLostFocus, true);
       this._hasListeners = true;
     }, 0);
   }
@@ -296,8 +296,8 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
   private _removeListeners() {
     this._events.off(this._targetWindow, 'scroll', this._dismissOnScroll, true);
     this._events.off(this._targetWindow, 'resize', this.dismiss, true);
-    this._events.off(this._targetWindow.document.body, 'focus', this._dismissOnLostFocus, true);
-    this._events.off(this._targetWindow.document.body, 'click', this._dismissOnLostFocus, true);
+    this._events.off(this._targetWindow.document.documentElement, 'focus', this._dismissOnLostFocus, true);
+    this._events.off(this._targetWindow.document.documentElement, 'click', this._dismissOnLostFocus, true);
     this._hasListeners = false;
   }
 


### PR DESCRIPTION
Problem being fixed:

If you put JUST a dropdown on the page, the BODY element will be the height of the dropdown. And, because the dismissal events are hooked up to body, clicking anywhere below the dropdown will not dismiss it.

Now you can click anywhere in the browser, even if the body is short, to dismiss any callout based thing.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5073)

