### PR TITLE
ScrollablePane: Fix DetailsList Header scroll position sync

### DIFF
--- a/common/changes/office-ui-fabric-react/scrollablePaneDetailsListFix_2018-06-12-00-54.json
+++ b/common/changes/office-ui-fabric-react/scrollablePaneDetailsListFix_2018-06-12-00-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ScrollablePane: Fix DetailsList example's DetailHeader not syncing scroll position.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -10,6 +10,7 @@ import { CollapseAllVisibility } from '../../GroupedList';
 import { DetailsRowCheck } from './DetailsRowCheck';
 import { ITooltipHostProps } from '../../Tooltip';
 import * as checkStylesModule from './DetailsRowCheck.scss';
+import { IViewport } from '../../utilities/decorators/withViewport';
 import { ISelection, SelectionMode, SELECTION_CHANGE } from '../../utilities/selection/interfaces';
 import * as stylesImport from './DetailsHeader.scss';
 const styles: any = stylesImport;
@@ -47,6 +48,7 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeader> {
   ariaLabelForSelectAllCheckbox?: string;
   ariaLabelForSelectionColumn?: string;
   selectAllVisibility?: SelectAllVisibility;
+  viewport?: IViewport;
 }
 
 export enum SelectAllVisibility {
@@ -121,7 +123,8 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
       ariaLabelForSelectAllCheckbox,
       selectAllVisibility,
       ariaLabelForSelectionColumn,
-      indentWidth
+      indentWidth,
+      viewport
     } = this.props;
     const { isAllSelected, columnResizeDetails, isSizing, groupNestingDepth, isAllCollapsed } = this.state;
 
@@ -143,6 +146,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         componentRef={this._root}
         onMouseMove={this._onRootMouseMove}
         data-automationid="DetailsHeader"
+        style={{ minWidth: viewport ? viewport.width : 0 }}
         direction={FocusZoneDirection.horizontal}
       >
         {showCheckbox

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -160,6 +160,13 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     }
   }
 
+  public componentDidMount(): void {
+    const { onScroll } = this.props;
+    if (onScroll && this._root.current) {
+      this._root.current.addEventListener('scroll', this._onScroll.bind(this));
+    }
+  }
+
   public componentDidUpdate(prevProps: any, prevState: any) {
     if (this._initialFocusedIndex !== undefined) {
       const item = this.props.items[this._initialFocusedIndex];
@@ -276,7 +283,8 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       listProps,
       usePageCache,
       onShouldVirtualize,
-      enableShimmer
+      enableShimmer,
+      viewport
     } = this.props;
     const { adjustedColumns, isCollapsed, isSizing, isSomeGroupExpanded } = this.state;
     const { _selection: selection, _dragDropHelper: dragDropHelper } = this;
@@ -359,7 +367,8 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
                   ariaLabelForSelectAllCheckbox: ariaLabelForSelectAllCheckbox,
                   ariaLabelForSelectionColumn: ariaLabelForSelectionColumn,
                   selectAllVisibility: selectAllVisibility,
-                  collapseAllVisibility: groupProps && groupProps.collapseAllVisibility
+                  collapseAllVisibility: groupProps && groupProps.collapseAllVisibility,
+                  viewport: viewport
                 },
                 this._onRenderDetailsHeader
               )}
@@ -876,6 +885,13 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
 
     return itemKey;
   }
