### PR TITLE
Reverse commit for PR #4897

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ReverseCommitForPR4897_2018-06-04-17-57.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ReverseCommitForPR4897_2018-06-04-17-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Revert PR 4897",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
+
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
-import { KeyCodes, createRef } from '../../Utilities';
+import { KeyCodes } from '../../Utilities';
+
 import { FocusZone, FocusZoneDirection } from '../FocusZone';
 import { FocusTrapZone } from './FocusTrapZone';
 
 // rAF does not exist in node - let's mock it
 window.requestAnimationFrame = (callback: FrameRequestCallback) => {
-  const r = window.setTimeout(callback, 16);
-  jest.runAllTimers();
-  return r;
+  return window.setTimeout(callback, 16);
 };
-const animationFrame = () => new Promise(resolve => window.requestAnimationFrame(resolve));
+
 jest.useFakeTimers();
 
 describe('FocusTrapZone', () => {
@@ -259,96 +259,5 @@ describe('FocusTrapZone', () => {
     });
 
     jest.runAllTimers();
-  });
-
-  describe('Focusing the FTZ', () => {
-    function setupTest(focusPreviouslyFocusedInnerElement: boolean) {
-      const focusTrapZoneRef = createRef<FocusTrapZone>();
-      const topLevelDiv = ReactTestUtils.renderIntoDocument(
-        <div onFocusCapture={ _onFocus }>
-          <FocusTrapZone
-            forceFocusInsideTrap={ false }
-            focusPreviouslyFocusedInnerElement={ focusPreviouslyFocusedInnerElement }
-            data-is-focusable={ true }
-            ref={ focusTrapZoneRef }
-          >
-            <button className={ 'f' }>f</button>
-            <FocusZone>
-              <button className={ 'a' }>a</button>
-              <button className={ 'b' }>b</button>
-            </FocusZone>
-          </FocusTrapZone>
-          <button className={ 'z' }>z</button>
-        </div>
-      ) as HTMLElement;
-
-      const focusTrapZone = ReactDOM.findDOMNode(focusTrapZoneRef.current!) as Element;
-      const buttonF = topLevelDiv.querySelector('.f') as HTMLElement;
-      const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
-      const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
-      const buttonZ = topLevelDiv.querySelector('.z') as HTMLElement;
-
-      // Assign bounding locations to buttons.
-      setupElement(buttonF, { clientRect: { top: 0, bottom: 10, left: 0, right: 10 } });
-      setupElement(buttonA, { clientRect: { top: 10, bottom: 20, left: 0, right: 10 } });
-      setupElement(buttonB, { clientRect: { top: 20, bottom: 30, left: 0, right: 10 } });
-      setupElement(buttonZ, { clientRect: { top: 30, bottom: 40, left: 0, right: 10 } });
-
-      return { focusTrapZone, buttonF, buttonA, buttonB, buttonZ };
-    }
-
-    it('goes to previously focused element when focusing the FTZ', async () => {
-      expect.assertions(4);
-
-      const { focusTrapZone, buttonF, buttonB, buttonZ } = setupTest(true /*focusPreviouslyFocusedInnerElement*/);
-
-      // Manually focusing FTZ when FTZ has never
-      // had focus within should go to 1st focusable inner element.
-      ReactTestUtils.Simulate.focus(focusTrapZone);
-      await animationFrame();
-      expect(lastFocusedElement).toBe(buttonF);
-
-      // Focus inside the trap zone, not the first element.
-      ReactTestUtils.Simulate.focus(buttonB);
-      await animationFrame();
-      expect(lastFocusedElement).toBe(buttonB);
-
-      // Focus outside the trap zone
-      ReactTestUtils.Simulate.focus(buttonZ);
-      await animationFrame();
-      expect(lastFocusedElement).toBe(buttonZ);
-
-      // Manually focusing FTZ should return to originally focused inner element.
-      ReactTestUtils.Simulate.focus(focusTrapZone);
-      await animationFrame();
-      expect(lastFocusedElement).toBe(buttonB);
-    });
-
-    it('goes to first focusable element when focusing the FTZ', async () => {
-      expect.assertions(4);
-
-      const { focusTrapZone, buttonF, buttonB, buttonZ } = setupTest(false /*focusPreviouslyFocusedInnerElement*/);
-
-      // Manually focusing FTZ when FTZ has never
-      // had focus within should go to 1st focusable inner element.
-      ReactTestUtils.Simulate.focus(focusTrapZone);
-      await animationFrame();
-      expect(lastFocusedElement).toBe(buttonF);
-
-      // Focus inside the trap zone, not the first element.
-      ReactTestUtils.Simulate.focus(buttonB);
-      await animationFrame();
-      expect(lastFocusedElement).toBe(buttonB);
-
-      // Focus outside the trap zone
-      ReactTestUtils.Simulate.focus(buttonZ);
-      await animationFrame();
-      expect(lastFocusedElement).toBe(buttonZ);
-
-      // Manually focusing FTZ should go to the first focusable element.
-      ReactTestUtils.Simulate.focus(focusTrapZone);
-      await animationFrame();
-      expect(lastFocusedElement).toBe(buttonF);
-    });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -14,12 +14,12 @@ import {
 import { IFocusTrapZone, IFocusTrapZoneProps } from './FocusTrapZone.types';
 
 export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implements IFocusTrapZone {
+
   private static _focusStack: FocusTrapZone[] = [];
   private static _clickStack: FocusTrapZone[] = [];
 
   private _root = createRef<HTMLDivElement>();
-  private _previouslyFocusedElementOutsideTrapZone: HTMLElement;
-  private _previouslyFocusedElementInTrapZone?: HTMLElement;
+  private _previouslyFocusedElement: HTMLElement;
   private _isInFocusStack = false;
   private _isInClickStack = false;
 
@@ -38,8 +38,8 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
   public componentDidMount(): void {
     const { isClickableOutsideFocusTrap = false, forceFocusInsideTrap = true, elementToFocusOnDismiss, disableFirstFocus = false } = this.props;
 
-    this._previouslyFocusedElementOutsideTrapZone = elementToFocusOnDismiss ? elementToFocusOnDismiss : document.activeElement as HTMLElement;
-    if (!elementContains(this._root.current, this._previouslyFocusedElementOutsideTrapZone) && !disableFirstFocus) {
+    this._previouslyFocusedElement = elementToFocusOnDismiss ? elementToFocusOnDismiss : document.activeElement as HTMLElement;
+    if (!elementContains(this._root.current, this._previouslyFocusedElement) && !disableFirstFocus) {
       this.focus();
     }
 
@@ -54,8 +54,8 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
 
   public componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void {
     const { elementToFocusOnDismiss } = nextProps;
-    if (elementToFocusOnDismiss && this._previouslyFocusedElementOutsideTrapZone !== elementToFocusOnDismiss) {
-      this._previouslyFocusedElementOutsideTrapZone = elementToFocusOnDismiss;
+    if (elementToFocusOnDismiss && this._previouslyFocusedElement !== elementToFocusOnDismiss) {
+      this._previouslyFocusedElement = elementToFocusOnDismiss;
     }
   }
 
@@ -77,10 +77,10 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
 
     const activeElement = document.activeElement as HTMLElement;
     if (!ignoreExternalFocusing &&
-      this._previouslyFocusedElementOutsideTrapZone &&
-      typeof this._previouslyFocusedElementOutsideTrapZone.focus === 'function' &&
+      this._previouslyFocusedElement &&
+      typeof this._previouslyFocusedElement.focus === 'function' &&
       (elementContains(this._root.value, activeElement) || activeElement === document.body)) {
-      focusAsync(this._previouslyFocusedElementOutsideTrapZone);
+      focusAsync(this._previouslyFocusedElement);
     }
   }
 
@@ -95,28 +95,20 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
         ref={ this._root }
         aria-labelledby={ ariaLabelledBy }
         onKeyDown={ this._onKeyboardHandler }
-        onFocusCapture={ this._onFocusCapture }
       >
         { this.props.children }
       </div>
     );
   }
 
+  /**
+   * Need to expose this method in case of popups since focus needs to be set when popup is opened
+   */
   public focus() {
-    const { focusPreviouslyFocusedInnerElement, firstFocusableSelector } = this.props;
-
-    if (
-      focusPreviouslyFocusedInnerElement &&
-      this._previouslyFocusedElementInTrapZone &&
-      elementContains(this._root.value, this._previouslyFocusedElementInTrapZone)
-    ) {
-      // focus on the last item that had focus in the zone before we left the zone
-      focusAsync(this._previouslyFocusedElementInTrapZone);
-      return;
-    }
-
-    const focusSelector =
-      typeof firstFocusableSelector === 'string' ? firstFocusableSelector : firstFocusableSelector && firstFocusableSelector();
+    const { firstFocusableSelector } = this.props;
+    const focusSelector = typeof firstFocusableSelector === 'string'
+      ? firstFocusableSelector
+      : firstFocusableSelector && firstFocusableSelector();
 
     let _firstFocusableChild;
 
@@ -132,29 +124,7 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
     }
   }
 
-  private _onFocusCapture = (ev: React.FocusEvent<HTMLDivElement>) => {
-    if (this.props.onFocusCapture) {
-      this.props.onFocusCapture(ev);
-    }
-    if (ev.isDefaultPrevented()) {
-      return;
-    }
-
-    if (ev.target === ev.currentTarget) {
-      // If the trap zone gets focus, pass on focus to either first focusable
-      // child element or the last focused element when this zone last had
-      // a focused child (depending on a prop).
-      this.focus();
-      ev.preventDefault();
-      ev.stopPropagation();
-    } else {
-      // every time focus changes within the trap zone, remember the focused element so that
-      // it can be restored if focus leaves the pane and returns via keystroke (i.e. via a call to this.focus(true))
-      this._previouslyFocusedElementInTrapZone = ev.target as HTMLElement;
-    }
-  }
-
-  private _onKeyboardHandler = (ev: React.KeyboardEvent<HTMLDivElement>): void => {
+  private _onKeyboardHandler = (ev: React.KeyboardEvent<HTMLElement>): void => {
     if (this.props.onKeyDown) {
       this.props.onKeyDown(ev);
     }

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.types.ts
@@ -2,9 +2,8 @@ import * as React from 'react';
 
 export interface IFocusTrapZone {
   /**
-   * Sets focus to a descendant in the Trap Zone.
-   * See firstFocusableSelector and focusPreviouslyFocusedInnerElement for details.
-   */
+  * Sets focus on the first focusable, or configured, child in focus trap zone
+  */
   focus: () => void;
 }
 
@@ -39,14 +38,14 @@ export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement
   ignoreExternalFocusing?: boolean;
 
   /**
-   * Indicates whether focus trap zone should force focus inside the focus trap zone
-   * @default true
-   */
+  * Indicates whether focus trap zone should force focus inside the focus trap zone
+  * @default true
+  */
   forceFocusInsideTrap?: boolean;
 
   /**
-   * Indicates the selector for first focusable item.  Only applies if focusPreviouslyFocusedInnerElement == false.
-   */
+  * Indicates the selector for first focusable item
+  */
   firstFocusableSelector?: string | (() => string);
 
   /**
@@ -56,11 +55,7 @@ export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement
   disableFirstFocus?: boolean;
 
   /**
-   * Specifies the algorithm used to determine which descendant element to focus when the FocusTrapZone is focused.
-   * If false, the first focusable descendant, filtered by the firstFocusableSelector property if present, is chosen.
-   * If true, the element that was focused when the Trap Zone last had a focused descendant is chosen.
-   * If it has never had a focused descendant before, behavior falls back to the first focused descendant.
-   * @default false
+   * Optional, onKeyDown event handler
    */
-  focusPreviouslyFocusedInnerElement?: boolean;
+  onKeyDown?: (ev: React.KeyboardEvent<HTMLElement>) => void;
 }


### PR DESCRIPTION
#### Pull request checklist

- Addresses an existing issue: Fixes #0000
- Include a change request file using `$ npm run change`
- Microsoft Alias (if you have one): jspurlin

#### Description of changes
This PR reverts PR #4897 which regressed focus callbacks in the FocusTrapZone

#### Focus areas to test
Verified reverting that PR fixed the regression

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5085)

