### PR TITLE
CommandBarPage: Remove FabricJS reference

### DIFF
--- a/common/changes/office-ui-fabric-react/commandbar-fabricjs_2018-06-04-19-00.json
+++ b/common/changes/office-ui-fabric-react/commandbar-fabricjs_2018-06-04-19-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBarPage: Remove fabric js reference.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBarPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBarPage.tsx
@@ -68,9 +68,6 @@ export class CommandBarPage extends React.Component<IComponentDemoPageProps, {}>
             { require<string>('!raw-loader!office-ui-fabric-react/src/components/CommandBar/docs/CommandBarDonts.md') }
           </PageMarkdown>
         }
-        related={
-          <a href='https://dev.office.com/fabric-js/Components/CommandBar/CommandBar.html'>Fabric JS</a>
-        }
         isHeaderVisible={ this.props.isHeaderVisible }
         componentStatus={
           <ComponentStatus


### PR DESCRIPTION
#### Pull request checklist

- Addresses an existing issue: Fixes #5084 
- Include a change request file using `$ npm run change`
- Microsoft Alias (if you have one): 

#### Description of changes

When the new CommandBar came in from experiments, it brought an old reference to FabricJS. Removing.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5087)

