### PR TITLE
Fluent color updates (experiment)

### DIFF
--- a/common/changes/@uifabric/experiments/miwhea-fluent-color-changes_2018-06-18-21-53.json
+++ b/common/changes/@uifabric/experiments/miwhea-fluent-color-changes_2018-06-18-21-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Update Fluent colors and theme",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "mike@mikewheaton.ca"
+}

--- a/packages/experiments/src/components/fluent/theme/FluentColors.ts
+++ b/packages/experiments/src/components/fluent/theme/FluentColors.ts
@@ -5,10 +5,9 @@ export const CommunicationColors: any = {
   communicationShade10: '#106ebe',
   communicationPrimary: '#0078d4',
   communicationTint10: '#2b88d8',
-  communicationTint20: '#71afe5',
-  communicationTint30: '#c7e0f4',
-  communicationTint40: '#deecf9',
-  communicationTint50: '#eff6fc'
+  communicationTint20: '#c7e0f4',
+  communicationTint30: '#deecf9',
+  communicationTint40: '#eff6fc'
 };
 
 export const NeutralColors: any = {
@@ -53,11 +52,9 @@ export const SharedColors: any = {
   sharedGreen20: '#0b6a0b',
   sharedGreen10: '#498205',
   sharedGreenCyan10: '#00ad56',
-  sharedCyan50: '#005b70',
-  sharedCyan40: '#038387',
-  sharedCyan30: '#00b7c3',
-  sharedCyan20: '#69797e',
-  sharedCyan10: '#a0aeb2',
+  sharedCyan30: '#005b70',
+  sharedCyan20: '#038387',
+  sharedCyan10: '#00b7c3',
   sharedCyanBlue20: '#004e8c',
   sharedCyanBlue10: '#0078d4',
   sharedBlue10: '#4f6bed',
@@ -68,13 +65,8 @@ export const SharedColors: any = {
   sharedMagenta10: '#c239b3',
   sharedMagentaPink20: '#9b0062',
   sharedMagentaPink10: '#e3008c',
-  sharedGray20: '#393939',
-  sharedGray10: '#7a7574'
-};
-
-export const HighContrastColors: any = {
-  contrastBlackDisabled: '#00ff00',
-  contrastWhiteDisabled: '#600000',
-  contrastBlackSelected: '#1aebff',
-  contrastWhiteSelected: '#37006e'
+  sharedGray40: '#393939',
+  sharedGray30: '#7a7574',
+  sharedGray20: '#69797e',
+  sharedGray10: '#a0aeb2'
 };

--- a/packages/experiments/src/components/fluent/theme/FluentTheme.ts
+++ b/packages/experiments/src/components/fluent/theme/FluentTheme.ts
@@ -1,5 +1,5 @@
 import { createTheme, ITheme } from 'office-ui-fabric-react';
-import { NeutralColors } from './FluentColors';
+import { NeutralColors, CommunicationColors } from './FluentColors';
 
 const FluentTheme: ITheme = createTheme({
   palette: {
@@ -15,7 +15,15 @@ const FluentTheme: ITheme = createTheme({
     neutralLight: NeutralColors.gray30,
     neutralLighter: NeutralColors.gray20,
     neutralLighterAlt: NeutralColors.gray10,
-    white: NeutralColors.white
+    white: NeutralColors.white,
+    themeDarker: CommunicationColors.communicationShade30,
+    themeDark: CommunicationColors.communicationShade20,
+    themeDarkAlt: CommunicationColors.communicationShade10,
+    themePrimary: CommunicationColors.communicationPrimary,
+    themeSecondary: CommunicationColors.communicationTint10,
+    themeLight: CommunicationColors.communicationTint20,
+    themeLighter: CommunicationColors.communicationTint30,
+    themeLighterAlt: CommunicationColors.communicationTint40
   }
 });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates to the Fluent colors and theme:
- Removed CommunicationTint20
- Renamed two cyans in the Shared palette to grays
- Removed High Contrast palette
- Update theme to include theme/Communication colors (values are the same)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5251)

