### PR TITLE
Accessibility: added aria hidden label to div containing search icon …

### DIFF
--- a/common/changes/office-ui-fabric-react/search-accessibility_2018-06-14-11-15.json
+++ b/common/changes/office-ui-fabric-react/search-accessibility_2018-06-14-11-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Accessibility: using the down arrow key to navigate the command bar currently skips over the search box - added aria-hidden to the div containing the search icon",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "sepodest@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -77,7 +77,7 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
 
     return (
       <div ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
-        <div className={classNames.iconContainer} onClick={this._onClickFocus}>
+        <div className={classNames.iconContainer} onClick={this._onClickFocus} aria-hidden={true}>
           <Icon className={classNames.icon} iconName="Search" />
         </div>
         <input

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
   onFocusCapture={[Function]}
 >
   <div
+    aria-hidden={true}
     className=
         ms-SearchBox-iconContainer
         {
@@ -170,6 +171,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
   onFocusCapture={[Function]}
 >
   <div
+    aria-hidden={true}
     className=
         ms-SearchBox-iconContainer
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -47,6 +47,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
       onFocusCapture={[Function]}
     >
       <div
+        aria-hidden={true}
         className=
             ms-SearchBox-iconContainer
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -68,6 +68,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       onFocusCapture={[Function]}
     >
       <div
+        aria-hidden={true}
         className=
             ms-SearchBox-iconContainer
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -51,6 +51,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       className=
           ms-SearchBox-iconContainer
           {
@@ -182,6 +183,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       className=
           ms-SearchBox-iconContainer
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -46,6 +46,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       className=
           ms-SearchBox-iconContainer
           {
@@ -170,6 +171,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       className=
           ms-SearchBox-iconContainer
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -46,6 +46,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       className=
           ms-SearchBox-iconContainer
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -45,6 +45,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
   onFocusCapture={[Function]}
 >
   <div
+    aria-hidden={true}
     className=
         ms-SearchBox-iconContainer
         {


### PR DESCRIPTION
...so downkey arrow navigation can find it in the command bar

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Currently when using keyboard navigation in the command bar, users are unable to use the down arrow to navigate into search (it focuses the container but not the actual search field). Adding aria-hidden=true to the div containing the search icon allows users to navigate there using the down arrow. 

#### Focus areas to test

Change in screen reader/keyboard navigation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5210)

