### PR TITLE
fixing official example page and datepicker/calendar components using…

### DIFF
--- a/common/changes/office-ui-fabric-react/jolore-contentBoxFix_2018-06-05-21-50.json
+++ b/common/changes/office-ui-fabric-react/jolore-contentBoxFix_2018-06-05-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "adding css fix to remove unnecessary scroll bars on calendar and datepicker components",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -57,6 +57,7 @@ $Calendar-dayPicker-margin: 10px;
   min-height: 212px;
   padding: 12px;
   display: flex;
+  box-sizing: content-box;
 }
 
 // Wrapper containing the calendar view to pick a specific date.


### PR DESCRIPTION
… box-sizing: content-box on the calendar component to prevent scroll bars

#### Pull request checklist

- Addresses an existing issue: Fixes #5060 
- Include a change request file using `$ npm run change`
- Microsoft Alias (if you have one): jolore

#### Description of changes

adding explicit css check for box-sizing: content-box to the Calendar root component so that the calendar component and datepicker components don't have unnecessary scrollbars.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5108)

