### PR TITLE
SplitButton: add default button props

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-SplitButtonAddDefaultButtonProps_2018-06-07-16-23.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-SplitButtonAddDefaultButtonProps_2018-06-07-16-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SplitButton: apply button props to the focusable element for split buttons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -475,9 +475,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       <KeytipData keytipProps={keytipProps} disabled={disabled}>
         {(keytipAttributes: any): JSX.Element => (
           <div
+            {...buttonProps}
             data-ktp-target={keytipAttributes['data-ktp-target']}
             role={'button'}
-            aria-labelledby={buttonProps.ariaLabel}
             aria-disabled={disabled}
             aria-haspopup={true}
             aria-expanded={this._isExpanded}
@@ -490,7 +490,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
             data-is-focusable={true}
             onClick={!disabled && !primaryDisabled ? this._onSplitButtonPrimaryClick : undefined}
             tabIndex={!disabled ? 0 : undefined}
-            aria-roledescription={buttonProps['aria-roledescription']}
           >
             <span style={{ display: 'flex' }}>
               {this._onRenderContent(tag, buttonProps)}


### PR DESCRIPTION
#### Pull request checklist

[ ] Addresses an existing issue: Fixes #0000
[X] Include a change request file using `$ npm run change`

#### Description of changes
Prior to this PR the focusable element for a split button was not getting the buttonProps.

This PR now applies the buttonProps to the focusable element (e.g. the button) for splitButtons

#### Focus areas to test
Verified that buttonProps are applied (and can be overridden) as expected and the attributes end up in the DOM
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5130)

