### PR TITLE
The style prop should be a function, or a partial style object

### DIFF
--- a/common/changes/@uifabric/utilities/styled-fix_2018-06-18-19-12.json
+++ b/common/changes/@uifabric/utilities/styled-fix_2018-06-18-19-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "All `styled` props should be a style function which returns partial styles, or just a partial styles object. (Previously it was a \"complete\" styles object, which was not intended.)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -5,7 +5,7 @@ import { IStyleFunction } from './IStyleFunction';
 import { CustomizableContextTypes } from './customizable';
 import { Customizations, ICustomizations } from './Customizations';
 
-export type IStyleFunctionOrObject<TStyleProps, TStyles> = IStyleFunction<TStyleProps, TStyles> | TStyles;
+export type IStyleFunctionOrObject<TStyleProps, TStyles> = IStyleFunction<TStyleProps, TStyles> | Partial<TStyles>;
 
 export interface IPropsWithStyles<TStyleProps, TStyles> {
   styles?: IStyleFunctionOrObject<TStyleProps, TStyles>;


### PR DESCRIPTION
Previously:
The `IStyleFunctionOrObject` type was expecting full style objects.

Now:
It expects a partial. This is what was expected and supported.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5244)

