### PR TITLE
Add optional prop to not dismiss Callout on focus loss

### DIFF
--- a/common/changes/office-ui-fabric-react/no-dismiss-callout_2018-06-04-21-44.json
+++ b/common/changes/office-ui-fabric-react/no-dismiss-callout_2018-06-04-21-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout: Add `preventDismissOnLostFocus` prop.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jetao@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -92,10 +92,16 @@ export interface ICalloutProps {
   isBeakVisible?: boolean;
 
   /**
-   * If true then the onClose will not not dismiss on scroll
+   * If true then the callout will not dismiss on scroll
    * @default false
    */
   preventDismissOnScroll?: boolean;
+
+  /**
+   * If true then the callout will not dismiss when it loses focus
+   * @default false
+   */
+  preventDismissOnLostFocus?: boolean;
 
   /**
    * If true the position returned will have the menu element cover the target.

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -58,6 +58,7 @@ export interface ICalloutState {
 export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutState> {
 
   public static defaultProps = {
+    preventDismissOnLostFocus: false,
     preventDismissOnScroll: false,
     isBeakVisible: true,
     beakWidth: 16,
@@ -253,13 +254,15 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
   protected _dismissOnLostFocus(ev: Event) {
     const target = ev.target as HTMLElement;
     const clickedOutsideCallout = this._hostElement.current && !elementContains(this._hostElement.current, target);
+    const { preventDismissOnLostFocus } = this.props;
 
     if (
-      (!this._target && clickedOutsideCallout) ||
+      !preventDismissOnLostFocus &&
+      ((!this._target && clickedOutsideCallout) ||
       ev.target !== this._targetWindow &&
       clickedOutsideCallout &&
       ((this._target as MouseEvent).stopPropagation ||
-        (!this._target || (target !== this._target && !elementContains(this._target as HTMLElement, target))))) {
+        (!this._target || (target !== this._target && !elementContains(this._target as HTMLElement, target)))))) {
       this.dismiss(ev);
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- Addresses an existing issue: Fixes #0000
- Include a change request file using `$ npm run change`
- Microsoft Alias (if you have one): jetao

#### Description of changes

This change adds an optional prop on Callout which, if set to true, prevents the Callout from dismissing itself when it loses focus. This is potentially useful in TeachingBubble cases where the Callout is unprompted and we may want the Callout to stick around until the user explicitly acknowledges it.

This is a backfix to 5.0 from #5092 

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5106)

