### PR TITLE
GroupedList show subgroup headers for empty lists

### DIFF
--- a/common/changes/office-ui-fabric-react/groupedListShowEmpty_2018-06-19-23-23.json
+++ b/common/changes/office-ui-fabric-react/groupedListShowEmpty_2018-06-19-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "GroupedList: render group headers if showEmptyGroups is true",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.tsx
@@ -163,6 +163,7 @@ export class GroupedList extends BaseComponent<IGroupedListProps, IGroupedListSt
         group={group}
         groupIndex={groupIndex}
         groupNestingDepth={groupNestingDepth}
+        groupProps={groupProps}
         headerProps={headerProps}
         listProps={listProps}
         items={items}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IGroup, IGroupDividerProps } from './GroupedList.types';
+import { IGroup, IGroupDividerProps, IGroupRenderProps } from './GroupedList.types';
 
 import { IDragDropContext, IDragDropEvents, IDragDropHelper } from '../../utilities/dragdrop/index';
 
@@ -49,6 +49,9 @@ export interface IGroupedListSectionProps extends React.Props<GroupedListSection
 
   /** Optional grouping instructions. */
   group?: IGroup;
+
+  /** Optional override properties to render groups. */
+  groupProps?: IGroupRenderProps;
 
   /** Information to pass in to the group header. */
   headerProps?: IGroupDividerProps;
@@ -308,6 +311,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
       eventsToRegister,
       getGroupItemLimit,
       groupNestingDepth,
+      groupProps,
       items,
       headerProps,
       showAllProps,
@@ -323,7 +327,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
       onShouldVirtualize
     } = this.props;
 
-    return !subGroup || subGroup.count > 0 ? (
+    return !subGroup || subGroup.count > 0 || (groupProps && groupProps.showEmptyGroups) ? (
       <GroupedListSection
         ref={'subGroup_' + subGroupIndex}
         key={this._getGroupKey(subGroup, subGroupIndex)}
@@ -335,6 +339,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
         group={subGroup}
         groupIndex={subGroupIndex}
         groupNestingDepth={groupNestingDepth}
+        groupProps={groupProps}
         headerProps={headerProps}
         items={items}
         listProps={listProps}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5050 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

GroupedList: Render group list sections when `showEmptyGroups` is true, even when the counts are 0 so that group headers are displayed.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5260)

Before:
![image](https://user-images.githubusercontent.com/14134000/41629383-16fea112-73de-11e8-95cf-ece40b97ec69.png)

After:
![image](https://user-images.githubusercontent.com/14134000/41629394-271e673a-73de-11e8-8441-00e8f94a183b.png)

