### PR TITLE
ThemeGenerator: revert to previous themeLighter

### DIFF
--- a/common/changes/office-ui-fabric-react/phkuo-revertThemeLighter_2018-06-08-01-20.json
+++ b/common/changes/office-ui-fabric-react/phkuo-revertThemeLighter_2018-06-08-01-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Theme Generator: add additional accessiblity pair",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
@@ -339,7 +339,8 @@ export class ThemeGeneratorPage extends BaseComponent<{}, IThemeGeneratorPageSta
       // primary color also needs to be accessible, this is also strong variant default
       this._accessibilityRow(FabricSlots.white, FabricSlots.themePrimary),
       this._accessibilityRow(FabricSlots.neutralPrimary, FabricSlots.neutralLighter), // neutral variant default
-      this._accessibilityRow(FabricSlots.themeDark, FabricSlots.neutralLighter)
+      this._accessibilityRow(FabricSlots.themeDark, FabricSlots.neutralLighter),
+      this._accessibilityRow(FabricSlots.neutralPrimary, FabricSlots.themeLighter)
     ]; // neutral variant with primary color
 
     // these are the text and primary colors on top of the soft variant, whose bg depends on invertedness of original theme

--- a/packages/office-ui-fabric-react/src/utilities/color/shades.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/shades.ts
@@ -16,7 +16,7 @@ const WhiteShadeTable = [0.537, 0.349, 0.216, 0.184, 0.145, 0.082, 0.043, 0.027]
 const BlackTintTable = [0.537, 0.45, 0.349, 0.216, 0.184, 0.145, 0.082, 0.043]; // black fg
 const LumTintTable = [0.88, 0.77, 0.66, 0.55, 0.44, 0.33, 0.22, 0.11]; // light (strongen all)
 const LumShadeTable = [0.11, 0.22, 0.33, 0.44, 0.55, 0.66, 0.77, 0.88]; // dark (soften all)
-const ColorTintTable = [0.96, 0.89, 0.7, 0.4, 0.12]; // default soften
+const ColorTintTable = [0.96, 0.84, 0.7, 0.4, 0.12]; // default soften
 const ColorShadeTable = [0.1, 0.24, 0.44]; // default strongen
 
 // If the given shade's luminance is below/above these values, we'll swap to using the White/Black tables above


### PR DESCRIPTION
#### Pull request checklist

[ ] Addresses an existing issue: Fixes #0000
[x] Include a change request file using `$ npm run change`

#### Description of changes

Design has decided to revert a recent change we made to themeLighter due to a change in how we use it for background colors. Also add another accessibility pair to check for the usage of themeLighter as a background.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5142)

