### PR TITLE
Colorpicker arialabels

### DIFF
--- a/common/changes/office-ui-fabric-react/colorpicker-arialabels_2018-06-15-17-48.json
+++ b/common/changes/office-ui-fabric-react/colorpicker-arialabels_2018-06-15-17-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ColorPicker: add aria-labels to textfields",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -101,6 +101,7 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
                     ref={ref => (this.hexText = ref!)}
                     onBlur={this._onHexChanged}
                     spellCheck={false}
+                    ariaLabel={this.props.hexLabel}
                   />
                 </td>
                 <td style={{ width: '18%' }}>
@@ -110,6 +111,7 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
                     value={String(color.r)}
                     ref={ref => (this.rText = ref!)}
                     spellCheck={false}
+                    ariaLabel={this.props.redLabel}
                   />
                 </td>
                 <td style={{ width: '18%' }}>
@@ -119,6 +121,7 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
                     value={String(color.g)}
                     ref={ref => (this.gText = ref!)}
                     spellCheck={false}
+                    ariaLabel={this.props.greenLabel}
                   />
                 </td>
                 <td style={{ width: '18%' }}>
@@ -128,6 +131,7 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
                     value={String(color.b)}
                     ref={ref => (this.bText = ref!)}
                     spellCheck={false}
+                    ariaLabel={this.props.blueLabel}
                   />
                 </td>
                 {!this.props.alphaSliderHidden && (
@@ -138,6 +142,7 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
                       value={String(color.a)}
                       ref={ref => (this.aText = ref!)}
                       spellCheck={false}
+                      ariaLabel={this.props.alphaLabel}
                     />
                   </td>
                 )}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Hex"
                     className="ms-TextField-field"
                     id="TextField0"
                     onBlur={[Function]}
@@ -326,7 +326,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Red"
                     className="ms-TextField-field"
                     id="TextField2"
                     onBlur={[Function]}
@@ -379,7 +379,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Green"
                     className="ms-TextField-field"
                     id="TextField4"
                     onBlur={[Function]}
@@ -432,7 +432,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Blue"
                     className="ms-TextField-field"
                     id="TextField6"
                     onBlur={[Function]}
@@ -485,7 +485,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Alpha"
                     className="ms-TextField-field"
                     id="TextField8"
                     onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -273,7 +273,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Hex"
                     className="ms-TextField-field"
                     id="TextField0"
                     onBlur={[Function]}
@@ -326,7 +326,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Red"
                     className="ms-TextField-field"
                     id="TextField2"
                     onBlur={[Function]}
@@ -379,7 +379,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Green"
                     className="ms-TextField-field"
                     id="TextField4"
                     onBlur={[Function]}
@@ -432,7 +432,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Blue"
                     className="ms-TextField-field"
                     id="TextField6"
                     onBlur={[Function]}
@@ -485,7 +485,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   <input
                     aria-describedby={undefined}
                     aria-invalid={false}
-                    aria-label={undefined}
+                    aria-label="Alpha"
                     className="ms-TextField-field"
                     id="TextField8"
                     onBlur={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #4940 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Use the hex, red, green, blue, and alpha labels as aria-labels for each textfield.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5229)

