### PR TITLE
SplitButton/SpinBUtton: fix styling and spin button focusablility

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-FixSplitButtonStylingAndSpinButtonFocusablility_2018-06-15-02-16.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-FixSplitButtonStylingAndSpinButtonFocusablility_2018-06-15-02-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix splitButton styling to not break existing usages and fix spinButton to make the contents focusable when disabled",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -119,7 +119,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         checked!,
         !!menuProps,
         this.props.split,
-        allowDisabledFocus!
+        !!allowDisabledFocus
       )
       : getBaseButtonClassNames(
         styles!,

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -110,28 +110,28 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     this._classNames = getClassNames
       ? getClassNames(
-          theme!,
-          className!,
-          variantClassName!,
-          iconProps && iconProps.className,
-          menuIconProps && menuIconProps.className,
-          allowDisabledFocus!,
-          isPrimaryButtonDisabled!,
-          checked!,
-          !!menuProps,
-          this.props.split
-        )
+        theme!,
+        className!,
+        variantClassName!,
+        iconProps && iconProps.className,
+        menuIconProps && menuIconProps.className,
+        allowDisabledFocus!,
+        isPrimaryButtonDisabled!,
+        checked!,
+        !!menuProps,
+        this.props.split
+      )
       : getBaseButtonClassNames(
-          styles!,
-          className!,
-          variantClassName!,
-          iconProps && iconProps.className,
-          menuIconProps && menuIconProps.className,
-          isPrimaryButtonDisabled!,
-          checked!,
-          !!menuProps,
-          this.props.split
-        );
+        styles!,
+        className!,
+        variantClassName!,
+        iconProps && iconProps.className,
+        menuIconProps && menuIconProps.className,
+        isPrimaryButtonDisabled!,
+        checked!,
+        !!menuProps,
+        this.props.split
+      );
 
     const { _ariaDescriptionId, _labelId, _descriptionId } = this;
     // Anchor tag cannot be disabled hence in disabled state rendering
@@ -470,7 +470,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     let { keytipProps } = this.props;
 
     const classNames = getSplitButtonClassNames
