### PR TITLE
Make uncheckable contextual menu items lack the aria-checked attribute.

### DIFF
--- a/common/changes/office-ui-fabric-react/wygoodin-unchecked_contextual_menu_2018-06-14-21-18.json
+++ b/common/changes/office-ui-fabric-react/wygoodin-unchecked_contextual_menu_2018-06-14-21-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Make uncheckable contextual menu items lack the aria-checked attribute",
+      "comment": "ContextualMenu: Fixed the fact that uncheckable contextual menu items incorrectly possessed the `aria-checked` attribute.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/wygoodin-unchecked_contextual_menu_2018-06-14-21-18.json
+++ b/common/changes/office-ui-fabric-react/wygoodin-unchecked_contextual_menu_2018-06-14-21-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make uncheckable contextual menu items lack the aria-checked attribute",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "wygoodin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -52,7 +52,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       'aria-haspopup': itemHasSubmenu || undefined,
       'aria-owns': item.key === expandedMenuItemKey ? subMenuId : undefined,
       'aria-expanded': itemHasSubmenu ? item.key === expandedMenuItemKey : undefined,
-      'aria-checked': !!isChecked,
+      'aria-checked': canCheck ? !!isChecked : undefined,
       'aria-posinset': focusableElementIndex + 1,
       'aria-setsize': totalItemCount,
       'aria-disabled': isItemDisabled(item),

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.deprecated.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ContextualMenuButton creates a normal button renders the contextual menu split button correctly 1`] = `
 <button
-  aria-checked={false}
+  aria-checked={undefined}
   aria-disabled={false}
   aria-expanded={undefined}
   aria-haspopup={undefined}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ContextualMenuButton creates a normal button renders the contextual menu split button correctly 1`] = `
 <button
-  aria-checked={false}
+  aria-checked={undefined}
   aria-disabled={false}
   aria-expanded={undefined}
   aria-haspopup={undefined}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4943
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Only allow the aria-checked attribute on contextual menu items when the item is checkable.

#### Focus areas to test

Inspection to make sure logic is implemented properly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5217)

