### PR TITLE
Theme Generator: have json output be IPalette

### DIFF
--- a/common/changes/office-ui-fabric-react/phkuo-tgOutput_2018-06-08-02-00.json
+++ b/common/changes/office-ui-fabric-react/phkuo-tgOutput_2018-06-08-02-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Theme Generator: have json output contain only IPalette members",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
@@ -371,7 +371,8 @@ export class ThemeGeneratorPage extends BaseComponent<{}, IThemeGeneratorPageSta
           ruleName.indexOf('ColorShade') === -1 &&
           ruleName !== 'primaryColor' &&
           ruleName !== 'backgroundColor' &&
-          ruleName !== 'foregroundColor'
+          ruleName !== 'foregroundColor' &&
+          ruleName.indexOf('body') === -1
         ) {
           abridgedTheme[ruleName] = themeRules[ruleName];
         }

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeRulesStandard.ts
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeRulesStandard.ts
@@ -180,25 +180,6 @@ export function themeRulesStandardCreator(): IThemeRules {
   slotRules[FabricSlots[FabricSlots.themeDark]].isCustomized = true;
   slotRules[FabricSlots[FabricSlots.themeDarker]].isCustomized = true;
 
-  // todo: can remove this once we remove these outdated slots from the product
-  const primaryBackground = 'primaryBackground';
-  slotRules[primaryBackground] = {
-    name: primaryBackground,
-    inherits: slotRules[FabricSlots[FabricSlots.white]],
-    isCustomized: false,
-    dependentRules: []
-  };
-  slotRules[FabricSlots[FabricSlots.white]].dependentRules.push(slotRules[primaryBackground]);
-
-  const primaryText = 'primaryText';
-  slotRules[primaryText] = {
-    name: primaryText,
-    inherits: slotRules[FabricSlots[FabricSlots.neutralPrimary]],
-    isCustomized: false,
-    dependentRules: []
-  };
-  slotRules[FabricSlots[FabricSlots.neutralPrimary]].dependentRules.push(slotRules[primaryText]);
-
   /*** SEMANTIC SLOTS */
   // create the SlotRule for a semantic slot
   function _makeSemanticSlotRule(semanticSlot: SemanticColorSlots, inheritedFabricSlot: FabricSlots): void {
@@ -216,8 +197,6 @@ export function themeRulesStandardCreator(): IThemeRules {
   // Basic simple slots
   _makeSemanticSlotRule(SemanticColorSlots.bodyBackground, FabricSlots.white);
   _makeSemanticSlotRule(SemanticColorSlots.bodyText, FabricSlots.neutralPrimary);
-  _makeSemanticSlotRule(SemanticColorSlots.disabledBackground, FabricSlots.neutralLighter);
-  _makeSemanticSlotRule(SemanticColorSlots.disabledText, FabricSlots.neutralTertiaryAlt);
 
   return slotRules;
 }


### PR DESCRIPTION
#### Pull request checklist

[x] Addresses an existing issue: Fixes #4986
[x] Include a change request file using `$ npm run change`

#### Description of changes

Have theme generator's JSON output only contain members from IPalette.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5143)

