### PR TITLE
Add prop setInitialFocus to set initial focus in hover card if needed.

### DIFF
--- a/common/changes/office-ui-fabric-react/chf-2018-06-hoverCard_defaultFirstFocus_2018-06-08-00-28.json
+++ b/common/changes/office-ui-fabric-react/chf-2018-06-hoverCard_defaultFirstFocus_2018-06-08-00-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make it possible to disable firstfocus in hover card",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chf@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/chf-2018-06-hoverCard_defaultFirstFocus_2018-06-08-00-28.json
+++ b/common/changes/office-ui-fabric-react/chf-2018-06-hoverCard_defaultFirstFocus_2018-06-08-00-28.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Make it possible to disable firstfocus in hover card",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
@@ -18,7 +18,8 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
     cardOpenDelay: 500,
     cardDismissDelay: 100,
     expandedCardOpenDelay: 1500,
-    instantOpenOnClick: false
+    instantOpenOnClick: false,
+    defaultFirstFocus: true
   };
 
   // The wrapping div that gets the hover events
@@ -97,7 +98,7 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
             {...getNativeProps(this.props, divProperties)}
             id={hoverCardId}
             trapFocus={!!this.props.trapFocus}
-            firstFocus={openMode === OpenCardMode.hotKey || openMode === OpenCardMode.hover}
+            firstFocus={openMode === (!!this.props.defaultFirstFocus || OpenCardMode.hotKey)}
             targetElement={this._getTargetElement()}
             onEnter={this._cardOpen}
             onLeave={this._executeCardDimiss}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
@@ -98,7 +98,7 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
             {...getNativeProps(this.props, divProperties)}
             id={hoverCardId}
             trapFocus={!!this.props.trapFocus}
-            firstFocus={openMode === (!!this.props.defaultFirstFocus || OpenCardMode.hotKey)}
+            firstFocus={!!this.props.defaultFirstFocus || openMode === OpenCardMode.hotKey}
             targetElement={this._getTargetElement()}
             onEnter={this._cardOpen}
             onLeave={this._executeCardDimiss}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
@@ -19,7 +19,7 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
     cardDismissDelay: 100,
     expandedCardOpenDelay: 1500,
     instantOpenOnClick: false,
-    setInitialFocus: true
+    setInitialFocus: false
   };
 
   // The wrapping div that gets the hover events

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
@@ -98,7 +98,7 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
             {...getNativeProps(this.props, divProperties)}
             id={hoverCardId}
             trapFocus={!!this.props.trapFocus}
-            firstFocus={!!this.props.setInitialFocus || openMode === OpenCardMode.hotKey}
+            firstFocus={this.props.setInitialFocus || openMode === OpenCardMode.hotKey}
             targetElement={this._getTargetElement()}
             onEnter={this._cardOpen}
             onLeave={this._executeCardDimiss}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
@@ -19,7 +19,7 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
     cardDismissDelay: 100,
     expandedCardOpenDelay: 1500,
     instantOpenOnClick: false,
-    defaultFirstFocus: true
+    setInitialFocus: true
   };
 
   // The wrapping div that gets the hover events
@@ -98,7 +98,7 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
             {...getNativeProps(this.props, divProperties)}
             id={hoverCardId}
             trapFocus={!!this.props.trapFocus}
-            firstFocus={!!this.props.defaultFirstFocus || openMode === OpenCardMode.hotKey}
+            firstFocus={!!this.props.setInitialFocus || openMode === OpenCardMode.hotKey}
             targetElement={this._getTargetElement()}
             onEnter={this._cardOpen}
             onLeave={this._executeCardDimiss}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -85,6 +85,11 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement | H
    * Should block hover card or not
    */
   shouldBlockHoverCard?: () => void;
+
+  /**
+   * Set first focus into hover card, default should be true
+   */
+  defaultFirstFocus?: boolean;
 }
 
 export interface IHoverCardStyles {

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -89,7 +89,7 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement | H
   /**
    * Set first focus into hover card, default should be true
    */
-  defaultFirstFocus?: boolean;
+  setInitialFocus?: boolean;
 }
 
 export interface IHoverCardStyles {


### PR DESCRIPTION
#### Pull request checklist

[ ] Addresses an existing issue: Fixes #0000
Issue link: https://github.com/OfficeDev/office-ui-fabric-react/issues/5049
Changes casue issue: https://github.com/OfficeDev/office-ui-fabric-react/commit/0f0a9fa47e601c3018cb1b484c5267f5df046c0d#diff-b116e21b87fb231b4fd30959df4356c3
[ ] Include a change request file using `$ npm run change`

#### Description of changes
This PR is trying to change the default behavior back and add a prop to allow setting first focus in hover card.
Add a prop to control first focus in hovercard

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5135)

