### PR TITLE
Spin button/run validation on empty string

### DIFF
--- a/common/changes/office-ui-fabric-react/SpinButton-RunValidationOnEmptyString_2018-06-04-19-04.json
+++ b/common/changes/office-ui-fabric-react/SpinButton-RunValidationOnEmptyString_2018-06-04-19-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "_onValidate should only skip validation on text entry if state.value is undefined (it was skipping when text entry was empty string)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rpsenski@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -335,6 +335,32 @@ describe('SpinButton', () => {
     expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleDefaultValue));
   });
 
+  it('should reset the value of the spin button when input value is cleared (empty)', () => {
+    const exampleLabelValue = 'SpinButton';
+    const exampleMinValue = 2;
+    const exampleMaxValue = 22;
+    const exampleDefaultValue = '12';
+
+    const renderedDOM: HTMLElement = renderIntoDocument(
+      <SpinButton
+        label={ exampleLabelValue }
+        min={ exampleMinValue }
+        max={ exampleMaxValue }
+        defaultValue={ exampleDefaultValue }
+      />
+    );
+
+    // Assert on the input element.
+    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent());
+    ReactTestUtils.Simulate.blur(inputDOM);
+
+    expect(inputDOM.value).toEqual(exampleDefaultValue);
+    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
+    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
+    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleDefaultValue));
+  });
+
   it('should revert to max value when input value is higher than the max of the spin button', () => {
     const exampleLabelValue = 'SpinButton';
     const exampleMinValue = 2;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -310,7 +310,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
    * Validate function to use if one is not passed in
    */
   private _defaultOnValidate = (value: string) => {
-    if (isNaN(Number(value))) {
+    if (value == null || value.trim().length === 0 || isNaN(Number(value))) {
       return this._lastValidValue;
     }
     const newValue = Math.min(this.props.max as number, Math.max(this.props.min as number, Number(value)));

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -310,7 +310,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
    * Validate function to use if one is not passed in
    */
   private _defaultOnValidate = (value: string) => {
-    if (value == null || value.trim().length === 0 || isNaN(Number(value))) {
+    if (value === null || value.trim().length === 0 || isNaN(Number(value))) {
       return this._lastValidValue;
     }
     const newValue = Math.min(this.props.max as number, Math.max(this.props.min as number, Number(value)));

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -369,7 +369,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
   private _validate = (event: React.FocusEvent<HTMLInputElement>): void => {
     const element: HTMLInputElement = event.target as HTMLInputElement;
     const value: string = element.value;
-    if (this.state.value) {
+    if (this.state.value !== undefined) {
       const newValue = this._onValidate!(value);
       if (newValue) {
         this._lastValidValue = newValue;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx
@@ -13,7 +13,7 @@ export class SpinButtonStatefulExample extends React.Component<any, any> {
           value={ '7' + suffix }
           onValidate={ (value: string) => {
             value = this._removeSuffix(value, suffix);
-            if (isNaN(+value)) {
+            if (value.trim().length === 0 || isNaN(+value)) {
               return '0' + suffix;
             }
 


### PR DESCRIPTION
#### Pull request checklist

- Addresses an existing issue: Fixes #5088
- Include a change request file using `$ npm run change`
- Microsoft Alias (if you have one): rpsenski

#### Description of changes

There is a check that the value in state is valid in the _validate function. If the check returns false, onValidate isn't called. The check returns false if state.value is empty string or pure whitespace. This update makes the check an explicit check for undefined so validation will run against empty and whitespace input.

To leverage this change, the _defaultValidation function needs to be updated to check for null, empty or pure whitespace input because the Number constructor with any of these as the argument gives a value of 0. 

Also updating the stateful example to also check for empty/whitespace for consistency.

#### Focus areas to test

SpinButton validation when the control loses focus

Specific scenario targeted with this fix is to clear the SpinButton value and then cause the control to lose focus. previously it did not validation. Now it invokes the onValidate function, which by default reverts the entry to the last valid input in the SpinButton control.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5091)

