### PR TITLE
Theme Generator: correct untheme when leaving the page

### DIFF
--- a/common/changes/office-ui-fabric-react/phkuo-untheming_2018-06-07-01-03.json
+++ b/common/changes/office-ui-fabric-react/phkuo-untheming_2018-06-07-01-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Theme Generator: untheme correctly when leaving theme generator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
@@ -58,9 +58,7 @@ export class ThemeGeneratorPage extends BaseComponent<{}, IThemeGeneratorPageSta
     document.body.style.color = '';
 
     // and apply the default theme to overwrite any existing custom theme
-    const themeRules = themeRulesStandardCreator();
-    ThemeGenerator.insureSlots(themeRules, false);
-    loadTheme({ palette: themeRules });
+    loadTheme({});
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
#### Pull request checklist

[ ] Addresses an existing issue: Fixes #0000
[x] Include a change request file using `$ npm run change`

#### Description of changes

The theme generator was passing in the wrong object to loadTheme() and breaking CSS on the page when unmounting. Fix it so when you navigate away from the theme generator page, it doesn't break all the other pages.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5127)

