### PR TITLE
Add styling output to component example snapshots

### DIFF
--- a/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
@@ -4,10 +4,14 @@ import * as renderer from 'react-test-renderer';
 import { resetIds } from '../Utilities';
 
 import * as DataUtil from '@uifabric/example-app-base/lib-commonjs/utilities/data';
+import * as mergeStylesSerializer from '@uifabric/jest-serializer-merge-styles';
 
 // Extend Jest Expect to allow us to map each component example to its own snapshot file.
 const snapshotsStateMap = new Map();
 const jestSnapshot = require('jest-snapshot');
+
+// Using this serializer makes sure we capture styling in snapshot output
+jestSnapshot.addSerializer(mergeStylesSerializer);
 
 expect.extend({
   toMatchSpecificSnapshot(received, snapshotFile) {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -3,15 +3,47 @@
 exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-ActivityItem exampleRoot-42"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: flex-start;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-46"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            font-size: 16px;
+            height: 32px;
+            line-height: 16px;
+            margin-top: 3px;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-52"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-1";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
         data-icon-name="Message"
         role="presentation"
       >
@@ -19,14 +51,73 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
       </i>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-47"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Philippe Lampros
@@ -36,14 +127,66 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
         </span>
       </span>
       <div
-        className="ms-ActivityItem-commentText css-49"
+        className=
+            ms-ActivityItem-commentText
+            {
+              color: #333333;
+            }
       >
         <span>
           Hello! I am making a comment and mentioning 
         </span>
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           @Anđela Debeljak
@@ -53,22 +196,63 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
         </span>
       </div>
       <div
-        className="ms-ActivityItem-timeStamp css-50"
+        className=
+            ms-ActivityItem-timeStamp
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #666666;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 10px;
+              font-weight: 400;
+            }
       >
         Just now
       </div>
     </div>
   </div>
   <div
-    className="ms-ActivityItem exampleRoot-42"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: flex-start;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-46"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            font-size: 16px;
+            height: 32px;
+            line-height: 16px;
+            margin-top: 3px;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-55"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
         data-icon-name="Trash"
         role="presentation"
       >
@@ -76,14 +260,73 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
       </i>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-47"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Lisha Refai
@@ -92,28 +335,73 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
            deleted 
         </span>
         <span
-          className="nameText-38"
+          className=
+
+              {
+                font-weight: bold;
+              }
         >
           DocumentTitle.docx
         </span>
       </span>
       <div
-        className="ms-ActivityItem-timeStamp css-50"
+        className=
+            ms-ActivityItem-timeStamp
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #666666;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 10px;
+              font-weight: 400;
+            }
       >
         2 hours ago
       </div>
     </div>
   </div>
   <div
-    className="ms-ActivityItem exampleRoot-42"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: flex-start;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-46"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            font-size: 16px;
+            height: 32px;
+            line-height: 16px;
+            margin-top: 3px;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-57"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-7";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
         data-icon-name="FabricMovetoFolder"
         role="presentation"
       >
@@ -121,14 +409,73 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
       </i>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-47"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Julian Arvidsson
@@ -138,7 +485,55 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
         </span>
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           PresentationTitle.pptx
@@ -148,14 +543,71 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
         </span>
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Destination Folder
         </button>
       </span>
       <div
-        className="ms-ActivityItem-timeStamp css-50"
+        className=
+            ms-ActivityItem-timeStamp
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #666666;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 10px;
+              font-weight: 400;
+            }
       >
         Yesterday
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
@@ -3,17 +3,84 @@
 exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-ActivityItem exampleRoot-61"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-64"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            align-items: center;
+            color: #0078d4;
+            display: flex;
+            font-size: 13px;
+            height: 16px;
+            justify-content: center;
+            line-height: 13px;
+            margin-top: 1px;
+            min-width: 16px;
+            position: relative;
+          }
+          & .ms-Persona-imageArea {
+            border-radius: 50%;
+            border: 2px solid#ffffff;
+            margin-bottom: 0;
+            margin-left: -2px;
+            margin-right: 0;
+            margin-top: -2px;
+          }
+          @media screen and (-ms-high-contrast: active){& .ms-Persona-imageArea {
+            border: none;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+          }
     >
       <div
-        className="ms-ActivityItem-personaContainer css-62"
+        className=
+            ms-ActivityItem-personaContainer
+            {
+              display: inline-flex;
+              flex-basis: auto;
+              flex-wrap: nowrap;
+              height: 16px;
+              min-width: 0;
+              padding-right: 6px;
+              width: auto;
+            }
       >
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-67"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                min-width: 8px;
+                overflow: visible;
+                width: 8px;
+              }
           size={8}
           style={
             Object {
@@ -25,11 +92,33 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           }
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -39,7 +128,22 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -51,13 +155,32 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
       </div>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-65"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            flex: 1;
+            overflow-x: hidden;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <span
-          className="nameText-38"
+          className=
+
+              {
+                font-weight: bold;
+              }
         >
           Tahlia Whittle
         </span>
@@ -68,17 +191,84 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
     </div>
   </div>
   <div
-    className="ms-ActivityItem exampleRoot-61"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-64"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            align-items: center;
+            color: #0078d4;
+            display: flex;
+            font-size: 13px;
+            height: 16px;
+            justify-content: center;
+            line-height: 13px;
+            margin-top: 1px;
+            min-width: 16px;
+            position: relative;
+          }
+          & .ms-Persona-imageArea {
+            border-radius: 50%;
+            border: 2px solid#ffffff;
+            margin-bottom: 0;
+            margin-left: -2px;
+            margin-right: 0;
+            margin-top: -2px;
+          }
+          @media screen and (-ms-high-contrast: active){& .ms-Persona-imageArea {
+            border: none;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+          }
     >
       <div
-        className="ms-ActivityItem-personaContainer css-62"
+        className=
+            ms-ActivityItem-personaContainer
+            {
+              display: inline-flex;
+              flex-basis: auto;
+              flex-wrap: nowrap;
+              height: 16px;
+              min-width: 0;
+              padding-right: 6px;
+              width: auto;
+            }
       >
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-67"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                min-width: 8px;
+                overflow: visible;
+                width: 8px;
+              }
           size={8}
           style={
             Object {
@@ -90,12 +280,37 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           }
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
               aria-hidden="true"
-              className="ms-Persona-initials initials-77"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #00A300;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 11px;
+                    font-weight: 400;
+                    height: 16px;
+                    line-height: 16px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                  }
               style={undefined}
             >
               <span>
@@ -103,7 +318,21 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               </span>
             </div>
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -113,7 +342,22 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -123,7 +367,21 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-67"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                min-width: 8px;
+                overflow: visible;
+                width: 8px;
+              }
           size={8}
           style={
             Object {
@@ -135,11 +393,33 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           }
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -149,7 +429,22 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -159,7 +454,21 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-67"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                min-width: 8px;
+                overflow: visible;
+                width: 8px;
+              }
           size={8}
           style={
             Object {
@@ -171,12 +480,37 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           }
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
               aria-hidden="true"
-              className="ms-Persona-initials initials-78"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #603CBA;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 11px;
+                    font-weight: 400;
+                    height: 16px;
+                    line-height: 16px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                  }
               style={undefined}
             >
               <span>
@@ -184,7 +518,21 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               </span>
             </div>
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -194,7 +542,22 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -206,13 +569,32 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
       </div>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-65"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            flex: 1;
+            overflow-x: hidden;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <span
-          className="nameText-38"
+          className=
+
+              {
+                font-weight: bold;
+              }
         >
           Patrick Loton
         </span>
@@ -220,7 +602,11 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
            and 
         </span>
         <span
-          className="nameText-38"
+          className=
+
+              {
+                font-weight: bold;
+              }
         >
            
           6 others
@@ -229,15 +615,68 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
     </div>
   </div>
   <div
-    className="ms-ActivityItem exampleRoot-61"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-64"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            align-items: center;
+            color: #0078d4;
+            display: flex;
+            font-size: 13px;
+            height: 16px;
+            justify-content: center;
+            line-height: 13px;
+            margin-top: 1px;
+            min-width: 16px;
+            position: relative;
+          }
+          & .ms-Persona-imageArea {
+            border-radius: 50%;
+            border: 2px solid#ffffff;
+            margin-bottom: 0;
+            margin-left: -2px;
+            margin-right: 0;
+            margin-top: -2px;
+          }
+          @media screen and (-ms-high-contrast: active){& .ms-Persona-imageArea {
+            border: none;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-55"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
         data-icon-name="Add"
         role="presentation"
       >
@@ -245,13 +684,32 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
       </i>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-65"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            flex: 1;
+            overflow-x: hidden;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <span
-          className="nameText-38"
+          className=
+
+              {
+                font-weight: bold;
+              }
         >
           Sabrina De Luca
         </span>
@@ -262,15 +720,68 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
     </div>
   </div>
   <div
-    className="ms-ActivityItem exampleRoot-61"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-64"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            align-items: center;
+            color: #0078d4;
+            display: flex;
+            font-size: 13px;
+            height: 16px;
+            justify-content: center;
+            line-height: 13px;
+            margin-top: 1px;
+            min-width: 16px;
+            position: relative;
+          }
+          & .ms-Persona-imageArea {
+            border-radius: 50%;
+            border: 2px solid#ffffff;
+            margin-bottom: 0;
+            margin-left: -2px;
+            margin-right: 0;
+            margin-top: -2px;
+          }
+          @media screen and (-ms-high-contrast: active){& .ms-Persona-imageArea {
+            border: none;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-55"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
         data-icon-name="Share"
         role="presentation"
       >
@@ -278,13 +789,32 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
       </i>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-65"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            flex: 1;
+            overflow-x: hidden;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <span
-          className="nameText-38"
+          className=
+
+              {
+                font-weight: bold;
+              }
         >
           Chuan Rojumanong
         </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -3,26 +3,89 @@
 exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-ActivityItem exampleRoot-42"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: flex-start;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-46"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            font-size: 16px;
+            height: 32px;
+            line-height: 16px;
+            margin-top: 3px;
+          }
     >
       <div
-        className="ms-ActivityItem-personaContainer css-44"
+        className=
+            ms-ActivityItem-personaContainer
+            {
+              display: flex;
+              flex-wrap: wrap;
+              height: 32px;
+              min-width: 32px;
+              width: 32px;
+            }
       >
         <div
-          className="ms-Persona-coin ms-Persona--size32 ms-ActivityItem-activityPersona coin-79"
+          className=
+              ms-Persona-coin
+              ms-Persona--size32
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={11}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-80"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 32px;
+                  position: relative;
+                  text-align: center;
+                  width: 32px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-83"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 32px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 32px;
+                  }
               style={
                 Object {
                   "height": 32,
@@ -32,7 +95,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -44,14 +122,73 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
       </div>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-47"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Jack Howden
@@ -60,45 +197,131 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
            renamed 
         </span>
         <span
-          className="nameText-38"
+          className=
+
+              {
+                font-weight: bold;
+              }
         >
           DocumentTitle.docx
         </span>
       </span>
       <div
-        className="ms-ActivityItem-commentText css-49"
+        className=
+            ms-ActivityItem-commentText
+            {
+              color: #333333;
+            }
       >
         Hello, this is the text of my basic comment!
       </div>
       <div
-        className="ms-ActivityItem-timeStamp css-50"
+        className=
+            ms-ActivityItem-timeStamp
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #666666;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 10px;
+              font-weight: 400;
+            }
       >
         23m ago
       </div>
     </div>
   </div>
   <div
-    className="ms-ActivityItem exampleRoot-42"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: flex-start;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-46"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            font-size: 16px;
+            height: 32px;
+            line-height: 16px;
+            margin-top: 3px;
+          }
     >
       <div
-        className="ms-ActivityItem-personaContainer css-44"
+        className=
+            ms-ActivityItem-personaContainer
+            {
+              display: flex;
+              flex-wrap: wrap;
+              height: 32px;
+              min-width: 32px;
+              width: 32px;
+            }
       >
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-86"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+              &:first-child {
+                align-self: flex-end;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
               aria-hidden="true"
-              className="ms-Persona-initials initials-87"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #B91D47;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 11px;
+                    font-weight: 400;
+                    height: 16px;
+                    line-height: 16px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                  }
               style={undefined}
             >
               <span>
@@ -106,7 +329,21 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               </span>
             </div>
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -116,7 +353,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -126,16 +378,52 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-86"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+              &:first-child {
+                align-self: flex-end;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -145,7 +433,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -157,14 +460,73 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
       </div>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-47"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Javiera Márquez
@@ -174,7 +536,55 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
         </span>
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Amelia Povalіy
@@ -184,41 +594,164 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
         </span>
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           SpreadsheetTitle.xlsx
         </button>
       </span>
       <div
-        className="ms-ActivityItem-timeStamp css-50"
+        className=
+            ms-ActivityItem-timeStamp
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #666666;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 10px;
+              font-weight: 400;
+            }
       >
         9:27 am
       </div>
     </div>
   </div>
   <div
-    className="ms-ActivityItem exampleRoot-42"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: flex-start;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-46"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            font-size: 16px;
+            height: 32px;
+            line-height: 16px;
+            margin-top: 3px;
+          }
     >
       <div
-        className="ms-ActivityItem-personaContainer css-44"
+        className=
+            ms-ActivityItem-personaContainer
+            {
+              display: flex;
+              flex-wrap: wrap;
+              height: 32px;
+              min-width: 32px;
+              width: 32px;
+            }
       >
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-79"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
               aria-hidden="true"
-              className="ms-Persona-initials initials-77"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #00A300;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 11px;
+                    font-weight: 400;
+                    height: 16px;
+                    line-height: 16px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                  }
               style={undefined}
             >
               <span>
@@ -226,7 +759,21 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               </span>
             </div>
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -236,7 +783,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -246,16 +808,49 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-79"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -265,7 +860,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -275,16 +885,49 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-79"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -294,7 +937,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -306,14 +964,73 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
       </div>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-47"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Robert Larsson
@@ -323,7 +1040,55 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
         </span>
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           2 others
@@ -333,34 +1098,109 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
         </span>
       </span>
       <div
-        className="ms-ActivityItem-timeStamp css-50"
+        className=
+            ms-ActivityItem-timeStamp
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #666666;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 10px;
+              font-weight: 400;
+            }
       >
         3 days ago
       </div>
     </div>
   </div>
   <div
-    className="ms-ActivityItem exampleRoot-42"
+    className=
+        ms-ActivityItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: flex-start;
+          box-sizing: border-box;
+          color: #666666;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          justify-content: flex-start;
+          line-height: 17px;
+          margin-top: 20px;
+        }
     style={undefined}
   >
     <div
-      className="ms-ActivityItem-activityTypeIcon css-46"
+      className=
+          ms-ActivityItem-activityTypeIcon
+          {
+            font-size: 16px;
+            height: 32px;
+            line-height: 16px;
+            margin-top: 3px;
+          }
     >
       <div
-        className="ms-ActivityItem-personaContainer css-44"
+        className=
+            ms-ActivityItem-personaContainer
+            {
+              display: flex;
+              flex-wrap: wrap;
+              height: 32px;
+              min-width: 32px;
+              width: 32px;
+            }
       >
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-79"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
               aria-hidden="true"
-              className="ms-Persona-initials initials-88"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #1E7145;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 11px;
+                    font-weight: 400;
+                    height: 16px;
+                    line-height: 16px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                  }
               style={undefined}
             >
               <span>
@@ -368,7 +1208,21 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               </span>
             </div>
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -378,7 +1232,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -388,16 +1257,49 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-79"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -407,7 +1309,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -417,17 +1334,53 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-79"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
               aria-hidden="true"
-              className="ms-Persona-initials initials-77"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #00A300;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 11px;
+                    font-weight: 400;
+                    height: 16px;
+                    line-height: 16px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                  }
               style={undefined}
             >
               <span>
@@ -435,7 +1388,21 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               </span>
             </div>
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -445,7 +1412,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -455,16 +1437,49 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-Persona-coin ms-Persona--size16 ms-ActivityItem-activityPersona coin-79"
+          className=
+              ms-Persona-coin
+              ms-Persona--size16
+              ms-ActivityItem-activityPersona
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={8}
           style={undefined}
         >
           <div
-            className="ms-Persona-imageArea imageArea-69"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 16px;
+                  position: relative;
+                  text-align: center;
+                  width: 16px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-73"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 16px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 16px;
+                  }
               style={
                 Object {
                   "height": undefined,
@@ -474,7 +1489,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -486,14 +1516,73 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
       </div>
     </div>
     <div
-      className="ms-ActivityItem-activityContent css-47"
+      className=
+          ms-ActivityItem-activityContent
+          {
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+          }
     >
       <span
-        className="ms-ActivityItem-activityText css-48"
+        className=
+            ms-ActivityItem-activityText
+            {
+              display: inline;
+            }
       >
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           Jin Cheng
@@ -503,7 +1592,55 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
         </span>
         <button
           aria-disabled={undefined}
-          className="ms-Link nameText-53"
+          className=
+              ms-Link
+              {
+                background-color: transparent;
+                background: none;
+                border: none;
+                color: #0078d4;
+                cursor: pointer;
+                display: inline;
+                font-size: inherit;
+                font-weight: bold;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                outline: transparent;
+                overflow: inherit;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                text-align: left;
+                text-overflow: inherit;
+                user-select: text;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           onClick={[Function]}
         >
           5 others
@@ -513,7 +1650,16 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
         </span>
       </span>
       <div
-        className="ms-ActivityItem-timeStamp css-50"
+        className=
+            ms-ActivityItem-timeStamp
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #666666;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 10px;
+              font-weight: 400;
+            }
       >
         August 3, 2017
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -3,12 +3,34 @@
 exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] = `
 <div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     With no maxDisplayedItems
   </label>
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -20,7 +42,14 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     >
       <div
         aria-label="Website breadcrumb"
-        className="ms-Breadcrumb root-90"
+        className=
+            ms-Breadcrumb
+            {
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 23px;
+            }
         role="navigation"
       >
         <div
@@ -34,15 +63,126 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           role="presentation"
         >
           <ol
-            className="ms-Breadcrumb-list list-91"
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
           >
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -58,7 +198,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -66,12 +228,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -87,7 +346,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -95,12 +376,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -116,7 +494,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -124,12 +524,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -145,7 +642,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -153,12 +672,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -174,7 +790,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -182,12 +820,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current="page"
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -208,7 +943,24 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
     style={
       Object {
         "marginTop": "24px",
@@ -218,7 +970,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     With Custom Divider Icon
   </label>
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -230,7 +987,14 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     >
       <div
         aria-label="Website breadcrumb"
-        className="ms-Breadcrumb root-90"
+        className=
+            ms-Breadcrumb
+            {
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 23px;
+            }
         role="navigation"
       >
         <div
@@ -244,15 +1008,126 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           role="presentation"
         >
           <ol
-            className="ms-Breadcrumb-list list-91"
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
           >
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -286,12 +1161,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </div>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -325,12 +1297,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </div>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -364,12 +1433,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </div>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -403,12 +1569,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </div>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -442,12 +1705,109 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </div>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current="page"
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -468,7 +1828,24 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
     style={
       Object {
         "marginTop": "24px",
@@ -478,7 +1855,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     With maxDisplayedItems set to three
   </label>
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -490,7 +1872,14 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     >
       <div
         aria-label="Website breadcrumb"
-        className="ms-Breadcrumb root-90"
+        className=
+            ms-Breadcrumb
+            {
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 23px;
+            }
         role="navigation"
       >
         <div
@@ -504,10 +1893,30 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           role="presentation"
         >
           <ol
-            className="ms-Breadcrumb-list list-91"
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
           >
             <li
-              className="ms-Breadcrumb-overflow overflow-94"
+              className=
+                  ms-Breadcrumb-overflow
+                  {
+                    align-items: center;
+                    display: flex;
+                    position: relative;
+                  }
             >
               <button
                 aria-describedby={undefined}
@@ -517,7 +1926,84 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 aria-labelledby={undefined}
                 aria-owns={null}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--icon ms-Breadcrumb-overflowButton overflowButton-101"
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-Breadcrumb-overflowButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 16px;
+                      font-weight: 400;
+                      height: 100%;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 32px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    &:hover:active {
+                      background-color: #d0d0d0;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      padding-bottom: 4px;
+                      padding-left: 6px;
+                      padding-right: 6px;
+                      padding-top: 4px;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 15px;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 onClick={[Function]}
@@ -526,11 +2012,39 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-102"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Button-icon icon-109"
+                    className=
+                        ms-Button-icon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 16px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          speak: none;
+                          text-align: center;
+                          vertical-align: middle;
+                        }
                     data-icon-name="More"
                     role="presentation"
                   >
@@ -540,7 +2054,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -548,12 +2084,98 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <a
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-110"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 href="#/examples/breadcrumb"
                 onClick={[Function]}
                 target={undefined}
@@ -571,7 +2193,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </a>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -579,12 +2223,98 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <a
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-110"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 href="#/examples/breadcrumb"
                 onClick={[Function]}
                 target={undefined}
@@ -602,7 +2332,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </a>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -610,12 +2362,98 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <a
                 aria-current="page"
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-110"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 href="#/examples/breadcrumb"
                 onClick={[Function]}
                 target={undefined}
@@ -638,7 +2476,24 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
     style={
       Object {
         "marginTop": "24px",
@@ -648,7 +2503,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     With maxDisplayedItems set to two and overflowIndex set to 1 (second element)
   </label>
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -660,7 +2520,14 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
     >
       <div
         aria-label={undefined}
-        className="ms-Breadcrumb root-90"
+        className=
+            ms-Breadcrumb
+            {
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 23px;
+            }
         role="navigation"
       >
         <div
@@ -674,13 +2541,59 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           role="presentation"
         >
           <ol
-            className="ms-Breadcrumb-list list-91"
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
           >
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <span
-                className="ms-Breadcrumb-item item-97"
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      max-width: 160px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
               >
                 <div
                   aria-describedby={undefined}
@@ -695,7 +2608,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </span>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -703,7 +2638,13 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-overflow overflow-94"
+              className=
+                  ms-Breadcrumb-overflow
+                  {
+                    align-items: center;
+                    display: flex;
+                    position: relative;
+                  }
             >
               <button
                 aria-describedby={undefined}
@@ -713,7 +2654,84 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 aria-labelledby={undefined}
                 aria-owns={null}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--icon ms-Breadcrumb-overflowButton overflowButton-101"
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-Breadcrumb-overflowButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 16px;
+                      font-weight: 400;
+                      height: 100%;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 32px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    &:hover:active {
+                      background-color: #d0d0d0;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      padding-bottom: 4px;
+                      padding-left: 6px;
+                      padding-right: 6px;
+                      padding-top: 4px;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 15px;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 onClick={[Function]}
@@ -722,11 +2740,39 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-102"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Button-icon icon-109"
+                    className=
+                        ms-Button-icon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 16px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          speak: none;
+                          text-align: center;
+                          vertical-align: middle;
+                        }
                     data-icon-name="More"
                     role="presentation"
                   >
@@ -736,7 +2782,29 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -744,10 +2812,42 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <span
-                className="ms-Breadcrumb-item item-97"
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      max-width: 160px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
               >
                 <div
                   aria-describedby={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -9,7 +9,12 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
   }
 >
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -21,7 +26,14 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
     >
       <div
         aria-label="Website breadcrumb"
-        className="ms-Breadcrumb root-90"
+        className=
+            ms-Breadcrumb
+            {
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 23px;
+            }
         role="navigation"
       >
         <div
@@ -35,10 +47,30 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
           role="presentation"
         >
           <ol
-            className="ms-Breadcrumb-list list-91"
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
           >
             <li
-              className="ms-Breadcrumb-overflow overflow-94"
+              className=
+                  ms-Breadcrumb-overflow
+                  {
+                    align-items: center;
+                    display: flex;
+                    position: relative;
+                  }
             >
               <button
                 aria-describedby={undefined}
@@ -48,7 +80,84 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                 aria-labelledby={undefined}
                 aria-owns={null}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--icon ms-Breadcrumb-overflowButton overflowButton-101"
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-Breadcrumb-overflowButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 16px;
+                      font-weight: 400;
+                      height: 100%;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 32px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    &:hover:active {
+                      background-color: #d0d0d0;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      padding-bottom: 4px;
+                      padding-left: 6px;
+                      padding-right: 6px;
+                      padding-top: 4px;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 15px;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 onClick={[Function]}
@@ -57,11 +166,39 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-102"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Button-icon icon-109"
+                    className=
+                        ms-Button-icon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 16px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          speak: none;
+                          text-align: center;
+                          vertical-align: middle;
+                        }
                     data-icon-name="More"
                     role="presentation"
                   >
@@ -71,7 +208,29 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -79,12 +238,109 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -100,7 +356,29 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -108,12 +386,109 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current={undefined}
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div
@@ -129,7 +504,29 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
               </button>
               <i
                 aria-hidden={true}
-                className="ms-Breadcrumb-chevron chevron-100"
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
                 data-icon-name="ChevronRight"
                 role="presentation"
               >
@@ -137,12 +534,109 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
               </i>
             </li>
             <li
-              className="ms-Breadcrumb-listItem listItem-92"
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
             >
               <button
                 aria-current="page"
                 aria-disabled={undefined}
-                className="ms-Link ms-Breadcrumb-itemLink itemLink-99"
+                className=
+                    ms-Link
+                    ms-Breadcrumb-itemLink
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      max-width: 160px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: left;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: text;
+                      white-space: nowrap;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:active, &:hover, &:active:hover {
+                      color: #004578;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                      text-decoration: underline;
+                    }
+                    &:focus {
+                      color: #212121;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: initial;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 17px;
+                      font-weight: 300;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      max-width: 116px;
+                    }
                 onClick={[Function]}
               >
                 <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Action.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Action.Example.tsx.shot
@@ -2,7 +2,14 @@
 
 exports[`Component Examples renders Button.Action.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsExample example-111"
+  className=
+      ms-BasicButtonsExample
+      & .ms-Button {
+        margin-bottom: 10px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 10px;
+      }
 >
   <button
     aria-describedby={undefined}
@@ -10,28 +17,135 @@ exports[`Component Examples renders Button.Action.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-pressed={undefined}
     checked={undefined}
-    className="ms-Button ms-Button--action ms-Button--command root-113"
+    className=
+        ms-Button
+        ms-Button--action
+        ms-Button--command
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: transparent;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 40px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          color: #0078d4;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:hover .ms-Button-icon {
+          color: #0078d4;
+        }
+        &:active {
+          color: #000000;
+        }
+        &:active .ms-Button-icon {
+          color: #004578;
+        }
     data-automation-id="test"
     data-is-focusable={true}
     disabled={undefined}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-114"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: flex-start;
+          }
     >
       <i
         aria-hidden={true}
-        className="ms-Button-icon icon-118"
+        className=
+            ms-Button-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #106ebe;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 16px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="AddFriend"
         role="presentation"
       >
         
       </i>
       <div
-        className="ms-Button-textContainer textContainer-115"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 0;
+            }
       >
         <div
-          className="ms-Button-label label-105"
+          className=
+              ms-Button-label
+              {
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Create account

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Anchor.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Anchor.Example.tsx.shot
@@ -2,7 +2,14 @@
 
 exports[`Component Examples renders Button.Anchor.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsExample example-111"
+  className=
+      ms-BasicButtonsExample
+      & .ms-Button {
+        margin-bottom: 10px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 10px;
+      }
 >
   <a
     aria-describedby={undefined}
@@ -10,7 +17,69 @@ exports[`Component Examples renders Button.Anchor.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-pressed={undefined}
     checked={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-automation-id="test"
     data-is-focusable={true}
     disabled={undefined}
@@ -19,13 +88,34 @@ exports[`Component Examples renders Button.Anchor.Example.tsx correctly 1`] = `
     title="let us bing!"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Bing

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Command.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Command.Example.tsx.shot
@@ -20,7 +20,73 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
       aria-owns={null}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--action ms-Button--command root-113"
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 40px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:active {
+            color: #000000;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       disabled={undefined}
@@ -29,21 +95,62 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-114"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-icon icon-118"
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #106ebe;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="Add"
           role="presentation"
         >
           
         </i>
         <div
-          className="ms-Button-textContainer textContainer-115"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 0;
+              }
         >
           <div
-            className="ms-Button-label label-105"
+            className=
+                ms-Button-label
+                {
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Create account
@@ -51,7 +158,28 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
         </div>
         <i
           aria-hidden={true}
-          className="ms-Button-menuIcon menuIcon-121"
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >
@@ -65,28 +193,135 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
       aria-labelledby={undefined}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--action ms-Button--command root-113"
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 40px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:active {
+            color: #000000;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
       data-automation-id="test2"
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-114"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-icon icon-118"
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #106ebe;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="Mail"
           role="presentation"
         >
           
         </i>
         <div
-          className="ms-Button-textContainer textContainer-115"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 0;
+              }
         >
           <div
-            className="ms-Button-label label-105"
+            className=
+                ms-Button-label
+                {
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__3"
           >
             Send Mail

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
@@ -20,7 +20,70 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
       aria-owns={null}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--commandBar root-122"
+      className=
+          ms-Button
+          ms-Button--commandBar
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            min-width: 40px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: 4px;
+            left: 4px;
+            outline-color: ButtonText;
+            right: 4px;
+            top: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: Highlight;
+          }
+          &:active {
+            background-color: #dadada;
+            color: #000000;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       disabled={undefined}
@@ -29,21 +92,63 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-icon icon-118"
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #106ebe;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="Add"
           role="presentation"
         >
           
         </i>
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-123"
+            className=
+                ms-Button-label
+                {
+                  font-weight: normal;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Create account
@@ -51,7 +156,28 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
         </div>
         <i
           aria-hidden={true}
-          className="ms-Button-menuIcon menuIcon-121"
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >
@@ -68,7 +194,40 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
       aria-labelledby={undefined}
       aria-pressed={undefined}
       checked={undefined}
-      className="css-125"
+      className=
+
+          {
+            display: inline-flex;
+            outline: transparent;
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            outline: none!important;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       data-ktp-target={undefined}
@@ -93,7 +252,70 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           checked={undefined}
-          className="ms-Button ms-Button--commandBar root-122"
+          className=
+              ms-Button
+              ms-Button--commandBar
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                min-width: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: 4px;
+                left: 4px;
+                outline-color: ButtonText;
+                right: 4px;
+                top: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border: none;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: Highlight;
+              }
+              &:active {
+                background-color: #dadada;
+                color: #000000;
+              }
           data-automation-id="test"
           data-is-focusable={false}
           disabled={undefined}
@@ -102,21 +324,63 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-118"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #106ebe;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="Add"
               role="presentation"
             >
               
             </i>
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-123"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: normal;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__3"
               >
                 Create account
@@ -132,7 +396,36 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           checked={undefined}
-          className="ms-Button root-128"
+          className=
+              ms-Button
+              {
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 0px;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                height: auto;
+                margin-left: -1px;
+                outline: transparent;
+                padding-bottom: 6px;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 6px;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: Highlight;
+              }
           data-is-focusable={false}
           data-ktp-execute-target={undefined}
           disabled={undefined}
@@ -142,11 +435,30 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-134"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #333333;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="ChevronDown"
               role="presentation"
             >
@@ -155,7 +467,18 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
           </div>
         </button>
         <span
-          className="css-127"
+          className=
+
+              {
+                background-color: #c8c8c8;
+                bottom: 8px;
+                margin-bottom: 4px;
+                margin-top: 4px;
+                position: absolute;
+                right: 31px;
+                top: 8px;
+                width: 1px;
+              }
         />
       </span>
     </div>
@@ -165,28 +488,133 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
       aria-labelledby={undefined}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--commandBar root-122"
+      className=
+          ms-Button
+          ms-Button--commandBar
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            min-width: 40px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: 4px;
+            left: 4px;
+            outline-color: ButtonText;
+            right: 4px;
+            top: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: Highlight;
+          }
+          &:active {
+            background-color: #dadada;
+            color: #000000;
+          }
       data-automation-id="test2"
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-icon icon-118"
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #106ebe;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="Mail"
           role="presentation"
         >
           
         </i>
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-123"
+            className=
+                ms-Button-label
+                {
+                  font-weight: normal;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__9"
           >
             Send Mail

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Compound.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Compound.Example.tsx.shot
@@ -2,11 +2,45 @@
 
 exports[`Component Examples renders Button.Compound.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsExample example-111 ms-BasicButtonsTwoUp twoup-112"
+  className=
+      ms-BasicButtonsExample
+      ms-BasicButtonsTwoUp
+      & .ms-Button {
+        margin-bottom: 10px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 10px;
+      }
+      {
+        display: flex;
+      }
+      & > * {
+        flex-grow: 1;
+      }
+      & .ms-Label {
+        margin-bottom: 10px;
+      }
 >
   <div>
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
     >
       Standard
     </label>
@@ -16,25 +50,132 @@ exports[`Component Examples renders Button.Compound.Example.tsx correctly 1`] = 
       aria-labelledby={undefined}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--compound root-135"
+      className=
+          ms-Button
+          ms-Button--compound
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            max-width: 280px;
+            min-height: 72px;
+            outline: transparent;
+            padding-bottom: 20px;
+            padding-left: 20px;
+            padding-right: 20px;
+            padding-top: 20px;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-description {
+            color: #212121;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
+          &:active .ms-Button-description {
+            color: inherit;
+          }
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-136"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: flex-start;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+              margin-bottom: ;
+              margin-left: ;
+              margin-right: ;
+              margin-top: ;
+              min-width: 100%;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-137"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+                text-align: left;
+              }
         >
           <div
-            className="ms-Button-label label-139"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 5px;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Create account
           </div>
           <div
-            className="ms-Button-description description-140"
+            className=
+                ms-Button-description
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #666666;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  line-height: 100%;
+                }
             id="id__1"
           >
             You can create a new account here.
@@ -45,7 +186,24 @@ exports[`Component Examples renders Button.Compound.Example.tsx correctly 1`] = 
   </div>
   <div>
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
     >
       Primary
     </label>
@@ -55,25 +213,152 @@ exports[`Component Examples renders Button.Compound.Example.tsx correctly 1`] = 
       aria-labelledby={undefined}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--compoundPrimary root-141"
+      className=
+          ms-Button
+          ms-Button--compoundPrimary
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #0078d4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #ffffff;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            max-width: 280px;
+            min-height: 72px;
+            outline: transparent;
+            padding-bottom: 20px;
+            padding-left: 20px;
+            padding-right: 20px;
+            padding-top: 20px;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: WindowText;
+            color: Window;
+          }
+          &:hover {
+            background-color: #106ebe;
+            color: #ffffff;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            background-color: Highlight;
+            color: Window;
+          }
+          &:hover .ms-Button-description {
+            color: #ffffff;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Button-description {
+            -ms-high-contrast-adjust: none;
+            background-color: Highlight;
+            color: Window;
+          }
+          &:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: WindowText;
+            color: Window;
+          }
+          &:active .ms-Button-description {
+            color: inherit;
+          }
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-136"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: flex-start;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+              margin-bottom: ;
+              margin-left: ;
+              margin-right: ;
+              margin-top: ;
+              min-width: 100%;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-137"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+                text-align: left;
+              }
         >
           <div
-            className="ms-Button-label label-139"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 5px;
+                  margin-left: 0;
+                  margin-right: 0;
+                  margin-top: 0;
+                }
             id="id__3"
           >
             Create account
           </div>
           <div
-            className="ms-Button-description description-142"
+            className=
+                ms-Button-description
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  line-height: 100%;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: WindowText;
+                  color: Window;
+                }
             id="id__4"
           >
             You can create a new account here.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ContextualMenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ContextualMenu.Example.tsx.shot
@@ -14,7 +14,69 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
       aria-owns={null}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       disabled={undefined}
@@ -23,21 +85,62 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-icon icon-109"
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="Add"
           role="presentation"
         >
           
         </i>
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             New
@@ -45,7 +148,27 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
         </div>
         <i
           aria-hidden={true}
-          className="ms-Button-menuIcon menuIcon-143"
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Default.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Default.Example.tsx.shot
@@ -2,11 +2,38 @@
 
 exports[`Component Examples renders Button.Default.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsTwoUp twoup-112"
+  className=
+      ms-BasicButtonsTwoUp
+      {
+        display: flex;
+      }
+      & > * {
+        flex-grow: 1;
+      }
+      & .ms-Label {
+        margin-bottom: 10px;
+      }
 >
   <div>
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
     >
       Standard
     </label>
@@ -16,20 +43,103 @@ exports[`Component Examples renders Button.Default.Example.tsx correctly 1`] = `
       aria-labelledby={undefined}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Button
@@ -40,7 +150,24 @@ exports[`Component Examples renders Button.Default.Example.tsx correctly 1`] = `
   </div>
   <div>
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
     >
       Primary
     </label>
@@ -50,7 +177,79 @@ exports[`Component Examples renders Button.Default.Example.tsx correctly 1`] = `
       aria-labelledby={undefined}
       aria-pressed={undefined}
       checked={undefined}
-      className="ms-Button ms-Button--primary root-144"
+      className=
+          ms-Button
+          ms-Button--primary
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #0078d4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #ffffff;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: WindowText;
+            color: Window;
+          }
+          &:hover {
+            background-color: #106ebe;
+            color: #ffffff;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            background-color: Highlight;
+            color: Window;
+          }
+          &:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: WindowText;
+            color: Window;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       disabled={undefined}
@@ -58,13 +257,34 @@ exports[`Component Examples renders Button.Default.Example.tsx correctly 1`] = `
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__3"
           >
             Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -2,7 +2,14 @@
 
 exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsExample example-111"
+  className=
+      ms-BasicButtonsExample
+      & .ms-Button {
+        margin-bottom: 10px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 10px;
+      }
 >
   <button
     aria-describedby={undefined}
@@ -10,18 +17,105 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-pressed={undefined}
     checked={undefined}
-    className="ms-Button ms-Button--icon root-145"
+    className=
+        ms-Button
+        ms-Button--icon
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: transparent;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+          width: 32px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          color: #004578;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          color: #0078d4;
+        }
     data-is-focusable={true}
     disabled={undefined}
     title="Emoji"
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <i
         aria-hidden={true}
-        className="ms-Button-icon icon-147"
+        className=
+            ms-Button-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons-0";
+              font-size: 16px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="Emoji2"
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Primary.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Primary.Example.tsx.shot
@@ -2,7 +2,14 @@
 
 exports[`Component Examples renders Button.Primary.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsExample example-111"
+  className=
+      ms-BasicButtonsExample
+      & .ms-Button {
+        margin-bottom: 10px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 10px;
+      }
 >
   <button
     aria-describedby={undefined}
@@ -10,7 +17,79 @@ exports[`Component Examples renders Button.Primary.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-pressed={undefined}
     checked={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-automation-id="test"
     data-is-focusable={true}
     disabled={undefined}
@@ -18,13 +97,34 @@ exports[`Component Examples renders Button.Primary.Example.tsx correctly 1`] = `
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Create account

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ScreenReader.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ScreenReader.Example.tsx.shot
@@ -2,7 +2,14 @@
 
 exports[`Component Examples renders Button.ScreenReader.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsExample example-111"
+  className=
+      ms-BasicButtonsExample
+      & .ms-Button {
+        margin-bottom: 10px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 10px;
+      }
 >
   <button
     aria-describedby="id__2"
@@ -10,27 +17,136 @@ exports[`Component Examples renders Button.ScreenReader.Example.tsx correctly 1`
     aria-labelledby={undefined}
     aria-pressed={undefined}
     checked={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-automation-id="test"
     data-is-focusable={true}
     disabled={undefined}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Aria Description
         </div>
       </div>
       <span
-        className="ms-Button-screenReaderText screenReaderText-108"
+        className=
+            ms-Button-screenReaderText
+            {
+              border: 0px;
+              height: 1px;
+              margin-bottom: -1px;
+              margin-left: -1px;
+              margin-right: -1px;
+              margin-top: -1px;
+              overflow: hidden;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: absolute;
+              width: 1px;
+            }
         id="id__2"
       >
         This is aria description used for screen reader.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -2,11 +2,38 @@
 
 exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsTwoUp twoup-112"
+  className=
+      ms-BasicButtonsTwoUp
+      {
+        display: flex;
+      }
+      & > * {
+        flex-grow: 1;
+      }
+      & .ms-Label {
+        margin-bottom: 10px;
+      }
 >
   <div>
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
     >
       Standard
     </label>
@@ -20,7 +47,40 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
       aria-pressed={undefined}
       aria-roledescription="split button"
       checked={undefined}
-      className="css-125"
+      className=
+
+          {
+            display: inline-flex;
+            outline: transparent;
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            outline: none!important;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       data-ktp-target={undefined}
@@ -51,7 +111,69 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           aria-pressed={undefined}
           aria-roledescription="split button"
           checked={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-automation-id="test"
           data-is-focusable={false}
           disabled={undefined}
@@ -65,13 +187,34 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__0"
               >
                 Create account
@@ -87,7 +230,35 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           checked={undefined}
-          className="ms-Button root-150"
+          className=
+              ms-Button
+              {
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 0px;
+                box-sizing: border-box;
+                color: #ffffff;
+                cursor: pointer;
+                display: inline-block;
+                height: auto;
+                margin-left: -1px;
+                outline: transparent;
+                padding-bottom: 6px;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 6px;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: Highlight;
+              }
           data-is-focusable={false}
           data-ktp-execute-target={undefined}
           disabled={undefined}
@@ -97,11 +268,30 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-134"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #333333;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="ChevronDown"
               role="presentation"
             >
@@ -110,14 +300,40 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           </div>
         </button>
         <span
-          className="css-149"
+          className=
+
+              {
+                background-color: #c8c8c8;
+                bottom: 8px;
+                position: absolute;
+                right: 31px;
+                top: 8px;
+                width: 1px;
+              }
         />
       </span>
     </div>
   </div>
   <div>
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
     >
       Primary
     </label>
@@ -131,7 +347,40 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
       aria-pressed={undefined}
       aria-roledescription="split button"
       checked={undefined}
-      className="css-125"
+      className=
+
+          {
+            display: inline-flex;
+            outline: transparent;
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            outline: none!important;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       data-ktp-target={undefined}
@@ -162,7 +411,79 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           aria-pressed={undefined}
           aria-roledescription="split button"
           checked={undefined}
-          className="ms-Button ms-Button--primary root-144"
+          className=
+              ms-Button
+              ms-Button--primary
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #0078d4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #ffffff;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: WindowText;
+                color: Window;
+              }
+              &:hover {
+                background-color: #106ebe;
+                color: #ffffff;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                background-color: Highlight;
+                color: Window;
+              }
+              &:active {
+                background-color: #005a9e;
+                color: #ffffff;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                -ms-high-contrast-adjust: none;
+                background-color: WindowText;
+                color: Window;
+              }
           data-automation-id="test"
           data-is-focusable={false}
           disabled={undefined}
@@ -176,13 +497,34 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__6"
               >
                 Create account
@@ -198,7 +540,35 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           checked={undefined}
-          className="ms-Button root-154"
+          className=
+              ms-Button
+              {
+                background-color: #0078d4;
+                border-radius: 0px;
+                border: 0px;
+                box-sizing: border-box;
+                color: #ffffff;
+                cursor: pointer;
+                display: inline-block;
+                height: auto;
+                margin-left: -1px;
+                outline: transparent;
+                padding-bottom: 6px;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 6px;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &:hover {
+                background-color: #005a9e;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: Highlight;
+              }
           data-is-focusable={false}
           data-ktp-execute-target={undefined}
           disabled={undefined}
@@ -208,11 +578,30 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-156"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #ffffff;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="ChevronDown"
               role="presentation"
             >
@@ -221,14 +610,40 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           </div>
         </button>
         <span
-          className="css-153"
+          className=
+
+              {
+                background-color: #deecf9;
+                bottom: 8px;
+                position: absolute;
+                right: 31px;
+                top: 8px;
+                width: 1px;
+              }
         />
       </span>
     </div>
   </div>
   <div>
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
     >
       Primary Action Disabled
     </label>
@@ -242,7 +657,40 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
       aria-pressed={undefined}
       aria-roledescription="split button"
       checked={undefined}
-      className="css-125"
+      className=
+
+          {
+            display: inline-flex;
+            outline: transparent;
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            outline: none!important;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       data-ktp-target={undefined}
@@ -273,7 +721,71 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           aria-pressed={undefined}
           aria-roledescription="split button"
           checked={undefined}
-          className="ms-Button ms-Button--primary is-disabled root-157"
+          className=
+              ms-Button
+              ms-Button--primary
+              is-disabled
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #a6a6a6;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                pointer-events: none;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window;
+                border-color: GrayText;
+                color: GrayText;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
           data-automation-id="test"
           data-is-focusable={false}
           disabled={true}
@@ -287,13 +799,34 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__12"
               >
                 Create account
@@ -309,7 +842,35 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           checked={undefined}
-          className="ms-Button root-154"
+          className=
+              ms-Button
+              {
+                background-color: #0078d4;
+                border-radius: 0px;
+                border: 0px;
+                box-sizing: border-box;
+                color: #ffffff;
+                cursor: pointer;
+                display: inline-block;
+                height: auto;
+                margin-left: -1px;
+                outline: transparent;
+                padding-bottom: 6px;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 6px;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &:hover {
+                background-color: #005a9e;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: Highlight;
+              }
           data-is-focusable={false}
           data-ktp-execute-target={undefined}
           disabled={undefined}
@@ -319,11 +880,30 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-156"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #ffffff;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="ChevronDown"
               role="presentation"
             >
@@ -332,14 +912,40 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           </div>
         </button>
         <span
-          className="css-153"
+          className=
+
+              {
+                background-color: #deecf9;
+                bottom: 8px;
+                position: absolute;
+                right: 31px;
+                top: 8px;
+                width: 1px;
+              }
         />
       </span>
     </div>
   </div>
   <div>
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
     >
       Button Disabled
     </label>
@@ -353,7 +959,38 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
       aria-pressed={undefined}
       aria-roledescription="split button"
       checked={undefined}
-      className="css-161"
+      className=
+
+          {
+            border: none;
+            display: inline-flex;
+            outline: none;
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            right: -2px;
+            top: -2px;
+          }
       data-automation-id="test"
       data-is-focusable={true}
       data-ktp-target={undefined}
@@ -384,7 +1021,71 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           aria-pressed={undefined}
           aria-roledescription="split button"
           checked={undefined}
-          className="ms-Button ms-Button--primary is-disabled root-157"
+          className=
+              ms-Button
+              ms-Button--primary
+              is-disabled
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #a6a6a6;
+                cursor: default;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                pointer-events: none;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window;
+                border-color: GrayText;
+                color: GrayText;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
           data-automation-id="test"
           data-is-focusable={false}
           disabled={true}
@@ -398,13 +1099,34 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__18"
               >
                 Create account
@@ -420,7 +1142,38 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           checked={undefined}
-          className="ms-Button is-disabled root-163"
+          className=
+              ms-Button
+              is-disabled
+              {
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 0px;
+                box-sizing: border-box;
+                color: #ffffff;
+                cursor: pointer;
+                display: inline-block;
+                height: auto;
+                margin-left: -1px;
+                outline: transparent;
+                padding-bottom: 6px;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 6px;
+                pointer-events: none;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &:hover {
+                background-color: #f4f4f4;
+                cursor: default;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: Highlight;
+              }
           data-is-focusable={false}
           data-ktp-execute-target={undefined}
           disabled={true}
@@ -430,11 +1183,30 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-166"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a6a6a6;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="ChevronDown"
               role="presentation"
             >
@@ -443,7 +1215,16 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           </div>
         </button>
         <span
-          className="css-153"
+          className=
+
+              {
+                background-color: #deecf9;
+                bottom: 8px;
+                position: absolute;
+                right: 31px;
+                top: 8px;
+                width: 1px;
+              }
         />
       </span>
     </div>
@@ -454,7 +1235,24 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
 exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
 <div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Split button with icon and custom styles
   </label>
@@ -468,7 +1266,40 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
     aria-pressed={undefined}
     aria-roledescription="split button"
     checked={undefined}
-    className="css-168"
+    className=
+
+        {
+          display: inline-flex;
+          outline: transparent;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border: none;
+        }
+        &:focus {
+          outline: none!important;
+        }
     data-automation-id="test"
     data-is-focusable={true}
     data-ktp-target={undefined}
@@ -494,7 +1325,66 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
         aria-pressed={undefined}
         aria-roledescription="split button"
         checked={undefined}
-        className="ms-Button ms-Button--icon root-145"
+        className=
+            ms-Button
+            ms-Button--icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              color: #004578;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              color: #0078d4;
+            }
         data-automation-id="test"
         data-is-focusable={false}
         disabled={undefined}
@@ -503,18 +1393,50 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-109"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="Upload"
             role="presentation"
           >
             
           </i>
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           />
         </div>
       </button>
@@ -526,7 +1448,28 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
         aria-labelledby={undefined}
         aria-pressed={undefined}
         checked={undefined}
-        className="ms-Button root-171"
+        className=
+            ms-Button
+            {
+              background-color: white;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: inline-block;
+              height: auto;
+              margin-left: -1px;
+              outline: transparent;
+              padding-bottom: 6px;
+              padding-left: 6px;
+              padding-right: 6px;
+              padding-top: 6px;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+              width: 10px;
+            }
         data-is-focusable={false}
         data-ktp-execute-target={undefined}
         disabled={undefined}
@@ -536,11 +1479,30 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-173"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 7px;
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -549,7 +1511,16 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
         </div>
       </button>
       <span
-        className="css-170"
+        className=
+
+            {
+              border-left: 1px solid #c8c8c8;
+              bottom: 8px;
+              position: absolute;
+              right: 12px;
+              top: 8px;
+              width: 1px;
+            }
       />
     </span>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Swap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Swap.Example.tsx.shot
@@ -2,7 +2,14 @@
 
 exports[`Component Examples renders Button.Swap.Example.tsx correctly 1`] = `
 <div
-  className="ms-BasicButtonsExample example-111"
+  className=
+      ms-BasicButtonsExample
+      & .ms-Button {
+        margin-bottom: 10px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 10px;
+      }
 >
   <button
     aria-describedby={undefined}
@@ -10,20 +17,113 @@ exports[`Component Examples renders Button.Swap.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-pressed={undefined}
     checked={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Swap

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Calendar.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Calendar.Button.Example.tsx.shot
@@ -8,20 +8,103 @@ exports[`Component Examples renders Calendar.Button.Example.tsx correctly 1`] = 
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Click for Calendar

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
@@ -3,14 +3,82 @@
 exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="buttonArea-174"
+    className=
+
+        {
+          display: inline-block;
+          text-align: center;
+          vertical-align: top;
+        }
   >
     <button
       aria-describedby={undefined}
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       id="toggleCallout"
@@ -18,13 +86,34 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Show callout

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -11,7 +11,25 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-89"
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Dropdown0"
         id="Dropdown0-label"
         required={undefined}
@@ -52,7 +70,17 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown root-55"
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -70,20 +98,103 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__1"
           >
             Show callout

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -16,7 +16,67 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
       aria-posinset={undefined}
       aria-setsize={undefined}
       checked={true}
-      className="ms-Checkbox is-checked is-enabled root-183"
+      className=
+          ms-Checkbox
+          is-checked
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background: none;
+            border: none;
+            cursor: pointer;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -2px;
+            content: "";
+            left: -2px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -2px;
+            top: -2px;
+            z-index: 1;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            background: WindowText;
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+            background: WindowText;
+            border-color: WindowText;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
+          }
       data-ktp-execute-target={undefined}
       disabled={undefined}
       id="checkbox-0"
@@ -28,16 +88,71 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
       type="button"
     >
       <label
-        className="ms-Checkbox-label label-184"
+        className=
+            ms-Checkbox-label
+            {
+              align-items: center;
+              cursor: pointer;
+              display: inline-flex;
+              margin-bottom: 0;
+              margin-left: -4px;
+              margin-right: -4px;
+              margin-top: 0;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
         htmlFor="checkbox-0"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-185"
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                background: #0078d4;
+                border-color: #0078d4;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                overflow: hidden;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: WindowText;
+                border-color: WindowText;
+              }
           data-ktp-target={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-188"
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 1;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
             data-icon-name="CheckMark"
             role="presentation"
           >
@@ -45,7 +160,16 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-187"
+          className=
+              ms-Checkbox-text
+              {
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
         >
           Show beak
         </span>
@@ -55,7 +179,24 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
       className="ms-Slider ms-Slider-enabled undefined ms-Slider-row undefined"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Slider1"
       >
         Gap Space
@@ -108,7 +249,25 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
           </div>
         </button>
         <label
-          className="ms-Label ms-Slider-value root-89"
+          className=
+              ms-Label
+              ms-Slider-value
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           0
         </label>
@@ -118,7 +277,24 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
       className="ms-Slider ms-Slider-enabled undefined ms-Slider-row undefined"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Slider2"
       >
         Beak Width
@@ -171,7 +347,25 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
           </div>
         </button>
         <label
-          className="ms-Label ms-Slider-value root-89"
+          className=
+              ms-Label
+              ms-Slider-value
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           16
         </label>
@@ -181,7 +375,25 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-89"
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Dropdown3"
         id="Dropdown3-label"
         required={undefined}
@@ -222,7 +434,17 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown root-55"
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -240,20 +462,104 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default calloutExampleButton root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          calloutExampleButton
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__4"
           >
             Show callout

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Nested.Example.tsx.shot
@@ -12,20 +12,103 @@ exports[`Component Examples renders Callout.Nested.Example.tsx correctly 1`] = `
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Show callout

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -10,7 +10,60 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
-    className="ms-Checkbox is-enabled root-189"
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-0"
@@ -22,16 +75,66 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-0"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -39,7 +142,16 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Standard checkbox
       </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.ImplementationExamples.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.ImplementationExamples.tsx.shot
@@ -10,7 +10,60 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
-    className="ms-Checkbox is-enabled root-193"
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-0"
@@ -22,16 +75,66 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-0"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -39,7 +142,16 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Uncontrolled checkbox
       </span>
@@ -59,7 +171,67 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
-    className="ms-Checkbox is-checked is-enabled root-194"
+    className=
+        ms-Checkbox
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          background: #106ebe;
+          border-color: #106ebe;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          background: #106ebe;
+          border-color: #106ebe;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          background: WindowText;
+          border-color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+          background: WindowText;
+          border-color: WindowText;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     defaultChecked={true}
     disabled={undefined}
@@ -72,16 +244,71 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-1"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-185"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: #0078d4;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText;
+              border-color: WindowText;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-188"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -89,7 +316,16 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Uncontrolled checkbox with defaultChecked true
       </span>
@@ -103,7 +339,44 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
-    className="ms-Checkbox is-disabled root-195"
+    className=
+        ms-Checkbox
+        is-disabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
     data-ktp-execute-target={undefined}
     disabled={true}
     id="checkbox-2"
@@ -115,16 +388,66 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-196"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: default;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-2"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-197"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #c8c8c8;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-200"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: InactiveBorder;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -132,7 +455,16 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-199"
+        className=
+            ms-Checkbox-text
+            {
+              color: #a6a6a6;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Disabled uncontrolled checkbox
       </span>
@@ -146,7 +478,45 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
-    className="ms-Checkbox is-checked is-disabled root-195"
+    className=
+        ms-Checkbox
+        is-checked
+        is-disabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
     data-ktp-execute-target={undefined}
     defaultChecked={true}
     disabled={true}
@@ -159,16 +529,67 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-196"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: default;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-3"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-201"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              background: #c8c8c8;
+              border-color: #c8c8c8;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-203"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #f4f4f4;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: InactiveBorder;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -176,7 +597,16 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-199"
+        className=
+            ms-Checkbox-text
+            {
+              color: #a6a6a6;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Disabled uncontrolled checkbox with defaultChecked true
       </span>
@@ -191,7 +621,60 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     aria-posinset={undefined}
     aria-setsize={undefined}
     checked={false}
-    className="ms-Checkbox is-enabled root-193"
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-4"
@@ -203,16 +686,66 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-4"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -220,7 +753,16 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Controlled checkbox
       </span>
@@ -234,7 +776,61 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
-    className="ms-Checkbox reversed is-enabled root-193"
+    className=
+        ms-Checkbox
+        reversed
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-5"
@@ -246,16 +842,68 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-204"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            flex-direction: row-reverse;
+            justify-content: flex-end;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-5"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -263,7 +911,16 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Checkbox rendered with boxSide "end"
       </span>
@@ -277,7 +934,60 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
-    className="ms-Checkbox is-enabled root-193"
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-6"
@@ -289,16 +999,66 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-6"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -306,20 +1066,82 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         </i>
       </div>
       <div
-        className="ms-Persona ms-Persona--size32 root-205"
+        className=
+            ms-Persona
+            ms-Persona--size32
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 32px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+            &:hover $primaryText {
+              color: #212121;
+            }
         size={11}
         style={undefined}
       >
         <div
-          className="ms-Persona-coin ms-Persona--size32 coin-72"
+          className=
+              ms-Persona-coin
+              ms-Persona--size32
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={11}
         >
           <div
-            className="ms-Persona-imageArea imageArea-80"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 32px;
+                  position: relative;
+                  text-align: center;
+                  width: 32px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-83"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 32px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 32px;
+                  }
               style={
                 Object {
                   "height": 32,
@@ -329,7 +1151,22 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -339,10 +1176,32 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
           </div>
         </div>
         <div
-          className="ms-Persona-details details-206"
+          className=
+              ms-Persona-details
+              {
+                display: flex;
+                flex-direction: column;
+                justify-content: space-around;
+                min-width: 0px;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 24px;
+                padding-top: 0;
+                text-align: left;
+                width: 100%;
+              }
         >
           <div
-            className="ms-Persona-primaryText primaryText-207"
+            className=
+                ms-Persona-primaryText
+                {
+                  color: #333333;
+                  font-size: 14px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
           >
             <div
               aria-describedby={undefined}
@@ -356,13 +1215,43 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
             </div>
           </div>
           <div
-            className="ms-Persona-secondaryText secondaryText-208"
+            className=
+                ms-Persona-secondaryText
+                {
+                  color: #666666;
+                  display: none;
+                  font-size: 12px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
           />
           <div
-            className="ms-Persona-tertiaryText tertiaryText-209"
+            className=
+                ms-Persona-tertiaryText
+                {
+                  color: #666666;
+                  display: none;
+                  font-size: 12px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
           />
           <div
-            className="ms-Persona-optionalText optionalText-210"
+            className=
+                ms-Persona-optionalText
+                {
+                  color: #666666;
+                  display: none;
+                  font-size: 12px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
           />
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -3,34 +3,98 @@
 exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="applicationRole-212"
+    className=
+
+
     role="application"
   >
     <div
       aria-labelledby="ChoiceGroup0-label"
-      className="ms-ChoiceFieldGroup root-213"
+      className=
+          ms-ChoiceFieldGroup
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       role="radiogroup"
     >
       <label
-        className="ms-Label label-215"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            &::after {
+              color: #a80000;
+              content: ' *';
+              padding-right: 12px;
+            }
         id="ChoiceGroup0-label"
         required={true}
       >
         Pick one
       </label>
       <div
-        className="ms-ChoiceFieldGroup-flexContainer flexContainer-214"
+        className=
+            ms-ChoiceFieldGroup-flexContainer
+
       >
         <div
-          className="ms-ChoiceField root-216"
+          className=
+              ms-ChoiceField
+              {
+                align-items: center;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: flex;
+                font-size: 14px;
+                font-weight: 400;
+                margin-top: 8px;
+                min-height: 26px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-A"
               checked={false}
-              className="ms-ChoiceField-input input-218"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    opacity: 0;
+                    position: absolute;
+                    top: 8px;
+                  }
               data-automation-id="auto1"
               disabled={undefined}
               id="ChoiceGroup0-A"
@@ -42,7 +106,61 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field field-219"
+              className=
+                  ms-ChoiceField-field
+                  {
+                    cursor: pointer;
+                    display: inline-block;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    position: relative;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:hover .ms-Label {
+                    color: #000000;
+                  }
+                  &:hover:before {
+                    border-color: #212121;
+                  }
+                  &:focus .ms-Label {
+                    color: #000000;
+                  }
+                  &:focus:before {
+                    border-color: #212121;
+                  }
+                  &:before {
+                    background-color: #ffffff;
+                    border-color: #666666;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  &:after {
+                    border-radius: 50%;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 0px;
+                    left: 10px;
+                    position: absolute;
+                    right: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 0px;
+                  }
               htmlFor="ChoiceGroup0-A"
             >
               <span
@@ -55,15 +173,44 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
           </div>
         </div>
         <div
-          className="ms-ChoiceField root-216"
+          className=
+              ms-ChoiceField
+              {
+                align-items: center;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: flex;
+                font-size: 14px;
+                font-weight: 400;
+                margin-top: 8px;
+                min-height: 26px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-B"
               checked={true}
-              className="ms-ChoiceField-input input-218"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    opacity: 0;
+                    position: absolute;
+                    top: 8px;
+                  }
               disabled={undefined}
               id="ChoiceGroup0-B"
               name="ChoiceGroup0"
@@ -74,7 +221,72 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field field-225"
+              className=
+                  ms-ChoiceField-field
+                  {
+                    border-color: #0078d4;
+                    cursor: pointer;
+                    display: inline-block;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    position: relative;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:hover .ms-Label {
+                    color: #000000;
+                  }
+                  &:hover:before {
+                    border-color: #106ebe;
+                  }
+                  &:focus .ms-Label {
+                    color: #000000;
+                  }
+                  &:focus:before {
+                    border-color: #106ebe;
+                  }
+                  &:before {
+                    background-color: #ffffff;
+                    border-color: #0078d4;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    border-color: Highlight;
+                  }
+                  &:after {
+                    border-color: #0078d4;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 5px;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 10px;
+                    left: 5px;
+                    position: absolute;
+                    right: 0px;
+                    top: 5px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 10px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:after {
+                    border-color: Highlight;
+                  }
               htmlFor="ChoiceGroup0-B"
             >
               <span
@@ -87,15 +299,44 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
           </div>
         </div>
         <div
-          className="ms-ChoiceField root-216"
+          className=
+              ms-ChoiceField
+              {
+                align-items: center;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: flex;
+                font-size: 14px;
+                font-weight: 400;
+                margin-top: 8px;
+                min-height: 26px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-C"
               checked={false}
-              className="ms-ChoiceField-input input-218"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    opacity: 0;
+                    position: absolute;
+                    top: 8px;
+                  }
               disabled={true}
               id="ChoiceGroup0-C"
               name="ChoiceGroup0"
@@ -106,7 +347,58 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field field-228"
+              className=
+                  ms-ChoiceField-field
+                  {
+                    cursor: default;
+                    display: inline-block;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    position: relative;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:before {
+                    background-color: #a6a6a6;
+                    border-color: #a6a6a6;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    color: GrayText;
+                  }
+                  &:after {
+                    border-radius: 50%;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 0px;
+                    left: 10px;
+                    position: absolute;
+                    right: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 0px;
+                  }
+                  & .ms-Label {
+                    color: #c8c8c8;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: GrayText;
+                  }
               htmlFor="ChoiceGroup0-C"
             >
               <span
@@ -119,15 +411,44 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
           </div>
         </div>
         <div
-          className="ms-ChoiceField root-216"
+          className=
+              ms-ChoiceField
+              {
+                align-items: center;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: flex;
+                font-size: 14px;
+                font-weight: 400;
+                margin-top: 8px;
+                min-height: 26px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-D"
               checked={false}
-              className="ms-ChoiceField-input input-218"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    opacity: 0;
+                    position: absolute;
+                    top: 8px;
+                  }
               disabled={true}
               id="ChoiceGroup0-D"
               name="ChoiceGroup0"
@@ -138,7 +459,58 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field field-228"
+              className=
+                  ms-ChoiceField-field
+                  {
+                    cursor: default;
+                    display: inline-block;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    position: relative;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:before {
+                    background-color: #a6a6a6;
+                    border-color: #a6a6a6;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    color: GrayText;
+                  }
+                  &:after {
+                    border-radius: 50%;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 0px;
+                    left: 10px;
+                    position: absolute;
+                    right: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 0px;
+                  }
+                  & .ms-Label {
+                    color: #c8c8c8;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: GrayText;
+                  }
               htmlFor="ChoiceGroup0-D"
             >
               <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -3,34 +3,98 @@
 exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="applicationRole-212"
+    className=
+
+
     role="application"
   >
     <div
       aria-labelledby="ChoiceGroup0-label"
-      className="ms-ChoiceFieldGroup root-213"
+      className=
+          ms-ChoiceFieldGroup
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       role="radiogroup"
     >
       <label
-        className="ms-Label label-215"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            &::after {
+              color: #a80000;
+              content: ' *';
+              padding-right: 12px;
+            }
         id="ChoiceGroup0-label"
         required={true}
       >
         Pick one
       </label>
       <div
-        className="ms-ChoiceFieldGroup-flexContainer flexContainer-214"
+        className=
+            ms-ChoiceFieldGroup-flexContainer
+
       >
         <div
-          className="ms-ChoiceField root-216"
+          className=
+              ms-ChoiceField
+              {
+                align-items: center;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: flex;
+                font-size: 14px;
+                font-weight: 400;
+                margin-top: 8px;
+                min-height: 26px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-A"
               checked={false}
-              className="ms-ChoiceField-input input-218"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    opacity: 0;
+                    position: absolute;
+                    top: 8px;
+                  }
               disabled={undefined}
               id="ChoiceGroup0-A"
               name="ChoiceGroup0"
@@ -44,7 +108,61 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               className=""
             >
               <label
-                className="ms-ChoiceField-field field-219"
+                className=
+                    ms-ChoiceField-field
+                    {
+                      cursor: pointer;
+                      display: inline-block;
+                      margin-top: 0px;
+                      min-height: 20px;
+                      position: relative;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &:hover .ms-Label {
+                      color: #000000;
+                    }
+                    &:hover:before {
+                      border-color: #212121;
+                    }
+                    &:focus .ms-Label {
+                      color: #000000;
+                    }
+                    &:focus:before {
+                      border-color: #212121;
+                    }
+                    &:before {
+                      background-color: #ffffff;
+                      border-color: #666666;
+                      border-radius: 50%;
+                      border-style: solid;
+                      border-width: 1px;
+                      box-sizing: border-box;
+                      content: "";
+                      display: inline-block;
+                      font-weight: normal;
+                      height: 20px;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      transition-duration: 200ms;
+                      transition-property: border-color;
+                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                      width: 20px;
+                    }
+                    &:after {
+                      border-radius: 50%;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 0px;
+                      left: 10px;
+                      position: absolute;
+                      right: 0px;
+                      transition-duration: 200ms;
+                      transition-property: border-width;
+                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                      width: 0px;
+                    }
                 htmlFor="ChoiceGroup0-A"
               >
                 <span
@@ -91,7 +209,17 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   >
                     <i
                       aria-hidden={true}
-                      className="ms-Dropdown-caretDown root-55"
+                      className=
+                          ms-Dropdown-caretDown
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            display: inline-block;
+                            font-family: "FabricMDL2Icons";
+                            font-style: normal;
+                            font-weight: normal;
+                            speak: none;
+                          }
                       data-icon-name="ChevronDown"
                       role="presentation"
                     >
@@ -104,15 +232,44 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
           </div>
         </div>
         <div
-          className="ms-ChoiceField root-216"
+          className=
+              ms-ChoiceField
+              {
+                align-items: center;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: flex;
+                font-size: 14px;
+                font-weight: 400;
+                margin-top: 8px;
+                min-height: 26px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-B"
               checked={true}
-              className="ms-ChoiceField-input input-218"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    opacity: 0;
+                    position: absolute;
+                    top: 8px;
+                  }
               disabled={undefined}
               id="ChoiceGroup0-B"
               name="ChoiceGroup0"
@@ -123,7 +280,72 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field field-225"
+              className=
+                  ms-ChoiceField-field
+                  {
+                    border-color: #0078d4;
+                    cursor: pointer;
+                    display: inline-block;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    position: relative;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:hover .ms-Label {
+                    color: #000000;
+                  }
+                  &:hover:before {
+                    border-color: #106ebe;
+                  }
+                  &:focus .ms-Label {
+                    color: #000000;
+                  }
+                  &:focus:before {
+                    border-color: #106ebe;
+                  }
+                  &:before {
+                    background-color: #ffffff;
+                    border-color: #0078d4;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    border-color: Highlight;
+                  }
+                  &:after {
+                    border-color: #0078d4;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 5px;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 10px;
+                    left: 5px;
+                    position: absolute;
+                    right: 0px;
+                    top: 5px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 10px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:after {
+                    border-color: Highlight;
+                  }
               htmlFor="ChoiceGroup0-B"
             >
               <span
@@ -136,15 +358,44 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
           </div>
         </div>
         <div
-          className="ms-ChoiceField root-216"
+          className=
+              ms-ChoiceField
+              {
+                align-items: center;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: flex;
+                font-size: 14px;
+                font-weight: 400;
+                margin-top: 8px;
+                min-height: 26px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-C"
               checked={false}
-              className="ms-ChoiceField-input input-218"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    opacity: 0;
+                    position: absolute;
+                    top: 8px;
+                  }
               disabled={true}
               id="ChoiceGroup0-C"
               name="ChoiceGroup0"
@@ -155,7 +406,58 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field field-228"
+              className=
+                  ms-ChoiceField-field
+                  {
+                    cursor: default;
+                    display: inline-block;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    position: relative;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:before {
+                    background-color: #a6a6a6;
+                    border-color: #a6a6a6;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    color: GrayText;
+                  }
+                  &:after {
+                    border-radius: 50%;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 0px;
+                    left: 10px;
+                    position: absolute;
+                    right: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 0px;
+                  }
+                  & .ms-Label {
+                    color: #c8c8c8;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: GrayText;
+                  }
               htmlFor="ChoiceGroup0-C"
             >
               <span
@@ -168,15 +470,44 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
           </div>
         </div>
         <div
-          className="ms-ChoiceField root-216"
+          className=
+              ms-ChoiceField
+              {
+                align-items: center;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: flex;
+                font-size: 14px;
+                font-weight: 400;
+                margin-top: 8px;
+                min-height: 26px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-D"
               checked={false}
-              className="ms-ChoiceField-input input-218"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    opacity: 0;
+                    position: absolute;
+                    top: 8px;
+                  }
               disabled={undefined}
               id="ChoiceGroup0-D"
               name="ChoiceGroup0"
@@ -187,7 +518,61 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field field-219"
+              className=
+                  ms-ChoiceField-field
+                  {
+                    cursor: pointer;
+                    display: inline-block;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    position: relative;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:hover .ms-Label {
+                    color: #000000;
+                  }
+                  &:hover:before {
+                    border-color: #212121;
+                  }
+                  &:focus .ms-Label {
+                    color: #000000;
+                  }
+                  &:focus:before {
+                    border-color: #212121;
+                  }
+                  &:before {
+                    background-color: #ffffff;
+                    border-color: #666666;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  &:after {
+                    border-radius: 50%;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 0px;
+                    left: 10px;
+                    position: absolute;
+                    right: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 0px;
+                  }
               htmlFor="ChoiceGroup0-D"
             >
               <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -2,34 +2,111 @@
 
 exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] = `
 <div
-  className="applicationRole-212"
+  className=
+
+
   role="application"
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
-    className="ms-ChoiceFieldGroup root-213"
+    className=
+        ms-ChoiceFieldGroup
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
     role="radiogroup"
   >
     <label
-      className="ms-Label label-230"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       id="ChoiceGroup0-label"
       required={undefined}
     >
       Pick one icon
     </label>
     <div
-      className="ms-ChoiceFieldGroup-flexContainer flexContainer-229"
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+          {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+          }
     >
       <div
-        className="ms-ChoiceField ms-ChoiceField--icon root-231"
+        className=
+            ms-ChoiceField
+            ms-ChoiceField--icon
+            {
+              align-items: center;
+              background-color: #f4f4f4;
+              border: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: inline-flex;
+              font-size: 0px;
+              font-weight: 400;
+              height: 100%;
+              margin-bottom: 4px;
+              margin-left: 0;
+              margin-right: 4px;
+              margin-top: 0;
+              min-height: 26px;
+              padding-left: 0px;
+              position: relative;
+            }
+            & .ms-Label {
+              display: inline-block;
+              font-size: 14px;
+              padding-bottom: 0;
+              padding-left: 26px;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <div
-          className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             aria-labelledby="ChoiceGroupLabel1-day"
             checked={false}
-            className="ms-ChoiceField-input input-232"
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
             disabled={undefined}
             id="ChoiceGroup0-day"
             name="ChoiceGroup0"
@@ -40,18 +117,119 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             type="radio"
           />
           <label
-            className="ms-ChoiceField-field ms-ChoiceField--icon field-233"
+            className=
+                ms-ChoiceField-field
+                ms-ChoiceField--icon
+                {
+                  align-items: center;
+                  border: 2px solid transparent;
+                  box-sizing: content-box;
+                  cursor: pointer;
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: center;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  padding-top: 22px;
+                  position: relative;
+                  text-align: center;
+                  transition-duration: 200ms;
+                  transition-property: all;
+                  transition-timing-function: ease;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover {
+                  border-color: #c8c8c8;
+                }
+                &:hover .ms-Label {
+                  color: #000000;
+                }
+                &:hover:before {
+                  border-color: #212121;
+                  opacity: 1;
+                }
+                &:focus {
+                  border-color: #c8c8c8;
+                }
+                &:focus .ms-Label {
+                  color: #000000;
+                }
+                &:focus:before {
+                  border-color: #212121;
+                  opacity: 1;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #666666;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: auto;
+                  opacity: 0;
+                  position: absolute;
+                  right: 3px;
+                  top: 3px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
             htmlFor="ChoiceGroup0-day"
           >
             <div
-              className="ms-ChoiceField-innerField innerField-234"
+              className=
+                  ms-ChoiceField-innerField
+                  {
+                    display: inline-block;
+                    padding-left: 30px;
+                    padding-right: 30px;
+                    position: relative;
+                  }
             >
               <div
-                className="ms-ChoiceField-iconWrapper iconWrapper-223"
+                className=
+                    ms-ChoiceField-iconWrapper
+                    {
+                      font-size: 32px;
+                      height: 32px;
+                      line-height: 32px;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="root-52"
+                  className=
+
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-1";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
                   data-icon-name="CalendarDay"
                   role="presentation"
                 >
@@ -60,7 +238,29 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               </div>
             </div>
             <div
-              className="ms-ChoiceField-labelWrapper labelWrapper-235"
+              className=
+                  ms-ChoiceField-labelWrapper
+                  {
+                    display: block;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    line-height: 15px;
+                    margin-bottom: 4px;
+                    margin-left: 8px;
+                    margin-right: 8px;
+                    margin-top: 4px;
+                    overflow: hidden;
+                    position: relative;
+                    text-overflow: ellipsis;
+                    white-space: pre-wrap;
+                  }
+                  & .ms-Label {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               style={
                 Object {
                   "maxWidth": 64,
@@ -78,15 +278,58 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-ChoiceField ms-ChoiceField--icon root-231"
+        className=
+            ms-ChoiceField
+            ms-ChoiceField--icon
+            {
+              align-items: center;
+              background-color: #f4f4f4;
+              border: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: inline-flex;
+              font-size: 0px;
+              font-weight: 400;
+              height: 100%;
+              margin-bottom: 4px;
+              margin-left: 0;
+              margin-right: 4px;
+              margin-top: 0;
+              min-height: 26px;
+              padding-left: 0px;
+              position: relative;
+            }
+            & .ms-Label {
+              display: inline-block;
+              font-size: 14px;
+              padding-bottom: 0;
+              padding-left: 26px;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <div
-          className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             aria-labelledby="ChoiceGroupLabel1-week"
             checked={false}
-            className="ms-ChoiceField-input input-232"
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
             disabled={undefined}
             id="ChoiceGroup0-week"
             name="ChoiceGroup0"
@@ -97,18 +340,119 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             type="radio"
           />
           <label
-            className="ms-ChoiceField-field ms-ChoiceField--icon field-233"
+            className=
+                ms-ChoiceField-field
+                ms-ChoiceField--icon
+                {
+                  align-items: center;
+                  border: 2px solid transparent;
+                  box-sizing: content-box;
+                  cursor: pointer;
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: center;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  padding-top: 22px;
+                  position: relative;
+                  text-align: center;
+                  transition-duration: 200ms;
+                  transition-property: all;
+                  transition-timing-function: ease;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover {
+                  border-color: #c8c8c8;
+                }
+                &:hover .ms-Label {
+                  color: #000000;
+                }
+                &:hover:before {
+                  border-color: #212121;
+                  opacity: 1;
+                }
+                &:focus {
+                  border-color: #c8c8c8;
+                }
+                &:focus .ms-Label {
+                  color: #000000;
+                }
+                &:focus:before {
+                  border-color: #212121;
+                  opacity: 1;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #666666;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: auto;
+                  opacity: 0;
+                  position: absolute;
+                  right: 3px;
+                  top: 3px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
             htmlFor="ChoiceGroup0-week"
           >
             <div
-              className="ms-ChoiceField-innerField innerField-234"
+              className=
+                  ms-ChoiceField-innerField
+                  {
+                    display: inline-block;
+                    padding-left: 30px;
+                    padding-right: 30px;
+                    position: relative;
+                  }
             >
               <div
-                className="ms-ChoiceField-iconWrapper iconWrapper-223"
+                className=
+                    ms-ChoiceField-iconWrapper
+                    {
+                      font-size: 32px;
+                      height: 32px;
+                      line-height: 32px;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="root-52"
+                  className=
+
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-1";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
                   data-icon-name="CalendarWeek"
                   role="presentation"
                 >
@@ -117,7 +461,29 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               </div>
             </div>
             <div
-              className="ms-ChoiceField-labelWrapper labelWrapper-235"
+              className=
+                  ms-ChoiceField-labelWrapper
+                  {
+                    display: block;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    line-height: 15px;
+                    margin-bottom: 4px;
+                    margin-left: 8px;
+                    margin-right: 8px;
+                    margin-top: 4px;
+                    overflow: hidden;
+                    position: relative;
+                    text-overflow: ellipsis;
+                    white-space: pre-wrap;
+                  }
+                  & .ms-Label {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               style={
                 Object {
                   "maxWidth": 64,
@@ -135,15 +501,58 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-ChoiceField ms-ChoiceField--icon root-231"
+        className=
+            ms-ChoiceField
+            ms-ChoiceField--icon
+            {
+              align-items: center;
+              background-color: #f4f4f4;
+              border: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: inline-flex;
+              font-size: 0px;
+              font-weight: 400;
+              height: 100%;
+              margin-bottom: 4px;
+              margin-left: 0;
+              margin-right: 4px;
+              margin-top: 0;
+              min-height: 26px;
+              padding-left: 0px;
+              position: relative;
+            }
+            & .ms-Label {
+              display: inline-block;
+              font-size: 14px;
+              padding-bottom: 0;
+              padding-left: 26px;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <div
-          className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             aria-labelledby="ChoiceGroupLabel1-month"
             checked={false}
-            className="ms-ChoiceField-input input-232"
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
             disabled={true}
             id="ChoiceGroup0-month"
             name="ChoiceGroup0"
@@ -154,18 +563,113 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             type="radio"
           />
           <label
-            className="ms-ChoiceField-field ms-ChoiceField--icon field-236"
+            className=
+                ms-ChoiceField-field
+                ms-ChoiceField--icon
+                {
+                  align-items: center;
+                  border: 2px solid transparent;
+                  box-sizing: content-box;
+                  cursor: default;
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: center;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  padding-top: 22px;
+                  position: relative;
+                  text-align: center;
+                  transition-duration: 200ms;
+                  transition-property: all;
+                  transition-timing-function: ease;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:before {
+                  background-color: #a6a6a6;
+                  border-color: #a6a6a6;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: auto;
+                  opacity: 0;
+                  position: absolute;
+                  right: 3px;
+                  top: 3px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){&:before {
+                  color: GrayText;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
+                & .ms-Label {
+                  color: #c8c8c8;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: GrayText;
+                }
             htmlFor="ChoiceGroup0-month"
           >
             <div
-              className="ms-ChoiceField-innerField innerField-237"
+              className=
+                  ms-ChoiceField-innerField
+                  {
+                    display: inline-block;
+                    opacity: 0.25;
+                    padding-left: 30px;
+                    padding-right: 30px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: GrayText;
+                    opacity: 1;
+                  }
             >
               <div
-                className="ms-ChoiceField-iconWrapper iconWrapper-223"
+                className=
+                    ms-ChoiceField-iconWrapper
+                    {
+                      font-size: 32px;
+                      height: 32px;
+                      line-height: 32px;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="root-55"
+                  className=
+
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
                   data-icon-name="Calendar"
                   role="presentation"
                 >
@@ -174,7 +678,29 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               </div>
             </div>
             <div
-              className="ms-ChoiceField-labelWrapper labelWrapper-235"
+              className=
+                  ms-ChoiceField-labelWrapper
+                  {
+                    display: block;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    line-height: 15px;
+                    margin-bottom: 4px;
+                    margin-left: 8px;
+                    margin-right: 8px;
+                    margin-top: 4px;
+                    overflow: hidden;
+                    position: relative;
+                    text-overflow: ellipsis;
+                    white-space: pre-wrap;
+                  }
+                  & .ms-Label {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               style={
                 Object {
                   "maxWidth": 64,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -3,34 +3,111 @@
 exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="applicationRole-212"
+    className=
+
+
     role="application"
   >
     <div
       aria-labelledby="ChoiceGroup0-label"
-      className="ms-ChoiceFieldGroup root-213"
+      className=
+          ms-ChoiceFieldGroup
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       role="radiogroup"
     >
       <label
-        className="ms-Label label-230"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         id="ChoiceGroup0-label"
         required={undefined}
       >
         Pick one image
       </label>
       <div
-        className="ms-ChoiceFieldGroup-flexContainer flexContainer-229"
+        className=
+            ms-ChoiceFieldGroup-flexContainer
+            {
+              display: flex;
+              flex-direction: row;
+              flex-wrap: wrap;
+            }
       >
         <div
-          className="ms-ChoiceField ms-ChoiceField--image root-231"
+          className=
+              ms-ChoiceField
+              ms-ChoiceField--image
+              {
+                align-items: center;
+                background-color: #f4f4f4;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: inline-flex;
+                font-size: 0px;
+                font-weight: 400;
+                height: 100%;
+                margin-bottom: 4px;
+                margin-left: 0;
+                margin-right: 4px;
+                margin-top: 0;
+                min-height: 26px;
+                padding-left: 0px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-bar"
               checked={true}
-              className="ms-ChoiceField-input input-232"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    opacity: 0;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
+                  }
               disabled={undefined}
               id="ChoiceGroup0-bar"
               name="ChoiceGroup0"
@@ -41,11 +118,107 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field ms-ChoiceField-field--image field-238"
+              className=
+                  ms-ChoiceField-field
+                  ms-ChoiceField-field--image
+                  {
+                    align-items: center;
+                    border-color: #0078d4;
+                    border: 2px solid transparent;
+                    box-sizing: content-box;
+                    cursor: pointer;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    padding-top: 22px;
+                    position: relative;
+                    text-align: center;
+                    transition-duration: 200ms;
+                    transition-property: all;
+                    transition-timing-function: ease;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:hover {
+                    border-color: #005a9e;
+                  }
+                  &:hover .ms-Label {
+                    color: #000000;
+                  }
+                  &:hover:before {
+                    border-color: #005a9e;
+                    opacity: 1;
+                  }
+                  &:focus {
+                    border-color: #005a9e;
+                  }
+                  &:focus .ms-Label {
+                    color: #000000;
+                  }
+                  &:focus:before {
+                    border-color: #005a9e;
+                    opacity: 1;
+                  }
+                  &:before {
+                    background-color: #ffffff;
+                    border-color: #0078d4;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: auto;
+                    opacity: 1;
+                    position: absolute;
+                    right: 3px;
+                    top: 3px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    border-color: Highlight;
+                  }
+                  &:after {
+                    border-color: #0078d4;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 5px;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 10px;
+                    left: auto;
+                    position: absolute;
+                    right: 8px;
+                    top: 8px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 10px;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:after {
+                    border-color: Highlight;
+                  }
               htmlFor="ChoiceGroup0-bar"
             >
               <div
-                className="ms-ChoiceField-innerField innerField-234"
+                className=
+                    ms-ChoiceField-innerField
+                    {
+                      display: inline-block;
+                      padding-left: 30px;
+                      padding-right: 30px;
+                      position: relative;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -54,10 +227,33 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 }
               >
                 <div
-                  className="ms-ChoiceField-imageWrapper is-hidden imageWrapper-226"
+                  className=
+                      ms-ChoiceField-imageWrapper
+                      is-hidden
+                      {
+                        height: 100%;
+                        left: 0px;
+                        opacity: 0;
+                        overflow: hidden;
+                        padding-bottom: 2px;
+                        position: absolute;
+                        top: 0px;
+                        transition-duration: 200ms;
+                        transition-property: opacity;
+                        transition-timing-function: ease;
+                        width: 100%;
+                      }
+                      & .ms-Image {
+                        border-style: none;
+                        display: inline-block;
+                      }
                 >
                   <div
-                    className="ms-Image root-239"
+                    className=
+                        ms-Image
+                        {
+                          overflow: hidden;
+                        }
                     style={
                       Object {
                         "height": 32,
@@ -67,7 +263,17 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   >
                     <img
                       alt="Bar chart icon"
-                      className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                      className=
+                          ms-Image-image
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: 100%;
+                            opacity: 0;
+                            width: 100%;
+                          }
                       onError={[Function]}
                       onLoad={[Function]}
                       role={undefined}
@@ -76,10 +282,25 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   </div>
                 </div>
                 <div
-                  className="ms-ChoiceField-imageWrapper selectedImageWrapper-227"
+                  className=
+                      ms-ChoiceField-imageWrapper
+                      {
+                        padding-bottom: 2px;
+                        transition-duration: 200ms;
+                        transition-property: opacity;
+                        transition-timing-function: ease;
+                      }
+                      & .ms-Image {
+                        border-style: none;
+                        display: inline-block;
+                      }
                 >
                   <div
-                    className="ms-Image root-239"
+                    className=
+                        ms-Image
+                        {
+                          overflow: hidden;
+                        }
                     style={
                       Object {
                         "height": 32,
@@ -89,7 +310,17 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   >
                     <img
                       alt="Bar chart icon"
-                      className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                      className=
+                          ms-Image-image
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: 100%;
+                            opacity: 0;
+                            width: 100%;
+                          }
                       onError={[Function]}
                       onLoad={[Function]}
                       role={undefined}
@@ -99,7 +330,29 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 </div>
               </div>
               <div
-                className="ms-ChoiceField-labelWrapper labelWrapper-235"
+                className=
+                    ms-ChoiceField-labelWrapper
+                    {
+                      display: block;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      line-height: 15px;
+                      margin-bottom: 4px;
+                      margin-left: 8px;
+                      margin-right: 8px;
+                      margin-top: 4px;
+                      overflow: hidden;
+                      position: relative;
+                      text-overflow: ellipsis;
+                      white-space: pre-wrap;
+                    }
+                    & .ms-Label {
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                    }
                 style={
                   Object {
                     "maxWidth": 64,
@@ -117,15 +370,58 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
           </div>
         </div>
         <div
-          className="ms-ChoiceField ms-ChoiceField--image root-231"
+          className=
+              ms-ChoiceField
+              ms-ChoiceField--image
+              {
+                align-items: center;
+                background-color: #f4f4f4;
+                border: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: inline-flex;
+                font-size: 0px;
+                font-weight: 400;
+                height: 100%;
+                margin-bottom: 4px;
+                margin-left: 0;
+                margin-right: 4px;
+                margin-top: 0;
+                min-height: 26px;
+                padding-left: 0px;
+                position: relative;
+              }
+              & .ms-Label {
+                display: inline-block;
+                font-size: 14px;
+                padding-bottom: 0;
+                padding-left: 26px;
+                padding-right: 0;
+                padding-top: 0;
+              }
         >
           <div
-            className="ms-ChoiceField-wrapper choiceFieldWrapper-217"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               aria-labelledby="ChoiceGroupLabel1-pie"
               checked={false}
-              className="ms-ChoiceField-input input-232"
+              className=
+                  ms-ChoiceField-input
+                  {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    opacity: 0;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
+                  }
               disabled={undefined}
               id="ChoiceGroup0-pie"
               name="ChoiceGroup0"
@@ -136,11 +432,96 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
               type="radio"
             />
             <label
-              className="ms-ChoiceField-field ms-ChoiceField-field--image field-233"
+              className=
+                  ms-ChoiceField-field
+                  ms-ChoiceField-field--image
+                  {
+                    align-items: center;
+                    border: 2px solid transparent;
+                    box-sizing: content-box;
+                    cursor: pointer;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    min-height: 20px;
+                    padding-top: 22px;
+                    position: relative;
+                    text-align: center;
+                    transition-duration: 200ms;
+                    transition-property: all;
+                    transition-timing-function: ease;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:hover {
+                    border-color: #c8c8c8;
+                  }
+                  &:hover .ms-Label {
+                    color: #000000;
+                  }
+                  &:hover:before {
+                    border-color: #212121;
+                    opacity: 1;
+                  }
+                  &:focus {
+                    border-color: #c8c8c8;
+                  }
+                  &:focus .ms-Label {
+                    color: #000000;
+                  }
+                  &:focus:before {
+                    border-color: #212121;
+                    opacity: 1;
+                  }
+                  &:before {
+                    background-color: #ffffff;
+                    border-color: #666666;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: auto;
+                    opacity: 0;
+                    position: absolute;
+                    right: 3px;
+                    top: 3px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  &:after {
+                    border-radius: 50%;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 0px;
+                    left: 10px;
+                    position: absolute;
+                    right: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 0px;
+                  }
               htmlFor="ChoiceGroup0-pie"
             >
               <div
-                className="ms-ChoiceField-innerField innerField-234"
+                className=
+                    ms-ChoiceField-innerField
+                    {
+                      display: inline-block;
+                      padding-left: 30px;
+                      padding-right: 30px;
+                      position: relative;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -149,10 +530,25 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 }
               >
                 <div
-                  className="ms-ChoiceField-imageWrapper imageWrapper-221"
+                  className=
+                      ms-ChoiceField-imageWrapper
+                      {
+                        padding-bottom: 2px;
+                        transition-duration: 200ms;
+                        transition-property: opacity;
+                        transition-timing-function: ease;
+                      }
+                      & .ms-Image {
+                        border-style: none;
+                        display: inline-block;
+                      }
                 >
                   <div
-                    className="ms-Image root-239"
+                    className=
+                        ms-Image
+                        {
+                          overflow: hidden;
+                        }
                     style={
                       Object {
                         "height": 32,
@@ -162,7 +558,17 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   >
                     <img
                       alt=""
-                      className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                      className=
+                          ms-Image-image
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: 100%;
+                            opacity: 0;
+                            width: 100%;
+                          }
                       onError={[Function]}
                       onLoad={[Function]}
                       role={undefined}
@@ -171,10 +577,33 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   </div>
                 </div>
                 <div
-                  className="ms-ChoiceField-imageWrapper is-hidden selectedImageWrapper-222"
+                  className=
+                      ms-ChoiceField-imageWrapper
+                      is-hidden
+                      {
+                        height: 100%;
+                        left: 0px;
+                        opacity: 0;
+                        overflow: hidden;
+                        padding-bottom: 2px;
+                        position: absolute;
+                        top: 0px;
+                        transition-duration: 200ms;
+                        transition-property: opacity;
+                        transition-timing-function: ease;
+                        width: 100%;
+                      }
+                      & .ms-Image {
+                        border-style: none;
+                        display: inline-block;
+                      }
                 >
                   <div
-                    className="ms-Image root-239"
+                    className=
+                        ms-Image
+                        {
+                          overflow: hidden;
+                        }
                     style={
                       Object {
                         "height": 32,
@@ -184,7 +613,17 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   >
                     <img
                       alt=""
-                      className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                      className=
+                          ms-Image-image
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: 100%;
+                            opacity: 0;
+                            width: 100%;
+                          }
                       onError={[Function]}
                       onLoad={[Function]}
                       role={undefined}
@@ -194,7 +633,29 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 </div>
               </div>
               <div
-                className="ms-ChoiceField-labelWrapper labelWrapper-235"
+                className=
+                    ms-ChoiceField-labelWrapper
+                    {
+                      display: block;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 30px;
+                      line-height: 15px;
+                      margin-bottom: 4px;
+                      margin-left: 8px;
+                      margin-right: 8px;
+                      margin-top: 4px;
+                      overflow: hidden;
+                      position: relative;
+                      text-overflow: ellipsis;
+                      white-space: pre-wrap;
+                    }
+                    & .ms-Label {
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                    }
                 style={
                   Object {
                     "maxWidth": 64,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -5,13 +5,35 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
   className={undefined}
 >
   <div
-    className="dropdownContainer-244"
+    className=
+
+        {
+          max-width: 400px;
+        }
   >
     <div
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-89"
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Dropdown0"
         id="Dropdown0-label"
         required={undefined}
@@ -53,7 +75,17 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown root-55"
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -64,27 +96,115 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    className="buttonContainer-245"
+    className=
+
+        {
+          display: inline-block;
+          margin-top: 30px;
+        }
   >
     <button
       aria-describedby={undefined}
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__1"
           >
             Show Coachmark

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -2,13 +2,33 @@
 
 exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] = `
 <div
-  className="ms-ColorPicker root-246"
+  className=
+      ms-ColorPicker
+      {
+        max-width: 300px;
+        position: relative;
+      }
 >
   <div
-    className="ms-ColorPicker-panel panel-247"
+    className=
+        ms-ColorPicker-panel
+        {
+          padding-bottom: 16px;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 16px;
+        }
   >
     <div
-      className="ms-ColorPicker-colorRect root-252"
+      className=
+          ms-ColorPicker-colorRect
+          {
+            margin-bottom: 10px;
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+          }
       onMouseDown={[Function]}
       style={
         Object {
@@ -19,13 +39,42 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       }
     >
       <div
-        className="ms-ColorPicker-light light-253"
+        className=
+            ms-ColorPicker-light
+            {
+              background: linear-gradient(to right, white 0%, transparent 100%);
+              bottom: 0px;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
       />
       <div
-        className="ms-ColorPicker-dark dark-254"
+        className=
+            ms-ColorPicker-dark
+            {
+              background: linear-gradient(to bottom, transparent 0, #000 100%);
+              bottom: 0px;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
       />
       <div
-        className="ms-ColorPicker-thumb thumb-255"
+        className=
+            ms-ColorPicker-thumb
+            {
+              background: white;
+              border-radius: 50%;
+              border: 1px solid rgba(255,255,255,.8);
+              box-shadow: 0 0 15px -5px black;
+              height: 20px;
+              position: absolute;
+              transform: translate(-50%, -50%);
+              width: 20px;
+            }
         style={
           Object {
             "backgroundColor": "#FFFFFF",
@@ -36,7 +85,16 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       />
     </div>
     <div
-      className="ms-ColorPicker-slider is-hue root-256"
+      className=
+          ms-ColorPicker-slider
+          is-hue
+          {
+            border: 1px solid #eaeaea;
+            box-sizing: border-box;
+            height: 20px;
+            margin-bottom: 5px;
+            position: relative;
+          }
       onMouseDown={[Function]}
       style={
         Object {
@@ -45,11 +103,33 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       }
     >
       <div
-        className="ms-ColorPicker-sliderOverlay sliderOverlay-257"
+        className=
+            ms-ColorPicker-sliderOverlay
+            {
+              bottom: 0px;
+              content: ;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
         style={undefined}
       />
       <div
-        className="ms-ColorPicker-thumb is-slider sliderThumb-258"
+        className=
+            ms-ColorPicker-thumb
+            is-slider
+            {
+              background: white;
+              border-radius: 50%;
+              border: 1px solid rgba(255,255,255,.8);
+              box-shadow: 0 0 15px -5px black;
+              height: 20px;
+              position: absolute;
+              top: 50%;
+              transform: translate(-50%, -50%);
+              width: 20px;
+            }
         style={
           Object {
             "left": "0%",
@@ -58,7 +138,16 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       />
     </div>
     <div
-      className="ms-ColorPicker-slider is-alpha root-256"
+      className=
+          ms-ColorPicker-slider
+          is-alpha
+          {
+            border: 1px solid #eaeaea;
+            box-sizing: border-box;
+            height: 20px;
+            margin-bottom: 5px;
+            position: relative;
+          }
       onMouseDown={[Function]}
       style={
         Object {
@@ -67,7 +156,16 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       }
     >
       <div
-        className="ms-ColorPicker-sliderOverlay sliderOverlay-257"
+        className=
+            ms-ColorPicker-sliderOverlay
+            {
+              bottom: 0px;
+              content: ;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
         style={
           Object {
             "background": "linear-gradient(to right, transparent 0, #FFFFFF 100%)",
@@ -75,7 +173,20 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
         }
       />
       <div
-        className="ms-ColorPicker-thumb is-slider sliderThumb-258"
+        className=
+            ms-ColorPicker-thumb
+            is-slider
+            {
+              background: white;
+              border-radius: 50%;
+              border: 1px solid rgba(255,255,255,.8);
+              box-shadow: 0 0 15px -5px black;
+              height: 20px;
+              position: absolute;
+              top: 50%;
+              transform: translate(-50%, -50%);
+              width: 20px;
+            }
         style={
           Object {
             "left": "100%",
@@ -86,14 +197,31 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
     <table
       cellPadding="0"
       cellSpacing="0"
-      className="ms-ColorPicker-table table-248"
+      className=
+          ms-ColorPicker-table
+          {
+            table-layout: fixed;
+            width: 100%;
+          }
     >
       <thead>
         <tr
-          className="tableHeader-249"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+              }
         >
           <td
-            className="tableHexCell-250"
+            className=
+
+                {
+                  width: 25%;
+                }
           >
             Hex
           </td>
@@ -115,7 +243,26 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
         <tr>
           <td>
             <div
-              className="ms-TextField ms-ColorPicker-input input-251"
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    border: none;
+                    box-sizing: border-box;
+                    height: 30px;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 2px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
             >
               <div
                 className="ms-TextField-wrapper"
@@ -149,7 +296,26 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             }
           >
             <div
-              className="ms-TextField ms-ColorPicker-input input-251"
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    border: none;
+                    box-sizing: border-box;
+                    height: 30px;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 2px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
             >
               <div
                 className="ms-TextField-wrapper"
@@ -183,7 +349,26 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             }
           >
             <div
-              className="ms-TextField ms-ColorPicker-input input-251"
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    border: none;
+                    box-sizing: border-box;
+                    height: 30px;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 2px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
             >
               <div
                 className="ms-TextField-wrapper"
@@ -217,7 +402,26 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             }
           >
             <div
-              className="ms-TextField ms-ColorPicker-input input-251"
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    border: none;
+                    box-sizing: border-box;
+                    height: 30px;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 2px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
             >
               <div
                 className="ms-TextField-wrapper"
@@ -251,7 +455,26 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             }
           >
             <div
-              className="ms-TextField ms-ColorPicker-input input-251"
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    border: none;
+                    box-sizing: border-box;
+                    height: 30px;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 2px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
             >
               <div
                 className="ms-TextField-wrapper"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -12,7 +12,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop1-input"
       id="Basicdrop1-label"
       required={undefined}
@@ -20,7 +37,103 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Basic uncontrolled example (allowFreeform: T, AutoComplete: T):
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop1wrapper"
     >
@@ -35,7 +148,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -64,7 +191,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -73,11 +273,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -92,20 +320,113 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__3"
         >
           Set focus
@@ -121,7 +442,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop11-input"
       id="Basicdrop11-label"
       required={undefined}
@@ -129,7 +467,103 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Basic uncontrolled multi select example (allowFreeform: T, AutoComplete: T):
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop11wrapper"
     >
@@ -144,7 +578,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -173,7 +621,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -182,11 +703,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -204,7 +753,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop2-input"
       id="Basicdrop2-label"
       required={undefined}
@@ -212,7 +778,103 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Basic uncontrolled example (allowFreeform: T, AutoComplete: F):
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop2wrapper"
     >
@@ -227,7 +889,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -256,7 +932,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -265,11 +1014,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -287,7 +1064,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop3-input"
       id="Basicdrop3-label"
       required={undefined}
@@ -295,7 +1089,103 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Basic uncontrolled example (allowFreeform: F, AutoComplete: T):
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop3wrapper"
     >
@@ -310,7 +1200,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -339,7 +1243,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -348,11 +1325,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -370,7 +1375,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop1-input"
       id="Basicdrop1-label"
       required={undefined}
@@ -378,7 +1400,103 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Scaled example with 1000 items (allowFreeform: T, AutoComplete: T):
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop1wrapper"
     >
@@ -393,7 +1511,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -422,7 +1554,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -431,11 +1636,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -453,7 +1686,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop4-input"
       id="Basicdrop4-label"
       required={undefined}
@@ -461,7 +1711,103 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Basic uncontrolled example (allowFreeform: F, AutoComplete: F):
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop4wrapper"
     >
@@ -476,7 +1822,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -505,7 +1865,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -514,11 +1947,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -536,7 +1997,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop5-input"
       id="Basicdrop5-label"
       required={undefined}
@@ -544,7 +2022,73 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Basic uncontrolled example:
     </label>
     <div
-      className="ms-ComboBox css-268"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a80000;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-bottom: 5px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #a80000;
+            margin-bottom: 5px;
+          }
+          &:active {
+            border-color: #a80000;
+            margin-bottom: 5px;
+          }
+          &:focus {
+            border-color: #a80000;
+            margin-bottom: 5px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop5wrapper"
     >
@@ -559,7 +2103,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -588,7 +2146,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -597,11 +2228,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -611,7 +2270,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       </button>
     </div>
     <div
-      className="css-261"
+      className=
+
+          {
+            color: #a80000;
+          }
     >
       Error! Here is some text!
     </div>
@@ -623,7 +2286,27 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-271"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #c8c8c8;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: GrayText;
+          }
       htmlFor="ComboBox24-input"
       id="ComboBox24-label"
       required={undefined}
@@ -631,7 +2314,65 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Disabled uncontrolled example with defaultSelectedKey:
     </label>
     <div
-      className="ms-ComboBox is-disabled css-269"
+      className=
+          ms-ComboBox
+          is-disabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-color: #f4f4f4;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #a6a6a6;
+            cursor: default;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-color: GrayText;
+            color: GrayText;
+          }
       data-ktp-target={undefined}
       id="ComboBox24wrapper"
     >
@@ -646,7 +2387,29 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-270"
+        className=
+            ms-ComboBox-Input
+            {
+              background-color: #f4f4f4;
+              border-color: #f4f4f4;
+              border-style: none;
+              box-sizing: border-box;
+              color: #a6a6a6;
+              cursor: default;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: GrayText;
+              color: GrayText;
+            }
         data-is-interactable={false}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -675,7 +2438,76 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon is-disabled ms-ComboBox-CaretDown-button root-272"
+        className=
+            ms-Button
+            ms-Button--icon
+            is-disabled
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #a6a6a6;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              pointer-events: none;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: GrayText;
+              color: GrayText;
+            }
+            &:hover {
+              outline: 0px;
+            }
+            &:focus {
+              outline: 0px;
+            }
         data-is-focusable={false}
         disabled={true}
         onClick={[Function]}
@@ -684,11 +2516,40 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-274"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -706,7 +2567,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop5-input"
       id="Basicdrop5-label"
       required={undefined}
@@ -714,7 +2592,103 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Basic controlled example:
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop5wrapper"
     >
@@ -729,7 +2703,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -758,7 +2746,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -767,11 +2828,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -789,7 +2878,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop5-input"
       id="Basicdrop5-label"
       required={undefined}
@@ -797,7 +2903,103 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       Basic controlled ComboBox multi-select example:
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop5wrapper"
     >
@@ -812,7 +3014,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -841,7 +3057,80 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -850,11 +3139,39 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -6,11 +6,32 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
 >
   <div
     autoComplete="on"
-    className="ms-ComboBox-container css-275"
+    className=
+        ms-ComboBox-container
+        {
+          max-width: 300px;
+        }
     id="Basicdrop6"
   >
     <label
-      className="ms-Label root-89"
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop6-input"
       id="Basicdrop6-label"
       required={undefined}
@@ -18,7 +39,103 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
       Custom styled uncontrolled ComboBox (allowFreeform: T, AutoComplete: T):
     </label>
     <div
-      className="ms-ComboBox css-259"
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
       data-ktp-target={undefined}
       id="Basicdrop6wrapper"
     >
@@ -33,7 +150,21 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
         aria-owns={undefined}
         autoCapitalize="off"
         autoComplete="off"
-        className="ms-ComboBox-Input css-260"
+        className=
+            ms-ComboBox-Input
+            {
+              border-style: none;
+              box-sizing: border-box;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
         data-is-interactable={true}
         data-ktp-execute-target={undefined}
         data-lpignore={true}
@@ -62,7 +193,80 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
         aria-labelledby={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Button ms-Button--icon ms-ComboBox-CaretDown-button root-265"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={[Function]}
@@ -71,11 +275,39 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-267"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -3,7 +3,12 @@
 exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -17,7 +22,18 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
         aria-describedby={undefined}
         aria-label="Use left and right arrow keys to navigate between commands"
         aria-labelledby={undefined}
-        className="ms-FocusZone ms-CommandBar root-276"
+        className=
+            ms-FocusZone
+            ms-CommandBar
+            {
+              background-color: #f4f4f4;
+              display: flex;
+              height: 40px;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+            }
         data-focuszone-id="FocusZone0"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -25,7 +41,14 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
         role="menubar"
       >
         <div
-          className="ms-OverflowSet ms-CommandBar-primaryCommand primarySet-277"
+          className=
+              ms-OverflowSet
+              ms-CommandBar-primaryCommand
+              {
+                align-items: stretch;
+                display: flex;
+                flex-grow: 1;
+              }
           role="presentation"
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -3,7 +3,12 @@
 exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -17,7 +22,18 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
         aria-describedby={undefined}
         aria-label="Use left and right arrow keys to navigate between commands"
         aria-labelledby={undefined}
-        className="ms-FocusZone ms-CommandBar root-276"
+        className=
+            ms-FocusZone
+            ms-CommandBar
+            {
+              background-color: #f4f4f4;
+              display: flex;
+              height: 40px;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+            }
         data-focuszone-id="FocusZone0"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -25,7 +41,14 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
         role="menubar"
       >
         <div
-          className="ms-OverflowSet ms-CommandBar-primaryCommand primarySet-277"
+          className=
+              ms-OverflowSet
+              ms-CommandBar-primaryCommand
+              {
+                align-items: stretch;
+                display: flex;
+                flex-grow: 1;
+              }
           role="presentation"
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
@@ -10,7 +10,69 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
     aria-labelledby={undefined}
     aria-owns={null}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     id="ContextualMenuButton1"
@@ -19,13 +81,34 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Click for ContextualMenu
@@ -33,7 +116,27 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
       </div>
       <i
         aria-hidden={true}
-        className="ms-Button-menuIcon menuIcon-143"
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="ChevronDown"
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Checkmarks.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Checkmarks.Example.tsx.shot
@@ -9,7 +9,69 @@ exports[`Component Examples renders ContextualMenu.Checkmarks.Example.tsx correc
   aria-labelledby={undefined}
   aria-owns={null}
   aria-pressed={undefined}
-  className="ms-Button ms-Button--default root-119"
+  className=
+      ms-Button
+      ms-Button--default
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background-color: #f4f4f4;
+        border-radius: 0px;
+        border: 1px solid transparent;
+        box-sizing: border-box;
+        color: #333333;
+        cursor: pointer;
+        display: inline-block;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 32px;
+        min-width: 80px;
+        outline: transparent;
+        padding-bottom: 0;
+        padding-left: 16px;
+        padding-right: 16px;
+        padding-top: 0;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        user-select: none;
+        vertical-align: top;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #ffffff;
+        bottom: 0px;
+        content: "";
+        left: 0px;
+        outline: 1px solid #666666;
+        position: absolute;
+        right: 0px;
+        top: 0px;
+        z-index: 1;
+      }
+      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+        border: none;
+        bottom: -2px;
+        left: -2px;
+        outline-color: ButtonText;
+        right: -2px;
+        top: -2px;
+      }
+      &:hover {
+        background-color: #eaeaea;
+        color: #000000;
+      }
+      @media screen and (-ms-high-contrast: active){&:hover {
+        border-color: Highlight;
+        color: Highlight;
+      }
+      &:active {
+        background-color: #c8c8c8;
+        color: #212121;
+      }
   data-is-focusable={true}
   disabled={undefined}
   id="ContextualMenuButton2"
@@ -18,13 +80,34 @@ exports[`Component Examples renders ContextualMenu.Checkmarks.Example.tsx correc
   type="button"
 >
   <div
-    className="ms-Button-flexContainer flexContainer-102"
+    className=
+        ms-Button-flexContainer
+        {
+          align-items: center;
+          display: flex;
+          flex-wrap: nowrap;
+          height: 100%;
+          justify-content: center;
+        }
   >
     <div
-      className="ms-Button-textContainer textContainer-103"
+      className=
+          ms-Button-textContainer
+          {
+            flex-grow: 1;
+          }
     >
       <div
-        className="ms-Button-label label-120"
+        className=
+            ms-Button-label
+            {
+              font-weight: 600;
+              line-height: 100%;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
         id="id__0"
       >
         Click for ContextualMenu
@@ -32,7 +115,27 @@ exports[`Component Examples renders ContextualMenu.Checkmarks.Example.tsx correc
     </div>
     <i
       aria-hidden={true}
-      className="ms-Button-menuIcon menuIcon-143"
+      className=
+          ms-Button-menuIcon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: inline-block;
+            flex-shrink: 0;
+            font-family: "FabricMDL2Icons";
+            font-size: 12px;
+            font-style: normal;
+            font-weight: normal;
+            height: 16px;
+            line-height: 16px;
+            margin-bottom: 0;
+            margin-left: 4px;
+            margin-right: 4px;
+            margin-top: 0;
+            speak: none;
+            text-align: center;
+            vertical-align: middle;
+          }
       data-icon-name="ChevronDown"
       role="presentation"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuItem.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuItem.Example.tsx.shot
@@ -10,7 +10,69 @@ exports[`Component Examples renders ContextualMenu.CustomMenuItem.Example.tsx co
     aria-labelledby={undefined}
     aria-owns={null}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     id="ContextualMenuButton1"
@@ -19,13 +81,34 @@ exports[`Component Examples renders ContextualMenu.CustomMenuItem.Example.tsx co
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Click for ContextualMenu
@@ -33,7 +116,27 @@ exports[`Component Examples renders ContextualMenu.CustomMenuItem.Example.tsx co
       </div>
       <i
         aria-hidden={true}
-        className="ms-Button-menuIcon menuIcon-143"
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="ChevronDown"
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Customization.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Customization.Example.tsx.shot
@@ -9,7 +9,70 @@ exports[`Component Examples renders ContextualMenu.Customization.Example.tsx cor
   aria-labelledby={undefined}
   aria-owns={null}
   aria-pressed={undefined}
-  className="ms-Button ms-Button--default ContextualMenuButton3 root-119"
+  className=
+      ms-Button
+      ms-Button--default
+      ContextualMenuButton3
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background-color: #f4f4f4;
+        border-radius: 0px;
+        border: 1px solid transparent;
+        box-sizing: border-box;
+        color: #333333;
+        cursor: pointer;
+        display: inline-block;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 32px;
+        min-width: 80px;
+        outline: transparent;
+        padding-bottom: 0;
+        padding-left: 16px;
+        padding-right: 16px;
+        padding-top: 0;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        user-select: none;
+        vertical-align: top;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #ffffff;
+        bottom: 0px;
+        content: "";
+        left: 0px;
+        outline: 1px solid #666666;
+        position: absolute;
+        right: 0px;
+        top: 0px;
+        z-index: 1;
+      }
+      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+        border: none;
+        bottom: -2px;
+        left: -2px;
+        outline-color: ButtonText;
+        right: -2px;
+        top: -2px;
+      }
+      &:hover {
+        background-color: #eaeaea;
+        color: #000000;
+      }
+      @media screen and (-ms-high-contrast: active){&:hover {
+        border-color: Highlight;
+        color: Highlight;
+      }
+      &:active {
+        background-color: #c8c8c8;
+        color: #212121;
+      }
   data-is-focusable={true}
   disabled={undefined}
   onClick={[Function]}
@@ -17,13 +80,34 @@ exports[`Component Examples renders ContextualMenu.Customization.Example.tsx cor
   type="button"
 >
   <div
-    className="ms-Button-flexContainer flexContainer-102"
+    className=
+        ms-Button-flexContainer
+        {
+          align-items: center;
+          display: flex;
+          flex-wrap: nowrap;
+          height: 100%;
+          justify-content: center;
+        }
   >
     <div
-      className="ms-Button-textContainer textContainer-103"
+      className=
+          ms-Button-textContainer
+          {
+            flex-grow: 1;
+          }
     >
       <div
-        className="ms-Button-label label-120"
+        className=
+            ms-Button-label
+            {
+              font-weight: 600;
+              line-height: 100%;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
         id="id__0"
       >
         Click for ContextualMenu
@@ -31,7 +115,27 @@ exports[`Component Examples renders ContextualMenu.Customization.Example.tsx cor
     </div>
     <i
       aria-hidden={true}
-      className="ms-Button-menuIcon menuIcon-143"
+      className=
+          ms-Button-menuIcon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: inline-block;
+            flex-shrink: 0;
+            font-family: "FabricMDL2Icons";
+            font-size: 12px;
+            font-style: normal;
+            font-weight: normal;
+            height: 16px;
+            line-height: 16px;
+            margin-bottom: 0;
+            margin-left: 4px;
+            margin-right: 4px;
+            margin-top: 0;
+            speak: none;
+            text-align: center;
+            vertical-align: middle;
+          }
       data-icon-name="ChevronDown"
       role="presentation"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomizationWithNoWrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomizationWithNoWrap.Example.tsx.shot
@@ -9,7 +9,70 @@ exports[`Component Examples renders ContextualMenu.CustomizationWithNoWrap.Examp
   aria-labelledby={undefined}
   aria-owns={null}
   aria-pressed={undefined}
-  className="ms-Button ms-Button--default ContextualMenuButton3 root-119"
+  className=
+      ms-Button
+      ms-Button--default
+      ContextualMenuButton3
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background-color: #f4f4f4;
+        border-radius: 0px;
+        border: 1px solid transparent;
+        box-sizing: border-box;
+        color: #333333;
+        cursor: pointer;
+        display: inline-block;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 32px;
+        min-width: 80px;
+        outline: transparent;
+        padding-bottom: 0;
+        padding-left: 16px;
+        padding-right: 16px;
+        padding-top: 0;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        user-select: none;
+        vertical-align: top;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #ffffff;
+        bottom: 0px;
+        content: "";
+        left: 0px;
+        outline: 1px solid #666666;
+        position: absolute;
+        right: 0px;
+        top: 0px;
+        z-index: 1;
+      }
+      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+        border: none;
+        bottom: -2px;
+        left: -2px;
+        outline-color: ButtonText;
+        right: -2px;
+        top: -2px;
+      }
+      &:hover {
+        background-color: #eaeaea;
+        color: #000000;
+      }
+      @media screen and (-ms-high-contrast: active){&:hover {
+        border-color: Highlight;
+        color: Highlight;
+      }
+      &:active {
+        background-color: #c8c8c8;
+        color: #212121;
+      }
   data-is-focusable={true}
   disabled={undefined}
   onClick={[Function]}
@@ -17,13 +80,34 @@ exports[`Component Examples renders ContextualMenu.CustomizationWithNoWrap.Examp
   type="button"
 >
   <div
-    className="ms-Button-flexContainer flexContainer-102"
+    className=
+        ms-Button-flexContainer
+        {
+          align-items: center;
+          display: flex;
+          flex-wrap: nowrap;
+          height: 100%;
+          justify-content: center;
+        }
   >
     <div
-      className="ms-Button-textContainer textContainer-103"
+      className=
+          ms-Button-textContainer
+          {
+            flex-grow: 1;
+          }
     >
       <div
-        className="ms-Button-label label-120"
+        className=
+            ms-Button-label
+            {
+              font-weight: 600;
+              line-height: 100%;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
         id="id__0"
       >
         Click for ContextualMenu
@@ -31,7 +115,27 @@ exports[`Component Examples renders ContextualMenu.CustomizationWithNoWrap.Examp
     </div>
     <i
       aria-hidden={true}
-      className="ms-Button-menuIcon menuIcon-143"
+      className=
+          ms-Button-menuIcon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: inline-block;
+            flex-shrink: 0;
+            font-family: "FabricMDL2Icons";
+            font-size: 12px;
+            font-style: normal;
+            font-weight: normal;
+            height: 16px;
+            line-height: 16px;
+            margin-bottom: 0;
+            margin-left: 4px;
+            margin-right: 4px;
+            margin-top: 0;
+            speak: none;
+            text-align: center;
+            vertical-align: middle;
+          }
       data-icon-name="ChevronDown"
       role="presentation"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -16,7 +16,60 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
       aria-posinset={undefined}
       aria-setsize={undefined}
       checked={false}
-      className="ms-Checkbox is-enabled root-189"
+      className=
+          ms-Checkbox
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background: none;
+            border: none;
+            cursor: pointer;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -2px;
+            content: "";
+            left: -2px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -2px;
+            top: -2px;
+            z-index: 1;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #212121;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #212121;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
+          }
       data-ktp-execute-target={undefined}
       disabled={undefined}
       id="checkbox-0"
@@ -28,16 +81,66 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
       type="button"
     >
       <label
-        className="ms-Checkbox-label label-184"
+        className=
+            ms-Checkbox-label
+            {
+              align-items: center;
+              cursor: pointer;
+              display: inline-flex;
+              margin-bottom: 0;
+              margin-left: -4px;
+              margin-right: -4px;
+              margin-top: 0;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
         htmlFor="checkbox-0"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-190"
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                border-color: #666666;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                overflow: hidden;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
           data-ktp-target={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-192"
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 0;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
             data-icon-name="CheckMark"
             role="presentation"
           >
@@ -45,7 +148,16 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-187"
+          className=
+              ms-Checkbox-text
+              {
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
         >
           Show beak
         </span>
@@ -55,7 +167,25 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-89"
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Dropdown1"
         id="Dropdown1-label"
         required={undefined}
@@ -96,7 +226,17 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown root-55"
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -117,7 +257,69 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
       aria-labelledby={undefined}
       aria-owns={null}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
@@ -125,13 +327,34 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__2"
           >
             Show context menu
@@ -139,7 +362,27 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
         </div>
         <i
           aria-hidden={true}
-          className="ms-Button-menuIcon menuIcon-143"
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Header.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Header.Example.tsx.shot
@@ -9,7 +9,69 @@ exports[`Component Examples renders ContextualMenu.Header.Example.tsx correctly 
   aria-labelledby={undefined}
   aria-owns={null}
   aria-pressed={undefined}
-  className="ms-Button ms-Button--default root-119"
+  className=
+      ms-Button
+      ms-Button--default
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background-color: #f4f4f4;
+        border-radius: 0px;
+        border: 1px solid transparent;
+        box-sizing: border-box;
+        color: #333333;
+        cursor: pointer;
+        display: inline-block;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 32px;
+        min-width: 80px;
+        outline: transparent;
+        padding-bottom: 0;
+        padding-left: 16px;
+        padding-right: 16px;
+        padding-top: 0;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        user-select: none;
+        vertical-align: top;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #ffffff;
+        bottom: 0px;
+        content: "";
+        left: 0px;
+        outline: 1px solid #666666;
+        position: absolute;
+        right: 0px;
+        top: 0px;
+        z-index: 1;
+      }
+      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+        border: none;
+        bottom: -2px;
+        left: -2px;
+        outline-color: ButtonText;
+        right: -2px;
+        top: -2px;
+      }
+      &:hover {
+        background-color: #eaeaea;
+        color: #000000;
+      }
+      @media screen and (-ms-high-contrast: active){&:hover {
+        border-color: Highlight;
+        color: Highlight;
+      }
+      &:active {
+        background-color: #c8c8c8;
+        color: #212121;
+      }
   data-is-focusable={true}
   disabled={undefined}
   id="ContextualMenuButton1"
@@ -18,13 +80,34 @@ exports[`Component Examples renders ContextualMenu.Header.Example.tsx correctly 
   type="button"
 >
   <div
-    className="ms-Button-flexContainer flexContainer-102"
+    className=
+        ms-Button-flexContainer
+        {
+          align-items: center;
+          display: flex;
+          flex-wrap: nowrap;
+          height: 100%;
+          justify-content: center;
+        }
   >
     <div
-      className="ms-Button-textContainer textContainer-103"
+      className=
+          ms-Button-textContainer
+          {
+            flex-grow: 1;
+          }
     >
       <div
-        className="ms-Button-label label-120"
+        className=
+            ms-Button-label
+            {
+              font-weight: 600;
+              line-height: 100%;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
         id="id__0"
       >
         Click for ContextualMenu
@@ -32,7 +115,27 @@ exports[`Component Examples renders ContextualMenu.Header.Example.tsx correctly 
     </div>
     <i
       aria-hidden={true}
-      className="ms-Button-menuIcon menuIcon-143"
+      className=
+          ms-Button-menuIcon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: inline-block;
+            flex-shrink: 0;
+            font-family: "FabricMDL2Icons";
+            font-size: 12px;
+            font-style: normal;
+            font-weight: normal;
+            height: 16px;
+            line-height: 16px;
+            margin-bottom: 0;
+            margin-left: 4px;
+            margin-right: 4px;
+            margin-top: 0;
+            speak: none;
+            text-align: center;
+            vertical-align: middle;
+          }
       data-icon-name="ChevronDown"
       role="presentation"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.Example.tsx.shot
@@ -10,7 +10,69 @@ exports[`Component Examples renders ContextualMenu.Icon.Example.tsx correctly 1`
     aria-labelledby={undefined}
     aria-owns={null}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     id="ContextualMenuButton2"
@@ -19,13 +81,34 @@ exports[`Component Examples renders ContextualMenu.Icon.Example.tsx correctly 1`
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Click for ContextualMenu
@@ -33,7 +116,27 @@ exports[`Component Examples renders ContextualMenu.Icon.Example.tsx correctly 1`
       </div>
       <i
         aria-hidden={true}
-        className="ms-Button-menuIcon menuIcon-143"
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="ChevronDown"
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.SecondaryText.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.SecondaryText.Example.tsx.shot
@@ -10,7 +10,69 @@ exports[`Component Examples renders ContextualMenu.Icon.SecondaryText.Example.ts
     aria-labelledby={undefined}
     aria-owns={null}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     id="ContextualMenuButton2"
@@ -19,13 +81,34 @@ exports[`Component Examples renders ContextualMenu.Icon.SecondaryText.Example.ts
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Click for ContextualMenu
@@ -33,7 +116,27 @@ exports[`Component Examples renders ContextualMenu.Icon.SecondaryText.Example.ts
       </div>
       <i
         aria-hidden={true}
-        className="ms-Button-menuIcon menuIcon-143"
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="ChevronDown"
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.ScrollBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.ScrollBar.Example.tsx.shot
@@ -10,7 +10,69 @@ exports[`Component Examples renders ContextualMenu.ScrollBar.Example.tsx correct
     aria-labelledby={undefined}
     aria-owns={null}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     id="ContextualMenuButton1"
@@ -19,13 +81,34 @@ exports[`Component Examples renders ContextualMenu.ScrollBar.Example.tsx correct
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Click for ContextualMenu
@@ -33,7 +116,27 @@ exports[`Component Examples renders ContextualMenu.ScrollBar.Example.tsx correct
       </div>
       <i
         aria-hidden={true}
-        className="ms-Button-menuIcon menuIcon-143"
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="ChevronDown"
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Section.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Section.Example.tsx.shot
@@ -10,7 +10,69 @@ exports[`Component Examples renders ContextualMenu.Section.Example.tsx correctly
     aria-labelledby={undefined}
     aria-owns={null}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     id="ContextualMenuButton1"
@@ -19,13 +81,34 @@ exports[`Component Examples renders ContextualMenu.Section.Example.tsx correctly
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Click for ContextualMenu
@@ -33,7 +116,27 @@ exports[`Component Examples renders ContextualMenu.Section.Example.tsx correctly
       </div>
       <i
         aria-hidden={true}
-        className="ms-Button-menuIcon menuIcon-143"
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="ChevronDown"
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -35,7 +35,69 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
     aria-labelledby={undefined}
     aria-owns={null}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     id="ContextualMenuButton2"
@@ -44,13 +106,34 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__2"
         >
           Click for ContextualMenu
@@ -58,7 +141,27 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
       </div>
       <i
         aria-hidden={true}
-        className="ms-Button-menuIcon menuIcon-143"
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="ChevronDown"
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -41,7 +41,17 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
             />
             <i
               aria-hidden={true}
-              className="ms-DatePicker-event--without-label root-55"
+              className=
+                  ms-DatePicker-event--without-label
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="Calendar"
               onClick={[Function]}
               role="presentation"
@@ -57,7 +67,25 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Dropdown2"
       id="Dropdown2-label"
       required={undefined}
@@ -98,7 +126,17 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -44,7 +44,17 @@ exports[`Component Examples renders DatePicker.Bounded.Example.tsx correctly 1`]
             />
             <i
               aria-hidden={true}
-              className="ms-DatePicker-event--without-label root-55"
+              className=
+                  ms-DatePicker-event--without-label
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="Calendar"
               onClick={[Function]}
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -18,7 +18,24 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
           className="ms-TextField-wrapper"
         >
           <label
-            className="ms-Label root-89"
+            className=
+                ms-Label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="TextField0"
           >
             Start date
@@ -50,7 +67,17 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
             />
             <i
               aria-hidden={true}
-              className="ms-DatePicker-event--with-label root-55"
+              className=
+                  ms-DatePicker-event--with-label
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="Calendar"
               onClick={[Function]}
               role="presentation"
@@ -67,20 +94,103 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__2"
         >
           Clear

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -18,7 +18,24 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
           className="ms-TextField-wrapper"
         >
           <label
-            className="ms-Label root-89"
+            className=
+                ms-Label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="TextField0"
           >
             Start date
@@ -50,7 +67,17 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
             />
             <i
               aria-hidden={true}
-              className="ms-DatePicker-event--with-label root-55"
+              className=
+                  ms-DatePicker-event--with-label
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="Calendar"
               onClick={[Function]}
               role="presentation"
@@ -67,20 +94,103 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__2"
         >
           Clear

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -18,7 +18,24 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
           className="ms-TextField-wrapper"
         >
           <label
-            className="ms-Label root-89"
+            className=
+                ms-Label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="TextField0"
           >
             Date required (with label)
@@ -50,7 +67,17 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
             />
             <i
               aria-hidden={true}
-              className="ms-DatePicker-event--with-label root-55"
+              className=
+                  ms-DatePicker-event--with-label
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="Calendar"
               onClick={[Function]}
               role="presentation"
@@ -99,7 +126,17 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
             />
             <i
               aria-hidden={true}
-              className="ms-DatePicker-event--without-label root-55"
+              className=
+                  ms-DatePicker-event--without-label
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="Calendar"
               onClick={[Function]}
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -41,7 +41,17 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
             />
             <i
               aria-hidden={true}
-              className="ms-DatePicker-event--without-label root-55"
+              className=
+                  ms-DatePicker-event--without-label
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="Calendar"
               onClick={[Function]}
               role="presentation"
@@ -57,7 +67,25 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Dropdown2"
       id="Dropdown2-label"
       required={undefined}
@@ -98,7 +126,17 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -5,7 +5,12 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
   className="ms-DetailsListAdvancedExample"
 >
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -19,7 +24,18 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
         aria-describedby={undefined}
         aria-label={undefined}
         aria-labelledby={undefined}
-        className="ms-FocusZone ms-CommandBar root-276"
+        className=
+            ms-FocusZone
+            ms-CommandBar
+            {
+              background-color: #f4f4f4;
+              display: flex;
+              height: 40px;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+            }
         data-focuszone-id="FocusZone0"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -27,7 +43,14 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
         role="menubar"
       >
         <div
-          className="ms-OverflowSet ms-CommandBar-primaryCommand primarySet-277"
+          className=
+              ms-OverflowSet
+              ms-CommandBar-primaryCommand
+              {
+                align-items: stretch;
+                display: flex;
+                flex-grow: 1;
+              }
           role="presentation"
         >
           <div
@@ -40,28 +63,135 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               aria-posinset={1}
               aria-pressed={undefined}
               aria-setsize={3}
-              className="ms-Button ms-Button--commandBar ms-CommandBarItem-link root-280"
+              className=
+                  ms-Button
+                  ms-Button--commandBar
+                  ms-CommandBarItem-link
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #f4f4f4;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 100%;
+                    min-width: 40px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: 4px;
+                    left: 4px;
+                    outline-color: ButtonText;
+                    right: 4px;
+                    top: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  &:hover {
+                    background-color: #eaeaea;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #dadada;
+                    color: #000000;
+                  }
               data-is-focusable={true}
               disabled={undefined}
               onClick={[Function]}
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-102"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="ms-Button-icon icon-118"
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
                   data-icon-name="Add"
                   role="presentation"
                 >
                   
                 </i>
                 <div
-                  className="ms-Button-textContainer textContainer-103"
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
                 >
                   <div
-                    className="ms-Button-label label-123"
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: normal;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
                     id="id__1"
                   >
                     Insert row
@@ -80,28 +210,135 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               aria-posinset={2}
               aria-pressed={undefined}
               aria-setsize={3}
-              className="ms-Button ms-Button--commandBar ms-CommandBarItem-link root-280"
+              className=
+                  ms-Button
+                  ms-Button--commandBar
+                  ms-CommandBarItem-link
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #f4f4f4;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 100%;
+                    min-width: 40px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: 4px;
+                    left: 4px;
+                    outline-color: ButtonText;
+                    right: 4px;
+                    top: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  &:hover {
+                    background-color: #eaeaea;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #dadada;
+                    color: #000000;
+                  }
               data-is-focusable={true}
               disabled={undefined}
               onClick={[Function]}
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-102"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="ms-Button-icon icon-118"
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
                   data-icon-name="Delete"
                   role="presentation"
                 >
                   
                 </i>
                 <div
-                  className="ms-Button-textContainer textContainer-103"
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
                 >
                   <div
-                    className="ms-Button-label label-123"
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: normal;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
                     id="id__4"
                   >
                     Delete row
@@ -123,7 +360,72 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               aria-posinset={3}
               aria-pressed={undefined}
               aria-setsize={3}
-              className="ms-Button ms-Button--commandBar ms-CommandBarItem-link root-280"
+              className=
+                  ms-Button
+                  ms-Button--commandBar
+                  ms-CommandBarItem-link
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #f4f4f4;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 100%;
+                    min-width: 40px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: 4px;
+                    left: 4px;
+                    outline-color: ButtonText;
+                    right: 4px;
+                    top: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  &:hover {
+                    background-color: #eaeaea;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #dadada;
+                    color: #000000;
+                  }
               data-is-focusable={true}
               disabled={undefined}
               onClick={[Function]}
@@ -131,21 +433,63 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-102"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="ms-Button-icon icon-118"
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
                   data-icon-name="Settings"
                   role="presentation"
                 >
                   
                 </i>
                 <div
-                  className="ms-Button-textContainer textContainer-103"
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
                 >
                   <div
-                    className="ms-Button-label label-123"
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: normal;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
                     id="id__7"
                   >
                     Configure
@@ -153,7 +497,28 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 </div>
                 <i
                   aria-hidden={true}
-                  className="ms-Button-menuIcon menuIcon-121"
+                  className=
+                      ms-Button-menuIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #666666;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
                   data-icon-name="ChevronDown"
                   role="presentation"
                 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -12,7 +12,24 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         Filter by name:
@@ -37,7 +54,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
     </div>
   </div>
   <div
-    className="root-281"
+    className=
+
+        {
+          cursor: default;
+          position: relative;
+        }
   >
     <div
       className="ms-Viewport"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -3,23 +3,101 @@
 exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-Toggle is-enabled root-285"
+    className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <label
-      className="ms-Label ms-Toggle-label label-230"
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Toggle0"
     >
       Enable Compact Mode
     </label>
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label="Enable Compact Mode"
         aria-pressed={false}
         checked={false}
-        className="ms-Toggle-background pill-287"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-color: #666666;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle0"
@@ -28,11 +106,52 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-288"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #212121;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-290"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
         htmlFor="Toggle0"
       >
         Normal
@@ -40,23 +159,101 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
     </div>
   </div>
   <div
-    className="ms-Toggle is-enabled root-285"
+    className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <label
-      className="ms-Label ms-Toggle-label label-230"
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Toggle1"
     >
       Enable Modal Selection
     </label>
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label="Enable Modal Selection"
         aria-pressed={false}
         checked={false}
-        className="ms-Toggle-background pill-287"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-color: #666666;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle1"
@@ -65,11 +262,52 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-288"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #212121;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-290"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
         htmlFor="Toggle1"
       >
         Normal
@@ -86,7 +324,24 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField2"
       >
         Filter by name:
@@ -111,7 +366,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
     </div>
   </div>
   <div
-    className="root-281"
+    className=
+
+        {
+          cursor: default;
+          position: relative;
+        }
   >
     <div
       className="ms-Viewport"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -6,7 +6,12 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
 >
   <div />
   <div
-    className="root-281"
+    className=
+
+        {
+          cursor: default;
+          position: relative;
+        }
   >
     <div
       className="ms-Viewport"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -2,27 +2,136 @@
 
 exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`] = `
 <div
-  className="ms-Fabric DetailsList-grouped-example root-291"
+  className=
+      ms-Fabric
+      DetailsList-grouped-example
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        color: #333333;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+      & button {
+        font-family: inherit;
+      }
+      & input {
+        font-family: inherit;
+      }
+      & textarea {
+        font-family: inherit;
+      }
+      button {
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        overflow: visible;
+      }
 >
   <button
     aria-describedby={undefined}
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Add an item

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Dialog

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = 
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Dialog

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.LargeHeader.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.LargeHeader.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Dialog.LargeHeader.Example.tsx correctly 1`]
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Dialog

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -15,7 +15,12 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
   >
     <div>
       <div
-        className="ms-Image root-300"
+        className=
+            ms-Image
+            {
+              overflow: hidden;
+              position: relative;
+            }
         style={
           Object {
             "height": 196,
@@ -25,7 +30,22 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
       >
         <img
           alt=""
-          className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+          className=
+              ms-Image-image
+              ms-Image-image--cover
+              ms-Image-image--portrait
+              is-notLoaded
+              is-fadeIn
+              {
+                display: block;
+                height: auto;
+                left: 50% /* @noflip */;
+                opacity: 0;
+                position: absolute;
+                top: 50%;
+                transform: translate(-50%,-50%);
+                width: 100%;
+              }
           onError={[Function]}
           onLoad={[Function]}
           role="presentation"
@@ -33,7 +53,12 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
         />
       </div>
       <div
-        className="ms-Image ms-DocumentCardPreview-icon root-239"
+        className=
+            ms-Image
+            ms-DocumentCardPreview-icon
+            {
+              overflow: hidden;
+            }
         style={
           Object {
             "height": undefined,
@@ -43,7 +68,15 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
       >
         <img
           alt=""
-          className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-301"
+          className=
+              ms-Image-image
+              ms-Image-image--portrait
+              is-notLoaded
+              is-fadeIn
+              {
+                display: block;
+                opacity: 0;
+              }
           onError={[Function]}
           onLoad={[Function]}
           role="presentation"
@@ -68,16 +101,47 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
         className="ms-DocumentCardActivity-avatar"
       >
         <div
-          className="ms-Persona-coin ms-Persona--size32 coin-72"
+          className=
+              ms-Persona-coin
+              ms-Persona--size32
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           role="persentation"
           size={11}
         >
           <div
-            className="ms-Persona-imageArea imageArea-80"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 32px;
+                  position: relative;
+                  text-align: center;
+                  width: 32px;
+                }
             style={undefined}
           >
             <div
-              className="ms-Image ms-Persona-image image-83"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 32px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 32px;
+                  }
               style={
                 Object {
                   "height": 32,
@@ -87,7 +151,22 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -20,7 +20,12 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         >
           <li>
             <div
-              className="ms-Image ms-DocumentCardPreview-fileListIcon root-239"
+              className=
+                  ms-Image
+                  ms-DocumentCardPreview-fileListIcon
+                  {
+                    overflow: hidden;
+                  }
               style={
                 Object {
                   "height": "16px",
@@ -30,7 +35,17 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                className=
+                    ms-Image-image
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      opacity: 0;
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role="presentation"
@@ -45,7 +60,12 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           </li>
           <li>
             <div
-              className="ms-Image ms-DocumentCardPreview-fileListIcon root-239"
+              className=
+                  ms-Image
+                  ms-DocumentCardPreview-fileListIcon
+                  {
+                    overflow: hidden;
+                  }
               style={
                 Object {
                   "height": "16px",
@@ -55,7 +75,17 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                className=
+                    ms-Image-image
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      opacity: 0;
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role="presentation"
@@ -70,7 +100,12 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           </li>
           <li>
             <div
-              className="ms-Image ms-DocumentCardPreview-fileListIcon root-239"
+              className=
+                  ms-Image
+                  ms-DocumentCardPreview-fileListIcon
+                  {
+                    overflow: hidden;
+                  }
               style={
                 Object {
                   "height": "16px",
@@ -80,7 +115,17 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                className=
+                    ms-Image-image
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      opacity: 0;
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role="presentation"
@@ -120,16 +165,47 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
             className="ms-DocumentCardActivity-avatar"
           >
             <div
-              className="ms-Persona-coin ms-Persona--size32 coin-72"
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
               role="persentation"
               size={11}
             >
               <div
-                className="ms-Persona-imageArea imageArea-80"
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
                 style={undefined}
               >
                 <div
-                  className="ms-Image ms-Persona-image image-83"
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
                   style={
                     Object {
                       "height": 32,
@@ -139,7 +215,22 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                 >
                   <img
                     alt=""
-                    className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
                     onError={[Function]}
                     onLoad={[Function]}
                     role={undefined}
@@ -182,7 +273,11 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
     >
       <div>
         <div
-          className="ms-Image root-239"
+          className=
+              ms-Image
+              {
+                overflow: hidden;
+              }
           style={
             Object {
               "height": undefined,
@@ -192,7 +287,17 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-302"
+            className=
+                ms-Image-image
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  opacity: 0;
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role="presentation"
@@ -200,7 +305,12 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           />
         </div>
         <div
-          className="ms-Image ms-DocumentCardPreview-icon root-239"
+          className=
+              ms-Image
+              ms-DocumentCardPreview-icon
+              {
+                overflow: hidden;
+              }
           style={
             Object {
               "height": undefined,
@@ -210,7 +320,15 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-301"
+            className=
+                ms-Image-image
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  opacity: 0;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role="presentation"
@@ -238,16 +356,47 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
             className="ms-DocumentCardActivity-avatar"
           >
             <div
-              className="ms-Persona-coin ms-Persona--size32 coin-72"
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
               role="persentation"
               size={11}
             >
               <div
-                className="ms-Persona-imageArea imageArea-80"
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
                 style={undefined}
               >
                 <div
-                  className="ms-Image ms-Persona-image image-83"
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
                   style={
                     Object {
                       "height": 32,
@@ -257,7 +406,22 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                 >
                   <img
                     alt=""
-                    className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
                     onError={[Function]}
                     onLoad={[Function]}
                     role={undefined}
@@ -309,7 +473,19 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
       >
         <i
           aria-hidden={true}
-          className="root-303"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-1";
+                font-size: 42px;
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="OpenFile"
           role="presentation"
         >
@@ -336,16 +512,47 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
             className="ms-DocumentCardActivity-avatar"
           >
             <div
-              className="ms-Persona-coin ms-Persona--size32 coin-72"
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
               role="persentation"
               size={11}
             >
               <div
-                className="ms-Persona-imageArea imageArea-80"
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
                 style={undefined}
               >
                 <div
-                  className="ms-Image ms-Persona-image image-83"
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
                   style={
                     Object {
                       "height": 32,
@@ -355,7 +562,22 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                 >
                   <img
                     alt=""
-                    className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
                     onError={[Function]}
                     onLoad={[Function]}
                     role={undefined}
@@ -407,7 +629,19 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
       >
         <i
           aria-hidden={true}
-          className="root-305"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #0078d7;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-8";
+                font-size: 42px;
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="OutlookLogo"
           role="presentation"
         >
@@ -434,16 +668,47 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
             className="ms-DocumentCardActivity-avatar"
           >
             <div
-              className="ms-Persona-coin ms-Persona--size32 coin-72"
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
               role="persentation"
               size={11}
             >
               <div
-                className="ms-Persona-imageArea imageArea-80"
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
                 style={undefined}
               >
                 <div
-                  className="ms-Image ms-Persona-image image-83"
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
                   style={
                     Object {
                       "height": 32,
@@ -453,7 +718,22 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                 >
                   <img
                     alt=""
-                    className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
                     onError={[Function]}
                     onLoad={[Function]}
                     role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -20,7 +20,12 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
         >
           <li>
             <div
-              className="ms-Image ms-DocumentCardPreview-fileListIcon root-239"
+              className=
+                  ms-Image
+                  ms-DocumentCardPreview-fileListIcon
+                  {
+                    overflow: hidden;
+                  }
               style={
                 Object {
                   "height": "16px",
@@ -30,7 +35,17 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                className=
+                    ms-Image-image
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      opacity: 0;
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role="presentation"
@@ -45,7 +60,12 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           </li>
           <li>
             <div
-              className="ms-Image ms-DocumentCardPreview-fileListIcon root-239"
+              className=
+                  ms-Image
+                  ms-DocumentCardPreview-fileListIcon
+                  {
+                    overflow: hidden;
+                  }
               style={
                 Object {
                   "height": "16px",
@@ -55,7 +75,17 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                className=
+                    ms-Image-image
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      opacity: 0;
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role="presentation"
@@ -70,7 +100,12 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           </li>
           <li>
             <div
-              className="ms-Image ms-DocumentCardPreview-fileListIcon root-239"
+              className=
+                  ms-Image
+                  ms-DocumentCardPreview-fileListIcon
+                  {
+                    overflow: hidden;
+                  }
               style={
                 Object {
                   "height": "16px",
@@ -80,7 +115,17 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+                className=
+                    ms-Image-image
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: 100%;
+                      opacity: 0;
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role="presentation"
@@ -125,17 +170,51 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           className="ms-DocumentCardActivity-avatar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             role="persentation"
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
                 aria-hidden="true"
-                className="ms-Persona-initials initials-306"
+                className=
+                    ms-Persona-initials
+                    {
+                      background-color: #00ABA9;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
                 style={undefined}
               >
                 <span>
@@ -143,7 +222,21 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 </span>
               </div>
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -153,7 +246,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -167,16 +275,47 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           className="ms-DocumentCardActivity-avatar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             role="persentation"
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -186,7 +325,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -223,18 +377,105 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           aria-label="share action"
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--icon root-145"
+          className=
+              ms-Button
+              ms-Button--icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                color: #0078d4;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-109"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="Share"
               role="presentation"
             >
@@ -251,18 +492,105 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           aria-label="pin action"
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--icon root-145"
+          className=
+              ms-Button
+              ms-Button--icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                color: #0078d4;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-147"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-0";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="Pin"
               role="presentation"
             >
@@ -279,18 +607,105 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           aria-label="ringer action"
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--icon root-145"
+          className=
+              ms-Button
+              ms-Button--icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                color: #0078d4;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-308"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-3";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="Ringer"
               role="presentation"
             >
@@ -304,7 +719,17 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       >
         <i
           aria-hidden={true}
-          className="root-55"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="View"
           role="presentation"
         >
@@ -330,7 +755,17 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
     >
       <i
         aria-hidden={true}
-        className="root-309"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-8";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
         data-icon-name="OutlookLogo"
         role="presentation"
       >
@@ -357,7 +792,21 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       >
         <i
           aria-hidden={true}
-          className="root-310"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-0";
+                font-style: normal;
+                font-weight: normal;
+                padding-bottom: 8px;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 8px;
+                speak: none;
+              }
           data-icon-name="attach"
           role="presentation"
         >
@@ -376,17 +825,51 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           className="ms-DocumentCardActivity-avatar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             role="persentation"
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
                 aria-hidden="true"
-                className="ms-Persona-initials initials-306"
+                className=
+                    ms-Persona-initials
+                    {
+                      background-color: #00ABA9;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
                 style={undefined}
               >
                 <span>
@@ -394,7 +877,21 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 </span>
               </div>
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -404,7 +901,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -418,16 +930,47 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           className="ms-DocumentCardActivity-avatar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             role="persentation"
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -437,7 +980,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -478,7 +1036,17 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
     >
       <i
         aria-hidden={true}
-        className="root-309"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-8";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
         data-icon-name="OutlookLogo"
         role="presentation"
       >
@@ -505,7 +1073,21 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       >
         <i
           aria-hidden={true}
-          className="root-310"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-0";
+                font-style: normal;
+                font-weight: normal;
+                padding-bottom: 8px;
+                padding-left: 8px;
+                padding-right: 8px;
+                padding-top: 8px;
+                speak: none;
+              }
           data-icon-name="attach"
           role="presentation"
         >
@@ -524,17 +1106,51 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           className="ms-DocumentCardActivity-avatar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             role="persentation"
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
                 aria-hidden="true"
-                className="ms-Persona-initials initials-306"
+                className=
+                    ms-Persona-initials
+                    {
+                      background-color: #00ABA9;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
                 style={undefined}
               >
                 <span>
@@ -542,7 +1158,21 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 </span>
               </div>
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -552,7 +1182,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -566,16 +1211,47 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           className="ms-DocumentCardActivity-avatar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             role="persentation"
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -585,7 +1261,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -626,7 +1317,17 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
     >
       <i
         aria-hidden={true}
-        className="root-309"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-8";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
         data-icon-name="OutlookLogo"
         role="presentation"
       >
@@ -659,17 +1360,51 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           className="ms-DocumentCardActivity-avatar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             role="persentation"
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
                 aria-hidden="true"
-                className="ms-Persona-initials initials-306"
+                className=
+                    ms-Persona-initials
+                    {
+                      background-color: #00ABA9;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
                 style={undefined}
               >
                 <span>
@@ -677,7 +1412,21 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 </span>
               </div>
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -687,7 +1436,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -701,16 +1465,47 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           className="ms-DocumentCardActivity-avatar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             role="persentation"
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -720,7 +1515,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -771,7 +1581,19 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       >
         <i
           aria-hidden={true}
-          className="root-303"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-1";
+                font-size: 42px;
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="OpenFile"
           role="presentation"
         >
@@ -798,16 +1620,47 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
             className="ms-DocumentCardActivity-avatar"
           >
             <div
-              className="ms-Persona-coin ms-Persona--size32 coin-72"
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
               role="persentation"
               size={11}
             >
               <div
-                className="ms-Persona-imageArea imageArea-80"
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
                 style={undefined}
               >
                 <div
-                  className="ms-Image ms-Persona-image image-83"
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
                   style={
                     Object {
                       "height": 32,
@@ -817,7 +1670,22 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 >
                   <img
                     alt=""
-                    className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
                     onError={[Function]}
                     onLoad={[Function]}
                     role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -8,7 +8,25 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Basicdrop1"
       id="Basicdrop1-label"
       required={undefined}
@@ -50,7 +68,17 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >
@@ -64,20 +92,113 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Set focus
@@ -89,7 +210,25 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Dropdown3"
       id="Dropdown3-label"
       required={undefined}
@@ -131,7 +270,17 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >
@@ -144,7 +293,25 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Dropdown4"
       id="Dropdown4-label"
       required={undefined}
@@ -186,7 +353,17 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >
@@ -199,7 +376,25 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Dropdown5"
       id="Dropdown5-label"
       required={undefined}
@@ -241,7 +436,17 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >
@@ -254,7 +459,25 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Dropdown6"
       id="Dropdown6-label"
       required={undefined}
@@ -296,7 +519,17 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >
@@ -309,7 +542,25 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Dropdown7"
       id="Dropdown7-label"
       required={undefined}
@@ -351,7 +602,17 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -8,7 +8,25 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Customdrop1"
       id="Customdrop1-label"
       required={undefined}
@@ -45,7 +63,17 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
         >
           <i
             aria-hidden={true}
-            className="root-312"
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-4";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="MessageFill"
             role="presentation"
             style={
@@ -66,7 +94,17 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
       >
         <i
           aria-hidden={true}
-          className="root-313"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-3";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="CirclePlus"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -8,7 +8,25 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
     className="ms-Dropdown-container"
   >
     <label
-      className="ms-Label ms-Dropdown-label root-89"
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Errormessagedrop1"
       id="Errormessagedrop1-label"
       required={undefined}
@@ -49,7 +67,17 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
       >
         <i
           aria-hidden={true}
-          className="ms-Dropdown-caretDown root-55"
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -72,20 +72,113 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__1"
         >
           Set focus

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
@@ -18,31 +18,130 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
       aria-label="Add a new person"
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Facepile-addButton ms-Facepile-itemButton root-314"
+      className=
+          ms-Button
+          ms-Facepile-addButton
+          ms-Facepile-itemButton
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Persona-coin ms-Persona--size32 coin-72"
+          className=
+              ms-Persona-coin
+              ms-Persona--size32
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={11}
         >
           <div
-            className="ms-Persona-imageArea imageArea-80"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 32px;
+                  position: relative;
+                  text-align: center;
+                  width: 32px;
+                }
             style={undefined}
           >
             <div
               aria-hidden="true"
-              className="ms-Persona-initials initials-315"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #2D89EF;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    line-height: 32px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                  }
               style={undefined}
             >
               <i
                 aria-hidden={true}
-                className="root-55"
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
                 data-icon-name="AddFriend"
                 role="presentation"
               >
@@ -50,7 +149,21 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
               </i>
             </div>
             <div
-              className="ms-Image ms-Persona-image image-83"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 32px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 32px;
+                  }
               style={
                 Object {
                   "height": 32,
@@ -60,7 +173,22 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -36,15 +36,46 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           title="Annie Lindqvist"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -54,7 +85,22 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -74,15 +120,46 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           title="Aaron Reid"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -92,7 +169,22 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -107,7 +199,54 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Facepile-itemButton ms-Facepile-person root-314"
+          className=
+              ms-Button
+              ms-Facepile-itemButton
+              ms-Facepile-person
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
           data="75%"
           data-is-focusable={true}
           disabled={undefined}
@@ -119,19 +258,61 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Persona-coin ms-Persona--size32 coin-72"
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
               size={11}
             >
               <div
-                className="ms-Persona-imageArea imageArea-80"
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
                 style={undefined}
               >
                 <div
                   aria-hidden="true"
-                  className="ms-Persona-initials initials-316"
+                  className=
+                      ms-Persona-initials
+                      {
+                        background-color: #1E7145;
+                        border-radius: 50%;
+                        color: #ffffff;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 32px;
+                        line-height: 32px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        background-color: Window !important;
+                        border: 1px solid WindowText;
+                        box-sizing: border-box;
+                        color: WindowText;
+                      }
                   style={undefined}
                 >
                   <span>
@@ -139,7 +320,21 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                   </span>
                 </div>
                 <div
-                  className="ms-Image ms-Persona-image image-83"
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
                   style={
                     Object {
                       "height": 32,
@@ -149,7 +344,22 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 >
                   <img
                     alt=""
-                    className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
                     onError={[Function]}
                     onLoad={[Function]}
                     role={undefined}
@@ -170,7 +380,24 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
       className="ms-Slider ms-Slider-enabled undefined ms-Slider-row undefined"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Slider5"
       >
         Number of Personas:
@@ -223,7 +450,25 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           </div>
         </button>
         <label
-          className="ms-Label ms-Slider-value root-89"
+          className=
+              ms-Label
+              ms-Slider-value
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           3
         </label>
@@ -233,7 +478,25 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-89"
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Dropdown6"
         id="Dropdown6-label"
         required={undefined}
@@ -274,7 +537,17 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown root-55"
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -292,7 +565,67 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
       aria-posinset={undefined}
       aria-setsize={undefined}
       checked={true}
-      className="ms-Checkbox is-checked is-enabled root-183"
+      className=
+          ms-Checkbox
+          is-checked
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background: none;
+            border: none;
+            cursor: pointer;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -2px;
+            content: "";
+            left: -2px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -2px;
+            top: -2px;
+            z-index: 1;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            background: WindowText;
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+            background: WindowText;
+            border-color: WindowText;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
+          }
       data-ktp-execute-target={undefined}
       disabled={undefined}
       id="checkbox-7"
@@ -304,16 +637,71 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
       type="button"
     >
       <label
-        className="ms-Checkbox-label label-184"
+        className=
+            ms-Checkbox-label
+            {
+              align-items: center;
+              cursor: pointer;
+              display: inline-flex;
+              margin-bottom: 0;
+              margin-left: -4px;
+              margin-right: -4px;
+              margin-top: 0;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
         htmlFor="checkbox-7"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-185"
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                background: #0078d4;
+                border-color: #0078d4;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                overflow: hidden;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: WindowText;
+                border-color: WindowText;
+              }
           data-ktp-target={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-188"
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 1;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
             data-icon-name="CheckMark"
             role="presentation"
           >
@@ -321,7 +709,16 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-187"
+          className=
+              ms-Checkbox-text
+              {
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
         >
           Fade In
         </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -36,15 +36,46 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
           title="Annie Lindqvist"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -54,7 +85,22 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -74,15 +120,46 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
           title="Aaron Reid"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -92,7 +169,22 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -107,7 +199,54 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Facepile-itemButton ms-Facepile-person root-314"
+          className=
+              ms-Button
+              ms-Facepile-itemButton
+              ms-Facepile-person
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
           data="75%"
           data-is-focusable={true}
           disabled={undefined}
@@ -119,19 +258,61 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Persona-coin ms-Persona--size32 coin-72"
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
               size={11}
             >
               <div
-                className="ms-Persona-imageArea imageArea-80"
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
                 style={undefined}
               >
                 <div
                   aria-hidden="true"
-                  className="ms-Persona-initials initials-316"
+                  className=
+                      ms-Persona-initials
+                      {
+                        background-color: #1E7145;
+                        border-radius: 50%;
+                        color: #ffffff;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 32px;
+                        line-height: 32px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        background-color: Window !important;
+                        border: 1px solid WindowText;
+                        box-sizing: border-box;
+                        color: WindowText;
+                      }
                   style={undefined}
                 >
                   <span>
@@ -139,7 +320,21 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   </span>
                 </div>
                 <div
-                  className="ms-Image ms-Persona-image image-83"
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
                   style={
                     Object {
                       "height": 32,
@@ -149,7 +344,22 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 >
                   <img
                     alt=""
-                    className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
                     onError={[Function]}
                     onLoad={[Function]}
                     role={undefined}
@@ -170,16 +380,50 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
           title="Roko Kolar"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
                 aria-hidden="true"
-                className="ms-Persona-initials initials-306"
+                className=
+                    ms-Persona-initials
+                    {
+                      background-color: #00ABA9;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
                 style={undefined}
               >
                 <span>
@@ -187,7 +431,21 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 </span>
               </div>
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -197,7 +455,22 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -217,16 +490,50 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
           title="Christian Bergqvist"
         >
           <div
-            className="ms-Persona-coin ms-Persona--size32 coin-72"
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
             size={11}
           >
             <div
-              className="ms-Persona-imageArea imageArea-80"
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
               style={undefined}
             >
               <div
                 aria-hidden="true"
-                className="ms-Persona-initials initials-317"
+                className=
+                    ms-Persona-initials
+                    {
+                      background-color: #00A300;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
                 style={undefined}
               >
                 <span>
@@ -234,7 +541,21 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 </span>
               </div>
               <div
-                className="ms-Image ms-Persona-image image-83"
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
                 style={
                   Object {
                     "height": 32,
@@ -244,7 +565,22 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               >
                 <img
                   alt=""
-                  className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
                   onError={[Function]}
                   onLoad={[Function]}
                   role={undefined}
@@ -264,7 +600,24 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
       className="ms-Slider ms-Slider-enabled undefined ms-Slider-row undefined"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Slider5"
       >
         Number of Personas:
@@ -317,7 +670,25 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
           </div>
         </button>
         <label
-          className="ms-Label ms-Slider-value root-89"
+          className=
+              ms-Label
+              ms-Slider-value
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           5
         </label>
@@ -327,7 +698,25 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-89"
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Dropdown6"
         id="Dropdown6-label"
         required={undefined}
@@ -368,7 +757,17 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown root-55"
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -6,16 +6,78 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
     className="ms-SearchBoxSmallExample"
   >
     <div
-      className="ms-SearchBox root-318"
+      className=
+          ms-SearchBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: stretch;
+            border: 1px solid #a6a6a6;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 1px;
+            padding-left: 4px;
+            padding-right: 0;
+            padding-top: 1px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: 1px solid WindowText;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+          &:hover $iconContainer {
+            color: #005a9e;
+          }
       onFocusCapture={[Function]}
     >
       <div
-        className="ms-SearchBox-iconContainer iconContainer-319"
+        className=
+            ms-SearchBox-iconContainer
+            {
+              color: #0078d4;
+              cursor: text;
+              display: flex;
+              flex-direction: column;
+              flex-shrink: 0;
+              font-size: 16px;
+              justify-content: center;
+              text-align: center;
+              transition: width 0.167s;
+              width: 32px;
+            }
         onClick={[Function]}
       >
         <i
           aria-hidden={true}
-          className="ms-SearchBox-icon icon-323"
+          className=
+              ms-SearchBox-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+                transition: opacity 0.167s 0s;
+              }
           data-icon-name="Search"
           role="presentation"
         >
@@ -24,7 +86,40 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
       </div>
       <input
         aria-label="Search a person"
-        className="ms-SearchBox-field field-322"
+        className=
+            ms-SearchBox-field
+            {
+              background-color: #ffffff;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              flex: 1 1 0px;
+              font-family: inherit;
+              font-size: inherit;
+              font-weight: inherit;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: none;
+              overflow: hidden;
+              padding-bottom: 0.5px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              text-overflow: ellipsis;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #666666;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #666666;
+            }
         disabled={undefined}
         id="SearchBox0"
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Go to Trap Zone
@@ -39,7 +122,24 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
           className="ms-TextField-wrapper"
         >
           <label
-            className="ms-Label root-89"
+            className=
+                ms-Label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="TextField3"
           >
             Default TextField
@@ -66,7 +166,54 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
       </div>
       <button
         aria-disabled={undefined}
-        className="ms-Link root-324"
+        className=
+            ms-Link
+            {
+              background-color: transparent;
+              background: none;
+              border: none;
+              color: #0078d4;
+              cursor: pointer;
+              display: inline;
+              font-size: inherit;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              overflow: inherit;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+              text-align: left;
+              text-overflow: inherit;
+              user-select: text;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:active, &:hover, &:active:hover {
+              color: #004578;
+            }
+            @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+              text-decoration: underline;
+            }
+            &:focus {
+              color: #0078d4;
+            }
         onClick={[Function]}
       >
         Hyperlink inside FocusTrapZone
@@ -74,23 +221,101 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
       <br />
       <br />
       <div
-        className="ms-Toggle is-enabled root-285"
+        className=
+            ms-Toggle
+            is-enabled
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 8px;
+            }
       >
         <label
-          className="ms-Label ms-Toggle-label label-230"
+          className=
+              ms-Label
+              ms-Toggle-label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="Toggle5"
         >
           Focus Trap Zone
         </label>
         <div
-          className="ms-Toggle-innerContainer container-286"
+          className=
+              ms-Toggle-innerContainer
+              {
+                display: inline-flex;
+                position: relative;
+              }
         >
           <button
             aria-disabled={undefined}
             aria-label="Focus Trap Zone"
             aria-pressed={false}
             checked={false}
-            className="ms-Toggle-background pill-287"
+            className=
+                ms-Toggle-background
+                {
+                  align-items: center;
+                  background: #ffffff;
+                  border-color: #666666;
+                  border-radius: 1em;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: flex;
+                  font-size: 20px;
+                  height: 1em;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: .2em;
+                  padding-right: .2em;
+                  padding-top: 0;
+                  position: relative;
+                  transition: all 0.1s ease;
+                  width: 2.2em;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -2px;
+                  content: "";
+                  left: -2px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: -2px;
+                  top: -2px;
+                  z-index: 1;
+                }
+                &:hover {
+                  border-color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                  border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                }
             data-is-focusable={true}
             disabled={undefined}
             id="Toggle5"
@@ -99,11 +324,52 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
             type="button"
           >
             <div
-              className="ms-Toggle-thumb thumb-288"
+              className=
+                  ms-Toggle-thumb
+                  {
+                    background-color: #212121;
+                    border-color: transparent;
+                    border-radius: .5em;
+                    border-style: solid;
+                    border-width: .28em;
+                    box-sizing: border-box;
+                    height: .5em;
+                    transition: all 0.1s ease;
+                    width: .5em;
+                  }
             />
           </button>
           <label
-            className="ms-Label ms-Toggle-stateText text-290"
+            className=
+                ms-Label
+                ms-Toggle-stateText
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
+                && {
+                  margin-bottom: 0;
+                  margin-left: 10px;
+                  margin-right: 10px;
+                  margin-top: 0;
+                  padding-bottom: 0;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 0;
+                  user-select: none;
+                }
             htmlFor="Toggle5"
           >
             Off

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Go to Trap Zone
@@ -39,7 +122,24 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
           className="ms-TextField-wrapper"
         >
           <label
-            className="ms-Label root-89"
+            className=
+                ms-Label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="TextField3"
           >
             Default TextField
@@ -66,7 +166,54 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
       </div>
       <button
         aria-disabled={undefined}
-        className="ms-Link root-324"
+        className=
+            ms-Link
+            {
+              background-color: transparent;
+              background: none;
+              border: none;
+              color: #0078d4;
+              cursor: pointer;
+              display: inline;
+              font-size: inherit;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              overflow: inherit;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+              text-align: left;
+              text-overflow: inherit;
+              user-select: text;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:active, &:hover, &:active:hover {
+              color: #004578;
+            }
+            @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+              text-decoration: underline;
+            }
+            &:focus {
+              color: #0078d4;
+            }
         onClick={[Function]}
       >
         Hyperlink inside FocusTrapZone
@@ -74,23 +221,101 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
       <br />
       <br />
       <div
-        className="ms-Toggle is-enabled root-285"
+        className=
+            ms-Toggle
+            is-enabled
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 8px;
+            }
       >
         <label
-          className="ms-Label ms-Toggle-label label-230"
+          className=
+              ms-Label
+              ms-Toggle-label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="Toggle5"
         >
           Focus Trap Zone
         </label>
         <div
-          className="ms-Toggle-innerContainer container-286"
+          className=
+              ms-Toggle-innerContainer
+              {
+                display: inline-flex;
+                position: relative;
+              }
         >
           <button
             aria-disabled={undefined}
             aria-label="Focus Trap Zone"
             aria-pressed={false}
             checked={false}
-            className="ms-Toggle-background pill-287"
+            className=
+                ms-Toggle-background
+                {
+                  align-items: center;
+                  background: #ffffff;
+                  border-color: #666666;
+                  border-radius: 1em;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: flex;
+                  font-size: 20px;
+                  height: 1em;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: .2em;
+                  padding-right: .2em;
+                  padding-top: 0;
+                  position: relative;
+                  transition: all 0.1s ease;
+                  width: 2.2em;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -2px;
+                  content: "";
+                  left: -2px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: -2px;
+                  top: -2px;
+                  z-index: 1;
+                }
+                &:hover {
+                  border-color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                  border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                }
             data-is-focusable={true}
             disabled={undefined}
             id="Toggle5"
@@ -99,11 +324,52 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             type="button"
           >
             <div
-              className="ms-Toggle-thumb thumb-288"
+              className=
+                  ms-Toggle-thumb
+                  {
+                    background-color: #212121;
+                    border-color: transparent;
+                    border-radius: .5em;
+                    border-style: solid;
+                    border-width: .28em;
+                    box-sizing: border-box;
+                    height: .5em;
+                    transition: all 0.1s ease;
+                    width: .5em;
+                  }
             />
           </button>
           <label
-            className="ms-Label ms-Toggle-stateText text-290"
+            className=
+                ms-Label
+                ms-Toggle-stateText
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
+                && {
+                  margin-bottom: 0;
+                  margin-left: 10px;
+                  margin-right: 10px;
+                  margin-top: 0;
+                  padding-bottom: 0;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 0;
+                  user-select: none;
+                }
             htmlFor="Toggle5"
           >
             Off

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Go to Trap Zone
@@ -39,7 +122,24 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
           className="ms-TextField-wrapper"
         >
           <label
-            className="ms-Label root-89"
+            className=
+                ms-Label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="TextField3"
           >
             Default TextField
@@ -66,7 +166,54 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
       </div>
       <button
         aria-disabled={undefined}
-        className="ms-Link root-324"
+        className=
+            ms-Link
+            {
+              background-color: transparent;
+              background: none;
+              border: none;
+              color: #0078d4;
+              cursor: pointer;
+              display: inline;
+              font-size: inherit;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              overflow: inherit;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+              text-align: left;
+              text-overflow: inherit;
+              user-select: text;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:active, &:hover, &:active:hover {
+              color: #004578;
+            }
+            @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+              text-decoration: underline;
+            }
+            &:focus {
+              color: #0078d4;
+            }
         onClick={[Function]}
       >
         Hyperlink inside FocusTrapZone
@@ -77,23 +224,101 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
         className="shouldFocus input"
       >
         <div
-          className="ms-Toggle is-enabled root-285"
+          className=
+              ms-Toggle
+              is-enabled
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 8px;
+              }
         >
           <label
-            className="ms-Label ms-Toggle-label label-230"
+            className=
+                ms-Label
+                ms-Toggle-label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="Toggle5"
           >
             Focus Trap Zone
           </label>
           <div
-            className="ms-Toggle-innerContainer container-286"
+            className=
+                ms-Toggle-innerContainer
+                {
+                  display: inline-flex;
+                  position: relative;
+                }
           >
             <button
               aria-disabled={undefined}
               aria-label="Focus Trap Zone"
               aria-pressed={false}
               checked={false}
-              className="ms-Toggle-background pill-287"
+              className=
+                  ms-Toggle-background
+                  {
+                    align-items: center;
+                    background: #ffffff;
+                    border-color: #666666;
+                    border-radius: 1em;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    cursor: pointer;
+                    display: flex;
+                    font-size: 20px;
+                    height: 1em;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: .2em;
+                    padding-right: .2em;
+                    padding-top: 0;
+                    position: relative;
+                    transition: all 0.1s ease;
+                    width: 2.2em;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -2px;
+                    content: "";
+                    left: -2px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -2px;
+                    top: -2px;
+                    z-index: 1;
+                  }
+                  &:hover {
+                    border-color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                    border-color: Highlight;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
               data-is-focusable={true}
               disabled={undefined}
               id="Toggle5"
@@ -102,11 +327,52 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
               type="button"
             >
               <div
-                className="ms-Toggle-thumb thumb-288"
+                className=
+                    ms-Toggle-thumb
+                    {
+                      background-color: #212121;
+                      border-color: transparent;
+                      border-radius: .5em;
+                      border-style: solid;
+                      border-width: .28em;
+                      box-sizing: border-box;
+                      height: .5em;
+                      transition: all 0.1s ease;
+                      width: .5em;
+                    }
               />
             </button>
             <label
-              className="ms-Label ms-Toggle-stateText text-290"
+              className=
+                  ms-Label
+                  ms-Toggle-stateText
+                  {
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    display: block;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    overflow-wrap: break-word;
+                    padding-bottom: 5px;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 5px;
+                    word-wrap: break-word;
+                  }
+                  && {
+                    margin-bottom: 0;
+                    margin-left: 10px;
+                    margin-right: 10px;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    user-select: none;
+                  }
               htmlFor="Toggle5"
             >
               Off

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -10,20 +10,103 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             One
@@ -32,22 +115,100 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
       </div>
     </button>
     <div
-      className="ms-Toggle is-enabled root-285"
+      className=
+          ms-Toggle
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 8px;
+          }
     >
       <label
-        className="ms-Label ms-Toggle-label label-230"
+        className=
+            ms-Label
+            ms-Toggle-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Toggle3"
       >
         Focus Trap Zone
       </label>
       <div
-        className="ms-Toggle-innerContainer container-286"
+        className=
+            ms-Toggle-innerContainer
+            {
+              display: inline-flex;
+              position: relative;
+            }
       >
         <button
           aria-disabled={undefined}
           aria-label="Focus Trap Zone"
           aria-pressed={false}
-          className="ms-Toggle-background pill-287"
+          className=
+              ms-Toggle-background
+              {
+                align-items: center;
+                background: #ffffff;
+                border-color: #666666;
+                border-radius: 1em;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: flex;
+                font-size: 20px;
+                height: 1em;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: .2em;
+                padding-right: .2em;
+                padding-top: 0;
+                position: relative;
+                transition: all 0.1s ease;
+                width: 2.2em;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: -2px;
+                content: "";
+                left: -2px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: -2px;
+                top: -2px;
+                z-index: 1;
+              }
+              &:hover {
+                border-color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Toggle3"
@@ -56,11 +217,52 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           type="button"
         >
           <div
-            className="ms-Toggle-thumb thumb-288"
+            className=
+                ms-Toggle-thumb
+                {
+                  background-color: #212121;
+                  border-color: transparent;
+                  border-radius: .5em;
+                  border-style: solid;
+                  border-width: .28em;
+                  box-sizing: border-box;
+                  height: .5em;
+                  transition: all 0.1s ease;
+                  width: .5em;
+                }
           />
         </button>
         <label
-          className="ms-Label ms-Toggle-stateText text-290"
+          className=
+              ms-Label
+              ms-Toggle-stateText
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+              && {
+                margin-bottom: 0;
+                margin-left: 10px;
+                margin-right: 10px;
+                margin-top: 0;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                user-select: none;
+              }
           htmlFor="Toggle3"
         >
           Off
@@ -75,20 +277,103 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         onClick={[Function]}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__4"
             >
               Two
@@ -97,22 +382,100 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         </div>
       </button>
       <div
-        className="ms-Toggle is-enabled root-285"
+        className=
+            ms-Toggle
+            is-enabled
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 8px;
+            }
       >
         <label
-          className="ms-Label ms-Toggle-label label-230"
+          className=
+              ms-Label
+              ms-Toggle-label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="Toggle7"
         >
           Focus Trap Zone
         </label>
         <div
-          className="ms-Toggle-innerContainer container-286"
+          className=
+              ms-Toggle-innerContainer
+              {
+                display: inline-flex;
+                position: relative;
+              }
         >
           <button
             aria-disabled={undefined}
             aria-label="Focus Trap Zone"
             aria-pressed={false}
-            className="ms-Toggle-background pill-287"
+            className=
+                ms-Toggle-background
+                {
+                  align-items: center;
+                  background: #ffffff;
+                  border-color: #666666;
+                  border-radius: 1em;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: flex;
+                  font-size: 20px;
+                  height: 1em;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: .2em;
+                  padding-right: .2em;
+                  padding-top: 0;
+                  position: relative;
+                  transition: all 0.1s ease;
+                  width: 2.2em;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -2px;
+                  content: "";
+                  left: -2px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: -2px;
+                  top: -2px;
+                  z-index: 1;
+                }
+                &:hover {
+                  border-color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                  border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                }
             data-is-focusable={true}
             disabled={undefined}
             id="Toggle7"
@@ -121,11 +484,52 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             type="button"
           >
             <div
-              className="ms-Toggle-thumb thumb-288"
+              className=
+                  ms-Toggle-thumb
+                  {
+                    background-color: #212121;
+                    border-color: transparent;
+                    border-radius: .5em;
+                    border-style: solid;
+                    border-width: .28em;
+                    box-sizing: border-box;
+                    height: .5em;
+                    transition: all 0.1s ease;
+                    width: .5em;
+                  }
             />
           </button>
           <label
-            className="ms-Label ms-Toggle-stateText text-290"
+            className=
+                ms-Label
+                ms-Toggle-stateText
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
+                && {
+                  margin-bottom: 0;
+                  margin-left: 10px;
+                  margin-right: 10px;
+                  margin-top: 0;
+                  padding-bottom: 0;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 0;
+                  user-select: none;
+                }
             htmlFor="Toggle7"
           >
             Off
@@ -140,20 +544,103 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__8"
               >
                 Three
@@ -162,22 +649,100 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           </div>
         </button>
         <div
-          className="ms-Toggle is-enabled root-285"
+          className=
+              ms-Toggle
+              is-enabled
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 8px;
+              }
         >
           <label
-            className="ms-Label ms-Toggle-label label-230"
+            className=
+                ms-Label
+                ms-Toggle-label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="Toggle11"
           >
             Focus Trap Zone
           </label>
           <div
-            className="ms-Toggle-innerContainer container-286"
+            className=
+                ms-Toggle-innerContainer
+                {
+                  display: inline-flex;
+                  position: relative;
+                }
           >
             <button
               aria-disabled={undefined}
               aria-label="Focus Trap Zone"
               aria-pressed={false}
-              className="ms-Toggle-background pill-287"
+              className=
+                  ms-Toggle-background
+                  {
+                    align-items: center;
+                    background: #ffffff;
+                    border-color: #666666;
+                    border-radius: 1em;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    cursor: pointer;
+                    display: flex;
+                    font-size: 20px;
+                    height: 1em;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: .2em;
+                    padding-right: .2em;
+                    padding-top: 0;
+                    position: relative;
+                    transition: all 0.1s ease;
+                    width: 2.2em;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -2px;
+                    content: "";
+                    left: -2px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -2px;
+                    top: -2px;
+                    z-index: 1;
+                  }
+                  &:hover {
+                    border-color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                    border-color: Highlight;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
               data-is-focusable={true}
               disabled={undefined}
               id="Toggle11"
@@ -186,11 +751,52 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               type="button"
             >
               <div
-                className="ms-Toggle-thumb thumb-288"
+                className=
+                    ms-Toggle-thumb
+                    {
+                      background-color: #212121;
+                      border-color: transparent;
+                      border-radius: .5em;
+                      border-style: solid;
+                      border-width: .28em;
+                      box-sizing: border-box;
+                      height: .5em;
+                      transition: all 0.1s ease;
+                      width: .5em;
+                    }
               />
             </button>
             <label
-              className="ms-Label ms-Toggle-stateText text-290"
+              className=
+                  ms-Label
+                  ms-Toggle-stateText
+                  {
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    display: block;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    overflow-wrap: break-word;
+                    padding-bottom: 5px;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 5px;
+                    word-wrap: break-word;
+                  }
+                  && {
+                    margin-bottom: 0;
+                    margin-left: 10px;
+                    margin-right: 10px;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    user-select: none;
+                  }
               htmlFor="Toggle11"
             >
               Off
@@ -206,20 +812,103 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__12"
               >
                 Four
@@ -228,22 +917,100 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           </div>
         </button>
         <div
-          className="ms-Toggle is-enabled root-285"
+          className=
+              ms-Toggle
+              is-enabled
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 8px;
+              }
         >
           <label
-            className="ms-Label ms-Toggle-label label-230"
+            className=
+                ms-Label
+                ms-Toggle-label
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
             htmlFor="Toggle15"
           >
             Focus Trap Zone
           </label>
           <div
-            className="ms-Toggle-innerContainer container-286"
+            className=
+                ms-Toggle-innerContainer
+                {
+                  display: inline-flex;
+                  position: relative;
+                }
           >
             <button
               aria-disabled={undefined}
               aria-label="Focus Trap Zone"
               aria-pressed={false}
-              className="ms-Toggle-background pill-287"
+              className=
+                  ms-Toggle-background
+                  {
+                    align-items: center;
+                    background: #ffffff;
+                    border-color: #666666;
+                    border-radius: 1em;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    cursor: pointer;
+                    display: flex;
+                    font-size: 20px;
+                    height: 1em;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: .2em;
+                    padding-right: .2em;
+                    padding-top: 0;
+                    position: relative;
+                    transition: all 0.1s ease;
+                    width: 2.2em;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -2px;
+                    content: "";
+                    left: -2px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -2px;
+                    top: -2px;
+                    z-index: 1;
+                  }
+                  &:hover {
+                    border-color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                    border-color: Highlight;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
               data-is-focusable={true}
               disabled={undefined}
               id="Toggle15"
@@ -252,11 +1019,52 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               type="button"
             >
               <div
-                className="ms-Toggle-thumb thumb-288"
+                className=
+                    ms-Toggle-thumb
+                    {
+                      background-color: #212121;
+                      border-color: transparent;
+                      border-radius: .5em;
+                      border-style: solid;
+                      border-width: .28em;
+                      box-sizing: border-box;
+                      height: .5em;
+                      transition: all 0.1s ease;
+                      width: .5em;
+                    }
               />
             </button>
             <label
-              className="ms-Label ms-Toggle-stateText text-290"
+              className=
+                  ms-Label
+                  ms-Toggle-stateText
+                  {
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    display: block;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    overflow-wrap: break-word;
+                    padding-bottom: 5px;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 5px;
+                    word-wrap: break-word;
+                  }
+                  && {
+                    margin-bottom: 0;
+                    margin-left: 10px;
+                    margin-right: 10px;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    user-select: none;
+                  }
               htmlFor="Toggle15"
             >
               Off
@@ -273,20 +1081,103 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         onClick={[Function]}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__16"
             >
               Five
@@ -295,22 +1186,100 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         </div>
       </button>
       <div
-        className="ms-Toggle is-enabled root-285"
+        className=
+            ms-Toggle
+            is-enabled
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 8px;
+            }
       >
         <label
-          className="ms-Label ms-Toggle-label label-230"
+          className=
+              ms-Label
+              ms-Toggle-label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="Toggle19"
         >
           Focus Trap Zone
         </label>
         <div
-          className="ms-Toggle-innerContainer container-286"
+          className=
+              ms-Toggle-innerContainer
+              {
+                display: inline-flex;
+                position: relative;
+              }
         >
           <button
             aria-disabled={undefined}
             aria-label="Focus Trap Zone"
             aria-pressed={false}
-            className="ms-Toggle-background pill-287"
+            className=
+                ms-Toggle-background
+                {
+                  align-items: center;
+                  background: #ffffff;
+                  border-color: #666666;
+                  border-radius: 1em;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: flex;
+                  font-size: 20px;
+                  height: 1em;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: .2em;
+                  padding-right: .2em;
+                  padding-top: 0;
+                  position: relative;
+                  transition: all 0.1s ease;
+                  width: 2.2em;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: -2px;
+                  content: "";
+                  left: -2px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: -2px;
+                  top: -2px;
+                  z-index: 1;
+                }
+                &:hover {
+                  border-color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                  border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                }
             data-is-focusable={true}
             disabled={undefined}
             id="Toggle19"
@@ -319,11 +1288,52 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             type="button"
           >
             <div
-              className="ms-Toggle-thumb thumb-288"
+              className=
+                  ms-Toggle-thumb
+                  {
+                    background-color: #212121;
+                    border-color: transparent;
+                    border-radius: .5em;
+                    border-style: solid;
+                    border-width: .28em;
+                    box-sizing: border-box;
+                    height: .5em;
+                    transition: all 0.1s ease;
+                    width: .5em;
+                  }
             />
           </button>
           <label
-            className="ms-Label ms-Toggle-stateText text-290"
+            className=
+                ms-Label
+                ms-Toggle-stateText
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
+                && {
+                  margin-bottom: 0;
+                  margin-left: 10px;
+                  margin-right: 10px;
+                  margin-top: 0;
+                  padding-bottom: 0;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 0;
+                  user-select: none;
+                }
             htmlFor="Toggle19"
           >
             Off
@@ -337,20 +1347,103 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__20"
         >
           Randomize

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -25,19 +25,102 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__1"
             >
               Button 1
@@ -50,19 +133,102 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__4"
             >
               Button 2
@@ -100,19 +266,102 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__9"
             >
               Button 3
@@ -130,19 +379,102 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__12"
           >
             Tabbable Element 1
@@ -172,19 +504,102 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__16"
             >
               Button 1
@@ -197,19 +612,102 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__19"
             >
               Button 2

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -17,7 +17,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={1}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone1"
     data-is-draggable={false}
@@ -50,11 +58,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -62,7 +115,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -104,7 +183,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x200"
           onClick={[Function]}
           target={undefined}
@@ -129,19 +238,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__2"
               >
                 http://placehold.it/100x200
@@ -164,7 +356,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={2}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone5"
     data-is-draggable={false}
@@ -197,11 +397,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -209,7 +454,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -251,7 +522,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x201"
           onClick={[Function]}
           target={undefined}
@@ -276,19 +577,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__6"
               >
                 http://placehold.it/100x201
@@ -311,7 +695,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={3}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone9"
     data-is-draggable={false}
@@ -344,11 +736,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -356,7 +793,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -398,7 +861,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x202"
           onClick={[Function]}
           target={undefined}
@@ -423,19 +916,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__10"
               >
                 http://placehold.it/100x202
@@ -458,7 +1034,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={4}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone13"
     data-is-draggable={false}
@@ -491,11 +1075,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -503,7 +1132,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -545,7 +1200,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x203"
           onClick={[Function]}
           target={undefined}
@@ -570,19 +1255,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__14"
               >
                 http://placehold.it/100x203
@@ -605,7 +1373,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={5}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone17"
     data-is-draggable={false}
@@ -638,11 +1414,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -650,7 +1471,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -692,7 +1539,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x204"
           onClick={[Function]}
           target={undefined}
@@ -717,19 +1594,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__18"
               >
                 http://placehold.it/100x204
@@ -752,7 +1712,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={6}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone21"
     data-is-draggable={false}
@@ -785,11 +1753,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -797,7 +1810,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -839,7 +1878,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x205"
           onClick={[Function]}
           target={undefined}
@@ -864,19 +1933,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__22"
               >
                 http://placehold.it/100x205
@@ -899,7 +2051,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={7}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone25"
     data-is-draggable={false}
@@ -932,11 +2092,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -944,7 +2149,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -986,7 +2217,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x206"
           onClick={[Function]}
           target={undefined}
@@ -1011,19 +2272,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__26"
               >
                 http://placehold.it/100x206
@@ -1046,7 +2390,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={8}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone29"
     data-is-draggable={false}
@@ -1079,11 +2431,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -1091,7 +2488,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -1133,7 +2556,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x207"
           onClick={[Function]}
           target={undefined}
@@ -1158,19 +2611,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__30"
               >
                 http://placehold.it/100x207
@@ -1193,7 +2729,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={9}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone33"
     data-is-draggable={false}
@@ -1226,11 +2770,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -1238,7 +2827,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -1280,7 +2895,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x208"
           onClick={[Function]}
           target={undefined}
@@ -1305,19 +2950,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__34"
               >
                 http://placehold.it/100x208
@@ -1340,7 +3068,15 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-rowindex={10}
     aria-selected={false}
-    className="ms-FocusZone ms-DetailsRow css-325"
+    className=
+        ms-FocusZone
+        ms-DetailsRow
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;};
+          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+        }
     data-automationid="DetailsRow"
     data-focuszone-id="FocusZone37"
     data-is-draggable={false}
@@ -1373,11 +3109,56 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         title={undefined}
       >
         <div
-          className="ms-Check root-326"
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Check-circle circle-329"
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
             data-icon-name="CircleRing"
             role="presentation"
           >
@@ -1385,7 +3166,33 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-Check-check check-330"
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
           >
@@ -1427,7 +3234,37 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
       >
         <a
           aria-disabled={undefined}
-          className="ms-Link root-331"
+          className=
+              ms-Link
+              {
+                color: #0078d4;
+                outline: transparent;
+                position: relative;
+                text-decoration: none;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:active, &:hover, &:active:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                text-decoration: underline;
+              }
+              &:focus {
+                color: #0078d4;
+              }
           href="http://placehold.it/100x209"
           onClick={[Function]}
           target={undefined}
@@ -1452,19 +3289,102 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-119"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__38"
               >
                 http://placehold.it/100x209

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Photos.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Photos.Example.tsx.shot
@@ -20,7 +20,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -30,7 +34,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -47,7 +61,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -57,7 +75,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -74,7 +102,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -84,7 +116,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -101,7 +143,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -111,7 +157,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -128,7 +184,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -138,7 +198,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -155,7 +225,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -165,7 +239,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -182,7 +266,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -192,7 +280,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -209,7 +307,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -219,7 +321,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -236,7 +348,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -246,7 +362,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -263,7 +389,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -273,7 +403,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -290,7 +430,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -300,7 +444,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -317,7 +471,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -327,7 +485,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -344,7 +512,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -354,7 +526,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -371,7 +553,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -381,7 +567,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -398,7 +594,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -408,7 +608,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -425,7 +635,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -435,7 +649,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -452,7 +676,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -462,7 +690,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -479,7 +717,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -489,7 +731,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -506,7 +758,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -516,7 +772,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -533,7 +799,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -543,7 +813,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -560,7 +840,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -570,7 +854,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -587,7 +881,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -597,7 +895,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -614,7 +922,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -624,7 +936,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -641,7 +963,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -651,7 +977,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -668,7 +1004,11 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     onClick={[Function]}
   >
     <div
-      className="ms-Image root-239"
+      className=
+          ms-Image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": 100,
@@ -678,7 +1018,17 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: 100%;
+              opacity: 0;
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -25,19 +25,102 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__1"
             >
               Button 1
@@ -50,19 +133,102 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__4"
             >
               Button 2
@@ -100,19 +266,102 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__9"
             >
               Button 3
@@ -128,7 +377,40 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="css-125"
+        className=
+
+            {
+              display: inline-flex;
+              outline: transparent;
+              position: relative;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              right: -2px;
+              top: -2px;
+            }
+            &:focus {
+              outline: none!important;
+            }
         data-is-focusable={true}
         data-ktp-target={undefined}
         disabled={undefined}
@@ -151,7 +433,69 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             aria-label={undefined}
             aria-labelledby={undefined}
             aria-pressed={undefined}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={false}
             disabled={undefined}
             onClick={undefined}
@@ -159,13 +503,34 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__12"
                 >
                   Create account
@@ -181,7 +546,35 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             aria-labelledby={undefined}
             aria-pressed={undefined}
             checked={undefined}
-            className="ms-Button root-150"
+            className=
+                ms-Button
+                {
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 0px;
+                  box-sizing: border-box;
+                  color: #ffffff;
+                  cursor: pointer;
+                  display: inline-block;
+                  height: auto;
+                  margin-left: -1px;
+                  outline: transparent;
+                  padding-bottom: 6px;
+                  padding-left: 6px;
+                  padding-right: 6px;
+                  padding-top: 6px;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 32px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
             data-is-focusable={false}
             data-ktp-execute-target={undefined}
             disabled={undefined}
@@ -191,11 +584,30 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-134"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
                 data-icon-name="ChevronDown"
                 role="presentation"
               >
@@ -204,7 +616,16 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             </div>
           </button>
           <span
-            className="css-149"
+            className=
+
+                {
+                  background-color: #c8c8c8;
+                  bottom: 8px;
+                  position: absolute;
+                  right: 31px;
+                  top: 8px;
+                  width: 1px;
+                }
           />
         </span>
       </div>
@@ -231,19 +652,102 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__19"
             >
               Button 1
@@ -256,19 +760,102 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__22"
             >
               Button 2
@@ -306,19 +893,102 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__27"
             >
               Button 3

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Basic.Example.tsx.shot
@@ -4,7 +4,17 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
 <div>
   <i
     aria-hidden={true}
-    className="ms-IconExample root-333"
+    className=
+        ms-IconExample
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-2";
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
     data-icon-name="CompassNW"
     role="presentation"
   >
@@ -12,7 +22,17 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
   </i>
   <i
     aria-hidden={true}
-    className="ms-IconExample root-52"
+    className=
+        ms-IconExample
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-1";
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
     data-icon-name="Dictionary"
     role="presentation"
   >
@@ -20,7 +40,17 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
   </i>
   <i
     aria-hidden={true}
-    className="ms-IconExample root-312"
+    className=
+        ms-IconExample
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-4";
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
     data-icon-name="TrainSolid"
     role="presentation"
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Color.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Color.Example.tsx.shot
@@ -4,7 +4,18 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
 <div>
   <i
     aria-hidden={true}
-    className="ms-IconExample ms-IconColorExample-deepSkyBlue root-333"
+    className=
+        ms-IconExample
+        ms-IconColorExample-deepSkyBlue
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-2";
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
     data-icon-name="CompassNW"
     role="presentation"
   >
@@ -12,7 +23,18 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
   </i>
   <i
     aria-hidden={true}
-    className="ms-IconExample ms-IconColorExample-greenYellow root-52"
+    className=
+        ms-IconExample
+        ms-IconColorExample-greenYellow
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-1";
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
     data-icon-name="Dictionary"
     role="presentation"
   >
@@ -20,7 +42,18 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
   </i>
   <i
     aria-hidden={true}
-    className="ms-IconExample ms-IconColorExample-salmon root-312"
+    className=
+        ms-IconExample
+        ms-IconColorExample-salmon
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: inline-block;
+          font-family: "FabricMDL2Icons-4";
+          font-style: normal;
+          font-weight: normal;
+          speak: none;
+        }
     data-icon-name="TrainSolid"
     role="presentation"
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.ImageSheet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.ImageSheet.Example.tsx.shot
@@ -4,12 +4,23 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
 <div>
   <div
     aria-hidden={true}
-    className="ms-Icon-imageContainer ms-IconImageSheetExample-one root-334"
+    className=
+        ms-Icon-imageContainer
+        ms-IconImageSheetExample-one
+        {
+          display: inline-block;
+          overflow: hidden;
+        }
     data-icon-name={undefined}
     role="presentation"
   >
     <div
-      className="ms-Image ms-IconImageSheetExample-one-image root-239"
+      className=
+          ms-Image
+          ms-IconImageSheetExample-one-image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": undefined,
@@ -19,7 +30,15 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-301"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              opacity: 0;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -29,12 +48,23 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
   </div>
   <div
     aria-hidden={true}
-    className="ms-Icon-imageContainer ms-IconImageSheetExample-check root-334"
+    className=
+        ms-Icon-imageContainer
+        ms-IconImageSheetExample-check
+        {
+          display: inline-block;
+          overflow: hidden;
+        }
     data-icon-name={undefined}
     role="presentation"
   >
     <div
-      className="ms-Image ms-IconImageSheetExample-check-image root-239"
+      className=
+          ms-Image
+          ms-IconImageSheetExample-check-image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": undefined,
@@ -44,7 +74,15 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-301"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              opacity: 0;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -54,12 +92,23 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
   </div>
   <div
     aria-hidden={true}
-    className="ms-Icon-imageContainer ms-IconImageSheetExample-lock root-334"
+    className=
+        ms-Icon-imageContainer
+        ms-IconImageSheetExample-lock
+        {
+          display: inline-block;
+          overflow: hidden;
+        }
     data-icon-name={undefined}
     role="presentation"
   >
     <div
-      className="ms-Image ms-IconImageSheetExample-lock-image root-239"
+      className=
+          ms-Image
+          ms-IconImageSheetExample-lock-image
+          {
+            overflow: hidden;
+          }
       style={
         Object {
           "height": undefined,
@@ -69,7 +118,15 @@ exports[`Component Examples renders Icon.ImageSheet.Example.tsx correctly 1`] = 
     >
       <img
         alt={undefined}
-        className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-301"
+        className=
+            ms-Image-image
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              opacity: 0;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Svg.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Svg.Example.tsx.shot
@@ -4,7 +4,11 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
 <div>
   <i
     aria-hidden={true}
-    className="ms-IconExample root-336"
+    className=
+        ms-IconExample
+        {
+          display: inline-block;
+        }
     data-icon-name="onedrive-svg"
     role="presentation"
   >
@@ -23,7 +27,15 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
   </i>
   <i
     aria-hidden={true}
-    className="ms-IconExample root-337"
+    className=
+        ms-IconExample
+        {
+          display: inline-block;
+          fill: red;
+        }
+        & .thing {
+          fill: green;
+        }
     data-icon-name="yammer-svg"
     role="presentation"
   >
@@ -42,7 +54,22 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
   </i>
   <i
     aria-hidden={true}
-    className="ms-IconExample root-339"
+    className=
+        ms-IconExample
+        {
+          display: inline-block;
+          height: 50px;
+          width: 50px;
+        }
+        & .borderblinds-part1 {
+          fill: red;
+        }
+        & .borderblinds-part2 {
+          fill: green;
+        }
+        & .borderblinds-part3 {
+          fill: pink;
+        }
     data-icon-name="borderblinds-svg"
     role="presentation"
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Center.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Center.Example.tsx.shot
@@ -6,12 +6,34 @@ exports[`Component Examples renders Image.Center.Example.tsx correctly 1`] = `
     Setting the imageFit property to "center" behaves the same as "none", while centering the image within the frame.
   </p>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image is larger than the frame, so all sides are cropped to center the image.
   </label>
   <div
-    className="ms-Image root-300"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
     style={
       Object {
         "height": 150,
@@ -21,7 +43,20 @@ exports[`Component Examples renders Image.Center.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation of the property image fit using the center value on an image larger than the frame."
-      className="ms-Image-image ms-Image-image--center ms-Image-image--portrait is-notLoaded is-fadeIn image-340"
+      className=
+          ms-Image-image
+          ms-Image-image--center
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            left: 50% /* @noflip */;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}
@@ -30,12 +65,34 @@ exports[`Component Examples renders Image.Center.Example.tsx correctly 1`] = `
   </div>
   <br />
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image is smaller than the frame, so there is empty space within the frame. The image is centered in the available space.
   </label>
   <div
-    className="ms-Image root-300"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
     style={
       Object {
         "height": 150,
@@ -45,7 +102,20 @@ exports[`Component Examples renders Image.Center.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation of the property image fit using the center value on an image smaller than the frame."
-      className="ms-Image-image ms-Image-image--center ms-Image-image--portrait is-notLoaded is-fadeIn image-340"
+      className=
+          ms-Image-image
+          ms-Image-image--center
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            left: 50% /* @noflip */;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Contain.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Contain.Example.tsx.shot
@@ -6,12 +6,34 @@ exports[`Component Examples renders Image.Contain.Example.tsx correctly 1`] = `
     Setting the imageFit property to "contain" will scale the image up or down to fit the frame, while maintaining its natural aspect ratio and without cropping the image.
   </p>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the width and centered in the available vertical space.
   </label>
   <div
-    className="ms-Image root-300"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
     style={
       Object {
         "height": 200,
@@ -21,7 +43,22 @@ exports[`Component Examples renders Image.Contain.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation of the property image fit using the contain value on an image wider than the frame."
-      className="ms-Image-image ms-Image-image--contain ms-Image-image--portrait is-notLoaded is-fadeIn image-341"
+      className=
+          ms-Image-image
+          ms-Image-image--contain
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: 100%;
+            left: 50% /* @noflip */;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+            width: auto;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}
@@ -30,12 +67,34 @@ exports[`Component Examples renders Image.Contain.Example.tsx correctly 1`] = `
   </div>
   <br />
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the height and centered in the available horizontal space.
   </label>
   <div
-    className="ms-Image root-300"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
     style={
       Object {
         "height": 50,
@@ -45,7 +104,22 @@ exports[`Component Examples renders Image.Contain.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation of the property image fit using the contain value on an image taller than the frame."
-      className="ms-Image-image ms-Image-image--contain ms-Image-image--portrait is-notLoaded is-fadeIn image-341"
+      className=
+          ms-Image-image
+          ms-Image-image--contain
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: 100%;
+            left: 50% /* @noflip */;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+            width: auto;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Cover.Example.tsx.shot
@@ -6,12 +6,34 @@ exports[`Component Examples renders Image.Cover.Example.tsx correctly 1`] = `
     Setting the imageFit property to "cover" will cause the image to scale up or down proportionally, while cropping from either the top and bottom or sides to completely fill the frame.
   </p>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the height and the sides are cropped evenly.
   </label>
   <div
-    className="ms-Image root-300"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
     style={
       Object {
         "height": 250,
@@ -21,7 +43,22 @@ exports[`Component Examples renders Image.Cover.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation of the property image fit using the cover value on an image wider than the frame."
-      className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+      className=
+          ms-Image-image
+          ms-Image-image--cover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: auto;
+            left: 50% /* @noflip */;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+            width: 100%;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}
@@ -30,12 +67,34 @@ exports[`Component Examples renders Image.Cover.Example.tsx correctly 1`] = `
   </div>
   <br />
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the width and the top and bottom are cropped evenly.
   </label>
   <div
-    className="ms-Image root-300"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
     style={
       Object {
         "height": 150,
@@ -45,7 +104,22 @@ exports[`Component Examples renders Image.Cover.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation of the property image fit using the cover value on an image taller than the frame."
-      className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+      className=
+          ms-Image-image
+          ms-Image-image--cover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: auto;
+            left: 50% /* @noflip */;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+            width: 100%;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Default.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Default.Example.tsx.shot
@@ -6,12 +6,33 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
     With no imageFit property set, the width and height props control the size of the frame. Depending on which of those props is used, the image may scale to fit the frame.
   </p>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Without a width or height specified, the frame remains at its natural size and the image will not be scaled.
   </label>
   <div
-    className="ms-Image root-239"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+        }
     style={
       Object {
         "height": undefined,
@@ -21,7 +42,15 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation with no image fit property and no height or width is specified."
-      className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-301"
+      className=
+          ms-Image-image
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            opacity: 0;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}
@@ -30,12 +59,33 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
   </div>
   <br />
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     If only a width is provided, the frame will be set to that width. The image will scale proportionally to fill the available width.
   </label>
   <div
-    className="ms-Image root-239"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+        }
     style={
       Object {
         "height": undefined,
@@ -45,7 +95,17 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation with no image fit property and only width is specified."
-      className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-302"
+      className=
+          ms-Image-image
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: auto;
+            opacity: 0;
+            width: 100%;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}
@@ -54,12 +114,33 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
   </div>
   <br />
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     If only a height is provided, the frame will be set to that height. The image will scale proportionally to fill the available height.
   </label>
   <div
-    className="ms-Image root-239"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+        }
     style={
       Object {
         "height": 100,
@@ -69,7 +150,17 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation with no image fit property and only height is specified."
-      className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-342"
+      className=
+          ms-Image-image
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: 100%;
+            opacity: 0;
+            width: auto;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}
@@ -78,7 +169,24 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
   </div>
   <br />
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     If both width and height are provided, the frame will be set to that width and height. The image will scale to fill both the available width and height. 
     <strong>
@@ -86,7 +194,11 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
     </strong>
   </label>
   <div
-    className="ms-Image root-239"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+        }
     style={
       Object {
         "height": 100,
@@ -96,7 +208,17 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation with no image fit property and height or width is specified."
-      className="ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-240"
+      className=
+          ms-Image-image
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: 100%;
+            opacity: 0;
+            width: 100%;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.MaximizeFrame.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.MaximizeFrame.Example.tsx.shot
@@ -6,7 +6,24 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
     Where the exact width and height of the image's frame is not known, such as when sizing an image as a percentage of its parent, you can use the "maximizeFrame" prop to expand the frame to fill the parent element.
   </p>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image is placed within a landscape container.
   </label>
@@ -19,7 +36,15 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
     }
   >
     <div
-      className="ms-Image ms-Image--maximizeFrame root-343"
+      className=
+          ms-Image
+          ms-Image--maximizeFrame
+          {
+            height: 100%;
+            overflow: hidden;
+            position: relative;
+            width: 100%;
+          }
       style={
         Object {
           "height": undefined,
@@ -29,7 +54,22 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
     >
       <img
         alt="Example implementation of the property maximize frame with a landscape container."
-        className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+        className=
+            ms-Image-image
+            ms-Image-image--cover
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: auto;
+              left: 50% /* @noflip */;
+              opacity: 0;
+              position: absolute;
+              top: 50%;
+              transform: translate(-50%,-50%);
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}
@@ -39,7 +79,24 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
   </div>
   <br />
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image is placed within a portrait container.
   </label>
@@ -52,7 +109,15 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
     }
   >
     <div
-      className="ms-Image ms-Image--maximizeFrame root-343"
+      className=
+          ms-Image
+          ms-Image--maximizeFrame
+          {
+            height: 100%;
+            overflow: hidden;
+            position: relative;
+            width: 100%;
+          }
       style={
         Object {
           "height": undefined,
@@ -62,7 +127,22 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
     >
       <img
         alt="Example implementation of the property maximize frame with a portrait container"
-        className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+        className=
+            ms-Image-image
+            ms-Image-image--cover
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: auto;
+              left: 50% /* @noflip */;
+              opacity: 0;
+              position: absolute;
+              top: 50%;
+              transform: translate(-50%,-50%);
+              width: 100%;
+            }
         onError={[Function]}
         onLoad={[Function]}
         role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.None.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.None.Example.tsx.shot
@@ -6,12 +6,33 @@ exports[`Component Examples renders Image.None.Example.tsx correctly 1`] = `
     By setting the imageFit property to "none", the image will remain at its natural size, even if the frame is made larger or smaller by setting the width and height props.
   </p>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image is larger than the frame, so it is cropped to fit. The image is positioned at the upper left of the frame.
   </label>
   <div
-    className="ms-Image root-239"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+        }
     style={
       Object {
         "height": 150,
@@ -21,7 +42,18 @@ exports[`Component Examples renders Image.None.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation of the property image fit using the none value on an image larger than the frame."
-      className="ms-Image-image ms-Image-image--none ms-Image-image--portrait is-notLoaded is-fadeIn image-344"
+      className=
+          ms-Image-image
+          ms-Image-image--none
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: auto;
+            opacity: 0;
+            width: auto;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}
@@ -30,12 +62,33 @@ exports[`Component Examples renders Image.None.Example.tsx correctly 1`] = `
   </div>
   <br />
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     The image is smaller than the frame, so there is empty space within the frame. The image is positioned at the upper left of the frame.
   </label>
   <div
-    className="ms-Image root-239"
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+        }
     style={
       Object {
         "height": 150,
@@ -45,7 +98,18 @@ exports[`Component Examples renders Image.None.Example.tsx correctly 1`] = `
   >
     <img
       alt="Example implementation of the property image fit using the none value on an image smaller than the frame."
-      className="ms-Image-image ms-Image-image--none ms-Image-image--portrait is-notLoaded is-fadeIn image-344"
+      className=
+          ms-Image-image
+          ms-Image-image--none
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: auto;
+            opacity: 0;
+            width: auto;
+          }
       onError={[Function]}
       onLoad={[Function]}
       role={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           data-ktp-execute-target="ktp-a"
           data-ktp-target="ktp-a"
@@ -36,7 +105,15 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -56,7 +133,74 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           data-ktp-execute-target="ktp-b"
           data-ktp-target="ktp-b"
@@ -69,7 +213,15 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -89,7 +241,74 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           data-ktp-execute-target="ktp-c"
           data-ktp-target="ktp-c"
@@ -102,7 +321,15 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -131,13 +358,44 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
         }
       >
         <div
-          className="css-345"
+          className=
+
+              {
+                font-size: 14px;
+                min-width: 86px;
+                outline: none;
+                width: 100%;
+              }
         >
           <div
-            className="css-346"
+            className=
+
+                {
+                  display: inline-flex;
+                  float: left;
+                  margin-right: 10px;
+                }
           >
             <label
-              className="ms-Label root-352"
+              className=
+                  ms-Label
+                  {
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    display: block;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    overflow-wrap: break-word;
+                    padding-bottom: 2px;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 2px;
+                    pointer-events: none;
+                    word-wrap: break-word;
+                  }
               htmlFor="input12"
               id="Label11"
             >
@@ -148,7 +406,25 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             aria-label={undefined}
             aria-posinset={undefined}
             aria-setsize={undefined}
-            className="css-349"
+            className=
+
+                {
+                  border-color: #a6a6a6;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  display: flex;
+                  height: 32px;
+                  min-width: 86px;
+                }
+                &:hover {
+                  border-color: #212121;
+                  outline: 2px dashed transparent;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  outline: none;
+                }
             data-ktp-target="ktp-a-3"
             title={undefined}
           >
@@ -161,7 +437,42 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               aria-valuenow={0}
               aria-valuetext={undefined}
               autoComplete="off"
-              className="ms-spinButton-input css-350"
+              className=
+                  ms-spinButton-input
+                  {
+                    border-style: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: text;
+                    display: block;
+                    float: left;
+                    font-size: 14px;
+                    height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    min-width: 72px;
+                    outline: 0;
+                    overflow: hidden;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 12px;
+                    padding-top: 0;
+                    text-overflow: ellipsis;
+                    user-select: text;
+                    width: calc(100% - 14px);
+                  }
+                  &::selection {
+                    background-color: #0078d4;
+                    color: #ffffff;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::selection {
+                    background-color: Highlight;
+                    border-color: Highlight;
+                    color: HighlightText;
+                  }
               data-ktp-execute-target="ktp-a-3"
               data-lpignore={true}
               disabled={false}
@@ -178,7 +489,21 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               value="0"
             />
             <span
-              className="css-351"
+              className=
+
+                  {
+                    box-sizing: border-box;
+                    cursor: default;
+                    display: block;
+                    float: left;
+                    font-size: 12px;
+                    height: 100%;
+                    outline: none;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                  }
             >
               <button
                 aria-describedby={undefined}
@@ -186,7 +511,74 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 aria-labelledby={undefined}
                 aria-pressed={false}
                 checked={false}
-                className="ms-Button ms-Button--icon ms-UpButton root-353"
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-UpButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: default;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 50%;
+                      outline: none;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                      width: 14px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      background-color: #eaeaea;
+                      color: #000000;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active {
+                      background-color: Highlight;
+                      color: HighlightText;
+                    }
                 data-is-focusable={false}
                 disabled={undefined}
                 onMouseDown={[Function]}
@@ -196,11 +588,39 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-102"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Button-icon icon-355"
+                    className=
+                        ms-Button-icon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-family: "FabricMDL2Icons-2";
+                          font-size: 6px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 0;
+                          margin-right: 0;
+                          margin-top: 0;
+                          speak: none;
+                          text-align: center;
+                          vertical-align: middle;
+                        }
                     data-icon-name="ChevronUpSmall"
                     role="presentation"
                   >
@@ -214,7 +634,74 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 aria-labelledby={undefined}
                 aria-pressed={false}
                 checked={false}
-                className="ms-Button ms-Button--icon ms-DownButton root-353"
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-DownButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: default;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 50%;
+                      outline: none;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                      width: 14px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      background-color: #eaeaea;
+                      color: #000000;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active {
+                      background-color: Highlight;
+                      color: HighlightText;
+                    }
                 data-is-focusable={false}
                 disabled={undefined}
                 onMouseDown={[Function]}
@@ -224,11 +711,39 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-102"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Button-icon icon-355"
+                    className=
+                        ms-Button-icon
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-family: "FabricMDL2Icons-2";
+                          font-size: 6px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 0;
+                          margin-right: 0;
+                          margin-top: 0;
+                          speak: none;
+                          text-align: center;
+                          vertical-align: middle;
+                        }
                     data-icon-name="ChevronDownSmall"
                     role="presentation"
                   >
@@ -240,17 +755,77 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
           </div>
         </div>
         <div
-          className="ms-Toggle is-enabled root-285"
+          className=
+              ms-Toggle
+              is-enabled
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 8px;
+              }
         >
           <div
-            className="ms-Toggle-innerContainer container-286"
+            className=
+                ms-Toggle-innerContainer
+                {
+                  display: inline-flex;
+                  position: relative;
+                }
           >
             <button
               aria-describedby=" ktp-layer-id ktp-a-1"
               aria-disabled={undefined}
               aria-label={undefined}
               aria-pressed={false}
-              className="ms-Toggle-background pill-287"
+              className=
+                  ms-Toggle-background
+                  {
+                    align-items: center;
+                    background: #ffffff;
+                    border-color: #666666;
+                    border-radius: 1em;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    cursor: pointer;
+                    display: flex;
+                    font-size: 20px;
+                    height: 1em;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: .2em;
+                    padding-right: .2em;
+                    padding-top: 0;
+                    position: relative;
+                    transition: all 0.1s ease;
+                    width: 2.2em;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -2px;
+                    content: "";
+                    left: -2px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -2px;
+                    top: -2px;
+                    z-index: 1;
+                  }
+                  &:hover {
+                    border-color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                    border-color: Highlight;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
               data-is-focusable={true}
               data-ktp-execute-target="ktp-a-1"
               data-ktp-target="ktp-a-1"
@@ -261,11 +836,52 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               type="button"
             >
               <div
-                className="ms-Toggle-thumb thumb-288"
+                className=
+                    ms-Toggle-thumb
+                    {
+                      background-color: #212121;
+                      border-color: transparent;
+                      border-radius: .5em;
+                      border-style: solid;
+                      border-width: .28em;
+                      box-sizing: border-box;
+                      height: .5em;
+                      transition: all 0.1s ease;
+                      width: .5em;
+                    }
               />
             </button>
             <label
-              className="ms-Label ms-Toggle-stateText text-290"
+              className=
+                  ms-Label
+                  ms-Toggle-stateText
+                  {
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    display: block;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    overflow-wrap: break-word;
+                    padding-bottom: 5px;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 5px;
+                    word-wrap: break-word;
+                  }
+                  && {
+                    margin-bottom: 0;
+                    margin-left: 10px;
+                    margin-right: 10px;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    user-select: none;
+                  }
               htmlFor="Toggle19"
             >
               No
@@ -278,7 +894,37 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
           <a
             aria-describedby=" ktp-layer-id ktp-a-2"
             aria-disabled={undefined}
-            className="ms-Link root-331"
+            className=
+                ms-Link
+                {
+                  color: #0078d4;
+                  outline: transparent;
+                  position: relative;
+                  text-decoration: none;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:active, &:hover, &:active:hover {
+                  color: #004578;
+                }
+                @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                  text-decoration: underline;
+                }
+                &:focus {
+                  color: #0078d4;
+                }
             data-ktp-execute-target="ktp-a-2"
             data-ktp-target="ktp-a-2"
             href="http://www.bing.com"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -10,7 +10,69 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     data-ktp-execute-target="ktp-1-a"
     data-ktp-target="ktp-1-a"
@@ -19,13 +81,34 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Button
@@ -38,7 +121,76 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby="id__3"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--compound root-135"
+    className=
+        ms-Button
+        ms-Button--compound
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          max-width: 280px;
+          min-height: 72px;
+          outline: transparent;
+          padding-bottom: 20px;
+          padding-left: 20px;
+          padding-right: 20px;
+          padding-top: 20px;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:hover .ms-Button-description {
+          color: #212121;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
+        &:active .ms-Button-description {
+          color: inherit;
+        }
     data-is-focusable={true}
     data-ktp-execute-target="ktp-1-b"
     data-ktp-target="ktp-1-b"
@@ -47,19 +199,57 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-136"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: flex-start;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+            margin-bottom: ;
+            margin-left: ;
+            margin-right: ;
+            margin-top: ;
+            min-width: 100%;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-137"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+              text-align: left;
+            }
       >
         <div
-          className="ms-Button-label label-139"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 5px;
+                margin-left: 0;
+                margin-right: 0;
+                margin-top: 0;
+              }
           id="id__3"
         >
           Compound Button
         </div>
         <div
-          className="ms-Button-description description-140"
+          className=
+              ms-Button-description
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+                line-height: 100%;
+              }
           id="id__4"
         >
           With a Keytip
@@ -75,7 +265,69 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     aria-labelledby={undefined}
     aria-owns={null}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     data-ktp-execute-target="ktp-2-a"
     data-ktp-target="ktp-2-a"
@@ -85,13 +337,34 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__6"
         >
           Button with Menu
@@ -99,7 +372,27 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
       </div>
       <i
         aria-hidden={true}
-        className="ms-Button-menuIcon menuIcon-143"
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
         data-icon-name="ChevronDown"
         role="presentation"
       >
@@ -115,7 +408,40 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="css-125"
+    className=
+
+        {
+          display: inline-flex;
+          outline: transparent;
+          position: relative;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border: none;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          right: -2px;
+          top: -2px;
+        }
+        &:focus {
+          outline: none!important;
+        }
     data-is-focusable={true}
     data-ktp-target="ktp-2-b"
     disabled={undefined}
@@ -138,7 +464,69 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={false}
         disabled={undefined}
         onClick={undefined}
@@ -146,13 +534,34 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__9"
             >
               Split Button
@@ -168,7 +577,35 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
         aria-labelledby={undefined}
         aria-pressed={undefined}
         checked={undefined}
-        className="ms-Button root-150"
+        className=
+            ms-Button
+            {
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #ffffff;
+              cursor: pointer;
+              display: inline-block;
+              height: auto;
+              margin-left: -1px;
+              outline: transparent;
+              padding-bottom: 6px;
+              padding-left: 6px;
+              padding-right: 6px;
+              padding-top: 6px;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
+            }
         data-is-focusable={false}
         data-ktp-execute-target="ktp-2-b"
         disabled={undefined}
@@ -178,11 +615,30 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-134"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #333333;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -191,7 +647,16 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
         </div>
       </button>
       <span
-        className="css-149"
+        className=
+
+            {
+              background-color: #c8c8c8;
+              bottom: 8px;
+              position: absolute;
+              right: 31px;
+              top: 8px;
+              width: 1px;
+            }
       />
     </span>
   </div>
@@ -200,19 +665,102 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__15"
         >
           I do not have a keytip
@@ -228,7 +776,69 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     data-ktp-execute-target="ktp-0-0"
     data-ktp-target="ktp-0-0"
@@ -237,13 +847,34 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__18"
         >
           Button keytip offset 10x10
@@ -255,16 +886,80 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     A keytip will become disabled when its corresponding component becomes disabled. A disabled keytip will be visible but cannot be triggered
   </p>
   <div
-    className="ms-Toggle is-checked is-enabled root-285"
+    className=
+        ms-Toggle
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label={undefined}
         aria-pressed={true}
-        className="ms-Toggle-background pill-356"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: transparent;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              background-color: #106ebe;
+              border-color: transparent;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              background-color: Highlight;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle21"
@@ -273,11 +968,56 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-357"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #ffffff;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-290"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
         htmlFor="Toggle21"
       >
         Enabled
@@ -289,7 +1029,69 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     data-ktp-execute-target="ktp-0-1"
     data-ktp-target="ktp-0-1"
@@ -298,13 +1100,34 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__22"
         >
           Enabled Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -9,7 +9,12 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
   }
 >
   <div
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
   >
     <div
       style={
@@ -23,7 +28,18 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
         aria-describedby={undefined}
         aria-label={undefined}
         aria-labelledby={undefined}
-        className="ms-FocusZone ms-CommandBar root-276"
+        className=
+            ms-FocusZone
+            ms-CommandBar
+            {
+              background-color: #f4f4f4;
+              display: flex;
+              height: 40px;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+            }
         data-focuszone-id="FocusZone0"
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -31,7 +47,14 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
         role="menubar"
       >
         <div
-          className="ms-OverflowSet ms-CommandBar-primaryCommand primarySet-277"
+          className=
+              ms-OverflowSet
+              ms-CommandBar-primaryCommand
+              {
+                align-items: stretch;
+                display: flex;
+                flex-grow: 1;
+              }
           role="presentation"
         >
           <div
@@ -44,7 +67,72 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               aria-posinset={1}
               aria-pressed={undefined}
               aria-setsize={2}
-              className="ms-Button ms-Button--commandBar ms-CommandBarItem-link root-280"
+              className=
+                  ms-Button
+                  ms-Button--commandBar
+                  ms-CommandBarItem-link
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #f4f4f4;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 100%;
+                    min-width: 40px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: 4px;
+                    left: 4px;
+                    outline-color: ButtonText;
+                    right: 4px;
+                    top: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  &:hover {
+                    background-color: #eaeaea;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #dadada;
+                    color: #000000;
+                  }
               data-is-focusable={true}
               data-ktp-execute-target="ktp-j"
               data-ktp-target="ktp-j"
@@ -53,21 +141,63 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-102"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="ms-Button-icon icon-118"
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
                   data-icon-name="Add"
                   role="presentation"
                 >
                   
                 </i>
                 <div
-                  className="ms-Button-textContainer textContainer-103"
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
                 >
                   <div
-                    className="ms-Button-label label-123"
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: normal;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
                     id="id__1"
                   >
                     New
@@ -86,7 +216,72 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               aria-posinset={2}
               aria-pressed={undefined}
               aria-setsize={2}
-              className="ms-Button ms-Button--commandBar ms-CommandBarItem-link root-280"
+              className=
+                  ms-Button
+                  ms-Button--commandBar
+                  ms-CommandBarItem-link
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #f4f4f4;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 100%;
+                    min-width: 40px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: 4px;
+                    left: 4px;
+                    outline-color: ButtonText;
+                    right: 4px;
+                    top: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  &:hover {
+                    background-color: #eaeaea;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #dadada;
+                    color: #000000;
+                  }
               data-is-focusable={true}
               data-ktp-execute-target="ktp-m"
               data-ktp-target="ktp-m"
@@ -95,21 +290,63 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-102"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="ms-Button-icon icon-118"
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
                   data-icon-name="Upload"
                   role="presentation"
                 >
                   
                 </i>
                 <div
-                  className="ms-Button-textContainer textContainer-103"
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
                 >
                   <div
-                    className="ms-Button-label label-123"
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: normal;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
                     id="id__4"
                   >
                     Upload
@@ -120,7 +357,14 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
           </div>
         </div>
         <div
-          className="ms-OverflowSet ms-CommandBar-secondaryCommand secondarySet-278"
+          className=
+              ms-OverflowSet
+              ms-CommandBar-secondaryCommand
+              {
+                align-items: stretch;
+                display: flex;
+                flex-shrink: 0;
+              }
           role="presentation"
         >
           <div
@@ -136,7 +380,72 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               aria-posinset={1}
               aria-pressed={undefined}
               aria-setsize={1}
-              className="ms-Button ms-Button--commandBar ms-CommandBarItem-link root-280"
+              className=
+                  ms-Button
+                  ms-Button--commandBar
+                  ms-CommandBarItem-link
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #f4f4f4;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 100%;
+                    min-width: 40px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: 4px;
+                    left: 4px;
+                    outline-color: ButtonText;
+                    right: 4px;
+                    top: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  &:hover {
+                    background-color: #eaeaea;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #dadada;
+                    color: #000000;
+                  }
               data-is-focusable={true}
               data-ktp-execute-target="ktp-l-k"
               data-ktp-target="ktp-l-k"
@@ -146,21 +455,63 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-102"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
               >
                 <i
                   aria-hidden={true}
-                  className="ms-Button-icon icon-118"
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
                   data-icon-name="SortLines"
                   role="presentation"
                 >
                   
                 </i>
                 <div
-                  className="ms-Button-textContainer textContainer-103"
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
                 >
                   <div
-                    className="ms-Button-label label-123"
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: normal;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
                     id="id__7"
                   >
                     Options
@@ -168,7 +519,28 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                 </div>
                 <i
                   aria-hidden={true}
-                  className="ms-Button-menuIcon menuIcon-121"
+                  className=
+                      ms-Button-menuIcon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #666666;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
                   data-icon-name="ChevronDown"
                   role="presentation"
                 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Overflow.Example.tsx.shot
@@ -23,7 +23,70 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--commandBar root-358"
+        className=
+            ms-Button
+            ms-Button--commandBar
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-width: 40px;
+              outline: transparent;
+              padding-bottom: 10px;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 10px;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: 4px;
+              left: 4px;
+              outline-color: ButtonText;
+              right: 4px;
+              top: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border: none;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
+            }
+            &:active {
+              background-color: #dadada;
+              color: #000000;
+            }
         data-is-focusable={true}
         data-ktp-execute-target="ktp-q"
         data-ktp-target="ktp-q"
@@ -33,13 +96,34 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-123"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: normal;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__1"
             >
               Link 1
@@ -56,7 +140,70 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--commandBar root-358"
+        className=
+            ms-Button
+            ms-Button--commandBar
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-width: 40px;
+              outline: transparent;
+              padding-bottom: 10px;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 10px;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: 4px;
+              left: 4px;
+              outline-color: ButtonText;
+              right: 4px;
+              top: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border: none;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
+            }
+            &:active {
+              background-color: #dadada;
+              color: #000000;
+            }
         data-is-focusable={true}
         data-ktp-execute-target="ktp-w"
         data-ktp-target="ktp-w"
@@ -66,13 +213,34 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-123"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: normal;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__4"
             >
               Link 2
@@ -89,7 +257,70 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--commandBar root-358"
+        className=
+            ms-Button
+            ms-Button--commandBar
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-width: 40px;
+              outline: transparent;
+              padding-bottom: 10px;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 10px;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: 4px;
+              left: 4px;
+              outline-color: ButtonText;
+              right: 4px;
+              top: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border: none;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
+            }
+            &:active {
+              background-color: #dadada;
+              color: #000000;
+            }
         data-is-focusable={true}
         data-ktp-execute-target="ktp-e"
         data-ktp-target="ktp-e"
@@ -99,13 +330,34 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-123"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: normal;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__7"
             >
               Link 3
@@ -125,7 +377,70 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
         aria-labelledby={undefined}
         aria-owns={null}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--commandBar root-122"
+        className=
+            ms-Button
+            ms-Button--commandBar
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-width: 40px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: 4px;
+              left: 4px;
+              outline-color: ButtonText;
+              right: 4px;
+              top: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border: none;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
+            }
+            &:active {
+              background-color: #dadada;
+              color: #000000;
+            }
         data-is-focusable={true}
         data-ktp-execute-target="ktp-r"
         data-ktp-target="ktp-r"
@@ -135,11 +450,40 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-menuIcon menuIcon-121"
+            className=
+                ms-Button-menuIcon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #666666;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="More"
             role="presentation"
           >
@@ -157,20 +501,103 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__13"
         >
           Move overflow items

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -3,17 +3,76 @@
 exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
 <div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     I'm a Label
   </label>
   <label
-    className="ms-Label root-271"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #c8c8c8;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          color: GrayText;
+        }
   >
     I'm a disabled Label
   </label>
   <label
-    className="ms-Label root-359"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+        &::after {
+          color: #a80000;
+          content: ' *';
+          padding-right: 12px;
+        }
     required={true}
   >
     I'm a required Label

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -2,7 +2,14 @@
 
 exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
 <div
-  className="LayerExample-content css-360"
+  className=
+      LayerExample-content
+      {
+        animation-duration: 0.367s;
+        animation-fill-mode: both;
+        animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:scale3d(.98,.98,1);}to{transform:scale3d(1,1,1);};
+        animation-timing-function: cubic-bezier(.1,.9,.2,1);
+      }
 >
   <div
     className="LayerExample-textContent"
@@ -24,7 +31,60 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 2`] = `
     aria-posinset={undefined}
     aria-setsize={undefined}
     checked={false}
-    className="ms-Checkbox is-enabled root-189"
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-0"
@@ -36,16 +96,66 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 2`] = `
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-0"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -53,14 +163,30 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 2`] = `
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Wrap the content box belowed in a Layer
       </span>
     </label>
   </button>
   <div
-    className="LayerExample-content css-360"
+    className=
+        LayerExample-content
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:scale3d(.98,.98,1);}to{transform:scale3d(1,1,1);};
+          animation-timing-function: cubic-bezier(.1,.9,.2,1);
+        }
   >
     <div
       className="LayerExample-textContent"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -18,7 +18,67 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
     aria-posinset={undefined}
     aria-setsize={undefined}
     checked={true}
-    className="ms-Checkbox is-checked is-enabled root-183"
+    className=
+        ms-Checkbox
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          background: #106ebe;
+          border-color: #106ebe;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          background: #106ebe;
+          border-color: #106ebe;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          background: WindowText;
+          border-color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+          background: WindowText;
+          border-color: WindowText;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-0"
@@ -30,16 +90,71 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-0"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-185"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: #0078d4;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText;
+              border-color: WindowText;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-188"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -47,7 +162,16 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Show panel
       </span>
@@ -62,7 +186,67 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
     aria-posinset={undefined}
     aria-setsize={undefined}
     checked={true}
-    className="ms-Checkbox is-checked is-enabled root-183"
+    className=
+        ms-Checkbox
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          background: #106ebe;
+          border-color: #106ebe;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          background: #106ebe;
+          border-color: #106ebe;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          background: WindowText;
+          border-color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+          background: WindowText;
+          border-color: WindowText;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-1"
@@ -74,16 +258,71 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-1"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-185"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: #0078d4;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText;
+              border-color: WindowText;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-188"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -91,7 +330,16 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Trap panel
       </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -3,23 +3,105 @@
 exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-Toggle is-checked is-enabled root-285"
+    className=
+        ms-Toggle
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <label
-      className="ms-Label ms-Toggle-label label-230"
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Toggle0"
     >
       Show host
     </label>
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label="Show host"
         aria-pressed={true}
         checked={true}
-        className="ms-Toggle-background pill-356"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: transparent;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              background-color: #106ebe;
+              border-color: transparent;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              background-color: Highlight;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle0"
@@ -28,7 +110,23 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-357"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #ffffff;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
         />
       </button>
     </div>
@@ -51,7 +149,60 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
     aria-posinset={undefined}
     aria-setsize={undefined}
     checked={false}
-    className="ms-Checkbox is-enabled root-189"
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-1"
@@ -63,16 +214,66 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-1"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -80,14 +281,30 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Render the box below in a Layer and target it at hostId=layerhost1
       </span>
     </label>
   </button>
   <div
-    className="LayerExample-content css-360"
+    className=
+        LayerExample-content
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:scale3d(.98,.98,1);}to{transform:scale3d(1,1,1);};
+          animation-timing-function: cubic-bezier(.1,.9,.2,1);
+        }
   >
     This is example layer content.
   </div>
@@ -108,7 +325,60 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
     aria-posinset={undefined}
     aria-setsize={undefined}
     checked={false}
-    className="ms-Checkbox is-enabled root-189"
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-2"
@@ -120,16 +390,66 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-2"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -137,14 +457,30 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Render the box below in a Layer without specifying a host, fixing it to the top of the page
       </span>
     </label>
   </button>
   <div
-    className="LayerExample-content css-360"
+    className=
+        LayerExample-content
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:scale3d(.98,.98,1);}to{transform:scale3d(1,1,1);};
+          animation-timing-function: cubic-bezier(.1,.9,.2,1);
+        }
   >
     This is example layer content.
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -9,7 +9,37 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
   </span>
   <a
     aria-disabled={undefined}
-    className="ms-Link root-331"
+    className=
+        ms-Link
+        {
+          color: #0078d4;
+          outline: transparent;
+          position: relative;
+          text-decoration: none;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        &:active, &:hover, &:active:hover {
+          color: #004578;
+        }
+        @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+          text-decoration: underline;
+        }
+        &:focus {
+          color: #0078d4;
+        }
     href="http://dev.office.com/fabric/components/link"
     onClick={[Function]}
     target={undefined}
@@ -21,7 +51,54 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
   </span>
   <button
     aria-disabled={undefined}
-    className="ms-Link root-324"
+    className=
+        ms-Link
+        {
+          background-color: transparent;
+          background: none;
+          border: none;
+          color: #0078d4;
+          cursor: pointer;
+          display: inline;
+          font-size: inherit;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          outline: transparent;
+          overflow: inherit;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          text-align: left;
+          text-overflow: inherit;
+          user-select: text;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        &:active, &:hover, &:active:hover {
+          color: #004578;
+        }
+        @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+          text-decoration: underline;
+        }
+        &:focus {
+          color: #0078d4;
+        }
     onClick={[Function]}
   >
     the link is rendered as a button
@@ -32,7 +109,33 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
   </span>
   <a
     aria-disabled={true}
-    className="ms-Link is-disabled root-363"
+    className=
+        ms-Link
+        is-disabled
+        {
+          color: #a6a6a6;
+          cursor: default;
+          outline: transparent;
+          position: relative;
+          text-decoration: none;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        &:link, &:visited {
+          pointer-events: none;
+        }
     href="http://dev.office.com/fabric/components/link"
     onClick={[Function]}
     target={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
@@ -2,7 +2,12 @@
 
 exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly 1`] = `
 <div
-  className="root-281"
+  className=
+
+      {
+        cursor: default;
+        position: relative;
+      }
 >
   <button
     aria-checked={true}
@@ -12,7 +17,67 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
     aria-labelledby={undefined}
     aria-posinset={undefined}
     aria-setsize={undefined}
-    className="ms-Checkbox is-checked is-enabled root-183"
+    className=
+        ms-Checkbox
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          background: #106ebe;
+          border-color: #106ebe;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          background: #106ebe;
+          border-color: #106ebe;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          background: WindowText;
+          border-color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+          background: WindowText;
+          border-color: WindowText;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     defaultChecked={true}
     disabled={undefined}
@@ -25,16 +90,71 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-0"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-185"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: #0078d4;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText;
+              border-color: WindowText;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-188"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -42,7 +162,16 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Is marquee enabled
       </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -5,7 +5,24 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
   className="ms-BasicMessageBarsExample"
 >
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Info/Default MessageBar
   </label>
@@ -22,7 +39,17 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       >
         <i
           aria-hidden={true}
-          className="root-55"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="Info"
           role="presentation"
         >
@@ -42,7 +69,24 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Error MessageBar - single line, with dismiss button
   </label>
@@ -57,7 +101,17 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       >
         <i
           aria-hidden={true}
-          className="root-313"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-3";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="ErrorBadge"
           role="presentation"
         >
@@ -82,18 +136,106 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           aria-label="Close"
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--icon ms-MessageBar-dismissal root-145"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-MessageBar-dismissal
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                color: #0078d4;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-109"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="Clear"
               role="presentation"
             >
@@ -105,7 +247,24 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Blocked MessageBar - single line, with dismiss button and truncated text. Truncation is not available if you use action buttons or multiline and should be used sparingly.
   </label>
@@ -120,7 +279,17 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       >
         <i
           aria-hidden={true}
-          className="root-312"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-4";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="Blocked2"
           role="presentation"
         >
@@ -145,18 +314,106 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           aria-label="Overflow"
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--icon ms-MessageBar-expand root-145"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-MessageBar-expand
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                color: #0078d4;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-365"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-6";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="DoubleChevronDown"
               role="presentation"
             >
@@ -173,18 +430,106 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           aria-label="Close"
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--icon ms-MessageBar-dismissal root-145"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-MessageBar-dismissal
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                color: #0078d4;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-109"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="Clear"
               role="presentation"
             >
@@ -196,7 +541,24 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     SevereWarning MessageBar - defaults to multiline, with action buttons
   </label>
@@ -213,7 +575,17 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       >
         <i
           aria-hidden={true}
-          className="root-366"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-0";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="Warning"
           role="presentation"
         >
@@ -240,19 +612,102 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-367"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #dadada;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #a6a6a6;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__13"
               >
                 Yes
@@ -265,19 +720,102 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-367"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #dadada;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #a6a6a6;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__16"
               >
                 No
@@ -289,7 +827,24 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Success MessageBar - single line, with action buttons
   </label>
@@ -304,7 +859,17 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       >
         <i
           aria-hidden={true}
-          className="root-333"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-2";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="Completed"
           role="presentation"
         >
@@ -330,19 +895,102 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             aria-label={undefined}
             aria-labelledby={undefined}
             aria-pressed={undefined}
-            className="ms-Button ms-Button--default root-367"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #dadada;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #a6a6a6;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__20"
                 >
                   Yes
@@ -355,19 +1003,102 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             aria-label={undefined}
             aria-labelledby={undefined}
             aria-pressed={undefined}
-            className="ms-Button ms-Button--default root-367"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #dadada;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #a6a6a6;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__23"
                 >
                   No
@@ -380,7 +1111,24 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Warning MessageBar - single line, with dismiss and action buttons
   </label>
@@ -395,7 +1143,17 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       >
         <i
           aria-hidden={true}
-          className="root-55"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="Info"
           role="presentation"
         >
@@ -421,19 +1179,102 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             aria-label={undefined}
             aria-labelledby={undefined}
             aria-pressed={undefined}
-            className="ms-Button ms-Button--default root-367"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #dadada;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #a6a6a6;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__27"
                 >
                   Action
@@ -451,18 +1292,106 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           aria-label="Close"
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--icon ms-MessageBar-dismissal root-145"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-MessageBar-dismissal
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 32px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #004578;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                color: #0078d4;
+              }
           data-is-focusable={true}
           disabled={undefined}
           onClick={[Function]}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-109"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons";
+                    font-size: 16px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="Clear"
               role="presentation"
             >
@@ -474,7 +1403,24 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Warning MessageBar - defaults to multiline, with dismiss and action buttons
   </label>
@@ -491,7 +1437,17 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       >
         <i
           aria-hidden={true}
-          className="root-55"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="Info"
           role="presentation"
         >
@@ -513,18 +1469,106 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
         aria-label="Close"
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--icon ms-MessageBar-dismissal root-145"
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-MessageBar-dismissal
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              color: #004578;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              color: #0078d4;
+            }
         data-is-focusable={true}
         disabled={undefined}
         onClick={[Function]}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-109"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="Clear"
             role="presentation"
           >
@@ -542,19 +1586,102 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-367"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #dadada;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #a6a6a6;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__37"
               >
                 Yes
@@ -567,19 +1694,102 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           aria-label={undefined}
           aria-labelledby={undefined}
           aria-pressed={undefined}
-          className="ms-Button ms-Button--default root-367"
+          className=
+              ms-Button
+              ms-Button--default
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #dadada;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 32px;
+                min-width: 80px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 16px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #a6a6a6;
+                color: #212121;
+              }
           data-is-focusable={true}
           disabled={undefined}
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <div
-              className="ms-Button-textContainer textContainer-103"
+              className=
+                  ms-Button-textContainer
+                  {
+                    flex-grow: 1;
+                  }
             >
               <div
-                className="ms-Button-label label-120"
+                className=
+                    ms-Button-label
+                    {
+                      font-weight: 600;
+                      line-height: 100%;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                    }
                 id="id__40"
               >
                 No

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Modal

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -16,36 +16,150 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
   >
     <nav
       aria-label={undefined}
-      className="ms-Nav root-369"
+      className=
+          ms-Nav
+          {
+            -webkit-overflow-scrolling: touch;
+            overflow-y: auto;
+            user-select: none;
+          }
       role="navigation"
     >
       <div
-        className="ms-Nav-group is-expanded group-377"
+        className=
+            ms-Nav-group
+            is-expanded
+
       >
         <div
-          className="ms-Nav-groupContent groupContent-378"
+          className=
+              ms-Nav-groupContent
+              {
+                animation-duration: 0.367s;
+                animation-fill-mode: both;
+                animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(0,-20px,0);}to{transform:translate3d(0,0,0);};
+                animation-timing-function: cubic-bezier(.1,.9,.2,1);
+                display: block;
+                margin-bottom: 40px;
+              }
         >
           <ul
-            className="ms-Nav-navItems navItems-376"
+            className=
+                ms-Nav-navItems
+                {
+                  list-style-type: none;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="list"
           >
             <li
-              className="ms-Nav-navItem navItem-375"
+              className=
+                  ms-Nav-navItem
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="listitem"
             >
               <div
-                className="ms-Nav-compositeLink is-expanded compositeLink-371"
+                className=
+                    ms-Nav-compositeLink
+                    is-expanded
+                    {
+                      background-color: #ffffff;
+                      color: #333333;
+                      display: block;
+                      position: relative;
+                    }
                 name="Home"
               >
                 <button
                   aria-expanded="true"
                   aria-label={undefined}
-                  className="ms-Nav-chevronButton chevronButton-382"
+                  className=
+                      ms-Nav-chevronButton
+                      {
+                        background-color: transparent;
+                        border: none;
+                        color: #333333;
+                        cursor: pointer;
+                        display: block;
+                        font-size: 12px;
+                        font-weight: 400;
+                        height: 34px;
+                        left: 1px;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: absolute;
+                        text-align: left;
+                        text-overflow: ellipsis;
+                        top: 1px;
+                        white-space: nowrap;
+                        width: 26px;
+                        z-index: 1;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      &:visited {
+                        color: inherit;
+                      }
+                      &:hover {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
+                      $compositeLink:hover & {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
                   onClick={[Function]}
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Nav-chevron chevronIcon-393"
+                    className=
+                        ms-Nav-chevron
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 12px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 36px;
+                          left: 8px;
+                          line-height: 36px;
+                          position: absolute;
+                          speak: none;
+                          top: 0px;
+                          transform: rotate(-180deg);
+                          transition: transform .1s linear;
+                        }
                     data-icon-name="ChevronDown"
                     role="presentation"
                   >
@@ -57,7 +171,83 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   aria-label={undefined}
                   aria-labelledby={undefined}
                   aria-pressed={undefined}
-                  className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #333333;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 36px;
+                        line-height: 36px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 3px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        vertical-align: top;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
                   data-is-focusable={true}
                   disabled={undefined}
                   href="http://example.com"
@@ -67,22 +257,73 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   title="Home"
                 >
                   <div
-                    className="ms-Button-flexContainer flexContainer-114"
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
                   >
                     <i
                       aria-hidden={true}
-                      className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                      className=
+                          ms-Icon-placeHolder
+                          ms-Button-icon
+                          {
+                            color: #106ebe;
+                            display: inline-block;
+                            flex-shrink: 0;
+                            font-size: 16px;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            text-align: center;
+                            vertical-align: middle;
+                            width: 1em;
+                          }
                       data-icon-name=""
                       role="presentation"
                     />
                     <span
-                      className="ms-Button-screenReaderText screenReaderText-108"
+                      className=
+                          ms-Button-screenReaderText
+                          {
+                            border: 0px;
+                            height: 1px;
+                            margin-bottom: -1px;
+                            margin-left: -1px;
+                            margin-right: -1px;
+                            margin-top: -1px;
+                            overflow: hidden;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: absolute;
+                            width: 1px;
+                          }
                       id="id__3"
                     >
                       Home
                     </span>
                     <div
-                      className="ms-Nav-linkText linkText-370"
+                      className=
+                          ms-Nav-linkText
+                          {
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            vertical-align: middle;
+                          }
                     >
                       Home
                     </div>
@@ -90,15 +331,37 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 </a>
               </div>
               <ul
-                className="ms-Nav-navItems navItems-376"
+                className=
+                    ms-Nav-navItems
+                    {
+                      list-style-type: none;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                    }
                 role="list"
               >
                 <li
-                  className="ms-Nav-navItem navItem-375"
+                  className=
+                      ms-Nav-navItem
+                      {
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                      }
                   role="listitem"
                 >
                   <div
-                    className="ms-Nav-compositeLink compositeLink-371"
+                    className=
+                        ms-Nav-compositeLink
+                        {
+                          background-color: #ffffff;
+                          color: #333333;
+                          display: block;
+                          position: relative;
+                        }
                     name="Activity"
                   >
                     <a
@@ -106,7 +369,83 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       aria-label={undefined}
                       aria-labelledby={undefined}
                       aria-pressed={undefined}
-                      className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-398"
+                      className=
+                          ms-Button
+                          ms-Button--action
+                          ms-Button--command
+                          ms-Nav-link
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            border-radius: 0px;
+                            border: 1px solid transparent;
+                            box-sizing: border-box;
+                            color: #333333;
+                            cursor: pointer;
+                            display: block;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 36px;
+                            line-height: 36px;
+                            outline: transparent;
+                            overflow: hidden;
+                            padding-bottom: 0;
+                            padding-left: 17px;
+                            padding-right: 20px;
+                            padding-top: 0;
+                            position: relative;
+                            text-align: center;
+                            text-decoration: none;
+                            text-overflow: ellipsis;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                            width: 100%;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #ffffff;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #666666;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                            border: none;
+                            bottom: -2px;
+                            left: -2px;
+                            outline-color: ButtonText;
+                            right: -2px;
+                            top: -2px;
+                          }
+                          &:hover {
+                            color: #0078d4;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:hover {
+                            border-color: Highlight;
+                            color: Highlight;
+                          }
+                          &:hover .ms-Button-icon {
+                            color: #0078d4;
+                          }
+                          &:active {
+                            color: #000000;
+                          }
+                          &:active .ms-Button-icon {
+                            color: #004578;
+                          }
+                          .ms-Nav-compositeLink:hover & {
+                            background-color: #f8f8f8;
+                            color: #333333;
+                          }
                       data-is-focusable={true}
                       disabled={undefined}
                       href="http://msn.com"
@@ -116,22 +455,73 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       title="Activity"
                     >
                       <div
-                        className="ms-Button-flexContainer flexContainer-114"
+                        className=
+                            ms-Button-flexContainer
+                            {
+                              align-items: center;
+                              display: flex;
+                              flex-wrap: nowrap;
+                              height: 100%;
+                              justify-content: flex-start;
+                            }
                       >
                         <i
                           aria-hidden={true}
-                          className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                          className=
+                              ms-Icon-placeHolder
+                              ms-Button-icon
+                              {
+                                color: #106ebe;
+                                display: inline-block;
+                                flex-shrink: 0;
+                                font-size: 16px;
+                                height: 16px;
+                                line-height: 16px;
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                text-align: center;
+                                vertical-align: middle;
+                                width: 1em;
+                              }
                           data-icon-name=""
                           role="presentation"
                         />
                         <span
-                          className="ms-Button-screenReaderText screenReaderText-108"
+                          className=
+                              ms-Button-screenReaderText
+                              {
+                                border: 0px;
+                                height: 1px;
+                                margin-bottom: -1px;
+                                margin-left: -1px;
+                                margin-right: -1px;
+                                margin-top: -1px;
+                                overflow: hidden;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: absolute;
+                                width: 1px;
+                              }
                           id="id__6"
                         >
                           Activity
                         </span>
                         <div
-                          className="ms-Nav-linkText linkText-370"
+                          className=
+                              ms-Nav-linkText
+                              {
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                vertical-align: middle;
+                              }
                         >
                           Activity
                         </div>
@@ -140,11 +530,25 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   </div>
                 </li>
                 <li
-                  className="ms-Nav-navItem navItem-375"
+                  className=
+                      ms-Nav-navItem
+                      {
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                      }
                   role="listitem"
                 >
                   <div
-                    className="ms-Nav-compositeLink compositeLink-371"
+                    className=
+                        ms-Nav-compositeLink
+                        {
+                          background-color: #ffffff;
+                          color: #333333;
+                          display: block;
+                          position: relative;
+                        }
                     name="News"
                   >
                     <a
@@ -152,7 +556,83 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       aria-label={undefined}
                       aria-labelledby={undefined}
                       aria-pressed={undefined}
-                      className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-398"
+                      className=
+                          ms-Button
+                          ms-Button--action
+                          ms-Button--command
+                          ms-Nav-link
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            border-radius: 0px;
+                            border: 1px solid transparent;
+                            box-sizing: border-box;
+                            color: #333333;
+                            cursor: pointer;
+                            display: block;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 36px;
+                            line-height: 36px;
+                            outline: transparent;
+                            overflow: hidden;
+                            padding-bottom: 0;
+                            padding-left: 17px;
+                            padding-right: 20px;
+                            padding-top: 0;
+                            position: relative;
+                            text-align: center;
+                            text-decoration: none;
+                            text-overflow: ellipsis;
+                            user-select: none;
+                            vertical-align: top;
+                            white-space: nowrap;
+                            width: 100%;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #ffffff;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #666666;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                            border: none;
+                            bottom: -2px;
+                            left: -2px;
+                            outline-color: ButtonText;
+                            right: -2px;
+                            top: -2px;
+                          }
+                          &:hover {
+                            color: #0078d4;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:hover {
+                            border-color: Highlight;
+                            color: Highlight;
+                          }
+                          &:hover .ms-Button-icon {
+                            color: #0078d4;
+                          }
+                          &:active {
+                            color: #000000;
+                          }
+                          &:active .ms-Button-icon {
+                            color: #004578;
+                          }
+                          .ms-Nav-compositeLink:hover & {
+                            background-color: #f8f8f8;
+                            color: #333333;
+                          }
                       data-is-focusable={true}
                       disabled={undefined}
                       href="http://msn.com"
@@ -162,22 +642,73 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       title="News"
                     >
                       <div
-                        className="ms-Button-flexContainer flexContainer-114"
+                        className=
+                            ms-Button-flexContainer
+                            {
+                              align-items: center;
+                              display: flex;
+                              flex-wrap: nowrap;
+                              height: 100%;
+                              justify-content: flex-start;
+                            }
                       >
                         <i
                           aria-hidden={true}
-                          className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                          className=
+                              ms-Icon-placeHolder
+                              ms-Button-icon
+                              {
+                                color: #106ebe;
+                                display: inline-block;
+                                flex-shrink: 0;
+                                font-size: 16px;
+                                height: 16px;
+                                line-height: 16px;
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                text-align: center;
+                                vertical-align: middle;
+                                width: 1em;
+                              }
                           data-icon-name=""
                           role="presentation"
                         />
                         <span
-                          className="ms-Button-screenReaderText screenReaderText-108"
+                          className=
+                              ms-Button-screenReaderText
+                              {
+                                border: 0px;
+                                height: 1px;
+                                margin-bottom: -1px;
+                                margin-left: -1px;
+                                margin-right: -1px;
+                                margin-top: -1px;
+                                overflow: hidden;
+                                padding-bottom: 0px;
+                                padding-left: 0px;
+                                padding-right: 0px;
+                                padding-top: 0px;
+                                position: absolute;
+                                width: 1px;
+                              }
                           id="id__9"
                         >
                           News
                         </span>
                         <div
-                          className="ms-Nav-linkText linkText-370"
+                          className=
+                              ms-Nav-linkText
+                              {
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                vertical-align: middle;
+                              }
                         >
                           News
                         </div>
@@ -188,11 +719,27 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
               </ul>
             </li>
             <li
-              className="ms-Nav-navItem navItem-375"
+              className=
+                  ms-Nav-navItem
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="listitem"
             >
               <div
-                className="ms-Nav-compositeLink is-expanded is-selected compositeLink-371"
+                className=
+                    ms-Nav-compositeLink
+                    is-expanded
+                    is-selected
+                    {
+                      background-color: #ffffff;
+                      color: #333333;
+                      display: block;
+                      position: relative;
+                    }
                 name="Documents"
               >
                 <a
@@ -200,7 +747,92 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   aria-label={undefined}
                   aria-labelledby={undefined}
                   aria-pressed={undefined}
-                  className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-399"
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: #f4f4f4;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #0078d4;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 36px;
+                        line-height: 36px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 3px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        vertical-align: top;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
+                      &:after {
+                        border-left: 2px solid #0078d4;
+                        bottom: 0px;
+                        content: "";
+                        left: 0px;
+                        position: absolute;
+                        right: 0px;
+                        top: 0px;
+                      }
                   data-is-focusable={true}
                   disabled={undefined}
                   href="http://example.com"
@@ -210,22 +842,73 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   title="Documents"
                 >
                   <div
-                    className="ms-Button-flexContainer flexContainer-114"
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
                   >
                     <i
                       aria-hidden={true}
-                      className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                      className=
+                          ms-Icon-placeHolder
+                          ms-Button-icon
+                          {
+                            color: #106ebe;
+                            display: inline-block;
+                            flex-shrink: 0;
+                            font-size: 16px;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            text-align: center;
+                            vertical-align: middle;
+                            width: 1em;
+                          }
                       data-icon-name=""
                       role="presentation"
                     />
                     <span
-                      className="ms-Button-screenReaderText screenReaderText-108"
+                      className=
+                          ms-Button-screenReaderText
+                          {
+                            border: 0px;
+                            height: 1px;
+                            margin-bottom: -1px;
+                            margin-left: -1px;
+                            margin-right: -1px;
+                            margin-top: -1px;
+                            overflow: hidden;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: absolute;
+                            width: 1px;
+                          }
                       id="id__12"
                     >
                       Documents
                     </span>
                     <div
-                      className="ms-Nav-linkText linkText-370"
+                      className=
+                          ms-Nav-linkText
+                          {
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            vertical-align: middle;
+                          }
                     >
                       Documents
                     </div>
@@ -234,11 +917,25 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
               </div>
             </li>
             <li
-              className="ms-Nav-navItem navItem-375"
+              className=
+                  ms-Nav-navItem
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="listitem"
             >
               <div
-                className="ms-Nav-compositeLink compositeLink-371"
+                className=
+                    ms-Nav-compositeLink
+                    {
+                      background-color: #ffffff;
+                      color: #333333;
+                      display: block;
+                      position: relative;
+                    }
                 name="Pages"
               >
                 <a
@@ -246,7 +943,83 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   aria-label={undefined}
                   aria-labelledby={undefined}
                   aria-pressed={undefined}
-                  className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #333333;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 36px;
+                        line-height: 36px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 3px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        vertical-align: top;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
                   data-is-focusable={true}
                   disabled={undefined}
                   href="http://msn.com"
@@ -256,22 +1029,73 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   title="Pages"
                 >
                   <div
-                    className="ms-Button-flexContainer flexContainer-114"
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
                   >
                     <i
                       aria-hidden={true}
-                      className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                      className=
+                          ms-Icon-placeHolder
+                          ms-Button-icon
+                          {
+                            color: #106ebe;
+                            display: inline-block;
+                            flex-shrink: 0;
+                            font-size: 16px;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            text-align: center;
+                            vertical-align: middle;
+                            width: 1em;
+                          }
                       data-icon-name=""
                       role="presentation"
                     />
                     <span
-                      className="ms-Button-screenReaderText screenReaderText-108"
+                      className=
+                          ms-Button-screenReaderText
+                          {
+                            border: 0px;
+                            height: 1px;
+                            margin-bottom: -1px;
+                            margin-left: -1px;
+                            margin-right: -1px;
+                            margin-top: -1px;
+                            overflow: hidden;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: absolute;
+                            width: 1px;
+                          }
                       id="id__15"
                     >
                       Pages
                     </span>
                     <div
-                      className="ms-Nav-linkText linkText-370"
+                      className=
+                          ms-Nav-linkText
+                          {
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            vertical-align: middle;
+                          }
                     >
                       Pages
                     </div>
@@ -280,11 +1104,25 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
               </div>
             </li>
             <li
-              className="ms-Nav-navItem navItem-375"
+              className=
+                  ms-Nav-navItem
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="listitem"
             >
               <div
-                className="ms-Nav-compositeLink compositeLink-371"
+                className=
+                    ms-Nav-compositeLink
+                    {
+                      background-color: #ffffff;
+                      color: #333333;
+                      display: block;
+                      position: relative;
+                    }
                 name="Notebook"
               >
                 <a
@@ -292,7 +1130,83 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   aria-label={undefined}
                   aria-labelledby={undefined}
                   aria-pressed={undefined}
-                  className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #333333;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 36px;
+                        line-height: 36px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 3px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        vertical-align: top;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
                   data-is-focusable={true}
                   disabled={undefined}
                   href="http://msn.com"
@@ -302,22 +1216,73 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   title="Notebook"
                 >
                   <div
-                    className="ms-Button-flexContainer flexContainer-114"
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
                   >
                     <i
                       aria-hidden={true}
-                      className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                      className=
+                          ms-Icon-placeHolder
+                          ms-Button-icon
+                          {
+                            color: #106ebe;
+                            display: inline-block;
+                            flex-shrink: 0;
+                            font-size: 16px;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            text-align: center;
+                            vertical-align: middle;
+                            width: 1em;
+                          }
                       data-icon-name=""
                       role="presentation"
                     />
                     <span
-                      className="ms-Button-screenReaderText screenReaderText-108"
+                      className=
+                          ms-Button-screenReaderText
+                          {
+                            border: 0px;
+                            height: 1px;
+                            margin-bottom: -1px;
+                            margin-left: -1px;
+                            margin-right: -1px;
+                            margin-top: -1px;
+                            overflow: hidden;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: absolute;
+                            width: 1px;
+                          }
                       id="id__18"
                     >
                       Notebook
                     </span>
                     <div
-                      className="ms-Nav-linkText linkText-370"
+                      className=
+                          ms-Nav-linkText
+                          {
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            vertical-align: middle;
+                          }
                     >
                       Notebook
                     </div>
@@ -326,11 +1291,25 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
               </div>
             </li>
             <li
-              className="ms-Nav-navItem navItem-375"
+              className=
+                  ms-Nav-navItem
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="listitem"
             >
               <div
-                className="ms-Nav-compositeLink compositeLink-371"
+                className=
+                    ms-Nav-compositeLink
+                    {
+                      background-color: #ffffff;
+                      color: #333333;
+                      display: block;
+                      position: relative;
+                    }
                 name="Long Name Test for ellipse"
               >
                 <a
@@ -338,7 +1317,83 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   aria-label={undefined}
                   aria-labelledby={undefined}
                   aria-pressed={undefined}
-                  className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #333333;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 36px;
+                        line-height: 36px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 3px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        vertical-align: top;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
                   data-is-focusable={true}
                   disabled={undefined}
                   href="http://msn.com"
@@ -348,22 +1403,73 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   title="Long Name Test for ellipse"
                 >
                   <div
-                    className="ms-Button-flexContainer flexContainer-114"
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
                   >
                     <i
                       aria-hidden={true}
-                      className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                      className=
+                          ms-Icon-placeHolder
+                          ms-Button-icon
+                          {
+                            color: #106ebe;
+                            display: inline-block;
+                            flex-shrink: 0;
+                            font-size: 16px;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            text-align: center;
+                            vertical-align: middle;
+                            width: 1em;
+                          }
                       data-icon-name=""
                       role="presentation"
                     />
                     <span
-                      className="ms-Button-screenReaderText screenReaderText-108"
+                      className=
+                          ms-Button-screenReaderText
+                          {
+                            border: 0px;
+                            height: 1px;
+                            margin-bottom: -1px;
+                            margin-left: -1px;
+                            margin-right: -1px;
+                            margin-top: -1px;
+                            overflow: hidden;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: absolute;
+                            width: 1px;
+                          }
                       id="id__21"
                     >
                       Long Name Test for ellipse
                     </span>
                     <div
-                      className="ms-Nav-linkText linkText-370"
+                      className=
+                          ms-Nav-linkText
+                          {
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            vertical-align: middle;
+                          }
                     >
                       Long Name Test for ellipse
                     </div>
@@ -372,11 +1478,25 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
               </div>
             </li>
             <li
-              className="ms-Nav-navItem navItem-375"
+              className=
+                  ms-Nav-navItem
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="listitem"
             >
               <div
-                className="ms-Nav-compositeLink compositeLink-371"
+                className=
+                    ms-Nav-compositeLink
+                    {
+                      background-color: #ffffff;
+                      color: #333333;
+                      display: block;
+                      position: relative;
+                    }
                 icon="Edit"
                 name="Edit"
               >
@@ -385,7 +1505,83 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   aria-label={undefined}
                   aria-labelledby={undefined}
                   aria-pressed={undefined}
-                  className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-400"
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #0078d4;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 36px;
+                        line-height: 36px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 3px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        vertical-align: top;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
                   data-is-focusable={true}
                   disabled={undefined}
                   href="http://cnn.com"
@@ -395,24 +1591,79 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   title="Edit"
                 >
                   <div
-                    className="ms-Button-flexContainer flexContainer-114"
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
                   >
                     <i
                       aria-hidden={true}
-                      className="ms-Button-icon icon-118"
+                      className=
+                          ms-Button-icon
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #106ebe;
+                            display: inline-block;
+                            flex-shrink: 0;
+                            font-family: "FabricMDL2Icons";
+                            font-size: 16px;
+                            font-style: normal;
+                            font-weight: normal;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            speak: none;
+                            text-align: center;
+                            vertical-align: middle;
+                          }
                       data-icon-name="Edit"
                       role="presentation"
                     >
                       
                     </i>
                     <span
-                      className="ms-Button-screenReaderText screenReaderText-108"
+                      className=
+                          ms-Button-screenReaderText
+                          {
+                            border: 0px;
+                            height: 1px;
+                            margin-bottom: -1px;
+                            margin-left: -1px;
+                            margin-right: -1px;
+                            margin-top: -1px;
+                            overflow: hidden;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: absolute;
+                            width: 1px;
+                          }
                       id="id__24"
                     >
                       Edit
                     </span>
                     <div
-                      className="ms-Nav-linkText linkText-370"
+                      className=
+                          ms-Nav-linkText
+                          {
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            vertical-align: middle;
+                          }
                     >
                       Edit
                     </div>
@@ -421,11 +1672,25 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
               </div>
             </li>
             <li
-              className="ms-Nav-navItem navItem-375"
+              className=
+                  ms-Nav-navItem
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="listitem"
             >
               <div
-                className="ms-Nav-compositeLink compositeLink-371"
+                className=
+                    ms-Nav-compositeLink
+                    {
+                      background-color: #ffffff;
+                      color: #333333;
+                      display: block;
+                      position: relative;
+                    }
                 name="Delete"
               >
                 <a
@@ -433,7 +1698,83 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   aria-label={undefined}
                   aria-labelledby={undefined}
                   aria-pressed={undefined}
-                  className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-400"
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #0078d4;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 36px;
+                        line-height: 36px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 3px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        vertical-align: top;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f8f8f8;
+                        color: #333333;
+                      }
                   data-is-focusable={true}
                   disabled={undefined}
                   href="http://cnn.com"
@@ -443,24 +1784,79 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   title="Delete"
                 >
                   <div
-                    className="ms-Button-flexContainer flexContainer-114"
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
                   >
                     <i
                       aria-hidden={true}
-                      className="ms-Button-icon icon-118"
+                      className=
+                          ms-Button-icon
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #106ebe;
+                            display: inline-block;
+                            flex-shrink: 0;
+                            font-family: "FabricMDL2Icons";
+                            font-size: 16px;
+                            font-style: normal;
+                            font-weight: normal;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            speak: none;
+                            text-align: center;
+                            vertical-align: middle;
+                          }
                       data-icon-name="Delete"
                       role="presentation"
                     >
                       
                     </i>
                     <span
-                      className="ms-Button-screenReaderText screenReaderText-108"
+                      className=
+                          ms-Button-screenReaderText
+                          {
+                            border: 0px;
+                            height: 1px;
+                            margin-bottom: -1px;
+                            margin-left: -1px;
+                            margin-right: -1px;
+                            margin-top: -1px;
+                            overflow: hidden;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: absolute;
+                            width: 1px;
+                          }
                       id="id__27"
                     >
                       Delete
                     </span>
                     <div
-                      className="ms-Nav-linkText linkText-370"
+                      className=
+                          ms-Nav-linkText
+                          {
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            vertical-align: middle;
+                          }
                     >
                       Delete
                     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.ByKeys.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.ByKeys.Example.tsx.shot
@@ -13,25 +13,65 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
 >
   <nav
     aria-label={undefined}
-    className="ms-Nav root-369"
+    className=
+        ms-Nav
+        {
+          -webkit-overflow-scrolling: touch;
+          overflow-y: auto;
+          user-select: none;
+        }
     role="navigation"
   >
     <div
-      className="ms-Nav-group is-expanded group-377"
+      className=
+          ms-Nav-group
+          is-expanded
+
     >
       <div
-        className="ms-Nav-groupContent groupContent-378"
+        className=
+            ms-Nav-groupContent
+            {
+              animation-duration: 0.367s;
+              animation-fill-mode: both;
+              animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(0,-20px,0);}to{transform:translate3d(0,0,0);};
+              animation-timing-function: cubic-bezier(.1,.9,.2,1);
+              display: block;
+              margin-bottom: 40px;
+            }
       >
         <ul
-          className="ms-Nav-navItems navItems-376"
+          className=
+              ms-Nav-navItems
+              {
+                list-style-type: none;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="list"
         >
           <li
-            className="ms-Nav-navItem navItem-375"
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="listitem"
           >
             <div
-              className="ms-Nav-compositeLink compositeLink-371"
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    background-color: #ffffff;
+                    color: #333333;
+                    display: block;
+                    position: relative;
+                  }
               name="Home"
             >
               <button
@@ -39,7 +79,83 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                 aria-label={undefined}
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 36px;
+                      line-height: 36px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 3px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 onClick={[Function]}
@@ -48,22 +164,73 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                    className=
+                        ms-Icon-placeHolder
+                        ms-Button-icon
+                        {
+                          color: #106ebe;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                          vertical-align: middle;
+                          width: 1em;
+                        }
                     data-icon-name=""
                     role="presentation"
                   />
                   <span
-                    className="ms-Button-screenReaderText screenReaderText-108"
+                    className=
+                        ms-Button-screenReaderText
+                        {
+                          border: 0px;
+                          height: 1px;
+                          margin-bottom: -1px;
+                          margin-left: -1px;
+                          margin-right: -1px;
+                          margin-top: -1px;
+                          overflow: hidden;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: absolute;
+                          width: 1px;
+                        }
                     id="id__3"
                   >
                     Home
                   </span>
                   <div
-                    className="ms-Nav-linkText linkText-370"
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
                   >
                     Home
                   </div>
@@ -72,11 +239,25 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
             </div>
           </li>
           <li
-            className="ms-Nav-navItem navItem-375"
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="listitem"
           >
             <div
-              className="ms-Nav-compositeLink compositeLink-371"
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    background-color: #ffffff;
+                    color: #333333;
+                    display: block;
+                    position: relative;
+                  }
               name="Activity"
             >
               <button
@@ -84,7 +265,83 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                 aria-label={undefined}
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 36px;
+                      line-height: 36px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 3px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 onClick={[Function]}
@@ -93,22 +350,73 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                    className=
+                        ms-Icon-placeHolder
+                        ms-Button-icon
+                        {
+                          color: #106ebe;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                          vertical-align: middle;
+                          width: 1em;
+                        }
                     data-icon-name=""
                     role="presentation"
                   />
                   <span
-                    className="ms-Button-screenReaderText screenReaderText-108"
+                    className=
+                        ms-Button-screenReaderText
+                        {
+                          border: 0px;
+                          height: 1px;
+                          margin-bottom: -1px;
+                          margin-left: -1px;
+                          margin-right: -1px;
+                          margin-top: -1px;
+                          overflow: hidden;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: absolute;
+                          width: 1px;
+                        }
                     id="id__6"
                   >
                     Activity
                   </span>
                   <div
-                    className="ms-Nav-linkText linkText-370"
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
                   >
                     Activity
                   </div>
@@ -117,11 +425,25 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
             </div>
           </li>
           <li
-            className="ms-Nav-navItem navItem-375"
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="listitem"
           >
             <div
-              className="ms-Nav-compositeLink compositeLink-371"
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    background-color: #ffffff;
+                    color: #333333;
+                    display: block;
+                    position: relative;
+                  }
               name="News"
             >
               <button
@@ -129,7 +451,83 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                 aria-label={undefined}
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 36px;
+                      line-height: 36px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 3px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 onClick={[Function]}
@@ -138,22 +536,73 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                    className=
+                        ms-Icon-placeHolder
+                        ms-Button-icon
+                        {
+                          color: #106ebe;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                          vertical-align: middle;
+                          width: 1em;
+                        }
                     data-icon-name=""
                     role="presentation"
                   />
                   <span
-                    className="ms-Button-screenReaderText screenReaderText-108"
+                    className=
+                        ms-Button-screenReaderText
+                        {
+                          border: 0px;
+                          height: 1px;
+                          margin-bottom: -1px;
+                          margin-left: -1px;
+                          margin-right: -1px;
+                          margin-top: -1px;
+                          overflow: hidden;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: absolute;
+                          width: 1px;
+                        }
                     id="id__9"
                   >
                     News
                   </span>
                   <div
-                    className="ms-Nav-linkText linkText-370"
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
                   >
                     News
                   </div>
@@ -162,11 +611,25 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
             </div>
           </li>
           <li
-            className="ms-Nav-navItem navItem-375"
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="listitem"
           >
             <div
-              className="ms-Nav-compositeLink compositeLink-371"
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    background-color: #ffffff;
+                    color: #333333;
+                    display: block;
+                    position: relative;
+                  }
               name="Documents"
             >
               <button
@@ -174,7 +637,83 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                 aria-label={undefined}
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 36px;
+                      line-height: 36px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 3px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 onClick={[Function]}
@@ -183,22 +722,73 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                    className=
+                        ms-Icon-placeHolder
+                        ms-Button-icon
+                        {
+                          color: #106ebe;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                          vertical-align: middle;
+                          width: 1em;
+                        }
                     data-icon-name=""
                     role="presentation"
                   />
                   <span
-                    className="ms-Button-screenReaderText screenReaderText-108"
+                    className=
+                        ms-Button-screenReaderText
+                        {
+                          border: 0px;
+                          height: 1px;
+                          margin-bottom: -1px;
+                          margin-left: -1px;
+                          margin-right: -1px;
+                          margin-top: -1px;
+                          overflow: hidden;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: absolute;
+                          width: 1px;
+                        }
                     id="id__12"
                   >
                     Documents
                   </span>
                   <div
-                    className="ms-Nav-linkText linkText-370"
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
                   >
                     Documents
                   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -13,36 +13,148 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
 >
   <nav
     aria-label={undefined}
-    className="ms-Nav root-369"
+    className=
+        ms-Nav
+        {
+          -webkit-overflow-scrolling: touch;
+          overflow-y: auto;
+          user-select: none;
+        }
     role="navigation"
   >
     <div
-      className="ms-Nav-group is-expanded group-377"
+      className=
+          ms-Nav-group
+          is-expanded
+
     >
       <div
-        className="ms-Nav-groupContent groupContent-378"
+        className=
+            ms-Nav-groupContent
+            {
+              animation-duration: 0.367s;
+              animation-fill-mode: both;
+              animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(0,-20px,0);}to{transform:translate3d(0,0,0);};
+              animation-timing-function: cubic-bezier(.1,.9,.2,1);
+              display: block;
+              margin-bottom: 40px;
+            }
       >
         <ul
-          className="ms-Nav-navItems navItems-376"
+          className=
+              ms-Nav-navItems
+              {
+                list-style-type: none;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
           role="list"
         >
           <li
-            className="ms-Nav-navItem navItem-375"
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="listitem"
           >
             <div
-              className="ms-Nav-compositeLink compositeLink-371"
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    background-color: #ffffff;
+                    color: #333333;
+                    display: block;
+                    position: relative;
+                  }
               name="Parent link"
             >
               <button
                 aria-expanded="false"
                 aria-label={undefined}
-                className="ms-Nav-chevronButton chevronButton-382"
+                className=
+                    ms-Nav-chevronButton
+                    {
+                      background-color: transparent;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: block;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 34px;
+                      left: 1px;
+                      line-height: 36px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: absolute;
+                      text-align: left;
+                      text-overflow: ellipsis;
+                      top: 1px;
+                      white-space: nowrap;
+                      width: 26px;
+                      z-index: 1;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:visited {
+                      color: inherit;
+                    }
+                    &:hover {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
+                    $compositeLink:hover & {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
                 onClick={[Function]}
               >
                 <i
                   aria-hidden={true}
-                  className="ms-Nav-chevron chevronIcon-401"
+                  className=
+                      ms-Nav-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 36px;
+                        left: 8px;
+                        line-height: 36px;
+                        position: absolute;
+                        speak: none;
+                        top: 0px;
+                        transition: transform .1s linear;
+                      }
                   data-icon-name="ChevronDown"
                   role="presentation"
                 >
@@ -54,7 +166,83 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 aria-label={undefined}
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 36px;
+                      line-height: 36px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 3px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 href="http://example.com"
@@ -64,22 +252,73 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 title="Parent link"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                    className=
+                        ms-Icon-placeHolder
+                        ms-Button-icon
+                        {
+                          color: #106ebe;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                          vertical-align: middle;
+                          width: 1em;
+                        }
                     data-icon-name=""
                     role="presentation"
                   />
                   <span
-                    className="ms-Button-screenReaderText screenReaderText-108"
+                    className=
+                        ms-Button-screenReaderText
+                        {
+                          border: 0px;
+                          height: 1px;
+                          margin-bottom: -1px;
+                          margin-left: -1px;
+                          margin-right: -1px;
+                          margin-top: -1px;
+                          overflow: hidden;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: absolute;
+                          width: 1px;
+                        }
                     id="id__3"
                   >
                     Parent link
                   </span>
                   <div
-                    className="ms-Nav-linkText linkText-370"
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
                   >
                     Parent link
                   </div>
@@ -88,22 +327,108 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
             </div>
           </li>
           <li
-            className="ms-Nav-navItem navItem-375"
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="listitem"
           >
             <div
-              className="ms-Nav-compositeLink compositeLink-371"
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    background-color: #ffffff;
+                    color: #333333;
+                    display: block;
+                    position: relative;
+                  }
               name="Parent link"
             >
               <button
                 aria-expanded="false"
                 aria-label={undefined}
-                className="ms-Nav-chevronButton chevronButton-382"
+                className=
+                    ms-Nav-chevronButton
+                    {
+                      background-color: transparent;
+                      border: none;
+                      color: #333333;
+                      cursor: pointer;
+                      display: block;
+                      font-size: 12px;
+                      font-weight: 400;
+                      height: 34px;
+                      left: 1px;
+                      line-height: 36px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: absolute;
+                      text-align: left;
+                      text-overflow: ellipsis;
+                      top: 1px;
+                      white-space: nowrap;
+                      width: 26px;
+                      z-index: 1;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    &:visited {
+                      color: inherit;
+                    }
+                    &:hover {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
+                    $compositeLink:hover & {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
                 onClick={[Function]}
               >
                 <i
                   aria-hidden={true}
-                  className="ms-Nav-chevron chevronIcon-401"
+                  className=
+                      ms-Nav-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 36px;
+                        left: 8px;
+                        line-height: 36px;
+                        position: absolute;
+                        speak: none;
+                        top: 0px;
+                        transition: transform .1s linear;
+                      }
                   data-icon-name="ChevronDown"
                   role="presentation"
                 >
@@ -115,7 +440,83 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 aria-label={undefined}
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
-                className="ms-Button ms-Button--action ms-Button--command ms-Nav-link link-394"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Nav-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 36px;
+                      line-height: 36px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 3px;
+                      padding-right: 20px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 100%;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    .ms-Nav-compositeLink:hover & {
+                      background-color: #f8f8f8;
+                      color: #333333;
+                    }
                 data-is-focusable={true}
                 disabled={undefined}
                 href="http://example.com"
@@ -125,22 +526,73 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 title="Parent link"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon-placeHolder ms-Button-icon icon-397"
+                    className=
+                        ms-Icon-placeHolder
+                        ms-Button-icon
+                        {
+                          color: #106ebe;
+                          display: inline-block;
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                          vertical-align: middle;
+                          width: 1em;
+                        }
                     data-icon-name=""
                     role="presentation"
                   />
                   <span
-                    className="ms-Button-screenReaderText screenReaderText-108"
+                    className=
+                        ms-Button-screenReaderText
+                        {
+                          border: 0px;
+                          height: 1px;
+                          margin-bottom: -1px;
+                          margin-left: -1px;
+                          margin-right: -1px;
+                          margin-top: -1px;
+                          overflow: hidden;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: absolute;
+                          width: 1px;
+                        }
                     id="id__6"
                   >
                     Parent link
                   </span>
                   <div
-                    className="ms-Nav-linkText linkText-370"
+                    className=
+                        ms-Nav-linkText
+                        {
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                          vertical-align: middle;
+                        }
                   >
                     Parent link
                   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -16,7 +16,54 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
   >
     <button
       aria-disabled={undefined}
-      className="ms-Link root-324"
+      className=
+          ms-Link
+          {
+            background-color: transparent;
+            background: none;
+            border: none;
+            color: #0078d4;
+            cursor: pointer;
+            display: inline;
+            font-size: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: transparent;
+            overflow: inherit;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            text-align: left;
+            text-overflow: inherit;
+            user-select: text;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
       onClick={[Function]}
     >
       Link 1
@@ -27,7 +74,54 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
   >
     <button
       aria-disabled={undefined}
-      className="ms-Link root-324"
+      className=
+          ms-Link
+          {
+            background-color: transparent;
+            background: none;
+            border: none;
+            color: #0078d4;
+            cursor: pointer;
+            display: inline;
+            font-size: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: transparent;
+            overflow: inherit;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            text-align: left;
+            text-overflow: inherit;
+            user-select: text;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
       onClick={[Function]}
     >
       Link 2
@@ -38,7 +132,54 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
   >
     <button
       aria-disabled={undefined}
-      className="ms-Link root-324"
+      className=
+          ms-Link
+          {
+            background-color: transparent;
+            background: none;
+            border: none;
+            color: #0078d4;
+            cursor: pointer;
+            display: inline;
+            font-size: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: transparent;
+            overflow: inherit;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            text-align: left;
+            text-overflow: inherit;
+            user-select: text;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
       onClick={[Function]}
     >
       Link 3
@@ -55,7 +196,66 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
       aria-labelledby={undefined}
       aria-owns={null}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--icon root-145"
+      className=
+          ms-Button
+          ms-Button--icon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 4px;
+            padding-right: 4px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+            width: 32px;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            color: #0078d4;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
@@ -63,11 +263,39 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-menuIcon menuIcon-143"
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="More"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -15,16 +15,78 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
     className="ms-OverflowSet-item"
   >
     <div
-      className="ms-SearchBox root-318"
+      className=
+          ms-SearchBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: stretch;
+            border: 1px solid #a6a6a6;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 1px;
+            padding-left: 4px;
+            padding-right: 0;
+            padding-top: 1px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: 1px solid WindowText;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+          &:hover $iconContainer {
+            color: #005a9e;
+          }
       onFocusCapture={[Function]}
     >
       <div
-        className="ms-SearchBox-iconContainer iconContainer-319"
+        className=
+            ms-SearchBox-iconContainer
+            {
+              color: #0078d4;
+              cursor: text;
+              display: flex;
+              flex-direction: column;
+              flex-shrink: 0;
+              font-size: 16px;
+              justify-content: center;
+              text-align: center;
+              transition: width 0.167s;
+              width: 32px;
+            }
         onClick={[Function]}
       >
         <i
           aria-hidden={true}
-          className="ms-SearchBox-icon icon-323"
+          className=
+              ms-SearchBox-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                speak: none;
+                transition: opacity 0.167s 0s;
+              }
           data-icon-name="Search"
           role="presentation"
         >
@@ -33,7 +95,40 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       </div>
       <input
         aria-label="Search"
-        className="ms-SearchBox-field field-322"
+        className=
+            ms-SearchBox-field
+            {
+              background-color: #ffffff;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              flex: 1 1 0px;
+              font-family: inherit;
+              font-size: inherit;
+              font-weight: inherit;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: none;
+              overflow: hidden;
+              padding-bottom: 0.5px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              text-overflow: ellipsis;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #666666;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #666666;
+            }
         disabled={undefined}
         id="SearchBox1"
         onChange={[Function]}
@@ -55,7 +150,69 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       aria-labelledby={undefined}
       aria-owns={null}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
@@ -63,21 +220,62 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-icon icon-109"
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="Add"
           role="presentation"
         >
           
         </i>
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__2"
           >
             New
@@ -85,7 +283,27 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
         </div>
         <i
           aria-hidden={true}
-          className="ms-Button-menuIcon menuIcon-143"
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="ChevronDown"
           role="presentation"
         >
@@ -102,27 +320,130 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-icon icon-109"
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="Upload"
           role="presentation"
         >
           
         </i>
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__5"
           >
             Upload
@@ -139,27 +460,130 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-icon icon-109"
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="Share"
           role="presentation"
         >
           
         </i>
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__8"
           >
             Share
@@ -179,7 +603,69 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       aria-labelledby={undefined}
       aria-owns={null}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
@@ -187,11 +673,39 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-menuIcon menuIcon-143"
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="More"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
@@ -27,18 +27,110 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--commandBar root-358"
+        className=
+            ms-Button
+            ms-Button--commandBar
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-width: 40px;
+              outline: transparent;
+              padding-bottom: 10px;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 10px;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: 4px;
+              left: 4px;
+              outline-color: ButtonText;
+              right: 4px;
+              top: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border: none;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
+            }
+            &:active {
+              background-color: #dadada;
+              color: #000000;
+            }
         data-is-focusable={true}
         disabled={undefined}
         onClick={[Function]}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-118"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #106ebe;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="Add"
             role="presentation"
           >
@@ -64,18 +156,110 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--commandBar root-358"
+        className=
+            ms-Button
+            ms-Button--commandBar
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-width: 40px;
+              outline: transparent;
+              padding-bottom: 10px;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 10px;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: 4px;
+              left: 4px;
+              outline-color: ButtonText;
+              right: 4px;
+              top: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border: none;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
+            }
+            &:active {
+              background-color: #dadada;
+              color: #000000;
+            }
         data-is-focusable={true}
         disabled={undefined}
         onClick={[Function]}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-118"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #106ebe;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="Upload"
             role="presentation"
           >
@@ -101,18 +285,110 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--commandBar root-358"
+        className=
+            ms-Button
+            ms-Button--commandBar
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-width: 40px;
+              outline: transparent;
+              padding-bottom: 10px;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 10px;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: 4px;
+              left: 4px;
+              outline-color: ButtonText;
+              right: 4px;
+              top: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border: none;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
+            }
+            &:active {
+              background-color: #dadada;
+              color: #000000;
+            }
         data-is-focusable={true}
         disabled={undefined}
         onClick={[Function]}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-Button-icon icon-118"
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #106ebe;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
             data-icon-name="Share"
             role="presentation"
           >
@@ -133,7 +409,70 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
       aria-labelledby={undefined}
       aria-owns={null}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--commandBar root-358"
+      className=
+          ms-Button
+          ms-Button--commandBar
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            min-width: 40px;
+            outline: transparent;
+            padding-bottom: 10px;
+            padding-left: 10px;
+            padding-right: 10px;
+            padding-top: 10px;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: 4px;
+            left: 4px;
+            outline-color: ButtonText;
+            right: 4px;
+            top: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: Highlight;
+          }
+          &:active {
+            background-color: #dadada;
+            color: #000000;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
@@ -141,11 +480,40 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <i
           aria-hidden={true}
-          className="ms-Button-menuIcon menuIcon-403"
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
           data-icon-name="More"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Overlay.Dark.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Overlay.Dark.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Overlay.Dark.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Show the overlay

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Overlay.Light.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Overlay.Light.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Overlay.Light.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Show the overlay

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Custom.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.Custom.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.ExtraLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.ExtraLarge.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.ExtraLarge.Example.tsx correctly 1`] =
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Footer.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Footer.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.Footer.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Large.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.Large.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.LargeFixed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.LargeFixed.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.LargeFixed.Example.tsx correctly 1`] =
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.LightDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.LightDismiss.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.LightDismiss.Example.tsx correctly 1`]
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.LightDismissCustom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.LightDismissCustom.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.LightDismissCustom.Example.tsx correct
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Medium.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Medium.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.Medium.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.NonModal.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.NonModal.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.NonModal.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallFluid.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallFluid.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.SmallFluid.Example.tsx correctly 1`] =
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallLeft.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallLeft.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.SmallLeft.Example.tsx correctly 1`] = 
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallRight.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallRight.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Panel.SmallRight.Example.tsx correctly 1`] =
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Open Panel

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -66,7 +66,25 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-89"
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Dropdown1"
         id="Dropdown1-label"
         required={undefined}
@@ -107,7 +125,17 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown root-55"
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="ChevronDown"
             role="presentation"
           >
@@ -117,22 +145,100 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
       </div>
     </div>
     <div
-      className="ms-Toggle is-enabled root-285"
+      className=
+          ms-Toggle
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 8px;
+          }
     >
       <label
-        className="ms-Label ms-Toggle-label label-230"
+        className=
+            ms-Label
+            ms-Toggle-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Toggle2"
       >
         Delay Suggestion Results
       </label>
       <div
-        className="ms-Toggle-innerContainer container-286"
+        className=
+            ms-Toggle-innerContainer
+            {
+              display: inline-flex;
+              position: relative;
+            }
       >
         <button
           aria-disabled={undefined}
           aria-label="Delay Suggestion Results"
           aria-pressed={false}
-          className="ms-Toggle-background pill-287"
+          className=
+              ms-Toggle-background
+              {
+                align-items: center;
+                background: #ffffff;
+                border-color: #666666;
+                border-radius: 1em;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: flex;
+                font-size: 20px;
+                height: 1em;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: .2em;
+                padding-right: .2em;
+                padding-top: 0;
+                position: relative;
+                transition: all 0.1s ease;
+                width: 2.2em;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: -2px;
+                content: "";
+                left: -2px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: -2px;
+                top: -2px;
+                z-index: 1;
+              }
+              &:hover {
+                border-color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Toggle2"
@@ -141,7 +247,19 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
           type="button"
         >
           <div
-            className="ms-Toggle-thumb thumb-288"
+            className=
+                ms-Toggle-thumb
+                {
+                  background-color: #212121;
+                  border-color: transparent;
+                  border-radius: .5em;
+                  border-style: solid;
+                  border-width: .28em;
+                  box-sizing: border-box;
+                  height: .5em;
+                  transition: all 0.1s ease;
+                  width: .5em;
+                }
           />
         </button>
       </div>
@@ -152,20 +270,113 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__3"
         >
           Set focus

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -5,20 +5,82 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
   className="ms-PersonaExample"
 >
   <div
-    className="ms-Persona ms-Persona--size24 root-405"
+    className=
+        ms-Persona
+        ms-Persona--size24
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 36px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 24px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={10}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size24 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size24
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={10}
     >
       <div
-        className="ms-Persona-imageArea imageArea-409"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 24px;
+              position: relative;
+              text-align: center;
+              width: 24px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-412"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 24px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 24px;
+              }
           style={
             Object {
               "height": 24,
@@ -28,7 +90,22 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -38,10 +115,35 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
       </div>
     </div>
     <div
-      className="ms-Persona-details details-406"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 12px;
+            padding-right: 12px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-407"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 14px;
+              font-weight: 400;
+              height: 18px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -55,7 +157,20 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-408"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              height: 16px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -69,7 +184,17 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -83,7 +208,17 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -99,20 +234,82 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size28 root-413"
+    className=
+        ms-Persona
+        ms-Persona--size28
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 28px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={7}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size28 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size28
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={7}
     >
       <div
-        className="ms-Persona-imageArea imageArea-415"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 28px;
+              position: relative;
+              text-align: center;
+              width: 28px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-418"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 28px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 28px;
+              }
           style={
             Object {
               "height": 28,
@@ -122,7 +319,22 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -132,10 +344,35 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
       </div>
     </div>
     <div
-      className="ms-Persona-details details-406"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 12px;
+            padding-right: 12px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-414"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 14px;
+              font-weight: 400;
+              height: 16px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -149,7 +386,20 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-408"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              height: 16px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -163,7 +413,17 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -177,7 +437,17 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -193,20 +463,83 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size32 ms-Persona--online root-205"
+    className=
+        ms-Persona
+        ms-Persona--size32
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 32px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={11}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size32 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size32
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={11}
     >
       <div
-        className="ms-Persona-imageArea imageArea-80"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 32px;
+              position: relative;
+              text-align: center;
+              width: 32px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-83"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 32px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 32px;
+              }
           style={
             Object {
               "height": 32,
@@ -216,7 +549,22 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -224,16 +572,61 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           />
         </div>
         <div
-          className="ms-Persona-presence presence-419"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #7FBA00;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 8px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 8px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
           style={undefined}
         />
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-414"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 14px;
+              font-weight: 400;
+              height: 16px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -247,7 +640,20 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-408"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              height: 16px;
+              line-height: 16px;
+              overflow-x: hidden;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -261,7 +667,17 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -275,7 +691,17 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -12,7 +12,67 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       aria-posinset={undefined}
       aria-setsize={undefined}
       checked={true}
-      className="ms-Checkbox is-checked is-enabled root-183"
+      className=
+          ms-Checkbox
+          is-checked
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background: none;
+            border: none;
+            cursor: pointer;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -2px;
+            content: "";
+            left: -2px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -2px;
+            top: -2px;
+            z-index: 1;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            background: WindowText;
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+            background: WindowText;
+            border-color: WindowText;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
+          }
       data-ktp-execute-target={undefined}
       disabled={undefined}
       id="checkbox-0"
@@ -24,16 +84,71 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       type="button"
     >
       <label
-        className="ms-Checkbox-label label-184"
+        className=
+            ms-Checkbox-label
+            {
+              align-items: center;
+              cursor: pointer;
+              display: inline-flex;
+              margin-bottom: 0;
+              margin-left: -4px;
+              margin-right: -4px;
+              margin-top: 0;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
         htmlFor="checkbox-0"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-185"
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                background: #0078d4;
+                border-color: #0078d4;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                overflow: hidden;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: WindowText;
+                border-color: WindowText;
+              }
           data-ktp-target={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-188"
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 1;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
             data-icon-name="CheckMark"
             role="presentation"
           >
@@ -41,7 +156,16 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-187"
+          className=
+              ms-Checkbox-text
+              {
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
         >
           Include persona details
         </span>
@@ -49,22 +173,94 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </button>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 10 Persona, with no presence
   </label>
   <div
-    className="ms-Persona ms-Persona--size10 root-420"
+    className=
+        ms-Persona
+        ms-Persona--size10
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 20px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 20px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={9}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size10 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size10
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={9}
     >
       <i
         aria-hidden={true}
-        className="size10WithoutPresenceIcon-426"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-0";
+              font-size: 10px;
+              font-style: normal;
+              font-weight: normal;
+              left: 0px;
+              position: absolute;
+              right: auto;
+              speak: none;
+              top: 5px;
+            }
         data-icon-name="Contact"
         role="presentation"
       >
@@ -72,10 +268,33 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       </i>
     </div>
     <div
-      className="ms-Persona-details details-421"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 17px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-422"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 12px;
+              font-weight: 400;
+              line-height: 20px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -89,7 +308,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-208"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -103,7 +332,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -117,7 +356,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -133,29 +382,133 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 10 Persona, with presence
   </label>
   <div
-    className="ms-Persona ms-Persona--size10 ms-Persona--offline root-420"
+    className=
+        ms-Persona
+        ms-Persona--size10
+        ms-Persona--offline
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 20px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 20px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={9}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size10 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size10
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={9}
     >
       <div
-        className="ms-Persona-presence presence-427"
+        className=
+            ms-Persona-presence
+            {
+              -ms-high-contrast-adjust: none;
+              background-clip: content-box;
+              background-color: #93ABBD;
+              border-radius: 50%;
+              border: 0px;
+              bottom: -2px;
+              box-sizing: content-box;
+              height: 8px;
+              left: 0px;
+              position: absolute;
+              right: auto;
+              text-align: center;
+              top: 7px;
+              width: 8px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+              border-color: Window;
+              border: 1px solid WindowText;
+              top: 9px;
+            }
         style={undefined}
       />
     </div>
     <div
-      className="ms-Persona-details details-421"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 17px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-422"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 12px;
+              font-weight: 400;
+              line-height: 20px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -169,7 +522,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-208"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -183,7 +546,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -197,7 +570,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -213,25 +596,105 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 24 Persona
   </label>
   <div
-    className="ms-Persona ms-Persona--size24 ms-Persona--online root-428"
+    className=
+        ms-Persona
+        ms-Persona--size24
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 24px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 24px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={10}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size24 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size24
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={10}
     >
       <div
-        className="ms-Persona-imageArea imageArea-409"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 24px;
+              position: relative;
+              text-align: center;
+              width: 24px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-412"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 24px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 24px;
+              }
           style={
             Object {
               "height": 24,
@@ -241,7 +704,22 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -249,16 +727,58 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           />
         </div>
         <div
-          className="ms-Persona-presence presence-419"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #7FBA00;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 8px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 8px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
           style={undefined}
         />
       </div>
     </div>
     <div
-      className="ms-Persona-details details-406"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 12px;
+            padding-right: 12px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-207"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -272,7 +792,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-208"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -286,7 +816,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -300,7 +840,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -316,25 +866,105 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 28 Persona
   </label>
   <div
-    className="ms-Persona ms-Persona--size28 ms-Persona--online root-429"
+    className=
+        ms-Persona
+        ms-Persona--size28
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 28px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 28px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={7}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size28 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size28
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={7}
     >
       <div
-        className="ms-Persona-imageArea imageArea-415"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 28px;
+              position: relative;
+              text-align: center;
+              width: 28px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-418"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 28px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 28px;
+              }
           style={
             Object {
               "height": 28,
@@ -344,7 +974,22 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -352,16 +997,58 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           />
         </div>
         <div
-          className="ms-Persona-presence presence-419"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #7FBA00;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 8px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 8px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
           style={undefined}
         />
       </div>
     </div>
     <div
-      className="ms-Persona-details details-406"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 12px;
+            padding-right: 12px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-207"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -375,7 +1062,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-208"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -389,7 +1086,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -403,7 +1110,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -419,25 +1136,105 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 32 Persona
   </label>
   <div
-    className="ms-Persona ms-Persona--size32 ms-Persona--online root-205"
+    className=
+        ms-Persona
+        ms-Persona--size32
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 32px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={11}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size32 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size32
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={11}
     >
       <div
-        className="ms-Persona-imageArea imageArea-80"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 32px;
+              position: relative;
+              text-align: center;
+              width: 32px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-83"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 32px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 32px;
+              }
           style={
             Object {
               "height": 32,
@@ -447,7 +1244,22 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -455,16 +1267,58 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           />
         </div>
         <div
-          className="ms-Persona-presence presence-419"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #7FBA00;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 8px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 8px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
           style={undefined}
         />
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-207"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -478,7 +1332,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-208"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -492,7 +1356,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -506,7 +1380,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -522,25 +1406,105 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 40 Persona
   </label>
   <div
-    className="ms-Persona ms-Persona--size40 ms-Persona--away root-430"
+    className=
+        ms-Persona
+        ms-Persona--size40
+        ms-Persona--away
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 40px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 40px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={12}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size40 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size40
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={12}
     >
       <div
-        className="ms-Persona-imageArea imageArea-432"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 40px;
+              position: relative;
+              text-align: center;
+              width: 40px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-435"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 40px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 40px;
+              }
           style={
             Object {
               "height": 40,
@@ -550,7 +1514,22 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -558,12 +1537,51 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           />
         </div>
         <div
-          className="ms-Persona-presence presence-436"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #FCD116;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 12px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 12px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Persona-presenceIcon presenceIcon-438"
+            className=
+                ms-Persona-presenceIcon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 6px;
+                  font-style: normal;
+                  font-weight: normal;
+                  left: 1px;
+                  line-height: 12px;
+                  position: relative;
+                  speak: none;
+                  vertical-align: top;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Window;
+                }
             data-icon-name="SkypeClock"
             role="presentation"
             style={undefined}
@@ -574,10 +1592,32 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-207"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -591,7 +1631,16 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -605,7 +1654,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -619,7 +1678,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -635,25 +1704,105 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 48 Persona (default) 
   </label>
   <div
-    className="ms-Persona ms-Persona--size48 ms-Persona--busy root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        ms-Persona--busy
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -663,7 +1812,22 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -671,12 +1835,45 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           />
         </div>
         <div
-          className="ms-Persona-presence presence-444"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #D93B3B;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 12px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 12px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Icon-placeHolder ms-Persona-presenceIcon presenceIcon-445"
+            className=
+                ms-Icon-placeHolder
+                ms-Persona-presenceIcon
+                {
+                  color: #ffffff;
+                  display: inline-block;
+                  font-size: 6px;
+                  line-height: 12px;
+                  vertical-align: top;
+                  width: 1em;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Window;
+                }
             data-icon-name=""
             role="presentation"
             style={undefined}
@@ -685,10 +1882,32 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -702,7 +1921,16 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -716,7 +1944,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -730,7 +1968,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -746,25 +1994,105 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 72 Persona
   </label>
   <div
-    className="ms-Persona ms-Persona--size72 ms-Persona--donotdisturb root-446"
+    className=
+        ms-Persona
+        ms-Persona--size72
+        ms-Persona--donotdisturb
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 72px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 72px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={14}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size72 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size72
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={14}
     >
       <div
-        className="ms-Persona-imageArea imageArea-450"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 72px;
+              position: relative;
+              text-align: center;
+              width: 72px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-453"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 72px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 72px;
+              }
           style={
             Object {
               "height": 72,
@@ -774,7 +2102,22 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -782,12 +2125,49 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           />
         </div>
         <div
-          className="ms-Persona-presence presence-454"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #E81123;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 20px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Persona-presenceIcon presenceIcon-456"
+            className=
+                ms-Persona-presenceIcon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  line-height: 20px;
+                  speak: none;
+                  vertical-align: top;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Window;
+                }
             data-icon-name="SkypeMinus"
             role="presentation"
             style={undefined}
@@ -798,10 +2178,32 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-447"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 21px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -815,7 +2217,16 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-448"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -829,7 +2240,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-449"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -843,7 +2264,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -859,25 +2290,105 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Size 100 Persona
   </label>
   <div
-    className="ms-Persona ms-Persona--size100 ms-Persona--blocked root-457"
+    className=
+        ms-Persona
+        ms-Persona--size100
+        ms-Persona--blocked
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 100px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 100px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={15}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size100 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size100
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={15}
     >
       <div
-        className="ms-Persona-imageArea imageArea-460"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 100px;
+              position: relative;
+              text-align: center;
+              width: 100px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-463"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100px;
+              }
           style={
             Object {
               "height": 100,
@@ -887,7 +2398,22 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -895,12 +2421,78 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           />
         </div>
         <div
-          className="ms-Persona-presence presence-464"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #ffffff;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 28px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 28px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
+              &:before {
+                border-radius: 50%;
+                border: 2px solid #D93B3B;
+                box-sizing: border-box;
+                content: "";
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
+              &:after {
+                background-color: #D93B3B;
+                content: "";
+                height: 2px;
+                left: 0px;
+                position: absolute;
+                top: 50%;
+                transform: translateY(-50%) rotate(-45deg);
+                width: 100%;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                border-color: Window;
+                height: calc(100% - 2px);
+                left: 1px;
+                top: 1px;
+                width: calc(100% - 2px);
+              }
+              @media screen and (-ms-high-contrast: active){&:after {
+                background-color: Window;
+                left: 2px;
+                width: calc(100% - 4px);
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Icon-placeHolder ms-Persona-presenceIcon presenceIcon-466"
+            className=
+                ms-Icon-placeHolder
+                ms-Persona-presenceIcon
+                {
+                  color: #ffffff;
+                  display: inline-block;
+                  font-size: 14px;
+                  line-height: 28px;
+                  vertical-align: top;
+                  width: 1em;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Window;
+                }
             data-icon-name=""
             role="presentation"
             style={undefined}
@@ -909,10 +2501,32 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-458"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 21px;
+              font-weight: 300;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -926,7 +2540,16 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-448"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -940,7 +2563,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-449"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -954,7 +2587,17 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-459"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
@@ -10,7 +10,39 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
     Custom functional element in place of persona coin's image
   </div>
   <div
-    className="ms-Persona ms-Persona--size72 ms-Persona--online root-446"
+    className=
+        ms-Persona
+        ms-Persona--size72
+        ms-Persona--online
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 72px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 72px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={14}
     style={
       Object {
@@ -20,11 +52,28 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
     }
   >
     <div
-      className="ms-Persona-coin ms-Persona--size72 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size72
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={14}
     >
       <div
-        className="ms-Persona-imageArea imageArea-450"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 72px;
+              position: relative;
+              text-align: center;
+              width: 72px;
+            }
         style={
           Object {
             "height": 72,
@@ -43,7 +92,27 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
           />
         </div>
         <div
-          className="ms-Persona-presence presence-467"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #7FBA00;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 20px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Highlight;
+                border-color: Window;
+              }
           style={
             Object {
               "height": "24px",
@@ -53,7 +122,24 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
         >
           <i
             aria-hidden={true}
-            className="ms-Persona-presenceIcon presenceIcon-456"
+            className=
+                ms-Persona-presenceIcon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  line-height: 20px;
+                  speak: none;
+                  vertical-align: top;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Window;
+                }
             data-icon-name="SkypeCheck"
             role="presentation"
             style={
@@ -69,10 +155,32 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-447"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 21px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -86,7 +194,16 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-448"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -100,10 +217,30 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-449"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       />
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
@@ -10,20 +10,83 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
     Custom icon in secondary text
   </div>
   <div
-    className="ms-Persona ms-Persona--size72 ms-Persona--offline root-446"
+    className=
+        ms-Persona
+        ms-Persona--size72
+        ms-Persona--offline
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 72px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 72px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={14}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size72 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size72
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={14}
     >
       <div
-        className="ms-Persona-imageArea imageArea-450"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 72px;
+              position: relative;
+              text-align: center;
+              width: 72px;
+            }
         style={undefined}
       >
         <div
-          className="ms-Image ms-Persona-image image-453"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 72px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 72px;
+              }
           style={
             Object {
               "height": 72,
@@ -33,7 +96,22 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -41,12 +119,45 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
           />
         </div>
         <div
-          className="ms-Persona-presence presence-468"
+          className=
+              ms-Persona-presence
+              {
+                -ms-high-contrast-adjust: none;
+                background-clip: content-box;
+                background-color: #93ABBD;
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -2px;
+                box-sizing: content-box;
+                height: 20px;
+                position: absolute;
+                right: -2px;
+                text-align: center;
+                top: auto;
+                width: 20px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
+                border-color: Window;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Icon-placeHolder ms-Persona-presenceIcon presenceIcon-469"
+            className=
+                ms-Icon-placeHolder
+                ms-Persona-presenceIcon
+                {
+                  color: #ffffff;
+                  display: inline-block;
+                  font-size: 12px;
+                  line-height: 20px;
+                  vertical-align: top;
+                  width: 1em;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Window;
+                }
             data-icon-name=""
             role="presentation"
             style={undefined}
@@ -55,10 +166,32 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-447"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 21px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -72,12 +205,31 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-448"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div>
           <i
             aria-hidden={true}
-            className="ms-JobIconExample root-471"
+            className=
+                ms-JobIconExample
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-5";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="Suitcase"
             role="presentation"
           >
@@ -87,7 +239,17 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-449"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -101,7 +263,17 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -5,21 +5,86 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
   className="ms-PersonaExample"
 >
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-472"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #1D1D1D;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <span>
@@ -27,7 +92,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </span>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -37,7 +116,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -47,10 +141,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -64,7 +180,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -78,7 +203,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -92,7 +227,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -108,21 +253,86 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-474"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #00A300;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <span>
@@ -130,7 +340,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </span>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -140,7 +364,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -150,10 +389,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -167,7 +428,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -181,7 +451,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -195,7 +475,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -211,21 +501,86 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-474"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #00A300;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <span>
@@ -233,7 +588,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </span>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -243,7 +612,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -253,10 +637,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -270,7 +676,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -284,7 +699,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -298,7 +723,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -314,21 +749,86 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-474"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #00A300;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <span>
@@ -336,7 +836,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </span>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -346,7 +860,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -356,10 +885,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -373,7 +924,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -387,7 +947,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -401,7 +971,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -417,21 +997,86 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-475"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #B91D47;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <span>
@@ -439,7 +1084,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </span>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -449,7 +1108,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -459,10 +1133,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -476,7 +1172,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -490,7 +1195,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -504,7 +1219,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -520,26 +1245,101 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-476"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #E773BD;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="root-366"
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-0";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="Contact"
             role="presentation"
           >
@@ -547,7 +1347,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </i>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -557,7 +1371,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -567,10 +1396,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -584,7 +1435,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -598,7 +1458,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -612,7 +1482,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -628,21 +1508,86 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-476"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #E773BD;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <span>
@@ -650,7 +1595,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </span>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -660,7 +1619,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -670,10 +1644,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -687,7 +1683,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -701,7 +1706,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -715,7 +1730,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -731,26 +1756,101 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-477"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #1E7145;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="root-366"
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-0";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="Contact"
             role="presentation"
           >
@@ -758,7 +1858,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </i>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -768,7 +1882,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -778,10 +1907,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -795,7 +1946,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -809,7 +1969,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -823,7 +1993,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -839,26 +2019,101 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-478"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #DA532C;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="root-366"
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-0";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="Contact"
             role="presentation"
           >
@@ -866,7 +2121,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </i>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -876,7 +2145,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -886,10 +2170,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -903,7 +2209,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -917,7 +2232,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -931,7 +2256,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -947,26 +2282,101 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-479"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #2B5797;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="root-366"
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-0";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="Contact"
             role="presentation"
           >
@@ -974,7 +2384,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </i>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -984,7 +2408,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -994,10 +2433,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1011,7 +2472,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1025,7 +2495,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1039,7 +2519,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1055,21 +2545,86 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-480"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #6BA5E7;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <span>
@@ -1077,7 +2632,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </span>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -1087,7 +2656,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -1097,10 +2681,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1114,7 +2720,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1128,7 +2743,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1142,7 +2767,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1158,21 +2793,86 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size48 root-439"
+    className=
+        ms-Persona
+        ms-Persona--size48
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 48px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 48px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={13}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size48 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size48
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={13}
     >
       <div
-        className="ms-Persona-imageArea imageArea-441"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 48px;
+              position: relative;
+              text-align: center;
+              width: 48px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-481"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #00ABA9;
+                border-radius: 50%;
+                color: #ffffff;
+                font-size: 17px;
+                font-weight: 400;
+                height: 48px;
+                line-height: 46px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <span>
@@ -1180,7 +2880,21 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           </span>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-443"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 100%;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 100%;
+              }
           style={
             Object {
               "height": 48,
@@ -1190,7 +2904,22 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -1200,10 +2929,32 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-440"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 17px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1217,7 +2968,16 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1231,7 +2991,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -1245,7 +3015,17 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
@@ -5,26 +5,101 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
   className="ms-PersonaExample"
 >
   <div
-    className="ms-Persona ms-Persona--size40 root-430"
+    className=
+        ms-Persona
+        ms-Persona--size40
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 40px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 40px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={12}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size40 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size40
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={12}
     >
       <div
-        className="ms-Persona-imageArea imageArea-432"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 40px;
+              position: relative;
+              text-align: center;
+              width: 40px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-482"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #eaeaea;
+                border-radius: 50%;
+                color: #a80000;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                line-height: 40px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="root-52"
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-1";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="Help"
             role="presentation"
           >
@@ -32,7 +107,21 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           </i>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-435"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 40px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 40px;
+              }
           style={
             Object {
               "height": 40,
@@ -42,7 +131,22 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -52,10 +156,32 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-207"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -69,7 +195,16 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-431"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -83,34 +218,129 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-209"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       />
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       />
     </div>
   </div>
   <div
-    className="ms-Persona ms-Persona--size72 root-446"
+    className=
+        ms-Persona
+        ms-Persona--size72
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 72px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 72px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        & .contextualHost {
+          display: none;
+        }
+        &:hover $primaryText {
+          color: #212121;
+        }
     size={14}
     style={undefined}
   >
     <div
-      className="ms-Persona-coin ms-Persona--size72 coin-72"
+      className=
+          ms-Persona-coin
+          ms-Persona--size72
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
       size={14}
     >
       <div
-        className="ms-Persona-imageArea imageArea-450"
+        className=
+            ms-Persona-imageArea
+            {
+              flex: 0 0 auto;
+              height: 72px;
+              position: relative;
+              text-align: center;
+              width: 72px;
+            }
         style={undefined}
       >
         <div
           aria-hidden="true"
-          className="ms-Persona-initials initials-483"
+          className=
+              ms-Persona-initials
+              {
+                background-color: #eaeaea;
+                border-radius: 50%;
+                color: #a80000;
+                font-size: 28px;
+                font-weight: 400;
+                height: 72px;
+                line-height: 72px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                background-color: Window !important;
+                border: 1px solid WindowText;
+                box-sizing: border-box;
+                color: WindowText;
+              }
           style={undefined}
         >
           <i
             aria-hidden={true}
-            className="root-52"
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-1";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
             data-icon-name="Help"
             role="presentation"
           >
@@ -118,7 +348,21 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           </i>
         </div>
         <div
-          className="ms-Image ms-Persona-image image-453"
+          className=
+              ms-Image
+              ms-Persona-image
+              {
+                border-radius: 50%;
+                border: 0px;
+                height: 72px;
+                left: 0px;
+                margin-right: 10px;
+                overflow: hidden;
+                perspective: 1px;
+                position: absolute;
+                top: 0px;
+                width: 72px;
+              }
           style={
             Object {
               "height": 72,
@@ -128,7 +372,22 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
         >
           <img
             alt=""
-            className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+            className=
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
+                }
             onError={[Function]}
             onLoad={[Function]}
             role={undefined}
@@ -138,10 +397,32 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
       </div>
     </div>
     <div
-      className="ms-Persona-details details-206"
+      className=
+          ms-Persona-details
+          {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            min-width: 0px;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 24px;
+            padding-top: 0;
+            text-align: left;
+            width: 100%;
+          }
     >
       <div
-        className="ms-Persona-primaryText primaryText-447"
+        className=
+            ms-Persona-primaryText
+            {
+              color: #333333;
+              font-size: 21px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -155,7 +436,16 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
         </div>
       </div>
       <div
-        className="ms-Persona-secondaryText secondaryText-448"
+        className=
+            ms-Persona-secondaryText
+            {
+              color: #666666;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -169,7 +459,17 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
         </div>
       </div>
       <div
-        className="ms-Persona-tertiaryText tertiaryText-449"
+        className=
+            ms-Persona-tertiaryText
+            {
+              color: #666666;
+              display: block;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       >
         <div
           aria-describedby={undefined}
@@ -183,7 +483,17 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
         </div>
       </div>
       <div
-        className="ms-Persona-optionalText optionalText-210"
+        className=
+            ms-Persona-optionalText
+            {
+              color: #666666;
+              display: none;
+              font-size: 12px;
+              font-weight: 400;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
       />
     </div>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           data-order={1}
           data-title="My Files Title"
@@ -36,7 +105,15 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -56,7 +133,74 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -67,7 +211,15 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -87,7 +239,74 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -98,7 +317,15 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -120,7 +347,24 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab0"
@@ -34,7 +103,15 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -54,7 +131,74 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -65,7 +209,15 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -85,7 +237,74 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -96,7 +315,15 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -118,20 +345,105 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Callout Example
         </label>
         <div>
           <div
-            className="buttonArea-174"
+            className=
+
+                {
+                  display: inline-block;
+                  text-align: center;
+                  vertical-align: top;
+                }
           >
             <button
               aria-describedby={undefined}
               aria-label={undefined}
               aria-labelledby={undefined}
               aria-pressed={undefined}
-              className="ms-Button ms-Button--default root-119"
+              className=
+                  ms-Button
+                  ms-Button--default
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #f4f4f4;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    min-width: 80px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 16px;
+                    padding-right: 16px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:hover {
+                    background-color: #eaeaea;
+                    color: #000000;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #c8c8c8;
+                    color: #212121;
+                  }
               data-is-focusable={true}
               disabled={undefined}
               id="toggleCallout"
@@ -139,13 +451,34 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-102"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
               >
                 <div
-                  className="ms-Button-textContainer textContainer-103"
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
                 >
                   <div
-                    className="ms-Button-label label-120"
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: 600;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
                     id="id__11"
                   >
                     Show callout

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab0"
@@ -34,7 +103,15 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -44,7 +121,17 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               >
                 <i
                   aria-hidden={true}
-                  className="root-366"
+                  className=
+
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-0";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
                   data-icon-name="Emoji2"
                   role="presentation"
                 >
@@ -73,7 +160,74 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -84,7 +238,15 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -94,7 +256,17 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               >
                 <i
                   aria-hidden={true}
-                  className="root-52"
+                  className=
+
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-1";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
                   data-icon-name="Recent"
                   role="presentation"
                 >
@@ -117,7 +289,74 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -128,7 +367,15 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -138,7 +385,17 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               >
                 <i
                   aria-hidden={true}
-                  className="root-366"
+                  className=
+
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-0";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
                   data-icon-name="Globe"
                   role="presentation"
                 >
@@ -154,7 +411,74 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab3"
@@ -165,7 +489,15 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -175,7 +507,17 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               >
                 <i
                   aria-hidden={true}
-                  className="root-313"
+                  className=
+
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-3";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
                   data-icon-name="Ringer"
                   role="presentation"
                 >
@@ -204,7 +546,74 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab4"
@@ -215,7 +624,15 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span>
               <span
@@ -226,7 +643,17 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 >
                   <i
                     aria-hidden={true}
-                    className="root-366"
+                    className=
+
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons-0";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
                     data-icon-name="Globe"
                     role="presentation"
                   >
@@ -249,7 +676,17 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               </span>
               <i
                 aria-hidden={true}
-                className="root-366"
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-0";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
                 data-icon-name="Airplane"
                 role="presentation"
                 style={
@@ -271,7 +708,24 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab0"
@@ -34,7 +103,15 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -54,7 +131,74 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -65,7 +209,15 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -85,7 +237,74 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -96,7 +315,15 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -118,7 +345,24 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab0"
@@ -34,7 +103,15 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -54,7 +131,74 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -65,7 +209,15 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -85,7 +237,74 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -96,7 +315,15 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -116,7 +343,74 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab3"
@@ -127,7 +421,15 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -149,7 +451,24 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab0"
@@ -34,7 +103,15 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -54,7 +131,74 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -65,7 +209,15 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -85,7 +237,74 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -96,7 +315,15 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -118,7 +345,24 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Pivot #1
         </label>
@@ -130,20 +374,103 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__11"
         >
           Select next item

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab0"
@@ -34,7 +103,15 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -54,7 +131,74 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -65,7 +209,15 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -85,7 +237,74 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -96,7 +315,15 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -116,7 +343,74 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab3"
@@ -127,7 +421,15 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -149,17 +451,68 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Click the button below to show/hide this pivot item.
         </label>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           The selected item will not change when the number of pivot items changes.
         </label>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           If the selected item was removed, the new first item will be selected.
         </label>
@@ -172,20 +525,103 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__14"
           >
             Hide First Pivot Item

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -35,7 +35,76 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="ShapeColorPivot_rectangleRed"
@@ -46,7 +115,15 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -66,7 +143,74 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="ShapeColorPivot_squareRed"
@@ -77,7 +221,15 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -97,7 +249,74 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="ShapeColorPivot_rectangleGreen"
@@ -108,7 +327,15 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab0"
@@ -34,7 +103,15 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -54,7 +131,74 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -65,7 +209,15 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -85,7 +237,74 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -96,7 +315,15 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -116,7 +343,74 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab3"
@@ -127,7 +421,15 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -149,7 +451,24 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -23,7 +23,76 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={true}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link is-selected undefined root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              is-selected
+              undefined
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab0"
@@ -34,7 +103,15 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -54,7 +131,74 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab1"
@@ -65,7 +209,15 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -85,7 +237,74 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab2"
@@ -96,7 +315,15 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -116,7 +343,74 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
           aria-labelledby={undefined}
           aria-pressed={undefined}
           aria-selected={false}
-          className="ms-Button ms-Button--action ms-Button--command ms-Pivot-link root-113"
+          className=
+              ms-Button
+              ms-Button--action
+              ms-Button--command
+              ms-Pivot-link
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: pointer;
+                display: inline-block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 40px;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: 4px;
+                padding-right: 4px;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:hover .ms-Button-icon {
+                color: #0078d4;
+              }
+              &:active {
+                color: #000000;
+              }
+              &:active .ms-Button-icon {
+                color: #004578;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Pivot0-Tab3"
@@ -127,7 +421,15 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-114"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: flex-start;
+                }
           >
             <span
               className="ms-Pivot-link-content"
@@ -149,7 +451,24 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
     >
       <div>
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PositioningContainer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PositioningContainer.Basic.Example.tsx.shot
@@ -10,20 +10,104 @@ exports[`Component Examples renders PositioningContainer.Basic.Example.tsx corre
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default ms-PositioningContainer-basicExampleButton root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          ms-PositioningContainer-basicExampleButton
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Show Positioning Container

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
@@ -2,25 +2,70 @@
 
 exports[`Component Examples renders ProgressIndicator.Basic.Example.tsx correctly 1`] = `
 <div
-  className="ms-ProgressIndicator root-487"
+  className=
+      ms-ProgressIndicator
+      {
+        font-weight: 400;
+      }
 >
   <div
-    className="ms-ProgressIndicator-itemName itemName-488"
+    className=
+        ms-ProgressIndicator-itemName
+        {
+          color: #333333;
+          font-size: 14px;
+          line-height: 20px;
+          overflow: hidden;
+          padding-top: 4px;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
   >
     Example title
   </div>
   <div
-    className="ms-ProgressIndicator-itemProgress itemProgress-490"
+    className=
+        ms-ProgressIndicator-itemProgress
+        {
+          height: 2px;
+          overflow: hidden;
+          padding-bottom: 8px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 8px;
+          position: relative;
+        }
   >
     <div
-      className="ms-ProgressIndicator-progressTrack progressTrack-491"
+      className=
+          ms-ProgressIndicator-progressTrack
+          {
+            background-color: #eaeaea;
+            height: 2px;
+            position: absolute;
+            width: 100%;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-bottom: 1px solid WindowText;
+          }
     />
     <div
       aria-valuemax={100}
       aria-valuemin={0}
       aria-valuenow={0}
       aria-valuetext={undefined}
-      className="ms-ProgressIndicator-progressBar progressBar-492"
+      className=
+          ms-ProgressIndicator-progressBar
+          {
+            background-color: #0078d4;
+            height: 2px;
+            position: absolute;
+            transition: width .15s linear;
+            width: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background-color: WindowText;
+          }
       role="progressbar"
       style={
         Object {
@@ -31,7 +76,13 @@ exports[`Component Examples renders ProgressIndicator.Basic.Example.tsx correctl
     />
   </div>
   <div
-    className="ms-ProgressIndicator-itemDescription itemDescription-489"
+    className=
+        ms-ProgressIndicator-itemDescription
+        {
+          color: #666666;
+          font-size: 11px;
+          line-height: 18px;
+        }
   >
     Example description
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
@@ -2,25 +2,73 @@
 
 exports[`Component Examples renders ProgressIndicator.Indeterminate.Example.tsx correctly 1`] = `
 <div
-  className="ms-ProgressIndicator root-487"
+  className=
+      ms-ProgressIndicator
+      {
+        font-weight: 400;
+      }
 >
   <div
-    className="ms-ProgressIndicator-itemName itemName-488"
+    className=
+        ms-ProgressIndicator-itemName
+        {
+          color: #333333;
+          font-size: 14px;
+          line-height: 20px;
+          overflow: hidden;
+          padding-top: 4px;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
   >
     Example title
   </div>
   <div
-    className="ms-ProgressIndicator-itemProgress itemProgress-490"
+    className=
+        ms-ProgressIndicator-itemProgress
+        {
+          height: 2px;
+          overflow: hidden;
+          padding-bottom: 8px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 8px;
+          position: relative;
+        }
   >
     <div
-      className="ms-ProgressIndicator-progressTrack progressTrack-491"
+      className=
+          ms-ProgressIndicator-progressTrack
+          {
+            background-color: #eaeaea;
+            height: 2px;
+            position: absolute;
+            width: 100%;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-bottom: 1px solid WindowText;
+          }
     />
     <div
       aria-valuemax={undefined}
       aria-valuemin={undefined}
       aria-valuenow={undefined}
       aria-valuetext={undefined}
-      className="ms-ProgressIndicator-progressBar progressBar-493"
+      className=
+          ms-ProgressIndicator-progressBar
+          {
+            animation: keyframes 0%{left:-30%;}100%{left:100%;} 3s infinite;
+            background-color: #0078d4;
+            background: linear-gradient(to right, transparent 0%, #0078d4 50%, transparent 100%);
+            height: 2px;
+            min-width: 33%;
+            position: absolute;
+            transition: width .3s ease;
+            width: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background-color: WindowText;
+          }
       role="progressbar"
       style={
         Object {
@@ -31,7 +79,13 @@ exports[`Component Examples renders ProgressIndicator.Indeterminate.Example.tsx 
     />
   </div>
   <div
-    className="ms-ProgressIndicator-itemDescription itemDescription-489"
+    className=
+        ms-ProgressIndicator-itemDescription
+        {
+          color: #666666;
+          font-size: 11px;
+          line-height: 18px;
+        }
   >
     Example description
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -7,13 +7,35 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   Large Stars:
   <div
     aria-label="Rating value is 1 of 5"
-    className="ms-Rating-star ms-RatingStar-root root-494 ms-RatingStar-root--large rootIsLarge-496"
+    className=
+        ms-Rating-star
+        ms-RatingStar-root
+        ms-RatingStar-root--large
+        &:hover .ms-RatingStar-back {
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-RatingStar-back {
+          color: Highlight;
+        }
+        {
+          height: 26px;
+        }
     id="Rating0"
   >
     <div
       aria-describedby={undefined}
       aria-labelledby={undefined}
-      className="ms-FocusZone ms-Rating-focuszone ratingFocusZone-504 ms-RatingStar-root--large rootIsLarge-496"
+      className=
+          ms-FocusZone
+          ms-Rating-focuszone
+          ms-RatingStar-root--large
+          {
+            display: inline-block;
+            padding-bottom: 1px;
+          }
+          {
+            height: 26px;
+          }
       data-focuszone-id="FocusZone2"
       data-is-focusable={false}
       onFocus={[Function]}
@@ -23,7 +45,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       tabIndex={-1}
     >
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--large ratingStarIsLarge-502"
+        className=
+            ms-Rating-button
+            ms-Rating--large
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 20px;
+              line-height: 20px;
+            }
         data-is-current={true}
         disabled={false}
         id="Rating0-star-0"
@@ -33,17 +114,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-1"
         >
           1 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -51,7 +165,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -65,7 +200,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--large ratingStarIsLarge-502"
+        className=
+            ms-Rating-button
+            ms-Rating--large
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 20px;
+              line-height: 20px;
+            }
         disabled={false}
         id="Rating0-star-1"
         onClick={[Function]}
@@ -74,17 +268,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-2"
         >
           2 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -92,7 +319,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -106,7 +354,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--large ratingStarIsLarge-502"
+        className=
+            ms-Rating-button
+            ms-Rating--large
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 20px;
+              line-height: 20px;
+            }
         disabled={false}
         id="Rating0-star-2"
         onClick={[Function]}
@@ -115,17 +422,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-3"
         >
           3 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -133,7 +473,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -147,7 +508,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--large ratingStarIsLarge-502"
+        className=
+            ms-Rating-button
+            ms-Rating--large
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 20px;
+              line-height: 20px;
+            }
         disabled={false}
         id="Rating0-star-3"
         onClick={[Function]}
@@ -156,17 +576,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-4"
         >
           4 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -174,7 +627,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -188,7 +662,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--large ratingStarIsLarge-502"
+        className=
+            ms-Rating-button
+            ms-Rating--large
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 20px;
+              line-height: 20px;
+            }
         disabled={false}
         id="Rating0-star-4"
         onClick={[Function]}
@@ -197,17 +730,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-5"
         >
           5 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -215,7 +781,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -233,13 +820,35 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   Small Stars
   <div
     aria-label="Rating value is 3 of 5"
-    className="ms-Rating-star ms-RatingStar-root root-494 ms-RatingStar-root--small rootIsSmall-495"
+    className=
+        ms-Rating-star
+        ms-RatingStar-root
+        ms-RatingStar-root--small
+        &:hover .ms-RatingStar-back {
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-RatingStar-back {
+          color: Highlight;
+        }
+        {
+          height: 22px;
+        }
     id="Rating3"
   >
     <div
       aria-describedby={undefined}
       aria-labelledby={undefined}
-      className="ms-FocusZone ms-Rating-focuszone ratingFocusZone-504 ms-RatingStar-root--small rootIsSmall-495"
+      className=
+          ms-FocusZone
+          ms-Rating-focuszone
+          ms-RatingStar-root--small
+          {
+            display: inline-block;
+            padding-bottom: 1px;
+          }
+          {
+            height: 22px;
+          }
       data-focuszone-id="FocusZone5"
       data-is-focusable={false}
       onFocus={[Function]}
@@ -249,7 +858,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       tabIndex={-1}
     >
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating3-star-0"
         onClick={[Function]}
@@ -258,17 +926,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel4-1"
         >
           1 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -276,7 +977,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -290,7 +1012,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating3-star-1"
         onClick={[Function]}
@@ -299,17 +1080,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel4-2"
         >
           2 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -317,7 +1131,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -331,7 +1166,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         data-is-current={true}
         disabled={false}
         id="Rating3-star-2"
@@ -341,17 +1235,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel4-3"
         >
           3 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -359,7 +1286,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -373,7 +1321,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating3-star-3"
         onClick={[Function]}
@@ -382,17 +1389,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel4-4"
         >
           4 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -400,7 +1440,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -414,7 +1475,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating3-star-4"
         onClick={[Function]}
@@ -423,17 +1543,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel4-5"
         >
           5 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -441,7 +1594,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -459,13 +1633,35 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   10 Small Stars
   <div
     aria-label="Rating value is 1 of 10"
-    className="ms-Rating-star ms-RatingStar-root root-494 ms-RatingStar-root--small rootIsSmall-495"
+    className=
+        ms-Rating-star
+        ms-RatingStar-root
+        ms-RatingStar-root--small
+        &:hover .ms-RatingStar-back {
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-RatingStar-back {
+          color: Highlight;
+        }
+        {
+          height: 22px;
+        }
     id="Rating6"
   >
     <div
       aria-describedby={undefined}
       aria-labelledby={undefined}
-      className="ms-FocusZone ms-Rating-focuszone ratingFocusZone-504 ms-RatingStar-root--small rootIsSmall-495"
+      className=
+          ms-FocusZone
+          ms-Rating-focuszone
+          ms-RatingStar-root--small
+          {
+            display: inline-block;
+            padding-bottom: 1px;
+          }
+          {
+            height: 22px;
+          }
       data-focuszone-id="FocusZone8"
       data-is-focusable={false}
       onFocus={[Function]}
@@ -475,7 +1671,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       tabIndex={-1}
     >
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         data-is-current={true}
         disabled={false}
         id="Rating6-star-0"
@@ -485,17 +1740,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-1"
         >
           1 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -503,7 +1791,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -517,7 +1826,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-1"
         onClick={[Function]}
@@ -526,17 +1894,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-2"
         >
           2 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -544,7 +1945,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -558,7 +1980,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-2"
         onClick={[Function]}
@@ -567,17 +2048,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-3"
         >
           3 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -585,7 +2099,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -599,7 +2134,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-3"
         onClick={[Function]}
@@ -608,17 +2202,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-4"
         >
           4 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -626,7 +2253,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -640,7 +2288,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-4"
         onClick={[Function]}
@@ -649,17 +2356,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-5"
         >
           5 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -667,7 +2407,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -681,7 +2442,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-5"
         onClick={[Function]}
@@ -690,17 +2510,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-6"
         >
           6 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -708,7 +2561,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -722,7 +2596,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-6"
         onClick={[Function]}
@@ -731,17 +2664,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-7"
         >
           7 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -749,7 +2715,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -763,7 +2750,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-7"
         onClick={[Function]}
@@ -772,17 +2818,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-8"
         >
           8 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -790,7 +2869,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -804,7 +2904,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-8"
         onClick={[Function]}
@@ -813,17 +2972,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-9"
         >
           9 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -831,7 +3023,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -845,7 +3058,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating6-star-9"
         onClick={[Function]}
@@ -854,17 +3126,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel7-10"
         >
           10 of 10 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -872,7 +3177,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -890,13 +3216,30 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   Disabled:
   <div
     aria-label=""
-    className="ms-Rating-star ms-RatingStar-root root-292 ms-RatingStar-root--small rootIsSmall-495"
+    className=
+        ms-Rating-star
+        ms-RatingStar-root
+        ms-RatingStar-root--small
+
+        {
+          height: 22px;
+        }
     id="Rating9"
   >
     <div
       aria-describedby={undefined}
       aria-labelledby={undefined}
-      className="ms-FocusZone ms-Rating-focuszone ratingFocusZone-504 ms-RatingStar-root--small rootIsSmall-495"
+      className=
+          ms-FocusZone
+          ms-Rating-focuszone
+          ms-RatingStar-root--small
+          {
+            display: inline-block;
+            padding-bottom: 1px;
+          }
+          {
+            height: 22px;
+          }
       data-focuszone-id="FocusZone11"
       data-is-focusable={false}
       onFocus={[Function]}
@@ -906,7 +3249,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       tabIndex={-1}
     >
       <button
-        className="ms-Rating-button ratingButton-508 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: default;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         data-is-current={true}
         disabled={true}
         id="Rating9-star-0"
@@ -916,17 +3300,53 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel10-1"
         >
           1 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-509"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: GrayText;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -935,7 +3355,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-508 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: default;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating9-star-1"
         onClick={[Function]}
@@ -944,17 +3405,53 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel10-2"
         >
           2 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-509"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: GrayText;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -963,7 +3460,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-508 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: default;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating9-star-2"
         onClick={[Function]}
@@ -972,17 +3510,53 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel10-3"
         >
           3 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-509"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: GrayText;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -991,7 +3565,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-508 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: default;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating9-star-3"
         onClick={[Function]}
@@ -1000,17 +3615,53 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel10-4"
         >
           4 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-509"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: GrayText;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1019,7 +3670,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-508 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: default;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating9-star-4"
         onClick={[Function]}
@@ -1028,17 +3720,53 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel10-5"
         >
           5 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-509"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: GrayText;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1051,13 +3779,30 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   Half star in readOnly mode:
   <div
     aria-label="Rating value is 2.5 of 5"
-    className="ms-Rating-star ms-RatingStar-root root-292 ms-RatingStar-root--small rootIsSmall-495"
+    className=
+        ms-Rating-star
+        ms-RatingStar-root
+        ms-RatingStar-root--small
+
+        {
+          height: 22px;
+        }
     id="Rating12"
   >
     <div
       aria-describedby={undefined}
       aria-labelledby={undefined}
-      className="ms-FocusZone ms-Rating-focuszone ratingFocusZone-504 ms-RatingStar-root--small rootIsSmall-495"
+      className=
+          ms-FocusZone
+          ms-Rating-focuszone
+          ms-RatingStar-root--small
+          {
+            display: inline-block;
+            padding-bottom: 1px;
+          }
+          {
+            height: 22px;
+          }
       data-focuszone-id="FocusZone14"
       data-is-focusable={true}
       onFocus={[Function]}
@@ -1067,7 +3812,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       tabIndex={0}
     >
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating12-star-0"
         onClick={[Function]}
@@ -1076,17 +3862,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel13-1"
         >
           1 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1094,7 +3913,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1108,7 +3948,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating12-star-1"
         onClick={[Function]}
@@ -1117,17 +3998,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel13-2"
         >
           2 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1135,7 +4049,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1149,7 +4084,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         data-is-current={true}
         disabled={true}
         id="Rating12-star-2"
@@ -1159,17 +4135,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel13-3"
         >
           3 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1177,7 +4186,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1191,7 +4221,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating12-star-3"
         onClick={[Function]}
@@ -1200,17 +4271,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel13-4"
         >
           4 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1218,7 +4322,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1232,7 +4357,48 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating12-star-4"
         onClick={[Function]}
@@ -1241,17 +4407,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel13-5"
         >
           5 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1259,7 +4458,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1277,13 +4497,35 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   Themed star
   <div
     aria-label="Rating value is 1 of 5"
-    className="ms-Rating-star ms-RatingStar-root root-511 ms-RatingStar-root--small rootIsSmall-495"
+    className=
+        ms-Rating-star
+        ms-RatingStar-root
+        ms-RatingStar-root--small
+        &:hover .ms-RatingStar-back {
+          color: #1E9FE8;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-RatingStar-back {
+          color: Highlight;
+        }
+        {
+          height: 22px;
+        }
     id="Rating15"
   >
     <div
       aria-describedby={undefined}
       aria-labelledby={undefined}
-      className="ms-FocusZone ms-Rating-focuszone ratingFocusZone-504 ms-RatingStar-root--small rootIsSmall-495"
+      className=
+          ms-FocusZone
+          ms-Rating-focuszone
+          ms-RatingStar-root--small
+          {
+            display: inline-block;
+            padding-bottom: 1px;
+          }
+          {
+            height: 22px;
+          }
       data-focuszone-id="FocusZone17"
       data-is-focusable={false}
       onFocus={[Function]}
@@ -1293,7 +4535,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
       tabIndex={-1}
     >
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         data-is-current={true}
         disabled={false}
         id="Rating15-star-0"
@@ -1303,17 +4604,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel16-1"
         >
           1 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1321,7 +4655,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-513"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #1E9FE8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1335,7 +4690,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating15-star-1"
         onClick={[Function]}
@@ -1344,17 +4758,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel16-2"
         >
           2 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1362,7 +4809,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-513"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #1E9FE8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1376,7 +4844,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating15-star-2"
         onClick={[Function]}
@@ -1385,17 +4912,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel16-3"
         >
           3 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1403,7 +4963,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-513"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #1E9FE8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1417,7 +4998,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating15-star-3"
         onClick={[Function]}
@@ -1426,17 +5066,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel16-4"
         >
           4 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1444,7 +5117,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-513"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #1E9FE8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -1458,7 +5152,66 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-500 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #a6a6a6;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={false}
         id="Rating15-star-4"
         onClick={[Function]}
@@ -1467,17 +5220,50 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel16-5"
         >
           5 of 5 stars selected
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -1485,7 +5271,28 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-513"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #1E9FE8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -6,13 +6,30 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
 >
   <div
     aria-label=""
-    className="ms-Rating-star ms-RatingStar-root root-292 ms-RatingStar-root--small rootIsSmall-495"
+    className=
+        ms-Rating-star
+        ms-RatingStar-root
+        ms-RatingStar-root--small
+
+        {
+          height: 22px;
+        }
     id="Rating0"
   >
     <div
       aria-describedby={undefined}
       aria-labelledby={undefined}
-      className="ms-FocusZone ms-Rating-focuszone ratingFocusZone-504 ms-RatingStar-root--small rootIsSmall-495"
+      className=
+          ms-FocusZone
+          ms-Rating-focuszone
+          ms-RatingStar-root--small
+          {
+            display: inline-block;
+            padding-bottom: 1px;
+          }
+          {
+            height: 22px;
+          }
       data-focuszone-id="FocusZone2"
       data-is-focusable={true}
       onFocus={[Function]}
@@ -22,7 +39,48 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
       tabIndex={0}
     >
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating0-star-0"
         onClick={[Function]}
@@ -31,17 +89,50 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-1"
         >
           
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -49,7 +140,28 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -63,7 +175,48 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating0-star-1"
         onClick={[Function]}
@@ -72,17 +225,50 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-2"
         >
           
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -90,7 +276,28 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -104,7 +311,48 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating0-star-2"
         onClick={[Function]}
@@ -113,17 +361,50 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-3"
         >
           
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -131,7 +412,28 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -145,7 +447,48 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating0-star-3"
         onClick={[Function]}
@@ -154,17 +497,50 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-4"
         >
           
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -172,7 +548,28 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -186,7 +583,48 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         </div>
       </button>
       <button
-        className="ms-Rating-button ratingButton-510 ms-Rating--small ratingStarIsSmall-501"
+        className=
+            ms-Rating-button
+            ms-Rating--small
+            {
+              background-color: transparent;
+              border: none;
+              cursor: pointer;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: transparent;
+              padding-bottom: 3px;
+              padding-left: 0px;
+              padding-right: 3px;
+              padding-top: 3px;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:disabled {
+              cursor: default;
+            }
+            &[disabled] {
+              cursor: default;
+            }
+            {
+              font-size: 16px;
+              line-height: 16px;
+            }
         disabled={true}
         id="Rating0-star-4"
         onClick={[Function]}
@@ -195,17 +633,50 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
         type="button"
       >
         <span
-          className="ms-Rating-labelText labelText-503"
+          className=
+              ms-Rating-labelText
+              {
+                border: 0px;
+                height: 1px;
+                margin-bottom: -1px;
+                margin-left: -1px;
+                margin-right: -1px;
+                margin-top: -1px;
+                overflow: hidden;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: absolute;
+                width: 1px;
+              }
           id="RatingLabel1-5"
         >
           
         </span>
         <div
-          className="ms-RatingStar-container ratingStar-497"
+          className=
+              ms-RatingStar-container
+              {
+                display: inline-block;
+                position: relative;
+              }
         >
           <i
             aria-hidden={true}
-            className="ms-RatingStar-back ratingStarBack-505"
+            className=
+                ms-RatingStar-back
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a6a6a6;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                  width: 100%;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
           >
@@ -213,7 +684,28 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           </i>
           <i
             aria-hidden={true}
-            className="ms-RatingStar-front ratingStarFront-506"
+            className=
+                ms-RatingStar-front
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #000000;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 100 %;
+                  left: 0;
+                  overflow: hidden;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0;
+                  vertical-align: middle;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: Highlight;
+                }
             data-icon-name="FavoriteStarFill"
             role="presentation"
             style={
@@ -233,20 +725,113 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__3"
         >
           Click to change rating to 5

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.FlexBox.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.FlexBox.Example.tsx.shot
@@ -2,7 +2,12 @@
 
 exports[`Component Examples renders ResizeGroup.FlexBox.Example.tsx correctly 1`] = `
 <div
-  className="ms-ResizeGroup root-98"
+  className=
+      ms-ResizeGroup
+      {
+        display: block;
+        position: relative;
+      }
 >
   <div
     style={
@@ -13,58 +18,184 @@ exports[`Component Examples renders ResizeGroup.FlexBox.Example.tsx correctly 1`
     }
   >
     <div
-      className="css-514"
+      className=
+
+          {
+            display: flex;
+            justify-content: space-between;
+            white-space: nowrap;
+          }
     >
       <div>
         <div
-          className="css-515"
+          className=
+
+              {
+                background-color: orange;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           1
         </div>
         <div
-          className="css-515"
+          className=
+
+              {
+                background-color: orange;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           2
         </div>
         <div
-          className="css-515"
+          className=
+
+              {
+                background-color: orange;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           3
         </div>
         <div
-          className="css-515"
+          className=
+
+              {
+                background-color: orange;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           4
         </div>
         <div
-          className="css-515"
+          className=
+
+              {
+                background-color: orange;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           5
         </div>
       </div>
       <div>
         <div
-          className="css-516"
+          className=
+
+              {
+                background-color: green;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           1
         </div>
         <div
-          className="css-516"
+          className=
+
+              {
+                background-color: green;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           2
         </div>
         <div
-          className="css-516"
+          className=
+
+              {
+                background-color: green;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           3
         </div>
         <div
-          className="css-516"
+          className=
+
+              {
+                background-color: green;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           4
         </div>
         <div
-          className="css-516"
+          className=
+
+              {
+                background-color: green;
+                display: inline-block;
+                font-size: 20px;
+                height: 50px;
+                line-height: 50px;
+                margin-left: 10px;
+                margin-right: 10px;
+                text-align: center;
+                width: 50px;
+              }
         >
           5
         </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -6,7 +6,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
 >
   <div
     aria-label="Resize Group with an Overflow Set"
-    className="ms-ResizeGroup root-98"
+    className=
+        ms-ResizeGroup
+        {
+          display: block;
+          position: relative;
+        }
     role="tabpanel"
   >
     <div
@@ -36,28 +41,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Add"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__1"
                 >
                   Item 0
@@ -75,28 +183,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Share"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__4"
                 >
                   Item 1
@@ -114,28 +325,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Upload"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__7"
                 >
                   Item 2
@@ -153,28 +467,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Add"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__10"
                 >
                   Item 3
@@ -192,28 +609,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Share"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__13"
                 >
                   Item 4
@@ -231,28 +751,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Upload"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__16"
                 >
                   Item 5
@@ -270,28 +893,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Add"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__19"
                 >
                   Item 6
@@ -309,28 +1035,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Share"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__22"
                 >
                   Item 7
@@ -348,28 +1177,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Upload"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__25"
                 >
                   Item 8
@@ -387,28 +1319,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Add"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__28"
                 >
                   Item 9
@@ -426,28 +1461,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Share"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__31"
                 >
                   Item 10
@@ -465,28 +1603,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Upload"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__34"
                 >
                   Item 11
@@ -504,28 +1745,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Add"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__37"
                 >
                   Item 12
@@ -543,28 +1887,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Share"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__40"
                 >
                   Item 13
@@ -582,28 +2029,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Upload"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__43"
                 >
                   Item 14
@@ -621,28 +2171,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Add"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__46"
                 >
                   Item 15
@@ -660,28 +2313,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Share"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__49"
                 >
                   Item 16
@@ -699,28 +2455,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Upload"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__52"
                 >
                   Item 17
@@ -738,28 +2597,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Add"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__55"
                 >
                   Item 18
@@ -777,28 +2739,131 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             aria-labelledby={undefined}
             aria-pressed={false}
             checked={false}
-            className="ms-Button ms-Button--default root-119"
+            className=
+                ms-Button
+                ms-Button--default
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #000000;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #c8c8c8;
+                  color: #212121;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={undefined}
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Share"
                 role="presentation"
               >
                 
               </i>
               <div
-                className="ms-Button-textContainer textContainer-103"
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
               >
                 <div
-                  className="ms-Button-label label-120"
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
                   id="id__58"
                 >
                   Item 19
@@ -822,7 +2887,60 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
       aria-posinset={undefined}
       aria-setsize={undefined}
       checked={false}
-      className="ms-Checkbox is-enabled root-189"
+      className=
+          ms-Checkbox
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background: none;
+            border: none;
+            cursor: pointer;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -2px;
+            content: "";
+            left: -2px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -2px;
+            top: -2px;
+            z-index: 1;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #212121;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #212121;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
+          }
       data-ktp-execute-target={undefined}
       disabled={undefined}
       id="checkbox-61"
@@ -834,16 +2952,66 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
       type="button"
     >
       <label
-        className="ms-Checkbox-label label-184"
+        className=
+            ms-Checkbox-label
+            {
+              align-items: center;
+              cursor: pointer;
+              display: inline-flex;
+              margin-bottom: 0;
+              margin-left: -4px;
+              margin-right: -4px;
+              margin-top: 0;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
         htmlFor="checkbox-61"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-190"
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                border-color: #666666;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                overflow: hidden;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
           data-ktp-target={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-192"
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 0;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
             data-icon-name="CheckMark"
             role="presentation"
           >
@@ -851,7 +3019,16 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-187"
+          className=
+              ms-Checkbox-text
+              {
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
         >
           Enable caching
         </span>
@@ -866,7 +3043,60 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
       aria-posinset={undefined}
       aria-setsize={undefined}
       checked={false}
-      className="ms-Checkbox is-enabled root-189"
+      className=
+          ms-Checkbox
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background: none;
+            border: none;
+            cursor: pointer;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -2px;
+            content: "";
+            left: -2px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -2px;
+            top: -2px;
+            z-index: 1;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #212121;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #212121;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
+          }
       data-ktp-execute-target={undefined}
       disabled={undefined}
       id="checkbox-62"
@@ -878,16 +3108,66 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
       type="button"
     >
       <label
-        className="ms-Checkbox-label label-184"
+        className=
+            ms-Checkbox-label
+            {
+              align-items: center;
+              cursor: pointer;
+              display: inline-flex;
+              margin-bottom: 0;
+              margin-left: -4px;
+              margin-right: -4px;
+              margin-top: 0;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
         htmlFor="checkbox-62"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-190"
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                border-color: #666666;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                overflow: hidden;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
           data-ktp-target={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-192"
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 0;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
             data-icon-name="CheckMark"
             role="presentation"
           >
@@ -895,7 +3175,16 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-187"
+          className=
+              ms-Checkbox-text
+              {
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
         >
           Set onGrowData
         </span>
@@ -910,7 +3199,60 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
       aria-posinset={undefined}
       aria-setsize={undefined}
       checked={false}
-      className="ms-Checkbox is-enabled root-189"
+      className=
+          ms-Checkbox
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background: none;
+            border: none;
+            cursor: pointer;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            outline: none;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 0;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -2px;
+            content: "";
+            left: -2px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -2px;
+            top: -2px;
+            z-index: 1;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #212121;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #212121;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
+          }
       data-ktp-execute-target={undefined}
       disabled={undefined}
       id="checkbox-63"
@@ -922,16 +3264,66 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
       type="button"
     >
       <label
-        className="ms-Checkbox-label label-184"
+        className=
+            ms-Checkbox-label
+            {
+              align-items: center;
+              cursor: pointer;
+              display: inline-flex;
+              margin-bottom: 0;
+              margin-left: -4px;
+              margin-right: -4px;
+              margin-top: 0;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
         htmlFor="checkbox-63"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-190"
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                border-color: #666666;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                overflow: hidden;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
           data-ktp-target={undefined}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-192"
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 0;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
             data-icon-name="CheckMark"
             role="presentation"
           >
@@ -939,7 +3331,16 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-187"
+          className=
+              ms-Checkbox-text
+              {
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
         >
           Buttons checked
         </span>
@@ -952,7 +3353,25 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         className="ms-Dropdown-container"
       >
         <label
-          className="ms-Label ms-Dropdown-label root-89"
+          className=
+              ms-Label
+              ms-Dropdown-label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="Dropdown64"
           id="Dropdown64-label"
           required={undefined}
@@ -993,7 +3412,17 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           >
             <i
               aria-hidden={true}
-              className="ms-Dropdown-caretDown root-55"
+              className=
+                  ms-Dropdown-caretDown
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
               data-icon-name="ChevronDown"
               role="presentation"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -5,16 +5,83 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
   className="ms-SearchBoxExample"
 >
   <div
-    className="ms-SearchBox is-disabled root-517"
+    className=
+        ms-SearchBox
+        is-disabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: stretch;
+          background-color: #f4f4f4;
+          border-color: #f4f4f4;
+          border: 1px solid #a6a6a6;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: default;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 1px;
+          padding-left: 4px;
+          padding-right: 0;
+          padding-top: 1px;
+          pointer-events: none;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border: 1px solid WindowText;
+        }
+        &:hover {
+          border-color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+        }
+        &:hover $iconContainer {
+          color: #005a9e;
+        }
     onFocusCapture={[Function]}
   >
     <div
-      className="ms-SearchBox-iconContainer iconContainer-518"
+      className=
+          ms-SearchBox-iconContainer
+          {
+            color: #a6a6a6;
+            cursor: text;
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+            font-size: 16px;
+            justify-content: center;
+            text-align: center;
+            transition: width 0.167s;
+            width: 32px;
+          }
       onClick={[Function]}
     >
       <i
         aria-hidden={true}
-        className="ms-SearchBox-icon icon-323"
+        className=
+            ms-SearchBox-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              opacity: 1;
+              speak: none;
+              transition: opacity 0.167s 0s;
+            }
         data-icon-name="Search"
         role="presentation"
       >
@@ -23,7 +90,40 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
-      className="ms-SearchBox-field field-519"
+      className=
+          ms-SearchBox-field
+          {
+            background-color: #ffffff;
+            border: none;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #a6a6a6;
+            flex: 1 1 0px;
+            font-family: inherit;
+            font-size: inherit;
+            font-weight: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: none;
+            overflow: hidden;
+            padding-bottom: 0.5px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            text-overflow: ellipsis;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          &::placeholder {
+            color: #666666;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #666666;
+          }
       disabled={true}
       id="SearchBox0"
       onChange={[Function]}
@@ -34,16 +134,85 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     />
   </div>
   <div
-    className="ms-SearchBox is-disabled is-underlined root-520"
+    className=
+        ms-SearchBox
+        is-disabled
+        is-underlined
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: stretch;
+          background-color: transparent;
+          border-color: #f4f4f4;
+          border-width: 0 0 1px 0;
+          border: 1px solid #a6a6a6;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: default;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 1px;
+          padding-left: 8px;
+          padding-right: 0;
+          padding-top: 1px;
+          pointer-events: none;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border: 1px solid WindowText;
+        }
+        &:hover {
+          border-color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+        }
+        &:hover $iconContainer {
+          color: #005a9e;
+        }
     onFocusCapture={[Function]}
   >
     <div
-      className="ms-SearchBox-iconContainer iconContainer-518"
+      className=
+          ms-SearchBox-iconContainer
+          {
+            color: #a6a6a6;
+            cursor: text;
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+            font-size: 16px;
+            justify-content: center;
+            text-align: center;
+            transition: width 0.167s;
+            width: 32px;
+          }
       onClick={[Function]}
     >
       <i
         aria-hidden={true}
-        className="ms-SearchBox-icon icon-323"
+        className=
+            ms-SearchBox-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              opacity: 1;
+              speak: none;
+              transition: opacity 0.167s 0s;
+            }
         data-icon-name="Search"
         role="presentation"
       >
@@ -52,7 +221,40 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
-      className="ms-SearchBox-field field-519"
+      className=
+          ms-SearchBox-field
+          {
+            background-color: #ffffff;
+            border: none;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #a6a6a6;
+            flex: 1 1 0px;
+            font-family: inherit;
+            font-size: inherit;
+            font-weight: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: none;
+            overflow: hidden;
+            padding-bottom: 0.5px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            text-overflow: ellipsis;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          &::placeholder {
+            color: #666666;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #666666;
+          }
       disabled={true}
       id="SearchBox1"
       onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -5,16 +5,78 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
   className="ms-SearchBoxExample"
 >
   <div
-    className="ms-SearchBox root-318"
+    className=
+        ms-SearchBox
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: stretch;
+          border: 1px solid #a6a6a6;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 1px;
+          padding-left: 4px;
+          padding-right: 0;
+          padding-top: 1px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border: 1px solid WindowText;
+        }
+        &:hover {
+          border-color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+        }
+        &:hover $iconContainer {
+          color: #005a9e;
+        }
     onFocusCapture={[Function]}
   >
     <div
-      className="ms-SearchBox-iconContainer iconContainer-319"
+      className=
+          ms-SearchBox-iconContainer
+          {
+            color: #0078d4;
+            cursor: text;
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+            font-size: 16px;
+            justify-content: center;
+            text-align: center;
+            transition: width 0.167s;
+            width: 32px;
+          }
       onClick={[Function]}
     >
       <i
         aria-hidden={true}
-        className="ms-SearchBox-icon icon-323"
+        className=
+            ms-SearchBox-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              opacity: 1;
+              speak: none;
+              transition: opacity 0.167s 0s;
+            }
         data-icon-name="Search"
         role="presentation"
       >
@@ -23,7 +85,40 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
-      className="ms-SearchBox-field field-322"
+      className=
+          ms-SearchBox-field
+          {
+            background-color: #ffffff;
+            border: none;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            flex: 1 1 0px;
+            font-family: inherit;
+            font-size: inherit;
+            font-weight: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: none;
+            overflow: hidden;
+            padding-bottom: 0.5px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            text-overflow: ellipsis;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          &::placeholder {
+            color: #666666;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #666666;
+          }
       disabled={undefined}
       id="SearchBox0"
       onChange={[Function]}
@@ -34,16 +129,76 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     />
   </div>
   <div
-    className="ms-SearchBox root-318"
+    className=
+        ms-SearchBox
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: stretch;
+          border: 1px solid #a6a6a6;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 1px;
+          padding-left: 4px;
+          padding-right: 0;
+          padding-top: 1px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border: 1px solid WindowText;
+        }
+        &:hover {
+          border-color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+        }
+        &:hover $iconContainer {
+          color: #005a9e;
+        }
     onFocusCapture={[Function]}
   >
     <div
-      className="ms-SearchBox-iconContainer iconContainer-521"
+      className=
+          ms-SearchBox-iconContainer
+          {
+            color: #0078d4;
+            cursor: text;
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+            font-size: 16px;
+            justify-content: center;
+            text-align: center;
+            width: 32px;
+          }
       onClick={[Function]}
     >
       <i
         aria-hidden={true}
-        className="ms-SearchBox-icon icon-523"
+        className=
+            ms-SearchBox-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              opacity: 1;
+              speak: none;
+            }
         data-icon-name="Search"
         role="presentation"
       >
@@ -52,7 +207,40 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search with no animation"
-      className="ms-SearchBox-field field-322"
+      className=
+          ms-SearchBox-field
+          {
+            background-color: #ffffff;
+            border: none;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            flex: 1 1 0px;
+            font-family: inherit;
+            font-size: inherit;
+            font-weight: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: none;
+            overflow: hidden;
+            padding-bottom: 0.5px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            text-overflow: ellipsis;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          &::placeholder {
+            color: #666666;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #666666;
+          }
       disabled={undefined}
       id="SearchBox1"
       onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -5,16 +5,78 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
   className="ms-SearchBoxSmallExample"
 >
   <div
-    className="ms-SearchBox root-318"
+    className=
+        ms-SearchBox
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: stretch;
+          border: 1px solid #a6a6a6;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 1px;
+          padding-left: 4px;
+          padding-right: 0;
+          padding-top: 1px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border: 1px solid WindowText;
+        }
+        &:hover {
+          border-color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+        }
+        &:hover $iconContainer {
+          color: #005a9e;
+        }
     onFocusCapture={[Function]}
   >
     <div
-      className="ms-SearchBox-iconContainer iconContainer-319"
+      className=
+          ms-SearchBox-iconContainer
+          {
+            color: #0078d4;
+            cursor: text;
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+            font-size: 16px;
+            justify-content: center;
+            text-align: center;
+            transition: width 0.167s;
+            width: 32px;
+          }
       onClick={[Function]}
     >
       <i
         aria-hidden={true}
-        className="ms-SearchBox-icon icon-323"
+        className=
+            ms-SearchBox-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              opacity: 1;
+              speak: none;
+              transition: opacity 0.167s 0s;
+            }
         data-icon-name="Search"
         role="presentation"
       >
@@ -23,7 +85,40 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
     </div>
     <input
       aria-label="Search"
-      className="ms-SearchBox-field field-322"
+      className=
+          ms-SearchBox-field
+          {
+            background-color: #ffffff;
+            border: none;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            flex: 1 1 0px;
+            font-family: inherit;
+            font-size: inherit;
+            font-weight: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: none;
+            overflow: hidden;
+            padding-bottom: 0.5px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            text-overflow: ellipsis;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          &::placeholder {
+            color: #666666;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #666666;
+          }
       disabled={undefined}
       id="SearchBox0"
       onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -2,16 +2,80 @@
 
 exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1`] = `
 <div
-  className="ms-SearchBox is-underlined root-524"
+  className=
+      ms-SearchBox
+      is-underlined
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: stretch;
+        border-width: 0 0 1px 0;
+        border: 1px solid #a6a6a6;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #333333;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 32px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 1px;
+        padding-left: 8px;
+        padding-right: 0;
+        padding-top: 1px;
+      }
+      @media screen and (-ms-high-contrast: active){& {
+        border: 1px solid WindowText;
+      }
+      &:hover {
+        border-color: #212121;
+      }
+      @media screen and (-ms-high-contrast: active){&:hover {
+        border-color: Highlight;
+      }
+      &:hover $iconContainer {
+        color: #005a9e;
+      }
   onFocusCapture={[Function]}
 >
   <div
-    className="ms-SearchBox-iconContainer iconContainer-319"
+    className=
+        ms-SearchBox-iconContainer
+        {
+          color: #0078d4;
+          cursor: text;
+          display: flex;
+          flex-direction: column;
+          flex-shrink: 0;
+          font-size: 16px;
+          justify-content: center;
+          text-align: center;
+          transition: width 0.167s;
+          width: 32px;
+        }
     onClick={[Function]}
   >
     <i
       aria-hidden={true}
-      className="ms-SearchBox-icon icon-323"
+      className=
+          ms-SearchBox-icon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: inline-block;
+            font-family: "FabricMDL2Icons";
+            font-style: normal;
+            font-weight: normal;
+            opacity: 1;
+            speak: none;
+            transition: opacity 0.167s 0s;
+          }
       data-icon-name="Search"
       role="presentation"
     >
@@ -20,7 +84,40 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
   </div>
   <input
     aria-label="Search"
-    className="ms-SearchBox-field field-322"
+    className=
+        ms-SearchBox-field
+        {
+          background-color: #ffffff;
+          border: none;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          flex: 1 1 0px;
+          font-family: inherit;
+          font-size: inherit;
+          font-weight: inherit;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          outline: none;
+          overflow: hidden;
+          padding-bottom: 0.5px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          text-overflow: ellipsis;
+        }
+        &::-ms-clear {
+          display: none;
+        }
+        &::placeholder {
+          color: #666666;
+          opacity: 1;
+        }
+        &:-ms-input-placeholder {
+          color: #666666;
+        }
     disabled={undefined}
     id="SearchBox0"
     onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -6,23 +6,101 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
     className={undefined}
   >
     <div
-      className="ms-Toggle is-enabled root-285"
+      className=
+          ms-Toggle
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 8px;
+          }
     >
       <label
-        className="ms-Label ms-Toggle-label label-230"
+        className=
+            ms-Label
+            ms-Toggle-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Toggle1"
       >
         Enable Modal Selection
       </label>
       <div
-        className="ms-Toggle-innerContainer container-286"
+        className=
+            ms-Toggle-innerContainer
+            {
+              display: inline-flex;
+              position: relative;
+            }
       >
         <button
           aria-disabled={undefined}
           aria-label="Enable Modal Selection"
           aria-pressed={false}
           checked={false}
-          className="ms-Toggle-background pill-287"
+          className=
+              ms-Toggle-background
+              {
+                align-items: center;
+                background: #ffffff;
+                border-color: #666666;
+                border-radius: 1em;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: flex;
+                font-size: 20px;
+                height: 1em;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: .2em;
+                padding-right: .2em;
+                padding-top: 0;
+                position: relative;
+                transition: all 0.1s ease;
+                width: 2.2em;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: -2px;
+                content: "";
+                left: -2px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: -2px;
+                top: -2px;
+                z-index: 1;
+              }
+              &:hover {
+                border-color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Toggle1"
@@ -31,11 +109,52 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
           type="button"
         >
           <div
-            className="ms-Toggle-thumb thumb-288"
+            className=
+                ms-Toggle-thumb
+                {
+                  background-color: #212121;
+                  border-color: transparent;
+                  border-radius: .5em;
+                  border-style: solid;
+                  border-width: .28em;
+                  box-sizing: border-box;
+                  height: .5em;
+                  transition: all 0.1s ease;
+                  width: .5em;
+                }
           />
         </button>
         <label
-          className="ms-Label ms-Toggle-stateText text-290"
+          className=
+              ms-Label
+              ms-Toggle-stateText
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+              && {
+                margin-bottom: 0;
+                margin-left: 10px;
+                margin-right: 10px;
+                margin-top: 0;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                user-select: none;
+              }
           htmlFor="Toggle1"
         >
           Normal
@@ -43,23 +162,101 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
       </div>
     </div>
     <div
-      className="ms-Toggle is-enabled root-285"
+      className=
+          ms-Toggle
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 8px;
+          }
     >
       <label
-        className="ms-Label ms-Toggle-label label-230"
+        className=
+            ms-Label
+            ms-Toggle-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Toggle2"
       >
         Enable Compact Mode
       </label>
       <div
-        className="ms-Toggle-innerContainer container-286"
+        className=
+            ms-Toggle-innerContainer
+            {
+              display: inline-flex;
+              position: relative;
+            }
       >
         <button
           aria-disabled={undefined}
           aria-label="Enable Compact Mode"
           aria-pressed={false}
           checked={false}
-          className="ms-Toggle-background pill-287"
+          className=
+              ms-Toggle-background
+              {
+                align-items: center;
+                background: #ffffff;
+                border-color: #666666;
+                border-radius: 1em;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: flex;
+                font-size: 20px;
+                height: 1em;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: .2em;
+                padding-right: .2em;
+                padding-top: 0;
+                position: relative;
+                transition: all 0.1s ease;
+                width: 2.2em;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: -2px;
+                content: "";
+                left: -2px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: -2px;
+                top: -2px;
+                z-index: 1;
+              }
+              &:hover {
+                border-color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Toggle2"
@@ -68,11 +265,52 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
           type="button"
         >
           <div
-            className="ms-Toggle-thumb thumb-288"
+            className=
+                ms-Toggle-thumb
+                {
+                  background-color: #212121;
+                  border-color: transparent;
+                  border-radius: .5em;
+                  border-style: solid;
+                  border-width: .28em;
+                  box-sizing: border-box;
+                  height: .5em;
+                  transition: all 0.1s ease;
+                  width: .5em;
+                }
           />
         </button>
         <label
-          className="ms-Label ms-Toggle-stateText text-290"
+          className=
+              ms-Label
+              ms-Toggle-stateText
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+              && {
+                margin-bottom: 0;
+                margin-left: 10px;
+                margin-right: 10px;
+                margin-top: 0;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                user-select: none;
+              }
           htmlFor="Toggle2"
         >
           Normal
@@ -80,23 +318,101 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
       </div>
     </div>
     <div
-      className="ms-Toggle is-enabled root-285"
+      className=
+          ms-Toggle
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 8px;
+          }
     >
       <label
-        className="ms-Label ms-Toggle-label label-230"
+        className=
+            ms-Label
+            ms-Toggle-label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Toggle3"
       >
         Enable content loading
       </label>
       <div
-        className="ms-Toggle-innerContainer container-286"
+        className=
+            ms-Toggle-innerContainer
+            {
+              display: inline-flex;
+              position: relative;
+            }
       >
         <button
           aria-disabled={undefined}
           aria-label="Enable content loading"
           aria-pressed={false}
           checked={false}
-          className="ms-Toggle-background pill-287"
+          className=
+              ms-Toggle-background
+              {
+                align-items: center;
+                background: #ffffff;
+                border-color: #666666;
+                border-radius: 1em;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: flex;
+                font-size: 20px;
+                height: 1em;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: .2em;
+                padding-right: .2em;
+                padding-top: 0;
+                position: relative;
+                transition: all 0.1s ease;
+                width: 2.2em;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: -2px;
+                content: "";
+                left: -2px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: -2px;
+                top: -2px;
+                z-index: 1;
+              }
+              &:hover {
+                border-color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
           data-is-focusable={true}
           disabled={undefined}
           id="Toggle3"
@@ -105,11 +421,52 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
           type="button"
         >
           <div
-            className="ms-Toggle-thumb thumb-288"
+            className=
+                ms-Toggle-thumb
+                {
+                  background-color: #212121;
+                  border-color: transparent;
+                  border-radius: .5em;
+                  border-style: solid;
+                  border-width: .28em;
+                  box-sizing: border-box;
+                  height: .5em;
+                  transition: all 0.1s ease;
+                  width: .5em;
+                }
           />
         </button>
         <label
-          className="ms-Label ms-Toggle-stateText text-290"
+          className=
+              ms-Label
+              ms-Toggle-stateText
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+              && {
+                margin-bottom: 0;
+                margin-left: 10px;
+                margin-right: 10px;
+                margin-top: 0;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                user-select: none;
+              }
           htmlFor="Toggle3"
         >
           Shimmer

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -6,10 +6,42 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
 >
   Basic Shimmer with no elements provided. It defaults to a line of 16px height.
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "100%",
@@ -17,7 +49,13 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -25,7 +63,23 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -34,7 +88,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -43,7 +104,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -52,7 +120,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -61,7 +136,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -74,11 +156,43 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="75%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "75%",
@@ -86,7 +200,13 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -94,7 +214,23 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -103,7 +239,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -112,7 +255,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -121,7 +271,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -130,7 +287,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -143,11 +307,43 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="50%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "50%",
@@ -155,7 +351,13 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -163,7 +365,23 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -172,7 +390,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -181,7 +406,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -190,7 +422,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -199,7 +438,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -213,10 +459,42 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
   </div>
   Basic Shimmer with elements provided.
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "100%",
@@ -224,7 +502,13 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -232,10 +516,33 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         }
       >
         <div
-          className="ms-ShimmerCircle-root root-536"
+          className=
+              ms-ShimmerCircle-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 0px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 0px;
+                box-sizing: content-box;
+                height: 24px;
+                min-width: 24px;
+                width: 24px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
         >
           <svg
-            className="ms-ShimmerCircle-svg svg-537"
+            className=
+                ms-ShimmerCircle-svg
+                {
+                  display: block;
+                  fill: #ffffff;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  fill: Window;
+                }
             height={24}
             viewBox="0 0 10 10"
             width={24}
@@ -246,7 +553,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -255,7 +577,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -264,7 +603,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -273,7 +619,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -282,7 +635,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -291,7 +651,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -304,10 +671,42 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "100%",
@@ -315,7 +714,13 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -323,10 +728,33 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         }
       >
         <div
-          className="ms-ShimmerCircle-root root-536"
+          className=
+              ms-ShimmerCircle-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 0px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 0px;
+                box-sizing: content-box;
+                height: 24px;
+                min-width: 24px;
+                width: 24px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
         >
           <svg
-            className="ms-ShimmerCircle-svg svg-537"
+            className=
+                ms-ShimmerCircle-svg
+                {
+                  display: block;
+                  fill: #ffffff;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  fill: Window;
+                }
             height={24}
             viewBox="0 0 10 10"
             width={24}
@@ -337,7 +765,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -346,7 +789,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -355,7 +815,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -364,7 +831,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -373,7 +847,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -382,7 +863,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -392,7 +880,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -401,7 +904,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -410,7 +930,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -419,7 +946,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -428,7 +962,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -437,7 +978,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -447,7 +995,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -456,7 +1019,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -465,7 +1045,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -474,7 +1061,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -483,7 +1077,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -492,7 +1093,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -502,7 +1110,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -511,7 +1134,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -520,7 +1160,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -529,7 +1176,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -538,7 +1192,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -547,7 +1208,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -560,11 +1228,43 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="70%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "70%",
@@ -572,7 +1272,13 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -580,10 +1286,33 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         }
       >
         <div
-          className="ms-ShimmerCircle-root root-536"
+          className=
+              ms-ShimmerCircle-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 0px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 0px;
+                box-sizing: content-box;
+                height: 24px;
+                min-width: 24px;
+                width: 24px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
         >
           <svg
-            className="ms-ShimmerCircle-svg svg-537"
+            className=
+                ms-ShimmerCircle-svg
+                {
+                  display: block;
+                  fill: #ffffff;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  fill: Window;
+                }
             height={24}
             viewBox="0 0 10 10"
             width={24}
@@ -594,7 +1323,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -603,7 +1347,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -612,7 +1373,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -621,7 +1389,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -630,7 +1405,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -639,7 +1421,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -649,7 +1438,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -658,7 +1462,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -667,7 +1488,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -676,7 +1504,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -685,7 +1520,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -694,7 +1536,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -704,7 +1553,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -713,7 +1577,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -722,7 +1603,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -731,7 +1619,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -740,7 +1635,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -749,7 +1651,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -759,7 +1668,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -768,7 +1692,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -777,7 +1718,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -786,7 +1734,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -795,7 +1750,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -804,7 +1766,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -818,10 +1787,42 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
   </div>
   Variations of vertical alignment for Circles and Lines.
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "100%",
@@ -829,7 +1830,13 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -837,10 +1844,33 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         }
       >
         <div
-          className="ms-ShimmerCircle-root root-536"
+          className=
+              ms-ShimmerCircle-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 0px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 0px;
+                box-sizing: content-box;
+                height: 24px;
+                min-width: 24px;
+                width: 24px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
         >
           <svg
-            className="ms-ShimmerCircle-svg svg-537"
+            className=
+                ms-ShimmerCircle-svg
+                {
+                  display: block;
+                  fill: #ffffff;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  fill: Window;
+                }
             height={24}
             viewBox="0 0 10 10"
             width={24}
@@ -851,7 +1881,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -860,10 +1905,33 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerCircle-root root-540"
+          className=
+              ms-ShimmerCircle-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 9px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 0px;
+                box-sizing: content-box;
+                height: 15px;
+                min-width: 15px;
+                width: 15px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
         >
           <svg
-            className="ms-ShimmerCircle-svg svg-537"
+            className=
+                ms-ShimmerCircle-svg
+                {
+                  display: block;
+                  fill: #ffffff;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  fill: Window;
+                }
             height={15}
             viewBox="0 0 10 10"
             width={15}
@@ -874,7 +1942,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -883,7 +1966,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-541"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 0px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 8px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -892,7 +1992,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -901,7 +2008,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -910,7 +2024,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -919,7 +2040,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -929,7 +2057,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -938,7 +2081,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-542"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 19px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 0px;
+                box-sizing: content-box;
+                height: 5px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -947,7 +2107,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -956,7 +2123,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -965,7 +2139,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -974,7 +2155,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -984,7 +2172,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -993,7 +2196,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-539"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -1002,7 +2222,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -1011,7 +2238,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -1020,7 +2254,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -1029,7 +2270,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -1039,7 +2287,22 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           </svg>
         </div>
         <div
-          className="ms-ShimmerGap-root root-538"
+          className=
+              ms-ShimmerGap-root
+              {
+                background-color: #ffffff;
+                border-bottom-style: solid;
+                border-bottom-width: 4px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 4px;
+                box-sizing: content-box;
+                height: 16px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -1048,7 +2311,24 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         />
         <div
-          className="ms-ShimmerLine-root root-543"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-bottom-width: 0px;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-top-width: 14px;
+                box-sizing: content-box;
+                height: 10px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -1057,7 +2337,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -1066,7 +2353,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -1075,7 +2369,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -1084,7 +2385,14 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -6,11 +6,43 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
 >
   Using ShimmerElementsGroup component to build complex structures of the placeholder you need.
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width={350}
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": 350,
@@ -25,7 +57,13 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
         }
       >
         <div
-          className="ms-ShimmerElementsGroup-root root-530"
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+              }
           style={
             Object {
               "width": "auto",
@@ -33,7 +71,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
           }
         >
           <div
-            className="ms-ShimmerLine-root root-544"
+            className=
+                ms-ShimmerLine-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 40px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
             style={
               Object {
                 "minWidth": "40px",
@@ -42,7 +97,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <svg
-              className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -51,7 +113,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -60,7 +129,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
               height="2"
               width="2"
             >
@@ -69,7 +145,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
               height="2"
               width="2"
             >
@@ -79,7 +162,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             </svg>
           </div>
           <div
-            className="ms-ShimmerGap-root root-545"
+            className=
+                ms-ShimmerGap-root
+                {
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 40px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
             style={
               Object {
                 "minWidth": "10px",
@@ -89,7 +187,13 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
           />
         </div>
         <div
-          className="ms-ShimmerElementsGroup-root root-546"
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: wrap;
+              }
           style={
             Object {
               "width": "auto",
@@ -97,7 +201,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
           }
         >
           <div
-            className="ms-ShimmerLine-root root-547"
+            className=
+                ms-ShimmerLine-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 5px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 5px;
+                  box-sizing: content-box;
+                  height: 10px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
             style={
               Object {
                 "minWidth": "300px",
@@ -106,7 +227,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <svg
-              className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -115,7 +243,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -124,7 +259,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
               height="2"
               width="2"
             >
@@ -133,7 +275,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
               height="2"
               width="2"
             >
@@ -143,7 +292,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             </svg>
           </div>
           <div
-            className="ms-ShimmerLine-root root-547"
+            className=
+                ms-ShimmerLine-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 5px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 5px;
+                  box-sizing: content-box;
+                  height: 10px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
             style={
               Object {
                 "minWidth": "200px",
@@ -152,7 +318,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <svg
-              className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -161,7 +334,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -170,7 +350,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
               height="2"
               width="2"
             >
@@ -179,7 +366,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
               height="2"
               width="2"
             >
@@ -189,7 +383,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             </svg>
           </div>
           <div
-            className="ms-ShimmerGap-root root-548"
+            className=
+                ms-ShimmerGap-root
+                {
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
             style={
               Object {
                 "minWidth": "100px",
@@ -202,11 +411,43 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width={550}
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": 550,
@@ -221,7 +462,13 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
         }
       >
         <div
-          className="ms-ShimmerElementsGroup-root root-530"
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+              }
           style={
             Object {
               "width": "auto",
@@ -229,10 +476,33 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
           }
         >
           <div
-            className="ms-ShimmerCircle-root root-549"
+            className=
+                ms-ShimmerCircle-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 40px;
+                  min-width: 40px;
+                  width: 40px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
           >
             <svg
-              className="ms-ShimmerCircle-svg svg-537"
+              className=
+                  ms-ShimmerCircle-svg
+                  {
+                    display: block;
+                    fill: #ffffff;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    fill: Window;
+                  }
               height={40}
               viewBox="0 0 10 10"
               width={40}
@@ -243,7 +513,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             </svg>
           </div>
           <div
-            className="ms-ShimmerGap-root root-545"
+            className=
+                ms-ShimmerGap-root
+                {
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 40px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
             style={
               Object {
                 "minWidth": "10px",
@@ -253,7 +538,13 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
           />
         </div>
         <div
-          className="ms-ShimmerElementsGroup-root root-546"
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: wrap;
+              }
           style={
             Object {
               "width": "auto",
@@ -261,7 +552,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
           }
         >
           <div
-            className="ms-ShimmerLine-root root-547"
+            className=
+                ms-ShimmerLine-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 5px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 5px;
+                  box-sizing: content-box;
+                  height: 10px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
             style={
               Object {
                 "minWidth": "400px",
@@ -270,7 +578,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <svg
-              className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -279,7 +594,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -288,7 +610,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
               height="2"
               width="2"
             >
@@ -297,7 +626,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
               height="2"
               width="2"
             >
@@ -307,7 +643,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             </svg>
           </div>
           <div
-            className="ms-ShimmerGap-root root-548"
+            className=
+                ms-ShimmerGap-root
+                {
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
             style={
               Object {
                 "minWidth": "100px",
@@ -316,7 +667,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           />
           <div
-            className="ms-ShimmerLine-root root-547"
+            className=
+                ms-ShimmerLine-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 5px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 5px;
+                  box-sizing: content-box;
+                  height: 10px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
             style={
               Object {
                 "minWidth": "500px",
@@ -325,7 +693,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <svg
-              className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -334,7 +709,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -343,7 +725,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
               height="2"
               width="2"
             >
@@ -352,7 +741,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
               height="2"
               width="2"
             >
@@ -366,11 +762,43 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="90%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "90%",
@@ -385,7 +813,13 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
         }
       >
         <div
-          className="ms-ShimmerElementsGroup-root root-530"
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+              }
           style={
             Object {
               "width": "90px",
@@ -393,7 +827,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
           }
         >
           <div
-            className="ms-ShimmerLine-root root-550"
+            className=
+                ms-ShimmerLine-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 80px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
             style={
               Object {
                 "minWidth": "80px",
@@ -402,7 +853,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <svg
-              className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -411,7 +869,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -420,7 +885,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
               height="2"
               width="2"
             >
@@ -429,7 +901,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
               height="2"
               width="2"
             >
@@ -439,7 +918,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             </svg>
           </div>
           <div
-            className="ms-ShimmerGap-root root-551"
+            className=
+                ms-ShimmerGap-root
+                {
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 80px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
             style={
               Object {
                 "minWidth": "10px",
@@ -458,7 +952,13 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
           }
         >
           <div
-            className="ms-ShimmerElementsGroup-root root-530"
+            className=
+                ms-ShimmerElementsGroup-root
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                }
             style={
               Object {
                 "width": "auto",
@@ -466,10 +966,33 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <div
-              className="ms-ShimmerCircle-root root-549"
+              className=
+                  ms-ShimmerCircle-root
+                  {
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    height: 40px;
+                    min-width: 40px;
+                    width: 40px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
             >
               <svg
-                className="ms-ShimmerCircle-svg svg-537"
+                className=
+                    ms-ShimmerCircle-svg
+                    {
+                      display: block;
+                      fill: #ffffff;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      fill: Window;
+                    }
                 height={40}
                 viewBox="0 0 10 10"
                 width={40}
@@ -480,7 +1003,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               </svg>
             </div>
             <div
-              className="ms-ShimmerGap-root root-545"
+              className=
+                  ms-ShimmerGap-root
+                  {
+                    background-color: #ffffff;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    height: 40px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: Window;
+                    border-color: Window;
+                  }
               style={
                 Object {
                   "minWidth": "10px",
@@ -490,7 +1028,13 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             />
           </div>
           <div
-            className="ms-ShimmerElementsGroup-root root-546"
+            className=
+                ms-ShimmerElementsGroup-root
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: wrap;
+                }
             style={
               Object {
                 "width": "calc(100% - 50px)",
@@ -498,7 +1042,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <div
-              className="ms-ShimmerLine-root root-547"
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    border-bottom-style: solid;
+                    border-bottom-width: 5px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 5px;
+                    box-sizing: content-box;
+                    height: 10px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
               style={
                 Object {
                   "minWidth": "auto",
@@ -507,7 +1068,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               }
             >
               <svg
-                className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -516,7 +1084,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -525,7 +1100,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -534,7 +1116,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                    }
                 height="2"
                 width="2"
               >
@@ -544,7 +1133,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               </svg>
             </div>
             <div
-              className="ms-ShimmerGap-root root-548"
+              className=
+                  ms-ShimmerGap-root
+                  {
+                    background-color: #ffffff;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    height: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: Window;
+                    border-color: Window;
+                  }
               style={
                 Object {
                   "minWidth": "auto",
@@ -553,7 +1157,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               }
             />
             <div
-              className="ms-ShimmerLine-root root-547"
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    border-bottom-style: solid;
+                    border-bottom-width: 5px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 5px;
+                    box-sizing: content-box;
+                    height: 10px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
               style={
                 Object {
                   "minWidth": "auto",
@@ -562,7 +1183,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               }
             >
               <svg
-                className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -571,7 +1199,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -580,7 +1215,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -589,7 +1231,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                    }
                 height="2"
                 width="2"
               >
@@ -600,7 +1249,13 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             </div>
           </div>
           <div
-            className="ms-ShimmerElementsGroup-root root-546"
+            className=
+                ms-ShimmerElementsGroup-root
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: wrap;
+                }
             style={
               Object {
                 "width": "100%",
@@ -608,7 +1263,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             }
           >
             <div
-              className="ms-ShimmerLine-root root-552"
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 10px;
+                    box-sizing: content-box;
+                    height: 10px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
               style={
                 Object {
                   "minWidth": "auto",
@@ -617,7 +1289,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               }
             >
               <svg
-                className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -626,7 +1305,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -635,7 +1321,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -644,7 +1337,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                    }
                 height="2"
                 width="2"
               >
@@ -654,7 +1354,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               </svg>
             </div>
             <div
-              className="ms-ShimmerGap-root root-548"
+              className=
+                  ms-ShimmerGap-root
+                  {
+                    background-color: #ffffff;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    height: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: Window;
+                    border-color: Window;
+                  }
               style={
                 Object {
                   "minWidth": "auto",
@@ -663,7 +1378,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               }
             />
             <div
-              className="ms-ShimmerLine-root root-552"
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 10px;
+                    box-sizing: content-box;
+                    height: 10px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
               style={
                 Object {
                   "minWidth": "auto",
@@ -672,7 +1404,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               }
             >
               <svg
-                className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -681,7 +1420,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -690,7 +1436,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -699,7 +1452,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                    }
                 height="2"
                 width="2"
               >
@@ -709,7 +1469,22 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               </svg>
             </div>
             <div
-              className="ms-ShimmerGap-root root-548"
+              className=
+                  ms-ShimmerGap-root
+                  {
+                    background-color: #ffffff;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    height: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: Window;
+                    border-color: Window;
+                  }
               style={
                 Object {
                   "minWidth": "auto",
@@ -718,7 +1493,24 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               }
             />
             <div
-              className="ms-ShimmerLine-root root-552"
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #ffffff;
+                    border-top-style: solid;
+                    border-top-width: 10px;
+                    box-sizing: content-box;
+                    height: 10px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
               style={
                 Object {
                   "minWidth": "auto",
@@ -727,7 +1519,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               }
             >
               <svg
-                className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -736,7 +1535,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -745,7 +1551,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      position: absolute;
+                      right: 0;
+                    }
                 height="2"
                 width="2"
               >
@@ -754,7 +1567,14 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 />
               </svg>
               <svg
-                className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #ffffff;
+                      left: 0;
+                      position: absolute;
+                    }
                 height="2"
                 width="2"
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -5,17 +5,77 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
   className={undefined}
 >
   <div
-    className="ms-Toggle is-enabled root-285"
+    className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Toggle-background pill-287"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-color: #666666;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle0"
@@ -24,11 +84,52 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-288"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #212121;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-290"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
         htmlFor="Toggle0"
       >
         Toggle to load content
@@ -36,10 +137,42 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "100%",
@@ -47,7 +180,13 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -55,7 +194,23 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -64,7 +219,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -73,7 +235,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -82,7 +251,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -91,7 +267,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -103,7 +286,20 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Shimmer-dataWrapper dataWrapper-529"
+      className=
+          ms-Shimmer-dataWrapper
+          {
+            background-color: transparent;
+            background: none;
+            border: none;
+            bottom: 0;
+            left: 0;
+            opacity: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+            transition: opacity 200ms;
+          }
     >
       <div
         style={
@@ -127,17 +323,77 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     />
   </div>
   <div
-    className="ms-Toggle is-enabled root-285"
+    className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label={undefined}
         aria-pressed={false}
         checked={false}
-        className="ms-Toggle-background pill-287"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-color: #666666;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle1"
@@ -146,11 +402,52 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-288"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #212121;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-290"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
         htmlFor="Toggle1"
       >
         Toggle to load content
@@ -158,11 +455,43 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width={300}
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-528"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": 300,
@@ -177,7 +506,13 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
         }
       >
         <div
-          className="ms-ShimmerElementsGroup-root root-530"
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+              }
           style={
             Object {
               "width": "auto",
@@ -185,10 +520,33 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
           }
         >
           <div
-            className="ms-ShimmerCircle-root root-549"
+            className=
+                ms-ShimmerCircle-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 40px;
+                  min-width: 40px;
+                  width: 40px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
           >
             <svg
-              className="ms-ShimmerCircle-svg svg-537"
+              className=
+                  ms-ShimmerCircle-svg
+                  {
+                    display: block;
+                    fill: #ffffff;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    fill: Window;
+                  }
               height={40}
               viewBox="0 0 10 10"
               width={40}
@@ -199,7 +557,22 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             </svg>
           </div>
           <div
-            className="ms-ShimmerGap-root root-545"
+            className=
+                ms-ShimmerGap-root
+                {
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 40px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
             style={
               Object {
                 "minWidth": "16px",
@@ -209,7 +582,13 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
           />
         </div>
         <div
-          className="ms-ShimmerElementsGroup-root root-546"
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: wrap;
+              }
           style={
             Object {
               "width": "100%",
@@ -217,7 +596,24 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
           }
         >
           <div
-            className="ms-ShimmerLine-root root-552"
+            className=
+                ms-ShimmerLine-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 10px;
+                  box-sizing: content-box;
+                  height: 10px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
             style={
               Object {
                 "minWidth": "auto",
@@ -226,7 +622,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             }
           >
             <svg
-              className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -235,7 +638,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -244,7 +654,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
               height="2"
               width="2"
             >
@@ -253,7 +670,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
               height="2"
               width="2"
             >
@@ -263,7 +687,24 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             </svg>
           </div>
           <div
-            className="ms-ShimmerLine-root root-553"
+            className=
+                ms-ShimmerLine-root
+                {
+                  border-bottom-style: solid;
+                  border-bottom-width: 6px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 6px;
+                  box-sizing: content-box;
+                  height: 8px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
             style={
               Object {
                 "minWidth": "auto",
@@ -272,7 +713,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             }
           >
             <svg
-              className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -281,7 +729,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
               height="2"
               width="2"
             >
@@ -290,7 +745,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
               height="2"
               width="2"
             >
@@ -299,7 +761,14 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               />
             </svg>
             <svg
-              className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
               height="2"
               width="2"
             >
@@ -309,7 +778,22 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             </svg>
           </div>
           <div
-            className="ms-ShimmerGap-root root-548"
+            className=
+                ms-ShimmerGap-root
+                {
+                  background-color: #ffffff;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  height: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
             style={
               Object {
                 "minWidth": "auto",
@@ -321,29 +805,118 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       </div>
     </div>
     <div
-      className="ms-Shimmer-dataWrapper dataWrapper-529"
+      className=
+          ms-Shimmer-dataWrapper
+          {
+            background-color: transparent;
+            background: none;
+            border: none;
+            bottom: 0;
+            left: 0;
+            opacity: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+            transition: opacity 200ms;
+          }
     >
       <div
-        className="ms-Persona ms-Persona--size40 ms-Persona--away root-430"
+        className=
+            ms-Persona
+            ms-Persona--size40
+            ms-Persona--away
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 40px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 40px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            & .contextualHost {
+              display: none;
+            }
+            &:hover $primaryText {
+              color: #212121;
+            }
         size={12}
         style={undefined}
       >
         <div
-          className="ms-Persona-coin ms-Persona--size40 coin-72"
+          className=
+              ms-Persona-coin
+              ms-Persona--size40
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
           size={12}
         >
           <div
-            className="ms-Persona-imageArea imageArea-432"
+            className=
+                ms-Persona-imageArea
+                {
+                  flex: 0 0 auto;
+                  height: 40px;
+                  position: relative;
+                  text-align: center;
+                  width: 40px;
+                }
             style={undefined}
           >
             <div
               aria-hidden="true"
-              className="ms-Persona-initials initials-554"
+              className=
+                  ms-Persona-initials
+                  {
+                    background-color: #2D89EF;
+                    border-radius: 50%;
+                    color: #ffffff;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    line-height: 40px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background-color: Window !important;
+                    border: 1px solid WindowText;
+                    box-sizing: border-box;
+                    color: WindowText;
+                  }
               style={undefined}
             >
               <i
                 aria-hidden={true}
-                className="root-366"
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-0";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
                 data-icon-name="Contact"
                 role="presentation"
               >
@@ -351,7 +924,21 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               </i>
             </div>
             <div
-              className="ms-Image ms-Persona-image image-435"
+              className=
+                  ms-Image
+                  ms-Persona-image
+                  {
+                    border-radius: 50%;
+                    border: 0px;
+                    height: 40px;
+                    left: 0px;
+                    margin-right: 10px;
+                    overflow: hidden;
+                    perspective: 1px;
+                    position: absolute;
+                    top: 0px;
+                    width: 40px;
+                  }
               style={
                 Object {
                   "height": 40,
@@ -361,7 +948,22 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             >
               <img
                 alt=""
-                className="ms-Image-image ms-Image-image--cover ms-Image-image--portrait is-notLoaded is-fadeIn image-74"
+                className=
+                    ms-Image-image
+                    ms-Image-image--cover
+                    ms-Image-image--portrait
+                    is-notLoaded
+                    is-fadeIn
+                    {
+                      display: block;
+                      height: auto;
+                      left: 50% /* @noflip */;
+                      opacity: 0;
+                      position: absolute;
+                      top: 50%;
+                      transform: translate(-50%,-50%);
+                      width: 100%;
+                    }
                 onError={[Function]}
                 onLoad={[Function]}
                 role={undefined}
@@ -369,12 +971,51 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               />
             </div>
             <div
-              className="ms-Persona-presence presence-436"
+              className=
+                  ms-Persona-presence
+                  {
+                    -ms-high-contrast-adjust: none;
+                    background-clip: content-box;
+                    background-color: #FCD116;
+                    border-radius: 50%;
+                    border: 2px solid #ffffff;
+                    bottom: -2px;
+                    box-sizing: content-box;
+                    height: 12px;
+                    position: absolute;
+                    right: -2px;
+                    text-align: center;
+                    top: auto;
+                    width: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: WindowText;
+                    border-color: Window;
+                  }
               style={undefined}
             >
               <i
                 aria-hidden={true}
-                className="ms-Persona-presenceIcon presenceIcon-438"
+                className=
+                    ms-Persona-presenceIcon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #ffffff;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 6px;
+                      font-style: normal;
+                      font-weight: normal;
+                      left: 1px;
+                      line-height: 12px;
+                      position: relative;
+                      speak: none;
+                      vertical-align: top;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: Window;
+                    }
                 data-icon-name="SkypeClock"
                 role="presentation"
                 style={undefined}
@@ -385,21 +1026,72 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
           </div>
         </div>
         <div
-          className="ms-Persona-details details-206"
+          className=
+              ms-Persona-details
+              {
+                display: flex;
+                flex-direction: column;
+                justify-content: space-around;
+                min-width: 0px;
+                padding-bottom: 0;
+                padding-left: 16px;
+                padding-right: 24px;
+                padding-top: 0;
+                text-align: left;
+                width: 100%;
+              }
         >
           <div
-            className="ms-Persona-primaryText primaryText-207"
+            className=
+                ms-Persona-primaryText
+                {
+                  color: #333333;
+                  font-size: 14px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
           >
             
           </div>
           <div
-            className="ms-Persona-secondaryText secondaryText-431"
+            className=
+                ms-Persona-secondaryText
+                {
+                  color: #666666;
+                  font-size: 12px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
           />
           <div
-            className="ms-Persona-tertiaryText tertiaryText-209"
+            className=
+                ms-Persona-tertiaryText
+                {
+                  color: #666666;
+                  display: none;
+                  font-size: 12px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
           />
           <div
-            className="ms-Persona-optionalText optionalText-210"
+            className=
+                ms-Persona-optionalText
+                {
+                  color: #666666;
+                  display: none;
+                  font-size: 12px;
+                  font-weight: 400;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                }
           />
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -5,11 +5,45 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
   className={undefined}
 >
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="75%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-555"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background-color: #deecf9;
+            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "75%",
@@ -17,7 +51,13 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -25,7 +65,23 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -34,7 +90,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -43,7 +106,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -52,7 +122,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -61,7 +138,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -74,11 +158,45 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="75%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-555"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background-color: #deecf9;
+            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "75%",
@@ -86,7 +204,13 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -94,7 +218,23 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -103,7 +243,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -112,7 +259,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -121,7 +275,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -130,7 +291,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -143,11 +311,45 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="75%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-555"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background-color: #deecf9;
+            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "75%",
@@ -155,7 +357,13 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -163,7 +371,23 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -172,7 +396,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -181,7 +412,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -190,7 +428,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -199,7 +444,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -212,11 +464,45 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="75%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-555"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background-color: #deecf9;
+            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "75%",
@@ -224,7 +510,13 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -232,7 +524,23 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -241,7 +549,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -250,7 +565,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -259,7 +581,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -268,7 +597,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >
@@ -281,11 +617,45 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    className="ms-Shimmer-container root-527"
+    className=
+        ms-Shimmer-container
+        {
+          height: auto;
+          position: relative;
+        }
     width="75%"
   >
     <div
-      className="ms-Shimmer-shimmerWrapper shimmerWrapper-555"
+      className=
+          ms-Shimmer-shimmerWrapper
+          {
+            animation-direction: normal;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+            animation-timing-function: ease-in-out;
+            background-color: #deecf9;
+            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+            background: #f4f4f4
+                              linear-gradient(
+                                to right,
+                                #f4f4f4 0%,
+                                #eaeaea 50%,
+                                #f4f4f4 100%)
+                              0 0 / 90% 100%
+                              no-repeat;
+            transition: opacity 200ms;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: WindowText
+                                  linear-gradient(
+                                    to right,
+                                    transparent 0%,
+                                    Window 50%,
+                                    transparent 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+          }
       style={
         Object {
           "width": "75%",
@@ -293,7 +663,13 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
       }
     >
       <div
-        className="ms-ShimmerElementsGroup-root root-530"
+        className=
+            ms-ShimmerElementsGroup-root
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+            }
         style={
           Object {
             "width": "auto",
@@ -301,7 +677,23 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
         }
       >
         <div
-          className="ms-ShimmerLine-root root-531"
+          className=
+              ms-ShimmerLine-root
+              {
+                border-bottom-style: solid;
+                border-color: #ffffff;
+                border-top-style: solid;
+                border-width: 0px;
+                box-sizing: content-box;
+                height: 16px;
+                position: relative;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: Window;
+              }
+              @media screen and (-ms-high-contrast: active){& > * {
+                fill: Window;
+              }
           style={
             Object {
               "minWidth": "auto",
@@ -310,7 +702,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
           }
         >
           <svg
-            className="ms-ShimmerLine-topLeftCorner topLeftCorner-532"
+            className=
+                ms-ShimmerLine-topLeftCorner
+                {
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -319,7 +718,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-topRightCorner topRightCorner-533"
+            className=
+                ms-ShimmerLine-topRightCorner
+                {
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                  top: 0;
+                }
             height="2"
             width="2"
           >
@@ -328,7 +734,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomRightCorner bottomRightCorner-534"
+            className=
+                ms-ShimmerLine-bottomRightCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  position: absolute;
+                  right: 0;
+                }
             height="2"
             width="2"
           >
@@ -337,7 +750,14 @@ exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = 
             />
           </svg>
           <svg
-            className="ms-ShimmerLine-bottomLeftCorner bottomLeftCorner-535"
+            className=
+                ms-ShimmerLine-bottomLeftCorner
+                {
+                  bottom: 0;
+                  fill: #ffffff;
+                  left: 0;
+                  position: absolute;
+                }
             height="2"
             width="2"
           >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
@@ -11,7 +11,24 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
       className="ms-Slider ms-Slider-enabled undefined ms-Slider-row undefined"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Slider0"
       >
         Basic example:
@@ -64,7 +81,25 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
           </div>
         </button>
         <label
-          className="ms-Label ms-Slider-value root-89"
+          className=
+              ms-Label
+              ms-Slider-value
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           2
         </label>
@@ -74,7 +109,24 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
       className="ms-Slider ms-Slider-disabled undefined ms-Slider-row undefined"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Slider1"
       >
         Disabled example:
@@ -124,7 +176,25 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
           </div>
         </button>
         <label
-          className="ms-Label ms-Slider-value root-89"
+          className=
+              ms-Label
+              ms-Slider-value
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           300
         </label>
@@ -134,7 +204,24 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
       className="ms-Slider ms-Slider-enabled undefined ms-Slider-row undefined"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="Slider2"
       >
         Controlled example:
@@ -187,7 +274,25 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
           </div>
         </button>
         <label
-          className="ms-Label ms-Slider-value root-89"
+          className=
+              ms-Label
+              ms-Slider-value
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
         >
           0
         </label>
@@ -204,7 +309,24 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
         className="ms-Slider ms-Slider-enabled undefined ms-Slider-column undefined"
       >
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="Slider3"
         >
           Basic example:
@@ -257,7 +379,25 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             </div>
           </button>
           <label
-            className="ms-Label ms-Slider-value root-89"
+            className=
+                ms-Label
+                ms-Slider-value
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
           >
             2
           </label>
@@ -271,7 +411,24 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
         className="ms-Slider ms-Slider-disabled undefined ms-Slider-column undefined"
       >
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="Slider4"
         >
           Disabled example:
@@ -321,7 +478,25 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             </div>
           </button>
           <label
-            className="ms-Label ms-Slider-value root-89"
+            className=
+                ms-Label
+                ms-Slider-value
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
           >
             300
           </label>
@@ -335,7 +510,24 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
         className="ms-Slider ms-Slider-enabled undefined ms-Slider-column undefined"
       >
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="Slider5"
         >
           Controlled example:
@@ -388,7 +580,25 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             </div>
           </button>
           <label
-            className="ms-Label ms-Slider-value root-89"
+            className=
+                ms-Label
+                ms-Slider-value
+                {
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  display: block;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow-wrap: break-word;
+                  padding-bottom: 5px;
+                  padding-left: 0;
+                  padding-right: 0;
+                  padding-top: 5px;
+                  word-wrap: break-word;
+                }
           >
             0
           </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -9,21 +9,67 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
   }
 >
   <div
-    className="css-345"
+    className=
+
+        {
+          font-size: 14px;
+          min-width: 86px;
+          outline: none;
+          width: 100%;
+        }
   >
     <div
-      className="css-346"
+      className=
+
+          {
+            display: inline-flex;
+            float: left;
+            margin-right: 10px;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-556"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-0";
+              font-size: 20px;
+              font-style: normal;
+              font-weight: normal;
+              padding-bottom: 2px;
+              padding-left: 5px;
+              padding-right: 5px;
+              padding-top: 2px;
+              speak: none;
+            }
         data-icon-name="IncreaseIndentLegacy"
         role="presentation"
       >
         
       </i>
       <label
-        className="ms-Label root-352"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 2px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 2px;
+              pointer-events: none;
+              word-wrap: break-word;
+            }
         htmlFor="input1"
         id="Label0"
       >
@@ -34,7 +80,25 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
       aria-label={undefined}
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="css-349"
+      className=
+
+          {
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            display: flex;
+            height: 32px;
+            min-width: 86px;
+          }
+          &:hover {
+            border-color: #212121;
+            outline: 2px dashed transparent;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            outline: none;
+          }
       data-ktp-target={undefined}
       title={undefined}
     >
@@ -47,7 +111,42 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
         aria-valuenow={0}
         aria-valuetext={undefined}
         autoComplete="off"
-        className="ms-spinButton-input css-350"
+        className=
+            ms-spinButton-input
+            {
+              border-style: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: text;
+              display: block;
+              float: left;
+              font-size: 14px;
+              height: 100%;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              min-width: 72px;
+              outline: 0;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 12px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              user-select: text;
+              width: calc(100% - 14px);
+            }
+            &::selection {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            @media screen and (-ms-high-contrast: active){&::selection {
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+            }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
         disabled={false}
@@ -64,7 +163,21 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
         value="0"
       />
       <span
-        className="css-351"
+        className=
+
+            {
+              box-sizing: border-box;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 12px;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <button
           aria-describedby={undefined}
@@ -72,7 +185,74 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-UpButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-UpButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -82,11 +262,39 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronUpSmall"
               role="presentation"
             >
@@ -100,7 +308,74 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-DownButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-DownButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -110,11 +385,39 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronDownSmall"
               role="presentation"
             >
@@ -126,13 +429,44 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
     </div>
   </div>
   <div
-    className="css-345"
+    className=
+
+        {
+          font-size: 14px;
+          min-width: 86px;
+          outline: none;
+          width: 100%;
+        }
   >
     <div
-      className="css-346"
+      className=
+
+          {
+            display: inline-flex;
+            float: left;
+            margin-right: 10px;
+          }
     >
       <label
-        className="ms-Label root-352"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 2px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 2px;
+              pointer-events: none;
+              word-wrap: break-word;
+            }
         htmlFor="input9"
         id="Label8"
       >
@@ -143,7 +477,25 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
       aria-label={undefined}
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="css-349"
+      className=
+
+          {
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            display: flex;
+            height: 32px;
+            min-width: 86px;
+          }
+          &:hover {
+            border-color: #212121;
+            outline: 2px dashed transparent;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            outline: none;
+          }
       data-ktp-target={undefined}
       title={undefined}
     >
@@ -156,7 +508,42 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
         aria-valuenow={0}
         aria-valuetext={undefined}
         autoComplete="off"
-        className="ms-spinButton-input css-350"
+        className=
+            ms-spinButton-input
+            {
+              border-style: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: text;
+              display: block;
+              float: left;
+              font-size: 14px;
+              height: 100%;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              min-width: 72px;
+              outline: 0;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 12px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              user-select: text;
+              width: calc(100% - 14px);
+            }
+            &::selection {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            @media screen and (-ms-high-contrast: active){&::selection {
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+            }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
         disabled={false}
@@ -173,7 +560,21 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
         value="0"
       />
       <span
-        className="css-351"
+        className=
+
+            {
+              box-sizing: border-box;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 12px;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <button
           aria-describedby={undefined}
@@ -181,7 +582,74 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-UpButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-UpButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -191,11 +659,39 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronUpSmall"
               role="presentation"
             >
@@ -209,7 +705,74 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-DownButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-DownButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -219,11 +782,39 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronDownSmall"
               role="presentation"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -9,13 +9,48 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
   }
 >
   <div
-    className="css-345"
+    className=
+
+        {
+          font-size: 14px;
+          min-width: 86px;
+          outline: none;
+          width: 100%;
+        }
   >
     <div
-      className="css-346"
+      className=
+
+          {
+            display: inline-flex;
+            float: left;
+            margin-right: 10px;
+          }
     >
       <label
-        className="ms-Label root-562"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #a6a6a6;
+              cursor: default;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 2px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 2px;
+              pointer-events: none;
+              word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: GrayText;
+            }
         htmlFor="input1"
         id="Label0"
       >
@@ -26,7 +61,24 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
       aria-label={undefined}
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="css-559"
+      className=
+
+          {
+            background-color: #f4f4f4;
+            border-color: transparent;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            color: #a6a6a6;
+            cursor: default;
+            display: flex;
+            height: 32px;
+            min-width: 86px;
+            pointer-events: none;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: GrayText;
+          }
       data-ktp-target={undefined}
       title={undefined}
     >
@@ -39,7 +91,39 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
         aria-valuenow={25}
         aria-valuetext={undefined}
         autoComplete="off"
-        className="ms-spinButton-input css-560"
+        className=
+            ms-spinButton-input
+            {
+              background-color: #f4f4f4;
+              border-color: transparent;
+              border-style: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #a6a6a6;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 14px;
+              height: 100%;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              min-width: 72px;
+              outline: 0;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 12px;
+              padding-top: 0;
+              pointer-events: none;
+              text-overflow: ellipsis;
+              user-select: text;
+              width: calc(100% - 14px);
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: GrayText;
+            }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
         disabled={true}
@@ -56,7 +140,28 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
         value="25"
       />
       <span
-        className="css-561"
+        className=
+
+            {
+              background-color: #f4f4f4;
+              border-color: transparent;
+              box-sizing: border-box;
+              color: #a6a6a6;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 12px;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              pointer-events: none;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: GrayText;
+            }
       >
         <button
           aria-describedby={undefined}
@@ -64,7 +169,71 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon is-disabled ms-UpButton root-563"
+          className=
+              ms-Button
+              ms-Button--icon
+              is-disabled
+              ms-UpButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #a6a6a6;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                opacity: 0.5;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                pointer-events: none;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: GrayText;
+                opacity: 1;
+              }
           data-is-focusable={false}
           disabled={true}
           onMouseDown={[Function]}
@@ -74,11 +243,40 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-565"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a6a6a6;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronUpSmall"
               role="presentation"
             >
@@ -92,7 +290,71 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon is-disabled ms-DownButton root-563"
+          className=
+              ms-Button
+              ms-Button--icon
+              is-disabled
+              ms-DownButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #a6a6a6;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                opacity: 0.5;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                pointer-events: none;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: GrayText;
+                opacity: 1;
+              }
           data-is-focusable={false}
           disabled={true}
           onMouseDown={[Function]}
@@ -102,11 +364,40 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-565"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a6a6a6;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronDownSmall"
               role="presentation"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -9,21 +9,67 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
   }
 >
   <div
-    className="css-345"
+    className=
+
+        {
+          font-size: 14px;
+          min-width: 86px;
+          outline: none;
+          width: 100%;
+        }
   >
     <div
-      className="css-566"
+      className=
+
+          {
+            display: inline-flex;
+            float: right;
+            margin-left: 10px;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-556"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-0";
+              font-size: 20px;
+              font-style: normal;
+              font-weight: normal;
+              padding-bottom: 2px;
+              padding-left: 5px;
+              padding-right: 5px;
+              padding-top: 2px;
+              speak: none;
+            }
         data-icon-name="Light"
         role="presentation"
       >
         
       </i>
       <label
-        className="ms-Label root-352"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 2px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 2px;
+              pointer-events: none;
+              word-wrap: break-word;
+            }
         htmlFor="input1"
         id="Label0"
       >
@@ -34,7 +80,25 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
       aria-label={undefined}
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="css-349"
+      className=
+
+          {
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            display: flex;
+            height: 32px;
+            min-width: 86px;
+          }
+          &:hover {
+            border-color: #212121;
+            outline: 2px dashed transparent;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            outline: none;
+          }
       data-ktp-target={undefined}
       title={undefined}
     >
@@ -47,7 +111,42 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
         aria-valuenow={0}
         aria-valuetext={undefined}
         autoComplete="off"
-        className="ms-spinButton-input css-350"
+        className=
+            ms-spinButton-input
+            {
+              border-style: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: text;
+              display: block;
+              float: left;
+              font-size: 14px;
+              height: 100%;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              min-width: 72px;
+              outline: 0;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 12px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              user-select: text;
+              width: calc(100% - 14px);
+            }
+            &::selection {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            @media screen and (-ms-high-contrast: active){&::selection {
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+            }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
         disabled={false}
@@ -64,7 +163,21 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
         value="0"
       />
       <span
-        className="css-351"
+        className=
+
+            {
+              box-sizing: border-box;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 12px;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <button
           aria-describedby={undefined}
@@ -72,7 +185,74 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-UpButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-UpButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -82,11 +262,39 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronUpSmall"
               role="presentation"
             >
@@ -100,7 +308,74 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-DownButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-DownButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -110,11 +385,39 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronDownSmall"
               role="presentation"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -9,21 +9,67 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
   }
 >
   <div
-    className="css-345"
+    className=
+
+        {
+          font-size: 14px;
+          min-width: 86px;
+          outline: none;
+          width: 100%;
+        }
   >
     <div
-      className="css-346"
+      className=
+
+          {
+            display: inline-flex;
+            float: left;
+            margin-right: 10px;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-556"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-0";
+              font-size: 20px;
+              font-style: normal;
+              font-weight: normal;
+              padding-bottom: 2px;
+              padding-left: 5px;
+              padding-right: 5px;
+              padding-top: 2px;
+              speak: none;
+            }
         data-icon-name="IncreaseIndentLegacy"
         role="presentation"
       >
         
       </i>
       <label
-        className="ms-Label root-352"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 2px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 2px;
+              pointer-events: none;
+              word-wrap: break-word;
+            }
         htmlFor="input1"
         id="Label0"
       >
@@ -34,7 +80,25 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
       aria-label={undefined}
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="css-349"
+      className=
+
+          {
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            display: flex;
+            height: 32px;
+            min-width: 86px;
+          }
+          &:hover {
+            border-color: #212121;
+            outline: 2px dashed transparent;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            outline: none;
+          }
       data-ktp-target={undefined}
       title={undefined}
     >
@@ -47,7 +111,42 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
         aria-valuenow={0}
         aria-valuetext={undefined}
         autoComplete="off"
-        className="ms-spinButton-input css-350"
+        className=
+            ms-spinButton-input
+            {
+              border-style: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: text;
+              display: block;
+              float: left;
+              font-size: 14px;
+              height: 100%;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              min-width: 72px;
+              outline: 0;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 12px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              user-select: text;
+              width: calc(100% - 14px);
+            }
+            &::selection {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            @media screen and (-ms-high-contrast: active){&::selection {
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+            }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
         disabled={false}
@@ -64,7 +163,21 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
         value="0"
       />
       <span
-        className="css-351"
+        className=
+
+            {
+              box-sizing: border-box;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 12px;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <button
           aria-describedby={undefined}
@@ -72,7 +185,74 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-UpButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-UpButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -82,11 +262,39 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronUpSmall"
               role="presentation"
             >
@@ -100,7 +308,74 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-DownButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-DownButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -110,11 +385,39 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronDownSmall"
               role="presentation"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -9,21 +9,72 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
   }
 >
   <div
-    className="css-345"
+    className=
+
+        {
+          font-size: 14px;
+          min-width: 86px;
+          outline: none;
+          width: 100%;
+        }
   >
     <div
-      className="css-346"
+      className=
+
+          {
+            display: inline-flex;
+            float: left;
+            margin-right: 10px;
+          }
     >
       <i
         aria-hidden={true}
-        className="root-567"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #a6a6a6;
+              display: inline-block;
+              font-family: "FabricMDL2Icons-0";
+              font-size: 20px;
+              font-style: normal;
+              font-weight: normal;
+              padding-bottom: 2px;
+              padding-left: 5px;
+              padding-right: 5px;
+              padding-top: 2px;
+              speak: none;
+            }
         data-icon-name="IncreaseIndentLegacy"
         role="presentation"
       >
         
       </i>
       <label
-        className="ms-Label root-562"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #a6a6a6;
+              cursor: default;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 2px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 2px;
+              pointer-events: none;
+              word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: GrayText;
+            }
         htmlFor="input1"
         id="Label0"
       >
@@ -34,7 +85,24 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
       aria-label={undefined}
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="css-559"
+      className=
+
+          {
+            background-color: #f4f4f4;
+            border-color: transparent;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            color: #a6a6a6;
+            cursor: default;
+            display: flex;
+            height: 32px;
+            min-width: 86px;
+            pointer-events: none;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: GrayText;
+          }
       data-ktp-target={undefined}
       title={undefined}
     >
@@ -47,7 +115,39 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
         aria-valuenow={0}
         aria-valuetext={undefined}
         autoComplete="off"
-        className="ms-spinButton-input css-560"
+        className=
+            ms-spinButton-input
+            {
+              background-color: #f4f4f4;
+              border-color: transparent;
+              border-style: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #a6a6a6;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 14px;
+              height: 100%;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              min-width: 72px;
+              outline: 0;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 12px;
+              padding-top: 0;
+              pointer-events: none;
+              text-overflow: ellipsis;
+              user-select: text;
+              width: calc(100% - 14px);
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: GrayText;
+            }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
         disabled={true}
@@ -64,7 +164,28 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
         value="0"
       />
       <span
-        className="css-561"
+        className=
+
+            {
+              background-color: #f4f4f4;
+              border-color: transparent;
+              box-sizing: border-box;
+              color: #a6a6a6;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 12px;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              pointer-events: none;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: GrayText;
+            }
       >
         <button
           aria-describedby={undefined}
@@ -72,7 +193,71 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon is-disabled ms-UpButton root-563"
+          className=
+              ms-Button
+              ms-Button--icon
+              is-disabled
+              ms-UpButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #a6a6a6;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                opacity: 0.5;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                pointer-events: none;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: GrayText;
+                opacity: 1;
+              }
           data-is-focusable={false}
           disabled={true}
           onMouseDown={[Function]}
@@ -82,11 +267,40 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-565"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a6a6a6;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronUpSmall"
               role="presentation"
             >
@@ -100,7 +314,71 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon is-disabled ms-DownButton root-563"
+          className=
+              ms-Button
+              ms-Button--icon
+              is-disabled
+              ms-DownButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #f4f4f4;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #a6a6a6;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                opacity: 0.5;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                pointer-events: none;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                outline: 0px;
+              }
+              &:focus {
+                outline: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: GrayText;
+                opacity: 1;
+              }
           data-is-focusable={false}
           disabled={true}
           onMouseDown={[Function]}
@@ -110,11 +388,40 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-565"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a6a6a6;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronDownSmall"
               role="presentation"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -3,13 +3,44 @@
 exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="css-568"
+    className=
+
+        {
+          font-size: 14px;
+          min-width: 86px;
+          outline: none;
+          width: 400px;
+        }
   >
     <div
-      className="css-346"
+      className=
+
+          {
+            display: inline-flex;
+            float: left;
+            margin-right: 10px;
+          }
     >
       <label
-        className="ms-Label root-352"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 2px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 2px;
+              pointer-events: none;
+              word-wrap: break-word;
+            }
         htmlFor="input1"
         id="Label0"
       >
@@ -20,7 +51,25 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
       aria-label={undefined}
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="css-349"
+      className=
+
+          {
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            display: flex;
+            height: 32px;
+            min-width: 86px;
+          }
+          &:hover {
+            border-color: #212121;
+            outline: 2px dashed transparent;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            outline: none;
+          }
       data-ktp-target={undefined}
       title={undefined}
     >
@@ -33,7 +82,42 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
         aria-valuenow={0}
         aria-valuetext={undefined}
         autoComplete="off"
-        className="ms-spinButton-input css-350"
+        className=
+            ms-spinButton-input
+            {
+              border-style: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: text;
+              display: block;
+              float: left;
+              font-size: 14px;
+              height: 100%;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              min-width: 72px;
+              outline: 0;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 12px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              user-select: text;
+              width: calc(100% - 14px);
+            }
+            &::selection {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            @media screen and (-ms-high-contrast: active){&::selection {
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+            }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
         disabled={false}
@@ -50,7 +134,21 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
         value="0"
       />
       <span
-        className="css-351"
+        className=
+
+            {
+              box-sizing: border-box;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 12px;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <button
           aria-describedby={undefined}
@@ -58,7 +156,74 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-UpButton root-569"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-UpButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: green;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -68,11 +233,39 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronUpSmall"
               role="presentation"
             >
@@ -86,7 +279,74 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-DownButton root-570"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-DownButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: red;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -96,11 +356,39 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronDownSmall"
               role="presentation"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -9,13 +9,44 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
   }
 >
   <div
-    className="css-345"
+    className=
+
+        {
+          font-size: 14px;
+          min-width: 86px;
+          outline: none;
+          width: 100%;
+        }
   >
     <div
-      className="css-346"
+      className=
+
+          {
+            display: inline-flex;
+            float: left;
+            margin-right: 10px;
+          }
     >
       <label
-        className="ms-Label root-352"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 2px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 2px;
+              pointer-events: none;
+              word-wrap: break-word;
+            }
         htmlFor="input1"
         id="Label0"
       >
@@ -26,7 +57,25 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
       aria-label={undefined}
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="css-349"
+      className=
+
+          {
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            display: flex;
+            height: 32px;
+            min-width: 86px;
+          }
+          &:hover {
+            border-color: #212121;
+            outline: 2px dashed transparent;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            outline: none;
+          }
       data-ktp-target={undefined}
       title={undefined}
     >
@@ -39,7 +88,42 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
         aria-valuenow={undefined}
         aria-valuetext="7 cm"
         autoComplete="off"
-        className="ms-spinButton-input css-350"
+        className=
+            ms-spinButton-input
+            {
+              border-style: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: text;
+              display: block;
+              float: left;
+              font-size: 14px;
+              height: 100%;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              min-width: 72px;
+              outline: 0;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 12px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              user-select: text;
+              width: calc(100% - 14px);
+            }
+            &::selection {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            @media screen and (-ms-high-contrast: active){&::selection {
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+            }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
         disabled={false}
@@ -56,7 +140,21 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
         value="7 cm"
       />
       <span
-        className="css-351"
+        className=
+
+            {
+              box-sizing: border-box;
+              cursor: default;
+              display: block;
+              float: left;
+              font-size: 12px;
+              height: 100%;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+            }
       >
         <button
           aria-describedby={undefined}
@@ -64,7 +162,74 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-UpButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-UpButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -74,11 +239,39 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronUpSmall"
               role="presentation"
             >
@@ -92,7 +285,74 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
           aria-labelledby={undefined}
           aria-pressed={false}
           checked={false}
-          className="ms-Button ms-Button--icon ms-DownButton root-353"
+          className=
+              ms-Button
+              ms-Button--icon
+              ms-DownButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-radius: 0px;
+                border: 1px solid transparent;
+                box-sizing: border-box;
+                color: #333333;
+                cursor: default;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 50%;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 0;
+                position: relative;
+                text-align: center;
+                text-decoration: none;
+                user-select: none;
+                vertical-align: top;
+                width: 14px;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                border: none;
+                bottom: -2px;
+                left: -2px;
+                outline-color: ButtonText;
+                right: -2px;
+                top: -2px;
+              }
+              &:hover {
+                background-color: #eaeaea;
+                color: #000000;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+                color: Highlight;
+              }
+              &:active {
+                background-color: #c8c8c8;
+                color: #212121;
+              }
+              @media screen and (-ms-high-contrast: active){&:active {
+                background-color: Highlight;
+                color: HighlightText;
+              }
           data-is-focusable={false}
           disabled={undefined}
           onMouseDown={[Function]}
@@ -102,11 +362,39 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
           type="button"
         >
           <div
-            className="ms-Button-flexContainer flexContainer-102"
+            className=
+                ms-Button-flexContainer
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  height: 100%;
+                  justify-content: center;
+                }
           >
             <i
               aria-hidden={true}
-              className="ms-Button-icon icon-355"
+              className=
+                  ms-Button-icon
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: "FabricMDL2Icons-2";
+                    font-size: 6px;
+                    font-style: normal;
+                    font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    speak: none;
+                    text-align: center;
+                    vertical-align: middle;
+                  }
               data-icon-name="ChevronDownSmall"
               role="presentation"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Basic.Example.tsx.shot
@@ -5,66 +5,272 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
   className="ms-BasicSpinnersExample"
 >
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Extra Small Spinner
   </label>
   <div
-    className="ms-Spinner root-292"
+    className=
+        ms-Spinner
+
   >
     <div
-      className="ms-Spinner-circle ms-Spinner--xSmall circle-571"
+      className=
+          ms-Spinner-circle
+          ms-Spinner--xSmall
+          {
+            animation-duration: 1.3s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-timing-function: cubic-bezier(.53,.21,.29,.67);
+            border-radius: 50%;
+            border-top-color: #0078d4;
+            border: 1.5px solid #c7e0f4;
+            box-sizing: border-box;
+            height: 12px;
+            margin-bottom: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: auto;
+            width: 12px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-top-color: Highlight;
+          }
     />
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Small Spinner
   </label>
   <div
-    className="ms-Spinner root-292"
+    className=
+        ms-Spinner
+
   >
     <div
-      className="ms-Spinner-circle ms-Spinner--small circle-573"
+      className=
+          ms-Spinner-circle
+          ms-Spinner--small
+          {
+            animation-duration: 1.3s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-timing-function: cubic-bezier(.53,.21,.29,.67);
+            border-radius: 50%;
+            border-top-color: #0078d4;
+            border: 1.5px solid #c7e0f4;
+            box-sizing: border-box;
+            height: 16px;
+            margin-bottom: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: auto;
+            width: 16px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-top-color: Highlight;
+          }
     />
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Medium Spinner
   </label>
   <div
-    className="ms-Spinner root-292"
+    className=
+        ms-Spinner
+
   >
     <div
-      className="ms-Spinner-circle ms-Spinner--medium circle-574"
+      className=
+          ms-Spinner-circle
+          ms-Spinner--medium
+          {
+            animation-duration: 1.3s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-timing-function: cubic-bezier(.53,.21,.29,.67);
+            border-radius: 50%;
+            border-top-color: #0078d4;
+            border: 1.5px solid #c7e0f4;
+            box-sizing: border-box;
+            height: 20px;
+            margin-bottom: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: auto;
+            width: 20px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-top-color: Highlight;
+          }
     />
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Large Spinner
   </label>
   <div
-    className="ms-Spinner root-292"
+    className=
+        ms-Spinner
+
   >
     <div
-      className="ms-Spinner-circle ms-Spinner--large circle-575"
+      className=
+          ms-Spinner-circle
+          ms-Spinner--large
+          {
+            animation-duration: 1.3s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-timing-function: cubic-bezier(.53,.21,.29,.67);
+            border-radius: 50%;
+            border-top-color: #0078d4;
+            border: 1.5px solid #c7e0f4;
+            box-sizing: border-box;
+            height: 28px;
+            margin-bottom: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: auto;
+            width: 28px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-top-color: Highlight;
+          }
     />
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Spinner With Label
   </label>
   <div
-    className="ms-Spinner root-292"
+    className=
+        ms-Spinner
+
   >
     <div
-      className="ms-Spinner-circle ms-Spinner--medium circle-574"
+      className=
+          ms-Spinner-circle
+          ms-Spinner--medium
+          {
+            animation-duration: 1.3s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-timing-function: cubic-bezier(.53,.21,.29,.67);
+            border-radius: 50%;
+            border-top-color: #0078d4;
+            border: 1.5px solid #c7e0f4;
+            box-sizing: border-box;
+            height: 20px;
+            margin-bottom: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: auto;
+            width: 20px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-top-color: Highlight;
+          }
     />
     <div
-      className="ms-Spinner-label label-572"
+      className=
+          ms-Spinner-label
+          {
+            color: #0078d4;
+            margin-top: 10px;
+            text-align: center;
+          }
     >
       I am definitely loading...
     </div>
@@ -74,18 +280,64 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
     />
   </div>
   <label
-    className="ms-Label root-89"
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
   >
     Large Spinner With Label
   </label>
   <div
-    className="ms-Spinner root-292"
+    className=
+        ms-Spinner
+
   >
     <div
-      className="ms-Spinner-circle ms-Spinner--large circle-575"
+      className=
+          ms-Spinner-circle
+          ms-Spinner--large
+          {
+            animation-duration: 1.3s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-timing-function: cubic-bezier(.53,.21,.29,.67);
+            border-radius: 50%;
+            border-top-color: #0078d4;
+            border: 1.5px solid #c7e0f4;
+            box-sizing: border-box;
+            height: 28px;
+            margin-bottom: auto;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: auto;
+            width: 28px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-top-color: Highlight;
+          }
     />
     <div
-      className="ms-Spinner-label label-572"
+      className=
+          ms-Spinner-label
+          {
+            color: #0078d4;
+            margin-top: 10px;
+            text-align: center;
+          }
     >
       Seriously, still loading...
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -8,7 +8,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
   <div
     aria-describedby={undefined}
     aria-labelledby={undefined}
-    className="ms-FocusZone ms-swatchColorPickerBodyContainer focusedContainer-578"
+    className=
+        ms-FocusZone
+        ms-swatchColorPickerBodyContainer
+        {
+          clear: both;
+          display: block;
+          min-width: 180px;
+        }
     data-focuszone-id="FocusZone2"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -19,7 +26,15 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
     <table
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="root-576"
+      className=
+
+          {
+            outline: none;
+            padding-bottom: 2px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 2px;
+          }
       id="id__1"
       onBlur={[Function]}
       role="grid"
@@ -29,7 +44,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           role="row"
         >
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -38,7 +60,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={0}
               data-is-focusable={true}
               disabled={undefined}
@@ -53,10 +206,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#00ff00"
                   viewBox="0 0 20 20"
                 >
@@ -70,7 +241,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -79,7 +257,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={1}
               data-is-focusable={true}
               disabled={undefined}
@@ -94,10 +403,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ffa500"
                   viewBox="0 0 20 20"
                 >
@@ -111,7 +438,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -120,7 +454,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={2}
               data-is-focusable={true}
               disabled={undefined}
@@ -135,10 +600,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#0000ff"
                   viewBox="0 0 20 20"
                 >
@@ -152,7 +635,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -161,7 +651,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={3}
               data-is-focusable={true}
               disabled={undefined}
@@ -176,10 +797,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ff0000"
                   viewBox="0 0 20 20"
                 >
@@ -193,7 +832,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -202,7 +848,148 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-583"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-color: #a6a6a6;
+                    border-radius: 100%;
+                    border: 1px solid;
+                    margin-bottom: 4px;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 4px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={4}
               data-is-focusable={true}
               disabled={undefined}
@@ -217,10 +1004,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ffffff"
                   viewBox="0 0 20 20"
                 >
@@ -243,7 +1048,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
   <div
     aria-describedby={undefined}
     aria-labelledby={undefined}
-    className="ms-FocusZone ms-swatchColorPickerBodyContainer focusedContainer-578"
+    className=
+        ms-FocusZone
+        ms-swatchColorPickerBodyContainer
+        {
+          clear: both;
+          display: block;
+          min-width: 180px;
+        }
     data-focuszone-id="FocusZone20"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -254,7 +1066,15 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
     <table
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="root-576"
+      className=
+
+          {
+            outline: none;
+            padding-bottom: 2px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 2px;
+          }
       id="id__19"
       onBlur={[Function]}
       role="grid"
@@ -264,7 +1084,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           role="row"
         >
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -273,7 +1100,135 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-585"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={0}
               data-is-focusable={true}
               disabled={undefined}
@@ -288,10 +1243,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#00ff00"
                   viewBox="0 0 20 20"
                 >
@@ -304,7 +1277,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -313,7 +1293,135 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-585"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={1}
               data-is-focusable={true}
               disabled={undefined}
@@ -328,10 +1436,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ffa500"
                   viewBox="0 0 20 20"
                 >
@@ -344,7 +1470,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -353,7 +1486,135 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-585"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={2}
               data-is-focusable={true}
               disabled={undefined}
@@ -368,10 +1629,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#0000ff"
                   viewBox="0 0 20 20"
                 >
@@ -384,7 +1663,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -393,7 +1679,135 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-585"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={3}
               data-is-focusable={true}
               disabled={undefined}
@@ -408,10 +1822,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ff0000"
                   viewBox="0 0 20 20"
                 >
@@ -424,7 +1856,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -433,7 +1872,147 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-587"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-color: #a6a6a6;
+                    border: 1px solid;
+                    margin-bottom: 4px;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 4px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={4}
               data-is-focusable={true}
               disabled={undefined}
@@ -448,10 +2027,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ffffff"
                   viewBox="0 0 20 20"
                 >
@@ -483,7 +2080,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
   <div
     aria-describedby={undefined}
     aria-labelledby={undefined}
-    className="ms-FocusZone ms-swatchColorPickerBodyContainer focusedContainer-578"
+    className=
+        ms-FocusZone
+        ms-swatchColorPickerBodyContainer
+        {
+          clear: both;
+          display: block;
+          min-width: 180px;
+        }
     data-focuszone-id="FocusZone38"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -494,7 +2098,15 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
     <table
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="root-576"
+      className=
+
+          {
+            outline: none;
+            padding-bottom: 2px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 2px;
+          }
       id="id__37"
       onBlur={[Function]}
       role="grid"
@@ -504,7 +2116,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           role="row"
         >
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -513,7 +2132,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={0}
               data-is-focusable={true}
               disabled={undefined}
@@ -528,10 +2278,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#00ff00"
                   viewBox="0 0 20 20"
                 >
@@ -545,7 +2313,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -554,7 +2329,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={1}
               data-is-focusable={true}
               disabled={undefined}
@@ -569,10 +2475,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ffa500"
                   viewBox="0 0 20 20"
                 >
@@ -586,7 +2510,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -595,7 +2526,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={2}
               data-is-focusable={true}
               disabled={undefined}
@@ -610,10 +2672,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#0000ff"
                   viewBox="0 0 20 20"
                 >
@@ -627,7 +2707,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -636,7 +2723,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={3}
               data-is-focusable={true}
               disabled={undefined}
@@ -651,10 +2869,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ff0000"
                   viewBox="0 0 20 20"
                 >
@@ -672,7 +2908,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           role="row"
         >
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -681,7 +2924,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={4}
               data-is-focusable={true}
               disabled={undefined}
@@ -696,10 +3070,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="green"
                   viewBox="0 0 20 20"
                 >
@@ -713,7 +3105,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -722,7 +3121,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={5}
               data-is-focusable={true}
               disabled={undefined}
@@ -737,10 +3267,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="orange"
                   viewBox="0 0 20 20"
                 >
@@ -754,7 +3302,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -763,7 +3318,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={6}
               data-is-focusable={true}
               disabled={undefined}
@@ -778,10 +3464,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="blue"
                   viewBox="0 0 20 20"
                 >
@@ -795,7 +3499,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -804,7 +3515,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={7}
               data-is-focusable={true}
               disabled={undefined}
@@ -819,10 +3661,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="red"
                   viewBox="0 0 20 20"
                 >
@@ -840,7 +3700,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           role="row"
         >
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -849,7 +3716,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={8}
               data-is-focusable={true}
               disabled={undefined}
@@ -864,10 +3862,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="black"
                   viewBox="0 0 20 20"
                 >
@@ -881,7 +3897,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -890,7 +3913,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={9}
               data-is-focusable={true}
               disabled={undefined}
@@ -905,10 +4059,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="grey"
                   viewBox="0 0 20 20"
                 >
@@ -922,7 +4094,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -931,7 +4110,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={10}
               data-is-focusable={true}
               disabled={undefined}
@@ -946,10 +4256,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="purple"
                   viewBox="0 0 20 20"
                 >
@@ -963,7 +4291,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -972,7 +4307,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #000000;
+                  }
               data-index={11}
               data-is-focusable={true}
               disabled={undefined}
@@ -987,10 +4453,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="yellow"
                   viewBox="0 0 20 20"
                 >
@@ -1013,7 +4497,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
   <div
     aria-describedby={undefined}
     aria-labelledby={undefined}
-    className="ms-FocusZone ms-swatchColorPickerBodyContainer focusedContainer-578"
+    className=
+        ms-FocusZone
+        ms-swatchColorPickerBodyContainer
+        {
+          clear: both;
+          display: block;
+          min-width: 180px;
+        }
     data-focuszone-id="FocusZone77"
     onBlur={[Function]}
     onFocus={[Function]}
@@ -1024,7 +4515,15 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
     <table
       aria-posinset={undefined}
       aria-setsize={undefined}
-      className="root-576"
+      className=
+
+          {
+            outline: none;
+            padding-bottom: 2px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 2px;
+          }
       id="id__76"
       onBlur={[Function]}
       role="grid"
@@ -1034,7 +4533,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           role="row"
         >
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -1043,7 +4549,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-589"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  undefined
+                  is-disabled
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #a6a6a6;
+                    cursor: default;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    opacity: 0.3;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    pointer-events: none;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
+                  }
               data-index={0}
               data-is-focusable={false}
               disabled={true}
@@ -1058,10 +4695,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#00ff00"
                   viewBox="0 0 20 20"
                 >
@@ -1075,7 +4730,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -1084,7 +4746,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-589"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  undefined
+                  is-disabled
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #a6a6a6;
+                    cursor: default;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    opacity: 0.3;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    pointer-events: none;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
+                  }
               data-index={1}
               data-is-focusable={false}
               disabled={true}
@@ -1099,10 +4892,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ffa500"
                   viewBox="0 0 20 20"
                 >
@@ -1116,7 +4927,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -1125,7 +4943,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-589"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  undefined
+                  is-disabled
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #a6a6a6;
+                    cursor: default;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    opacity: 0.3;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    pointer-events: none;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
+                  }
               data-index={2}
               data-is-focusable={false}
               disabled={true}
@@ -1140,10 +5089,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#0000ff"
                   viewBox="0 0 20 20"
                 >
@@ -1157,7 +5124,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -1166,7 +5140,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-589"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  undefined
+                  is-disabled
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #a6a6a6;
+                    cursor: default;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    opacity: 0.3;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    pointer-events: none;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-radius: 100%;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
+                  }
               data-index={3}
               data-is-focusable={false}
               disabled={true}
@@ -1181,10 +5286,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ff0000"
                   viewBox="0 0 20 20"
                 >
@@ -1198,7 +5321,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             </button>
           </td>
           <td
-            className="tableCell-577"
+            className=
+
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
             role="presentation"
           >
             <button
@@ -1207,7 +5337,148 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               aria-labelledby={undefined}
               aria-pressed={undefined}
               aria-selected={false}
-              className="ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-591"
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  undefined
+                  is-disabled
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    background: transparent;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #a6a6a6;
+                    cursor: default;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    opacity: 0.3;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    pointer-events: none;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                    border: none;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:hover $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: none;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:focus $svg {
+                    border-color: #dadada;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  &:active $svg {
+                    border-color: #969696;
+                    border: 4px solid;
+                    box-shadow: 0 0 0 1px #969696;
+                    height: 12px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 4px;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 4px;
+                    width: 12px;
+                  }
+                  & $svg {
+                    border-color: #a6a6a6;
+                    border-radius: 100%;
+                    border: 1px solid;
+                    margin-bottom: 4px;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 4px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
+                  }
               data-index={4}
               data-is-focusable={false}
               disabled={true}
@@ -1222,10 +5493,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               type="button"
             >
               <div
-                className="ms-Button-flexContainer flexContainer-114"
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
               >
                 <svg
-                  className="svg-580"
+                  className=
+
+                      {
+                        box-sizing: content-box;
+                        height: 20px;
+                        padding-bottom: 4px;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 4px;
+                        width: 20px;
+                      }
                   fill="#ffffff"
                   viewBox="0 0 20 20"
                 >
@@ -1262,7 +5551,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
     <div
       aria-describedby={undefined}
       aria-labelledby={undefined}
-      className="ms-FocusZone ms-swatchColorPickerBodyContainer focusedContainer-578"
+      className=
+          ms-FocusZone
+          ms-swatchColorPickerBodyContainer
+          {
+            clear: both;
+            display: block;
+            min-width: 180px;
+          }
       data-focuszone-id="FocusZone95"
       onBlur={[Function]}
       onFocus={[Function]}
@@ -1273,7 +5569,15 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
       <table
         aria-posinset={undefined}
         aria-setsize={undefined}
-        className="root-576"
+        className=
+
+            {
+              outline: none;
+              padding-bottom: 2px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 2px;
+            }
         id="id__94"
         onBlur={[Function]}
         role="grid"
@@ -1283,7 +5587,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             role="row"
           >
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1292,7 +5603,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={0}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1307,10 +5749,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="#00ff00"
                     viewBox="0 0 20 20"
                   >
@@ -1324,7 +5784,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1333,7 +5800,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={1}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1348,10 +5946,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="#ffa500"
                     viewBox="0 0 20 20"
                   >
@@ -1365,7 +5981,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1374,7 +5997,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={2}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1389,10 +6143,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="#0000ff"
                     viewBox="0 0 20 20"
                   >
@@ -1406,7 +6178,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1415,7 +6194,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={3}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1430,10 +6340,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="#ff0000"
                     viewBox="0 0 20 20"
                   >
@@ -1451,7 +6379,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             role="row"
           >
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1460,7 +6395,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={4}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1475,10 +6541,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="green"
                     viewBox="0 0 20 20"
                   >
@@ -1492,7 +6576,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1501,7 +6592,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={5}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1516,10 +6738,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="orange"
                     viewBox="0 0 20 20"
                   >
@@ -1533,7 +6773,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1542,7 +6789,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={6}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1557,10 +6935,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="blue"
                     viewBox="0 0 20 20"
                   >
@@ -1574,7 +6970,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1583,7 +6986,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={7}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1598,10 +7132,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="red"
                     viewBox="0 0 20 20"
                   >
@@ -1619,7 +7171,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             role="row"
           >
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1628,7 +7187,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={8}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1643,10 +7333,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="black"
                     viewBox="0 0 20 20"
                   >
@@ -1660,7 +7368,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1669,7 +7384,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={9}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1684,10 +7530,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="grey"
                     viewBox="0 0 20 20"
                   >
@@ -1701,7 +7565,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1710,7 +7581,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={10}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1725,10 +7727,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="purple"
                     viewBox="0 0 20 20"
                   >
@@ -1742,7 +7762,14 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               </button>
             </td>
             <td
-              className="tableCell-577"
+              className=
+
+                  {
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                  }
               role="presentation"
             >
               <button
@@ -1751,7 +7778,138 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 aria-labelledby={undefined}
                 aria-pressed={undefined}
                 aria-selected={false}
-                className="ms-Button ms-Button--action ms-Button--command colorCell-581"
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: transparent;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 40px;
+                      outline: transparent;
+                      overflow: visible;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
+                      border: none;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:hover $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: none;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:focus $svg {
+                      border-color: #dadada;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    &:active $svg {
+                      border-color: #969696;
+                      border: 4px solid;
+                      box-shadow: 0 0 0 1px #969696;
+                      height: 12px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 4px;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 4px;
+                      width: 12px;
+                    }
+                    & $svg {
+                      border-radius: 100%;
+                    }
+                    &:hover {
+                      color: #0078d4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      color: #000000;
+                    }
                 data-index={11}
                 data-is-focusable={true}
                 disabled={undefined}
@@ -1766,10 +7924,28 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                 type="button"
               >
                 <div
-                  className="ms-Button-flexContainer flexContainer-114"
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
                 >
                   <svg
-                    className="svg-580"
+                    className=
+
+                        {
+                          box-sizing: content-box;
+                          height: 20px;
+                          padding-bottom: 4px;
+                          padding-left: 4px;
+                          padding-right: 4px;
+                          padding-top: 4px;
+                          width: 20px;
+                        }
                     fill="yellow"
                     viewBox="0 0 20 20"
                   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -11,7 +11,60 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
     aria-posinset={undefined}
     aria-setsize={undefined}
     checked={false}
-    className="ms-Checkbox is-enabled root-189"
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: none;
+          border: none;
+          cursor: pointer;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: none;
+          padding-bottom: 0;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 0;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -2px;
+          content: "";
+          left: -2px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -2px;
+          top: -2px;
+          z-index: 1;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #212121;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
     data-ktp-execute-target={undefined}
     disabled={undefined}
     id="checkbox-0"
@@ -23,16 +76,66 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
     type="button"
   >
     <label
-      className="ms-Checkbox-label label-184"
+      className=
+          ms-Checkbox-label
+          {
+            align-items: center;
+            cursor: pointer;
+            display: inline-flex;
+            margin-bottom: 0;
+            margin-left: -4px;
+            margin-right: -4px;
+            margin-top: 0;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
       htmlFor="checkbox-0"
     >
       <div
-        className="ms-Checkbox-checkbox checkbox-190"
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
         data-ktp-target={undefined}
       >
         <i
           aria-hidden={true}
-          className="ms-Checkbox-checkmark checkmark-192"
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
           data-icon-name="CheckMark"
           role="presentation"
         >
@@ -40,7 +143,16 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
         </i>
       </div>
       <span
-        className="ms-Checkbox-text text-187"
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
       >
         Disable Tag Picker
       </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Basic.Example.tsx.shot
@@ -12,20 +12,103 @@ exports[`Component Examples renders TeachingBubble.Basic.Example.tsx correctly 1
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Show TeachingBubble

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Condensed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Condensed.Example.tsx.shot
@@ -12,20 +12,103 @@ exports[`Component Examples renders TeachingBubble.Condensed.Example.tsx correct
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Show TeachingBubble

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Illustration.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Illustration.Example.tsx.shot
@@ -12,20 +12,103 @@ exports[`Component Examples renders TeachingBubble.Illustration.Example.tsx corr
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Show TeachingBubble

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.SmallHeadline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.SmallHeadline.Example.tsx.shot
@@ -12,20 +12,103 @@ exports[`Component Examples renders TeachingBubble.SmallHeadline.Example.tsx cor
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Show TeachingBubble

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.WideIllustration.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.WideIllustration.Example.tsx.shot
@@ -12,20 +12,103 @@ exports[`Component Examples renders TeachingBubble.WideIllustration.Example.tsx 
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       onClick={[Function]}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Show TeachingBubble

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AllErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AllErrorMessage.Example.tsx.shot
@@ -11,7 +11,24 @@ exports[`Component Examples renders TextField.AllErrorMessage.Example.tsx correc
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         Default with error message
@@ -82,7 +99,24 @@ exports[`Component Examples renders TextField.AllErrorMessage.Example.tsx correc
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField4"
       >
         Underlined with error message:
@@ -120,7 +154,24 @@ exports[`Component Examples renders TextField.AllErrorMessage.Example.tsx correc
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField6"
       >
         Multiline with error message

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AutoComplete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AutoComplete.Example.tsx.shot
@@ -12,7 +12,24 @@ exports[`Component Examples renders TextField.AutoComplete.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         Fill in and submit this form. The page will reload and autocomplete suggestions will appear.
@@ -43,19 +60,112 @@ exports[`Component Examples renders TextField.AutoComplete.Example.tsx correctly
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--primary root-144"
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
     data-is-focusable={true}
     disabled={undefined}
     type="submit"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__2"
         >
           Submit

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -11,7 +11,24 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         Standard
@@ -42,7 +59,24 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField2"
       >
         Disabled
@@ -74,7 +108,24 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField4"
       >
         Required 
@@ -106,7 +157,24 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField6"
       >
         With error message
@@ -144,7 +212,24 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField8"
       >
         With input mask

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -11,7 +11,24 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         Borderless Multiline TextField
@@ -43,7 +60,24 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField2"
       >
         Borderless Standard TextField

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -30,7 +30,66 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
             aria-label="Info"
             aria-labelledby={undefined}
             aria-pressed={undefined}
-            className="ms-Button ms-Button--icon root-145"
+            className=
+                ms-Button
+                ms-Button--icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 32px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:hover {
+                  color: #004578;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  color: #0078d4;
+                }
             data-is-focusable={true}
             disabled={undefined}
             onClick={[Function]}
@@ -38,11 +97,39 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
             type="button"
           >
             <div
-              className="ms-Button-flexContainer flexContainer-102"
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
             >
               <i
                 aria-hidden={true}
-                className="ms-Button-icon icon-109"
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
                 data-icon-name="Info"
                 role="presentation"
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -11,7 +11,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         TextField with a string-based validator. Hint: the length of the input string must be less than 3.
@@ -42,7 +59,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField2"
       >
         TextField with a Promise-based validator. Hint: the length of the input string must be less than 3.
@@ -73,7 +107,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField4"
       >
         TextField with a string-based validator. Hint: the length of the input string must be less than 3.
@@ -111,7 +162,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField6"
       >
         TextField with a string-based validator. Hint: the length of the input string must be less than 3.
@@ -142,7 +210,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField8"
       >
         TextField with a Promise-based validator. Hint: the length of the input string must be less than 3.
@@ -173,7 +258,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField10"
       >
         TextField has both description and error message.
@@ -216,7 +318,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField12"
       >
         TextField with a string-based validator. Hint: the length of the input string must be less than 3.
@@ -248,7 +367,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField14"
       >
         TextField that validates only on focus and blur. Hint: the length of the input string must be less than 3.
@@ -280,7 +416,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField16"
       >
         TextField that validates only on blur. Hint: the length of the input string must be less than 3.
@@ -312,7 +465,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField18"
       >
         Underlined TextField
@@ -343,7 +513,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField20"
       >
         TextField that uses the errorMessage property to set an error state.
@@ -385,7 +572,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
         className="ms-TextField-wrapper"
       >
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="TextField22"
         >
           Number TextField with valid initial value
@@ -417,20 +621,103 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         onClick={[Function]}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__24"
             >
               Restore
@@ -450,7 +737,24 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
         className="ms-TextField-wrapper"
       >
         <label
-          className="ms-Label root-89"
+          className=
+              ms-Label
+              {
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
           htmlFor="TextField27"
         >
           Number TextField with invalid initial value
@@ -489,20 +793,103 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
         aria-label={undefined}
         aria-labelledby={undefined}
         aria-pressed={undefined}
-        className="ms-Button ms-Button--default root-119"
+        className=
+            ms-Button
+            ms-Button--default
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #f4f4f4;
+              border-radius: 0px;
+              border: 1px solid transparent;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              min-width: 80px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:hover {
+              background-color: #eaeaea;
+              color: #000000;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #c8c8c8;
+              color: #212121;
+            }
         data-is-focusable={true}
         disabled={undefined}
         onClick={[Function]}
         type="button"
       >
         <div
-          className="ms-Button-flexContainer flexContainer-102"
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
         >
           <div
-            className="ms-Button-textContainer textContainer-103"
+            className=
+                ms-Button-textContainer
+                {
+                  flex-grow: 1;
+                }
           >
             <div
-              className="ms-Button-label label-120"
+              className=
+                  ms-Button-label
+                  {
+                    font-weight: 600;
+                    line-height: 100%;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
+                  }
               id="id__29"
             >
               Restore

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Icon.Example.tsx.shot
@@ -11,7 +11,24 @@ exports[`Component Examples renders TextField.Icon.Example.tsx correctly 1`] = `
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         TextField with an icon
@@ -34,7 +51,17 @@ exports[`Component Examples renders TextField.Icon.Example.tsx correctly 1`] = `
         />
         <i
           aria-hidden={true}
-          className="root-55"
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
           data-icon-name="Calendar"
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -11,7 +11,24 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         Standard
@@ -42,7 +59,24 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField2"
       >
         Disabled
@@ -74,7 +108,24 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField4"
       >
         Required
@@ -106,7 +157,24 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField6"
       >
         With error message
@@ -144,7 +212,24 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField8"
       >
         Non-resizable
@@ -174,7 +259,24 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField10"
       >
         With auto adjusting height

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Underlined.Example.tsx.shot
@@ -11,7 +11,24 @@ exports[`Component Examples renders TextField.Underlined.Example.tsx correctly 1
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField0"
       >
         Standard:
@@ -42,7 +59,24 @@ exports[`Component Examples renders TextField.Underlined.Example.tsx correctly 1
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField2"
       >
         Disabled:
@@ -74,7 +108,24 @@ exports[`Component Examples renders TextField.Underlined.Example.tsx correctly 1
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField4"
       >
         Required:
@@ -106,7 +157,24 @@ exports[`Component Examples renders TextField.Underlined.Example.tsx correctly 1
       className="ms-TextField-wrapper"
     >
       <label
-        className="ms-Label root-89"
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
         htmlFor="TextField6"
       >
         With error message:

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.AriaLabel.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.AriaLabel.Example.tsx.shot
@@ -9,22 +9,104 @@ exports[`Component Examples renders Toggle.AriaLabel.Example.tsx correctly 1`] =
   }
 >
   <div
-    className="ms-Toggle is-checked is-enabled root-285"
+    className=
+        ms-Toggle
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <label
-      className="ms-Label ms-Toggle-label label-230"
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Toggle0"
     >
       Enabled and checked
     </label>
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label="This toggle is checked. Press to uncheck."
         aria-pressed={true}
-        className="ms-Toggle-background pill-356"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: transparent;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              background-color: #106ebe;
+              border-color: transparent;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              background-color: Highlight;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle0"
@@ -35,11 +117,56 @@ exports[`Component Examples renders Toggle.AriaLabel.Example.tsx correctly 1`] =
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-357"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #ffffff;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-290"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
         htmlFor="Toggle0"
       >
         On

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -9,22 +9,104 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
   }
 >
   <div
-    className="ms-Toggle is-checked is-enabled root-285"
+    className=
+        ms-Toggle
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <label
-      className="ms-Label ms-Toggle-label label-230"
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Toggle0"
     >
       Enabled and checked
     </label>
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label="Enabled and checked"
         aria-pressed={true}
-        className="ms-Toggle-background pill-356"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: transparent;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              background-color: #106ebe;
+              border-color: transparent;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              background-color: Highlight;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle0"
@@ -35,11 +117,56 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-357"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #ffffff;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-290"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
         htmlFor="Toggle0"
       >
         On
@@ -47,22 +174,100 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Toggle is-enabled root-285"
+    className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <label
-      className="ms-Label ms-Toggle-label label-230"
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
       htmlFor="Toggle1"
     >
       Enabled and unchecked
     </label>
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={undefined}
         aria-label="Enabled and unchecked"
         aria-pressed={false}
-        className="ms-Toggle-background pill-287"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-color: #666666;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
         data-is-focusable={true}
         disabled={undefined}
         id="Toggle1"
@@ -73,11 +278,52 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-288"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #212121;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-290"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
         htmlFor="Toggle1"
       >
         Off
@@ -85,22 +331,97 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Toggle is-checked is-disabled root-285"
+    className=
+        ms-Toggle
+        is-checked
+        is-disabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <label
-      className="ms-Label ms-Toggle-label label-596"
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #a6a6a6;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: GrayText;
+          }
       htmlFor="Toggle2"
     >
       Disabled and checked
     </label>
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={true}
         aria-label="Disabled and checked"
         aria-pressed={true}
-        className="ms-Toggle-background pill-593"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background-color: #c8c8c8;
+              background: #ffffff;
+              border-color: transparent;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: default;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
         data-is-focusable={true}
         disabled={true}
         id="Toggle2"
@@ -111,11 +432,56 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-594"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #f4f4f4;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-597"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              color: #a6a6a6;
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
+            @media screen and (-ms-high-contrast: active){&& {
+              color: GrayText;
+            }
         htmlFor="Toggle2"
       >
         On
@@ -123,22 +489,94 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Toggle is-disabled root-285"
+    className=
+        ms-Toggle
+        is-disabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
   >
     <label
-      className="ms-Label ms-Toggle-label label-596"
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #a6a6a6;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: GrayText;
+          }
       htmlFor="Toggle3"
     >
       Disabled and unchecked
     </label>
     <div
-      className="ms-Toggle-innerContainer container-286"
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
     >
       <button
         aria-disabled={true}
         aria-label="Disabled and unchecked"
         aria-pressed={false}
-        className="ms-Toggle-background pill-598"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-color: #c8c8c8;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: default;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
         data-is-focusable={true}
         disabled={true}
         id="Toggle3"
@@ -149,11 +587,56 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
         type="button"
       >
         <div
-          className="ms-Toggle-thumb thumb-599"
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #c8c8c8;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
         />
       </button>
       <label
-        className="ms-Label ms-Toggle-stateText text-597"
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              color: #a6a6a6;
+              margin-bottom: 0;
+              margin-left: 10px;
+              margin-right: 10px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
+            @media screen and (-ms-high-contrast: active){&& {
+              color: GrayText;
+            }
         htmlFor="Toggle3"
       >
         Off

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
@@ -15,19 +15,102 @@ exports[`Component Examples renders Tooltip.Basic.Example.tsx correctly 1`] = `
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Hover Over Me

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
@@ -14,19 +14,102 @@ exports[`Component Examples renders Tooltip.Custom.Example.tsx correctly 1`] = `
     aria-label={undefined}
     aria-labelledby="id__0"
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__0"
         >
           Hover Over Me

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
@@ -15,19 +15,102 @@ exports[`Component Examples renders Tooltip.Interactive.Example.tsx correctly 1`
       aria-label={undefined}
       aria-labelledby={undefined}
       aria-pressed={undefined}
-      className="ms-Button ms-Button--default root-119"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #000000;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
       data-is-focusable={true}
       disabled={undefined}
       type="button"
     >
       <div
-        className="ms-Button-flexContainer flexContainer-102"
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
       >
         <div
-          className="ms-Button-textContainer textContainer-103"
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
         >
           <div
-            className="ms-Button-label label-120"
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
             id="id__0"
           >
             Interact with my tooltip

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Overflow.Example.tsx.shot
@@ -7,20 +7,103 @@ exports[`Component Examples renders Tooltip.Overflow.Example.tsx correctly 1`] =
     aria-label={undefined}
     aria-labelledby={undefined}
     aria-pressed={undefined}
-    className="ms-Button ms-Button--default root-119"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
     data-is-focusable={true}
     disabled={undefined}
     onClick={[Function]}
     type="button"
   >
     <div
-      className="ms-Button-flexContainer flexContainer-102"
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
     >
       <div
-        className="ms-Button-textContainer textContainer-103"
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
       >
         <div
-          className="ms-Button-label label-120"
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
           id="id__1"
         >
           Toggle showing overflow

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/VerticalDivider.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/VerticalDivider.Basic.Example.tsx.shot
@@ -2,22 +2,73 @@
 
 exports[`Component Examples renders VerticalDivider.Basic.Example.tsx correctly 1`] = `
 <div
-  className="wrapper-294"
+  className=
+
+      {
+        background-color: #F4F4F4;
+        height: 40px;
+        padding-bottom: 0;
+        padding-left: 10px;
+        padding-right: 10px;
+        padding-top: 0;
+      }
 >
   <p
-    className="text-295"
+    className=
+
+        {
+          display: inline-block;
+          height: 40px;
+          line-height: 40px;
+          margin-bottom: auto;
+          margin-left: auto;
+          margin-right: auto;
+          margin-top: auto;
+          padding-bottom: 0;
+          padding-left: 8px;
+          padding-right: 8px;
+          padding-top: 0;
+          vertical-align: top;
+        }
   >
      Some text before the divider. 
   </p>
   <span
-    className="wrapper-296"
+    className=
+
+        {
+          align-items: center;
+          display: inline-flex;
+          height: 100%;
+        }
   >
     <span
-      className="divider-297"
+      className=
+
+          {
+            background-color: #c8c8c8;
+            height: 100%;
+            width: 1px;
+          }
     />
   </span>
   <p
-    className="text-295"
+    className=
+
+        {
+          display: inline-block;
+          height: 40px;
+          line-height: 40px;
+          margin-bottom: auto;
+          margin-left: auto;
+          margin-right: auto;
+          margin-top: auto;
+          padding-bottom: 0;
+          padding-left: 8px;
+          padding-right: 8px;
+          padding-top: 0;
+          vertical-align: top;
+        }
   >
     Some text after the divider. 
   </p>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/VerticalDivider.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/VerticalDivider.Custom.Example.tsx.shot
@@ -2,22 +2,73 @@
 
 exports[`Component Examples renders VerticalDivider.Custom.Example.tsx correctly 1`] = `
 <div
-  className="wrapper-298"
+  className=
+
+      {
+        background-color: #F4F4F4;
+        height: 40px;
+        padding-bottom: 0;
+        padding-left: 0;
+        padding-right: 0;
+        padding-top: 0;
+      }
 >
   <p
-    className="text-295"
+    className=
+
+        {
+          display: inline-block;
+          height: 40px;
+          line-height: 40px;
+          margin-bottom: auto;
+          margin-left: auto;
+          margin-right: auto;
+          margin-top: auto;
+          padding-bottom: 0;
+          padding-left: 8px;
+          padding-right: 8px;
+          padding-top: 0;
+          vertical-align: top;
+        }
   >
      Some text before the divider. 
   </p>
   <span
-    className="wrapper-296"
+    className=
+
+        {
+          align-items: center;
+          display: inline-flex;
+          height: 100%;
+        }
   >
     <span
-      className="divider-299"
+      className=
+
+          {
+            background-color: #c8c8c8;
+            height: 28px;
+            width: 1px;
+          }
     />
   </span>
   <p
-    className="text-295"
+    className=
+
+        {
+          display: inline-block;
+          height: 40px;
+          line-height: 40px;
+          margin-bottom: auto;
+          margin-left: auto;
+          margin-right: auto;
+          margin-top: auto;
+          padding-bottom: 0;
+          padding-left: 8px;
+          padding-right: 8px;
+          padding-top: 0;
+          vertical-align: top;
+        }
   >
     Some text after the divider. 
   </p>


### PR DESCRIPTION
#### Pull request checklist

[ ] Addresses an existing issue: Fixes #0000
[ ] Include a change request file using `$ npm run change`

#### Description of changes

When I converted snapshot output in #5151 from one massive snapshot file to 200 snapshot files, the styling output got lost. This PR adds the merge style serializer to ensure that styled output is captured in the snapshot tests.

#### Focus areas to test

n/a
