### PR TITLE
Don't use Object.entries

### DIFF
--- a/scripts/lint-staged/tslint.js
+++ b/scripts/lint-staged/tslint.js
@@ -46,7 +46,12 @@ function runTsLintOnFilesGroupedPerPackage(filesGroupedByPackage) {
   // Log an empty line on error to make the tslint output look better
   console.log('');
 
-  for (let [package, files] of Object.entries(filesGroupedByPackage)) {
+  const fileEntries = Object.keys(filesGroupedByPackage).reduce((entries, package) => {
+    entries.push([package, filesGroupedByPackage[package]]);
+    return entries;
+  }, []);
+
+  for (let [package, files] of fileEntries) {
     const tslintConfig = path.join(path.resolve(__dirname, '..', '..'), package, 'tslint.json');
 
     execSync(`${tslintPath} --config ${tslintConfig} -t stylish -r ${rulesPath} ${files.join(' ')}`);


### PR DESCRIPTION
#### Description of changes

The pre-commit hook can fail for folks who are on Node 6. We'll create the value originally returned by `Object.entries` manually to be compatible with Node 6.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5215)

