### PR TITLE
ContextualMenu: fix hover click submenu behavior

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-FixHoverClickSubMenuBehavior_2018-06-08-00-31.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-FixHoverClickSubMenuBehavior_2018-06-08-00-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Remove the ability for click to close a submenu. This aligns with windows behavior",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -877,10 +877,7 @@ export class ContextualMenu extends BaseComponent<IContextualMenuProps, IContext
       // This is an item without a menu. Click it.
       this._executeItemClick(item, ev);
     } else {
-      if (item.key === this.state.expandedMenuItemKey) {
-        // This has an expanded sub menu. collapse it.
-        this._onSubMenuDismiss(ev);
-      } else {
+      if (item.key !== this.state.expandedMenuItemKey) {
         // This has a collapsed sub menu. Expand it.
         this.setState({
           // When Edge + Narrator are used together (regardless of if the button is in a form or not), pressing


### PR DESCRIPTION
#### Pull request checklist

[ ] Addresses an existing issue: Fixes #0000
[X] Include a change request file using `$ npm run change`

#### Description of changes
Prior to this change if a user hovered over a menu item which launches a submenu and then click, the menu would expand from the hover and then be dismissed by the click...

The expected behavior is that clicking on the parent menu item does not collapse the expanded submenu (following windows behavior)

Here's the hover (which expands the menu)and then click behavior before and after:

Before (expanding and then clicking with different pauses because it's too fast otherwise):
![contextualmenusubmenuclickoriginal2](https://user-images.githubusercontent.com/7033561/41133405-9409416a-6a7b-11e8-82e5-9f3d8c7433e8.gif)

After:
![contextualmenusubmenuclickfix](https://user-images.githubusercontent.com/7033561/41133295-dbe6ea24-6a7a-11e8-8501-e98076663bc7.gif)

#### Focus areas to test
Verified that the accidental collapse case is fixed and no other functionality is affected (for both button and split button items)
