### PR TITLE
Upgrade npm version to 5.4.0

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -1,5 +1,5 @@
 {
-  "npmVersion": "5.3.0",
+  "npmVersion": "5.4.0",
   "rushVersion": "4.3.0",
   "repository": {
     "url": "https://github.com/OfficeDev/office-ui-fabric-react.git"


### PR DESCRIPTION
#### Description of changes

Upgrade npm version to 5.4.0

NPM 5.3.0 has a bug that causes friction with `rush install` (which in turn runs `npm prune`). This bug was fixed in NPM 5.4.0.

#### Focus areas to test

rush install/rush build works locally.