+
+  private _onScroll = (e: Event): void => {
+    const { onScroll } = this.props;
+    if (onScroll) {
+      onScroll(e);
+    }
+  };
 }
 
 export function buildColumns(

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -155,6 +155,11 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   }
 
   public componentWillUnmount(): void {
+    const { onScroll } = this.props;
+    if (onScroll && this._root.current) {
+      this._root.current.removeEventListener('scroll', this._onScroll);
+    }
+
     if (this._dragDropHelper) {
       this._dragDropHelper.dispose();
     }
@@ -163,7 +168,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   public componentDidMount(): void {
     const { onScroll } = this.props;
     if (onScroll && this._root.current) {
-      this._root.current.addEventListener('scroll', this._onScroll.bind(this));
+      this._root.current.addEventListener('scroll', this._onScroll);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -231,6 +231,11 @@ export interface IDetailsListProps extends React.Props<DetailsList>, IWithViewpo
    * Whether or not the selection zone should enter modal state on touch.
    */
   enterModalSelectionOnTouch?: boolean;
+
+  /**
+   * On horizontal scroll event listener
+   */
+  onScroll?: (e?: Event) => void;
 }
 
 export interface IColumn {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -13,6 +13,11 @@ exports[`DetailsHeader can render 1`] = `
   onMouseDownCapture={[Function]}
   onMouseMove={[Function]}
   role="row"
+  style={
+    Object {
+      "minWidth": 0,
+    }
+  }
 >
   <div
     aria-colindex={1}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -39,6 +39,11 @@ exports[`DetailsList renders List correctly 1`] = `
           onMouseDownCapture={[Function]}
           onMouseMove={[Function]}
           role="row"
+          style={
+            Object {
+              "minWidth": 0,
+            }
+          }
         >
           <div
             aria-colindex={1}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -380,9 +380,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   };
 
   private _onWindowResize = (): void => {
-    this._async.setTimeout(() => {
-      this.notifySubscribers();
-    }, 5);
+    this.notifySubscribers();
   };
 
   private _getStickyContainerStyle = (height: number): React.CSSProperties => {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -75,7 +75,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<
   }
 
   public render(): JSX.Element {
-    const { items } = this.state;
+    const { items, selectionDetails } = this.state;
 
     return (
       <div
@@ -86,6 +86,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<
         }}
       >
         <ScrollablePane componentRef={this._scrollablePane}>
+          <Sticky stickyPosition={StickyPositionType.Header}>{selectionDetails}</Sticky>
           <TextField
             label="Filter by name:"
             // tslint:disable-next-line:jsx-no-lambda

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -7,9 +7,9 @@ import {
   Selection,
   IColumn
 } from 'office-ui-fabric-react/lib/DetailsList';
-import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { IRenderFunction, createRef } from 'office-ui-fabric-react/lib/Utilities';
 import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Tooltip';
-import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { ScrollablePane, IScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 
@@ -47,6 +47,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<
     selectionDetails: string;
   }
 > {
+  private _scrollablePane = createRef<IScrollablePane>();
   private _selection: Selection;
 
   constructor(props: {}) {
@@ -74,7 +75,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<
   }
 
   public render(): JSX.Element {
-    const { items, selectionDetails } = this.state;
+    const { items } = this.state;
 
     return (
       <div
@@ -84,8 +85,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<
           maxHeight: 'inherit'
         }}
       >
-        <ScrollablePane>
-          <Sticky stickyPosition={StickyPositionType.Header}>{selectionDetails}</Sticky>
+        <ScrollablePane componentRef={this._scrollablePane}>
           <TextField
             label="Filter by name:"
             // tslint:disable-next-line:jsx-no-lambda
@@ -102,6 +102,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<
               columns={_columns}
               setKey="set"
               layoutMode={DetailsListLayoutMode.fixedColumns}
+              onScroll={this._onScroll}
               onRenderDetailsHeader={
                 // tslint:disable-next-line:jsx-no-lambda
                 (detailsHeaderProps: IDetailsHeaderProps, defaultRender: IRenderFunction<IDetailsHeaderProps>) => (
@@ -127,6 +128,12 @@ export class ScrollablePaneDetailsListExample extends React.Component<
       </div>
     );
   }
+
+  private _onScroll = (e: Event): void => {
+    if (this._scrollablePane.current) {
+      this._scrollablePane.current.forceLayoutUpdate();
+    }
+  };
 
   private _getSelectionDetails(): string {
     const selectionCount = this._selection.getSelectedCount();

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -14,7 +14,8 @@ export interface IStickyContext {
 
 export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
   public static defaultProps: IStickyProps = {
-    stickyPosition: StickyPositionType.Both
+    stickyPosition: StickyPositionType.Both,
+    isScrollSynced: true
   };
 
   public static contextTypes: IStickyContext = {
@@ -114,12 +115,22 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     return (
       <div ref={this._root}>
         {this.canStickyTop && (
-          <div className={this.props.stickyClassName} ref={this._stickyContentTop} aria-hidden={!isStickyTop}>
+          <div
+            className={this.props.stickyClassName}
+            ref={this._stickyContentTop}
+            aria-hidden={!isStickyTop}
+            style={this._getStickyContainerStyle()}
+          >
             <div style={this._getStickyPlaceholderHeight(isStickyTop)} />
           </div>
         )}
         {this.canStickyBottom && (
-          <div className={this.props.stickyClassName} ref={this._stickyContentBottom} aria-hidden={!isStickyBottom}>
+          <div
+            className={this.props.stickyClassName}
+            ref={this._stickyContentBottom}
+            aria-hidden={!isStickyBottom}
+            style={this._getStickyContainerStyle()}
+          >
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
@@ -157,6 +168,13 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     };
   }
 
+  private _getStickyContainerStyle(): React.CSSProperties {
+    const { isScrollSynced } = this.props;
+    return {
+      overflow: isScrollSynced ? 'hidden' : 'auto'
+    };
+  }
+
   private _getStickyPlaceholderHeight(isSticky: boolean): React.CSSProperties {
     const height = this.nonStickyContent ? this.nonStickyContent.offsetHeight : 0;
 
@@ -186,6 +204,10 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       let isStickyTop = false;
       let isStickyBottom = false;
 
+      if (this.props.isScrollSynced) {
+        this._syncScroll(container);
+      }
+
       if (this.canStickyTop) {
         const distanceToStickTop = this.distanceFromTop - this._getStickyDistanceFromTop();
         isStickyTop = distanceToStickTop < container.scrollTop;
@@ -202,6 +224,24 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         isStickyTop: this.canStickyTop && isStickyTop,
         isStickyBottom: isStickyBottom
       });
+    }
+  };
+
+  private _syncScroll = (container: HTMLElement): void => {
+    if (this.root) {
+      let scrollLeft = 0;
+      let scrollTop = 0;
+      let curr = this.root as HTMLElement;
+      while (curr !== container) {
+        scrollLeft += curr.scrollLeft;
+        scrollTop += curr.scrollTop;
+        curr = curr.parentElement as HTMLElement;
+      }
+
+      if (this.stickyContentTop) {
+        this.stickyContentTop.scrollLeft = scrollLeft;
+        this.stickyContentTop.scrollTop = scrollTop;
+      }
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.types.ts
@@ -22,6 +22,12 @@ export interface IStickyProps extends React.Props<Sticky> {
    * @default Both
    */
   stickyPosition?: StickyPositionType;
+
+  /**
+   * If true, then match scrolling position of placeholder element in Sticky.
+   * @default true
+   */
+  isScrollSynced?: boolean;
 }
 
 export enum StickyPositionType {


### PR DESCRIPTION
#### Pull request checklist

[ ] Addresses an existing issue: Fixes #5116  #4890
[ ] Include a change request file using `$ npm run change`

#### Description of changes

- Adds viewport prop to DetailsHeader to have same min-width as DetailsRow
- Add optional onScroll event handler to DetailsList to have a horizontal scroll event listener
- Add isScrollSync prop to Sticky.  This prop is true by default and will calculate the scrollLeft and scrollTop position of a Sticky component.

**Video of changes in action**
https://streamable.com/ysaqk

**DetailsHeader Before:**
![detailsheader-before](https://user-images.githubusercontent.com/1291968/41257559-29aa29ba-6d82-11e8-8b63-e59ee60346ff.JPG)

**DetailsHeader After:**
![detailsheader-after](https://user-images.githubusercontent.com/1291968/41257562-2e766332-6d82-11e8-9212-9f2912c85942.JPG)


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5169)

