### PR TITLE
fix the build to setting for npm postinstall scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "_rushInstall": "node node_modules/@microsoft/rush/bin/rush install -c",
     "_rushBuild": "node node_modules/@microsoft/rush/bin/rush build",
-    "_rushBuildToFabric": "node node_modules/@microsoft/rush/bin/rush build --to office-ui-fabric-react --verbose",
+    "_rushBuildToFabric": "node node_modules/@microsoft/rush/bin/rush build --to @uifabric/demo --verbose",
     "_rushRebuild": "node node_modules/@microsoft/rush/bin/rush rebuild --production --verbose --lint",
     "_rushRebuildCi": "node node_modules/@microsoft/rush/bin/rush rebuild --verbose --lint",
     "_rushRebuildFast": "node node_modules/@microsoft/rush/bin/rush rebuild",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

After my big refactor of demo pages, npm start needs to go to the demo project which means npm postinstall should prebuild up to demo instead of just OUFR since example-app-base is nolonger a dependency of OUFR

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5179)