-      ? getSplitButtonClassNames(!!disabled, !!allowDisabledFocus, !!this.state.menuProps, !!checked)
+      ? getSplitButtonClassNames(!!disabled, !!this.state.menuProps, !!checked, !!allowDisabledFocus)
       : styles && getBaseSplitButtonClassNames(styles!, !!disabled, !!this.state.menuProps, !!checked);
 
     assign(buttonProps, {

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -115,11 +115,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         variantClassName!,
         iconProps && iconProps.className,
         menuIconProps && menuIconProps.className,
-        allowDisabledFocus!,
         isPrimaryButtonDisabled!,
         checked!,
         !!menuProps,
-        this.props.split
+        this.props.split,
+        allowDisabledFocus!
       )
       : getBaseButtonClassNames(
         styles!,

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -237,9 +237,9 @@ export interface IButtonProps
    */
   getSplitButtonClassNames?: (
     disabled: boolean,
-    allowDisabledFocus: boolean,
     expanded: boolean,
-    checked: boolean
+    checked: boolean,
+    allowDisabledFocus: boolean
   ) => ISplitButtonClassNames;
 
   /**

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -223,10 +223,10 @@ export interface IButtonProps
     iconClassName: string | undefined,
     menuIconClassName: string | undefined,
     disabled: boolean,
-    allowDisabledFocus: boolean,
     checked: boolean,
     expanded: boolean,
-    isSplit: boolean | undefined
+    isSplit: boolean | undefined,
+    allowDisabledFocus: boolean
   ) => IButtonClassNames;
 
   /**

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -183,7 +183,6 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
                 onKeyDown={this._handleKeyDown}
                 onKeyUp={this._handleKeyUp}
                 readOnly={disabled}
-                disabled={disabled}
                 aria-disabled={disabled}
                 data-lpignore={true}
                 data-ktp-execute-target={keytipAttributes['data-ktp-execute-target']}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -119,7 +119,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
           }
       data-ktp-execute-target={undefined}
       data-lpignore={true}
-      disabled={false}
       id="input1"
       onBlur={[Function]}
       onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -478,7 +478,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                   }
               data-ktp-execute-target="ktp-a-3"
               data-lpignore={true}
-              disabled={false}
               id="input12"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -149,7 +149,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
             }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
-        disabled={false}
         id="input1"
         onBlur={[Function]}
         onChange={[Function]}
@@ -548,7 +547,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
             }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
-        disabled={false}
         id="input9"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -126,7 +126,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
             }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
-        disabled={true}
         id="input1"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -149,7 +149,6 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
             }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
-        disabled={false}
         id="input1"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -149,7 +149,6 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
             }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
-        disabled={false}
         id="input1"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -150,7 +150,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
             }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
-        disabled={true}
         id="input1"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -120,7 +120,6 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
             }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
-        disabled={false}
         id="input1"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -126,7 +126,6 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
             }
         data-ktp-execute-target={undefined}
         data-lpignore={true}
-        disabled={false}
         id="input1"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -4577,7 +4577,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   ms-Button--action
                   ms-Button--command
                   undefined
-                  is-checked
+                  is-disabled
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -4586,7 +4586,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     border-radius: 0px;
                     border: 1px solid transparent;
                     box-sizing: border-box;
-                    color: #000000;
+                    color: #a6a6a6;
                     cursor: default;
                     display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
@@ -4631,6 +4631,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){& {
                     border: none;
+                    bordercolor: grayText;
+                    color: grayText;
                   }
                   .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
                     border: none;
@@ -4697,6 +4699,12 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   & $svg {
                     border-radius: 100%;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
                   }
               data-index={0}
               data-is-focusable={false}
@@ -4769,7 +4777,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   ms-Button--action
                   ms-Button--command
                   undefined
-                  is-checked
+                  is-disabled
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -4778,7 +4786,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     border-radius: 0px;
                     border: 1px solid transparent;
                     box-sizing: border-box;
-                    color: #000000;
+                    color: #a6a6a6;
                     cursor: default;
                     display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
@@ -4823,6 +4831,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){& {
                     border: none;
+                    bordercolor: grayText;
+                    color: grayText;
                   }
                   .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
                     border: none;
@@ -4889,6 +4899,12 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   & $svg {
                     border-radius: 100%;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
                   }
               data-index={1}
               data-is-focusable={false}
@@ -4961,7 +4977,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   ms-Button--action
                   ms-Button--command
                   undefined
-                  is-checked
+                  is-disabled
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -4970,7 +4986,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     border-radius: 0px;
                     border: 1px solid transparent;
                     box-sizing: border-box;
-                    color: #000000;
+                    color: #a6a6a6;
                     cursor: default;
                     display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
@@ -5015,6 +5031,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){& {
                     border: none;
+                    bordercolor: grayText;
+                    color: grayText;
                   }
                   .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
                     border: none;
@@ -5081,6 +5099,12 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   & $svg {
                     border-radius: 100%;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
                   }
               data-index={2}
               data-is-focusable={false}
@@ -5153,7 +5177,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   ms-Button--action
                   ms-Button--command
                   undefined
-                  is-checked
+                  is-disabled
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -5162,7 +5186,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     border-radius: 0px;
                     border: 1px solid transparent;
                     box-sizing: border-box;
-                    color: #000000;
+                    color: #a6a6a6;
                     cursor: default;
                     display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
@@ -5207,6 +5231,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){& {
                     border: none;
+                    bordercolor: grayText;
+                    color: grayText;
                   }
                   .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
                     border: none;
@@ -5273,6 +5299,12 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   & $svg {
                     border-radius: 100%;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
                   }
               data-index={3}
               data-is-focusable={false}
@@ -5345,7 +5377,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   ms-Button--action
                   ms-Button--command
                   undefined
-                  is-checked
+                  is-disabled
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -5354,7 +5386,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     border-radius: 0px;
                     border: 1px solid transparent;
                     box-sizing: border-box;
-                    color: #000000;
+                    color: #a6a6a6;
                     cursor: default;
                     display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
@@ -5399,6 +5431,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){& {
                     border: none;
+                    bordercolor: grayText;
+                    color: grayText;
                   }
                   .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
                     border: none;
@@ -5475,6 +5509,12 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     padding-left: 0px;
                     padding-right: 0px;
                     padding-top: 0px;
+                  }
+                  &:hover {
+                    outline: 0px;
+                  }
+                  &:focus {
+                    outline: 0px;
                   }
               data-index={4}
               data-is-focusable={false}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
#4716 - Add allowDisabledFocus flag to Button & SplitButton

Introduced a regression in getClassNames and getSplitButtonClassNames where the parameters will no longer line up for custom callbacks

This PR fixes those issues and makes spinButtons focusable when they are disabled to align with comboBox

#### Focus areas to test
Verified the works again and spinButtons can get focus when they are disabled

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5222)

