### PR TITLE
Restore amd build target

### DIFF
--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -25,6 +25,10 @@ module.exports = function(options) {
     runPromises.push(runTscFor('lib', 'es2015', extraParams));
   }
 
+  if (options.isProduction) {
+    runPromises.push(runTscFor('lib-amd', 'amd', extraParams));
+  }
+
   return Promise.all(runPromises);
 
   function logFirstStdOutAndRethrow(process) {


### PR DESCRIPTION
#### Description of changes

The amd build target got lost in the speed optimisation merged. I thought we removed it but was mistaken. This PR restores it.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5255)

