### PR TITLE
ScrollablePane: Fix overflow css and remove unnecessary stickyClassName prop in render

### DIFF
--- a/common/changes/office-ui-fabric-react/scrollablePaneFixes_2018-06-14-22-42.json
+++ b/common/changes/office-ui-fabric-react/scrollablePaneFixes_2018-06-14-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ScrollablePane: Fix overflow css and remove unncessary stickyClassName in render",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
@@ -15,9 +15,7 @@ export const getStyles = (props: IScrollablePaneStyleProps): IScrollablePaneStyl
     position: 'absolute',
     pointerEvents: 'auto',
     width: '100%',
-    zIndex: ZIndexes.ScrollablePane,
-    overflowY: 'hidden',
-    overflowX: 'auto'
+    zIndex: ZIndexes.ScrollablePane
   };
 
   const positioningStyle: IStyle = {

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -111,36 +111,27 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
   public render(): JSX.Element {
     const { isStickyTop, isStickyBottom } = this.state;
+    const { stickyClassName, children } = this.props;
 
     return (
       <div ref={this._root}>
         {this.canStickyTop && (
-          <div
-            className={this.props.stickyClassName}
-            ref={this._stickyContentTop}
-            aria-hidden={!isStickyTop}
-            style={this._getStickyContainerStyle()}
-          >
+          <div ref={this._stickyContentTop} aria-hidden={!isStickyTop}>
             <div style={this._getStickyPlaceholderHeight(isStickyTop)} />
           </div>
         )}
         {this.canStickyBottom && (
-          <div
-            className={this.props.stickyClassName}
-            ref={this._stickyContentBottom}
-            aria-hidden={!isStickyBottom}
-            style={this._getStickyContainerStyle()}
-          >
+          <div ref={this._stickyContentBottom} aria-hidden={!isStickyBottom}>
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
         <div style={this._getNonStickyPlaceholderHeight()} />
         <div
           ref={this._nonStickyContent}
-          className={isStickyTop || isStickyBottom ? this.props.stickyClassName : undefined}
+          className={isStickyTop || isStickyBottom ? stickyClassName : undefined}
           style={this._getContentStyles(isStickyTop || isStickyBottom)}
         >
-          {this.props.children}
+          {children}
         </div>
       </div>
     );
@@ -164,14 +155,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
   private _getContentStyles(isSticky: boolean): React.CSSProperties {
     return {
-      backgroundColor: this.props.stickyBackgroundColor || this._getBackground()
-    };
-  }
-
-  private _getStickyContainerStyle(): React.CSSProperties {
-    const { isScrollSynced } = this.props;
-    return {
-      overflow: isScrollSynced ? 'hidden' : 'auto'
+      backgroundColor: this.props.stickyBackgroundColor || this._getBackground(),
+      overflow: isSticky ? 'hidden' : ''
     };
   }
 
@@ -238,9 +223,9 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         curr = curr.parentElement as HTMLElement;
       }
 
-      if (this.stickyContentTop) {
-        this.stickyContentTop.scrollLeft = scrollLeft;
-        this.stickyContentTop.scrollTop = scrollTop;
+      if (this.nonStickyContent) {
+        this.nonStickyContent.scrollLeft = scrollLeft;
+        this.nonStickyContent.scrollTop = scrollTop;
       }
     }
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

- Fixes overflow css for ScrollablePane.  
- Remove unncesssary stickyClassName props in render

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5220)

