### PR TITLE
Fixes CI release job that passes --production flag to webpack-utils' tsc call

### DIFF
--- a/common/changes/@uifabric/webpack-utils/webpackutilprod_2018-06-08-14-56.json
+++ b/common/changes/@uifabric/webpack-utils/webpackutilprod_2018-06-08-14-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/webpack-utils",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/webpack-utils",
+  "email": "ken@gizzar.com"
+}

--- a/packages/webpack-utils/package.json
+++ b/packages/webpack-utils/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "node ../../scripts/build-webpack-utils.js",
     "code-style": "node ../../scripts/code-style.js",
     "clean": "node ../../scripts/clean.js"
   },

--- a/rush.json
+++ b/rush.json
@@ -15,7 +15,7 @@
     {
       "packageName": "@uifabric/webpack-utils",
       "projectFolder": "packages/webpack-utils",
-      "shouldPublish": false
+      "shouldPublish": true
     },
     {
       "packageName": "@uifabric/experiments",

--- a/scripts/build-webpack-utils.js
+++ b/scripts/build-webpack-utils.js
@@ -1,0 +1,2 @@
+const tsTask = require('./tasks/ts');
+tsTask({ commonjsOnly: true });

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -1,11 +1,13 @@
-module.exports = function (options) {
+module.exports = function(options) {
+  options = options || {};
   const path = require('path');
   const exec = require('../exec');
   const resolve = require('resolve');
   const typescriptPath = 'node ' + require.resolve('typescript/lib/tsc');
   const libPath = path.resolve(process.cwd(), 'lib');
   const srcPath = path.resolve(process.cwd(), 'src');
-  const extraParams = '--pretty' + (options.isProduction ? ` --inlineSources --sourceRoot ${path.relative(libPath, srcPath)}` : '');
+  const extraParams =
+    '--pretty' + (options.isProduction ? ` --inlineSources --sourceRoot ${path.relative(libPath, srcPath)}` : '');
 
   // Flag to keep track of if we already logged errors.
   // Since we run the ts builds in parallel, we do not want
@@ -14,11 +16,15 @@ module.exports = function (options) {
   let hasLoggedErrors = false;
 
   // We wait for all compilations to be done to report success
-  return Promise.all([
-    runTscFor('lib-commonjs', 'commonjs', extraParams),
-    runTscFor('lib', 'es2015', extraParams),
-  ]);
+  const runPromises = [];
 
+  runPromises.push(runTscFor('lib-commonjs', 'commonjs', extraParams));
+
+  if (!options.commonjsOnly) {
+    runPromises.push(runTscFor('lib', 'es2015', extraParams));
+  }
+
+  return Promise.all(runPromises);
 
   function logFirstStdOutAndRethrow(process) {
     if (!hasLoggedErrors) {
@@ -33,7 +39,9 @@ module.exports = function (options) {
   }
 
   function runTscFor(outDir, moduleType, extraParams) {
-    return exec(typescriptPath + ` -outDir ${outDir} -t es5 -m ${moduleType} ` + extraParams)
-      .then(logSuccessFor(outDir), logFirstStdOutAndRethrow)
+    return exec(typescriptPath + ` -outDir ${outDir} -t es5 -m ${moduleType} ` + extraParams).then(
+      logSuccessFor(outDir),
+      logFirstStdOutAndRethrow
+    );
   }
 };


### PR DESCRIPTION
#### Pull request checklist

[ ] Addresses an existing issue: Fixes #0000
[ ] Include a change request file using `$ npm run change`

#### Description of changes
Fixes CI release job that passes --production flag to webpack-utils' tsc call

This adds a new build script that will just call ts task with commonjs only flag passed in.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5147)

