### PR TITLE
Add 'styles' alias for 'getStyles' for 6.0 compatibility

### DIFF
--- a/common/changes/@uifabric/utilities/styles_2018-06-18-20-42.json
+++ b/common/changes/@uifabric/utilities/styles_2018-06-18-20-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Add 'styles' as alias for 'getStyles' to match 6.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -9,6 +9,10 @@ export interface IPropsWithStyles<TStyleProps, TStyles> {
   };
 }
 
+interface IMaybeNewStyles<TStyleProps, TStyles> {
+  styles?: IStyleFunction<TStyleProps, TStyles>;
+}
+
 interface IWrappedComponent<P> {
   (props: P): JSX.Element;
   displayName: string;
@@ -34,12 +38,14 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
   getProps?: (props: TComponentProps) => Partial<TComponentProps>
 ): (props: TComponentProps) => JSX.Element {
 
-  const Wrapped = ((componentProps: TComponentProps) => {
+  const Wrapped = ((componentProps: TComponentProps & IMaybeNewStyles<TStyleProps, TStyles>) => {
+    const originalGetStyles = componentProps.styles || componentProps.getStyles;
+
     const getStyles = (
       styleProps: TStyleProps
     ) => concatStyleSets(
       getBaseStyles && getBaseStyles(styleProps),
-      componentProps && componentProps.getStyles && componentProps.getStyles(styleProps)
+      componentProps && originalGetStyles && originalGetStyles(styleProps)
     );
     const additionalProps = getProps ? getProps(componentProps) : {};
 

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -10,7 +10,7 @@ export interface IPropsWithStyles<TStyleProps, TStyles> {
 }
 
 interface IMaybeNewStyles<TStyleProps, TStyles> {
-  styles?: IStyleFunction<TStyleProps, TStyles>;
+  styles?: IStyleFunction<TStyleProps, TStyles> | TStyles;
 }
 
 interface IWrappedComponent<P> {
@@ -39,7 +39,11 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
 ): (props: TComponentProps) => JSX.Element {
 
   const Wrapped = ((componentProps: TComponentProps & IMaybeNewStyles<TStyleProps, TStyles>) => {
-    const originalGetStyles = componentProps.styles || componentProps.getStyles;
+    const styles = componentProps.styles;
+
+    const originalGetStyles =
+      styles && (typeof styles === 'function' ? styles : () => styles) ||
+      componentProps.getStyles;
 
     const getStyles = (
       styleProps: TStyleProps


### PR DESCRIPTION
This change adds runtime support for a `styles` prop in `getStyles`, in case code compiled against 6.0 is given 5.0 at runtime. This will ease the transition for codebases with heavy legacy dependency management.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5247)

