### PR TITLE
Addressing onReset undefined scenarios.

### DIFF
--- a/common/changes/@uifabric/styling/fix-onReset_2018-06-19-05-36.json
+++ b/common/changes/@uifabric/styling/fix-onReset_2018-06-19-05-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/styling",
-      "comment": "Handling `stylesheet.onReset` undefi",
+      "comment": "Handling `stylesheet.onReset` undefined scenarios better.",
       "type": "patch"
     }
   ],

--- a/common/changes/@uifabric/styling/fix-onReset_2018-06-19-05-36.json
+++ b/common/changes/@uifabric/styling/fix-onReset_2018-06-19-05-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Handling `stylesheet.onReset` undefi",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/fix-onReset_2018-06-19-05-36.json
+++ b/common/changes/@uifabric/utilities/fix-onReset_2018-06-19-05-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Handling `stylesheet.onReset` undefi",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/fix-onReset_2018-06-19-05-36.json
+++ b/common/changes/@uifabric/utilities/fix-onReset_2018-06-19-05-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/utilities",
-      "comment": "Handling `stylesheet.onReset` undefi",
+      "comment": "Handling `stylesheet.onReset` undefined scenarios better.",
       "type": "patch"
     }
   ],

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -61,13 +61,17 @@ const _iconSettings = GlobalSettings.getValue<IIconRecords>(ICON_SETTING_NAME, {
 });
 
 // Reset icon registration on stylesheet resets.
-Stylesheet.getInstance().onReset(() => {
-  for (const name in _iconSettings) {
-    if (_iconSettings.hasOwnProperty(name) && !!(_iconSettings[name] as IIconRecord).subset) {
-      (_iconSettings[name] as IIconRecord).subset.className = undefined;
+const stylesheet = Stylesheet.getInstance();
+
+if (stylesheet && stylesheet.onReset) {
+  stylesheet.onReset(() => {
+    for (const name in _iconSettings) {
+      if (_iconSettings.hasOwnProperty(name) && !!(_iconSettings[name] as IIconRecord).subset) {
+        (_iconSettings[name] as IIconRecord).subset.className = undefined;
+      }
     }
-  }
-});
+  });
+}
 
 /**
  * Registers a given subset of icons.

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -1,6 +1,10 @@
 import { Stylesheet } from '@uifabric/merge-styles';
 
-Stylesheet.getInstance().onReset(resetMemoizations);
+const stylesheet = Stylesheet.getInstance();
+
+if (stylesheet && stylesheet.onReset) {
+  Stylesheet.getInstance().onReset(resetMemoizations);
+}
 
 // tslint:disable:no-any
 declare class WeakMap {

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -80,7 +80,11 @@ export function filteredAssign(isAllowed: (propName: string) => boolean, target:
 }
 
 // Configure ids to reset on stylesheet resets.
-Stylesheet.getInstance().onReset(resetIds);
+const stylesheet = Stylesheet.getInstance();
+
+if (stylesheet && stylesheet.onReset) {
+  stylesheet.onReset(resetIds);
+}
 
 /**
  * Generates a unique id in the global scope (this spans across duplicate copies of the same library.)


### PR DESCRIPTION
In cases where multiple copies of mergeStyles is on the page, we were seeing nullrefs with scenarios where onReset was missing from the shared singleton.

This addresses the issue.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5253)

