### PR TITLE
Allow SelectedItemsList and ExtendedPicker to be controlled components

### DIFF
--- a/common/changes/office-ui-fabric-react/amyngu-makePickerControledComponents_2018-06-08-17-02.json
+++ b/common/changes/office-ui-fabric-react/amyngu-makePickerControledComponents_2018-06-08-17-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Enable SelectedItemsList and ExtendedPicker to be controlled components",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "amyngu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -90,7 +90,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
   public render(): JSX.Element {
     const { className, inputProps, disabled } = this.props;
     const activeDescendant =
-      this.floatingPicker.current && this.floatingPicker.current
+      this.floatingPicker.current && this.floatingPicker.current.currentSelectedSuggestionIndex !== -1
         ? 'sug-' + this.floatingPicker.current.currentSelectedSuggestionIndex
         : undefined;
 

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -93,13 +93,23 @@ export interface IBaseExtendedPickerProps<T> {
   itemLimit?: number;
 
   /**
-   * A callback to process a selection after the user selects something from the picker.
+   * A callback to process a selection after the user selects a suggestion from the picker.
+   * The returned item will be added to the selected items list
    */
   onItemSelected?: (selectedItem?: T) => T | PromiseLike<T>;
 
   /**
-   * Deprecated at 5.96.0. Use defaultSelectedItems or selectedItems in selectedItemsListProps instead.
-   * @deprecated
+   * A callback on when an item was added to the selected item list
+   */
+  onItemAdded?: (addedItem: T) => void;
+
+  /**
+   * A callback on when an item or items were removed from the selected item list
+   */
+  onItemsRemoved?: (removedItems: T[]) => void;
+
+  /**
+   * If using as a controlled component use selectedItems here instead of the SelectedItemsList
    */
   selectedItems?: T[];
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
@@ -19,6 +19,7 @@ import {
   SelectedPeopleList,
   IExtendedPersonaProps
 } from '../../SelectedItemsList';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 
 import * as stylesImport from './ExtendedPeoplePicker.Basic.Example.scss';
 // tslint:disable-next-line:no-any
@@ -28,6 +29,8 @@ export interface IPeoplePickerExampleState {
   peopleList: IPersonaProps[];
   mostRecentlyUsed: IPersonaProps[];
   searchMoreAvailable: boolean;
+  currentlySelectedItems: IExtendedPersonaProps[];
+  controlledComponent: boolean;
 }
 
 // tslint:disable-next-line:no-any
@@ -50,7 +53,9 @@ export class ExtendedPeoplePickerTypesExample extends BaseComponent<{}, IPeopleP
     this.state = {
       peopleList: peopleList,
       mostRecentlyUsed: mru,
-      searchMoreAvailable: true
+      searchMoreAvailable: true,
+      currentlySelectedItems: [],
+      controlledComponent: false
     };
 
     this._suggestionProps = {
@@ -154,6 +159,7 @@ export class ExtendedPeoplePickerTypesExample extends BaseComponent<{}, IPeopleP
     return (
       <div>
         {this._renderExtendedPicker()}
+        <Toggle label="Controlled component" defaultChecked={false} onChanged={this._toggleControlledComponent} />
         <PrimaryButton text="Set focus" onClick={this._onSetFocusButtonClicked} />
       </div>
     );
@@ -162,6 +168,9 @@ export class ExtendedPeoplePickerTypesExample extends BaseComponent<{}, IPeopleP
   private _renderExtendedPicker(): JSX.Element {
     return (
       <ExtendedPeoplePicker
+        selectedItems={this.state.controlledComponent ? this.state.currentlySelectedItems : undefined}
+        onItemAdded={this.state.controlledComponent ? this._onItemAdded : undefined}
+        onItemsRemoved={this.state.controlledComponent ? this._onItemsRemoved : undefined}
         floatingPickerProps={this._floatingPickerProps}
         selectedItemsListProps={this._selectedItemsListProps}
         onRenderFloatingPicker={this._onRenderFloatingPicker}
@@ -178,6 +187,10 @@ export class ExtendedPeoplePickerTypesExample extends BaseComponent<{}, IPeopleP
       />
     );
   }
+
+  private _toggleControlledComponent = (toggleState: boolean): void => {
+    this.setState({ controlledComponent: toggleState });
+  };
 
   private _renderHeader(): JSX.Element {
     return <div>TO:</div>;
@@ -315,6 +328,15 @@ export class ExtendedPeoplePickerTypesExample extends BaseComponent<{}, IPeopleP
     // tslint:disable-next-line:no-any
     return new Promise<IPersonaProps[]>((resolve: any, reject: any) => setTimeout(() => resolve(results), 150));
   }
+
+  private _onItemAdded = (selectedSuggestion: IExtendedPersonaProps) => {
+    this.setState({ currentlySelectedItems: this.state.currentlySelectedItems.concat(selectedSuggestion) });
+  };
+
+  private _onItemsRemoved = (items: IExtendedPersonaProps[]): void => {
+    const newItems = this.state.currentlySelectedItems.filter(value => items.indexOf(value) === -1);
+    this.setState({ currentlySelectedItems: newItems });
+  };
 
   private _validateInput = (input: string): boolean => {
     if (input.indexOf('@') !== -1) {

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, getRTL, createRef } from '../../Utilities';
+import { BaseComponent, KeyCodes, css, createRef } from '../../Utilities';
 import { Callout, DirectionalHint } from '../../Callout';
 import { ISuggestionModel } from '../../Pickers';
 import {
@@ -60,6 +60,10 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
     } else {
       this._onValidateInput();
     }
+  }
+
+  public get currentSelectedSuggestionIndex(): number {
+    return this.suggestionsControl && this.suggestionsControl.currentSuggestionIndex;
   }
 
   public get isSuggestionsShown(): boolean {
@@ -152,7 +156,8 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
         gapSpace={5}
         target={this.props.inputElement}
         onDismiss={this.hidePicker}
-        directionalHint={getRTL() ? DirectionalHint.bottomRightEdge : DirectionalHint.bottomLeftEdge}
+        directionalHint={DirectionalHint.bottomLeftEdge}
+        directionalHintForRTL={DirectionalHint.bottomRightEdge}
         calloutWidth={this.props.calloutWidth ? this.props.calloutWidth : 0}
       >
         <TypedSuggestionsControl

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -63,7 +63,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
   }
 
   public get currentSelectedSuggestionIndex(): number {
-    return this.suggestionsControl && this.suggestionsControl.currentSuggestionIndex;
+    return this.suggestionsControl ? this.suggestionsControl.currentSuggestionIndex : -1;
   }
 
   public get isSuggestionsShown(): boolean {

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
@@ -102,6 +102,10 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
     return this._suggestions && this._suggestions.getCurrentItem();
   }
 
+  public get currentSuggestionIndex(): number {
+    return this._suggestions && this._suggestions.currentIndex;
+  }
+
   public hasSuggestionSelected(): boolean {
     return this._suggestions && this._suggestions.hasSuggestionSelected();
   }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
@@ -103,7 +103,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
   }
 
   public get currentSuggestionIndex(): number {
-    return this._suggestions && this._suggestions.currentIndex;
+    return this._suggestions ? this._suggestions.currentIndex : -1;
   }
 
   public hasSuggestionSelected(): boolean {

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
@@ -7,13 +7,6 @@ import { IBaseSelectedItemsList, IBaseSelectedItemsListProps, ISelectedItemProps
 export interface IBaseSelectedItemsListState {
   // tslint:disable-next-line:no-any
   items?: any;
-  suggestedDisplayValue?: string;
-  moreSuggestionsAvailable?: boolean;
-  isSearching?: boolean;
-  isMostRecentlyUsedVisible?: boolean;
-  suggestionsVisible?: boolean;
-  suggestionsLoading?: boolean;
-  isResultsFooterVisible?: boolean;
 }
 
 export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>>
@@ -58,7 +51,6 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>>
       const newItems: T[] = this.state.items.concat(processedItemObjects);
       this.updateItems(newItems);
     }
-    this.setState({ suggestedDisplayValue: '' });
   };
 
   public removeItemAt = (index: number): void => {
@@ -66,8 +58,8 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>>
 
     if (this._canRemoveItem(items[index])) {
       if (index > -1) {
-        if (this.props.onItemDeleted) {
-          (this.props.onItemDeleted as (item: T) => void)(items[index]);
+        if (this.props.onItemsDeleted) {
+          (this.props.onItemsDeleted as (item: T[]) => void)([items[index]]);
         }
 
         const newItems = items.slice(0, index).concat(items.slice(index + 1));
@@ -92,10 +84,8 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>>
     const firstItemToRemove = itemsCanRemove[0];
     const index: number = items.indexOf(firstItemToRemove);
 
-    if (this.props.onItemDeleted) {
-      itemsCanRemove.forEach((item: T) => {
-        (this.props.onItemDeleted as (item: T) => void)(item);
-      });
+    if (this.props.onItemsDeleted) {
+      (this.props.onItemsDeleted as (item: T[]) => void)(itemsCanRemove);
     }
 
     this.updateItems(newItems, index);
@@ -113,7 +103,7 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>>
    */
   public updateItems(items: T[], focusIndex?: number): void {
     if (this.props.selectedItems) {
-      // If the component is a controlled component then the controlling component will need
+      // If the component is a controlled component then the controlling component will need to pass the new props
       this.onChange(items);
     } else {
       this.setState({ items: items }, () => {
@@ -191,10 +181,6 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>>
   protected onChange(items?: T[]): void {
     if (this.props.onChange) {
       (this.props.onChange as (items?: T[]) => void)(items);
-    }
-
-    if (items) {
-      this.selection.setItems(items);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.types.ts
@@ -58,11 +58,16 @@ export interface IBaseSelectedItemsListProps<T> extends React.Props<any> {
    * @default ''
    */
   removeButtonAriaLabel?: string;
-
   /**
-   * A callback when and item is deleted
+   * A callback when an item is deleted
+   * @deprecated Please use onItemsDeleted
    */
   onItemDeleted?: (deletedItem: T) => void;
+
+  /**
+   * A callback when and item or items are deleted
+   */
+  onItemsDeleted?: (deletedItems: T[]) => void;
 
   /**
    * A callback on whether this item can be deleted

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -82,7 +82,8 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
       menuItems: this._createMenuItems(item)
     };
 
-    if ((item as IExtendedPersonaProps).isEditing) {
+    const hasContextMenu = props.menuItems.length > 0;
+    if ((item as IExtendedPersonaProps).isEditing && hasContextMenu) {
       return (
         <EditingItem
           {...props}
@@ -95,7 +96,7 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
     } else {
       const onRenderItem = this.props.onRenderItem as (props: ISelectedPeopleItemProps) => JSX.Element;
       const renderedItem = onRenderItem(props);
-      return props.menuItems.length > 0 ? (
+      return hasContextMenu ? (
         <SelectedItemWithContextMenu
           renderedItem={renderedItem}
           beginEditing={this._beginEditing}

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/examples/SelectedPeopleList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/examples/SelectedPeopleList.Basic.Example.tsx
@@ -12,23 +12,43 @@ import {
 } from '../SelectedPeopleList/SelectedPeopleList';
 import { ExtendedSelectedItem } from '../SelectedPeopleList/Items/ExtendedSelectedItem';
 import { Selection } from 'office-ui-fabric-react/lib/Selection';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 
 import * as stylesImport from './SelectedPeopleList.Basic.Example.scss';
 const styles: any = stylesImport;
 
-export class PeopleSelectedItemsListExample extends BaseComponent<{}, {}> {
+export interface IPeopleSelectedItemsListExampleState {
+  currentSelectedItems: IExtendedPersonaProps[];
+  controlledComponent: boolean;
+}
+
+export class PeopleSelectedItemsListExample extends BaseComponent<{}, IPeopleSelectedItemsListExampleState> {
   private _selectionList: SelectedPeopleList;
   private index: number;
   private selection: Selection = new Selection({ onSelectionChanged: () => this._onSelectionChange() });
 
+  constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      controlledComponent: false,
+      currentSelectedItems: [people[40]]
+    };
+  }
+
   public render(): JSX.Element {
     return (
       <div className={'ms-BasePicker-text'}>
+        <Toggle label="Controlled component" defaultChecked={false} onChanged={this._toggleControlledComponent} />
         <PrimaryButton text="Add another item" onClick={this._onAddItemButtonClicked} />
         {this._renderExtendedPicker()}
       </div>
     );
   }
+
+  private _toggleControlledComponent = (toggleState: boolean): void => {
+    this.setState({ controlledComponent: toggleState });
+  };
 
   private _renderExtendedPicker(): JSX.Element {
     return (
@@ -37,6 +57,7 @@ export class PeopleSelectedItemsListExample extends BaseComponent<{}, {}> {
           key={'normal'}
           removeButtonAriaLabel={'Remove'}
           defaultSelectedItems={[people[40]]}
+          selectedItems={this.state.controlledComponent ? this.state.currentSelectedItems : undefined}
           componentRef={this._setComponentRef}
           onCopyItems={this._onCopyItems}
           onExpandGroup={this._onExpandItem}
@@ -44,6 +65,7 @@ export class PeopleSelectedItemsListExample extends BaseComponent<{}, {}> {
           removeMenuItemText={'Remove'}
           selection={this.selection}
           onRenderItem={this._onRenderItem}
+          onItemDeleted={this.state.controlledComponent ? this._onItemDeleted : undefined}
         />
       </div>
     );
@@ -62,14 +84,37 @@ export class PeopleSelectedItemsListExample extends BaseComponent<{}, {}> {
       if (!this.index) {
         this.index = 0;
       }
-      this._selectionList.addItems([people[this.index]]);
+
+      if (this.state.controlledComponent) {
+        this.setState({ currentSelectedItems: [...this.state.currentSelectedItems, people[this.index]] });
+      } else {
+        this._selectionList.addItems([people[this.index]]);
+      }
       this.index++;
     }
   };
 
+  private _onItemDeleted = (item: IExtendedPersonaProps): void => {
+    const indexToRemove = this.state.currentSelectedItems.indexOf(item);
+    this.setState({
+      currentSelectedItems: this.state.currentSelectedItems
+        .slice(0, indexToRemove)
+        .concat(this.state.currentSelectedItems.slice(indexToRemove + 1))
+    });
+  };
+
   private _onExpandItem = (item: IExtendedPersonaProps): void => {
-    // tslint:disable-next-line:no-any
-    this._selectionList.replaceItem(item, this._getExpandedGroupItems(item as any));
+    if (this.state.controlledComponent) {
+      const indexToExpand = this.state.currentSelectedItems.indexOf(item);
+      this.setState({
+        currentSelectedItems: this.state.currentSelectedItems
+          .slice(0, indexToExpand)
+          .concat(this._getExpandedGroupItems(item as any))
+          .concat(this.state.currentSelectedItems.slice(indexToExpand + 1))
+      });
+    } else {
+      this._selectionList.replaceItem(item, this._getExpandedGroupItems(item as any));
+    }
   };
 
   private _onSelectionChange(): void {


### PR DESCRIPTION
#### Pull request checklist
[x] Include a change request file using `$ npm run change`

#### Description of changes
- Allow SelectedItemsList and ExtendedPicker's selected items to be controlled components by utilizing the selectedItems prop
- Add onItemAdded and onItemsRemoved callbacks in BaseExtendedPicker props
- Add onItemsDeleted callback in BaseSelectedItemsList props (deprecating onItemDeleted)
- Actually use onItemSelected as a filtering method in BaseExtendedPicker
- Fix aria-activedecendent label on BaseExtendedPicker
- Remove unneeded/unused properties in IBaseSelectedItemsListState 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5149)

