### PR TITLE
HoverCard: IE11 fix

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-HoverCard-IEfix_2018-06-05-17-33.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-HoverCard-IEfix_2018-06-05-17-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "HoverCard: Removing unnecessary animation class causing a visual bug in IE browser.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.tsx
@@ -3,7 +3,7 @@ import { BaseComponent, getNativeProps, divProperties, customizable, KeyCodes, c
 import { IExpandingCardProps, IExpandingCardStyles, ExpandingCardMode } from './ExpandingCard.types';
 import { Callout, ICallout } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { AnimationStyles, mergeStyles } from '../../Styling';
+import { mergeStyles } from '../../Styling';
 import { FocusTrapZone } from '../../FocusTrapZone';
 import { getStyles } from './ExpandingCard.styles';
 
@@ -67,7 +67,7 @@ export class ExpandingCard extends BaseComponent<IExpandingCardProps, IExpanding
       <Callout
         {...getNativeProps(this.props, divProperties)}
         componentRef={this._callout}
-        className={mergeStyles(AnimationStyles.scaleUpIn100, this._styles.root)}
+        className={mergeStyles(this._styles.root)}
         target={targetElement}
         isBeakVisible={false}
         directionalHint={this.props.directionalHint}


### PR DESCRIPTION
#### Pull request checklist

- Include a change request file using `$ npm run change`
- Microsoft Alias (if you have one):  v-vibr

#### Description of changes
Removing an animation style causing a visual bug in IE. When you hover the file it plays the animation before positioning the card next to the target making it flash for a split second in the upper left corner.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5105)

