### PR TITLE
Add alias for final CommandBar to @uifabric/experiments

### DIFF
--- a/common/changes/@uifabric/experiments/command-bar_2018-06-16-17-34.json
+++ b/common/changes/@uifabric/experiments/command-bar_2018-06-16-17-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add alias to CommandBar to final version",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/CommandBar.ts
+++ b/packages/experiments/src/CommandBar.ts
@@ -1,0 +1,3 @@
+// The CommandBar in @uifabric/experiments has 'graduated'.
+// Consumer projects should switch to using the version from 'office-ui-fabric-react' before Fabric 7.
+export * from 'office-ui-fabric-react/lib/CommandBar';


### PR DESCRIPTION
The `6.0` release simultaneously upgrades the official `CommandBar` to the version from `@uifabric/experiments` and also removes its API surface from the `experiments` package.
This presents a dilemma to projects which need to declare support for both Fabric 5 and 6.

To remedy this, the version of `@uifabric/experiments/lib/CommandBar` now points at `office-ui-fabric-react/lib/CommandBar`, but is deprecated, giving downstream project one more major version to handle the switch.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5237)

