### PR TITLE
Fix hit target of Details column headers

### DIFF
--- a/common/changes/office-ui-fabric-react/details-header_2018-06-05-16-46.json
+++ b/common/changes/office-ui-fabric-react/details-header_2018-06-05-16-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Detials column header hit targets",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.scss
@@ -161,19 +161,18 @@ $isPaddedMargin: 24px;
 }
 
 .cellTitle {
-  display: inline-flex;
+  display: flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: stretch;
   box-sizing: border-box;
   overflow: hidden;
-  max-width: 100%;
   @include focus-border($position: auto);
   padding: 0 8px;
 }
 
 .cellName {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
### Overview

This fixes a bug with the details headers, where the hit target for context menu and clicking was not the width of the column, despite the hover target suggesting it was.
The fix involves making the `cellTitle` element use `flex-shrink: 1` but *not* `flex-grow: 1`, so that the status indicators only anchor at the end when the text content is too wide.

![details header target fix](https://user-images.githubusercontent.com/6828233/40990656-61382796-68a6-11e8-8451-22652ca52b85.gif)