### PR TITLE
Fix Jest watcher hang by removing invalid mapping.

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-fix-jest-watch_2018-06-20-18-53.json
+++ b/common/changes/office-ui-fabric-react/jg-fix-jest-watch_2018-06-20-18-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Jest watcher hang by removing invalid mapping.",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/jest.config.js
+++ b/packages/office-ui-fabric-react/jest.config.js
@@ -5,9 +5,8 @@ const config = createConfig({
   setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
 
   moduleNameMapper: {
-    // These mappings allow Jest to run snapshot tests against Example files
-    'office-ui-fabric-react/lib/(.*)': '<rootDir>/src/$1',
-    '@uifabric/example-app-base': '@uifabric/example-app-base/lib-commonjs/utilities/data'
+    // These mappings allow Jest to run snapshot tests against Example files.
+    'office-ui-fabric-react/lib/(.*)$': '<rootDir>/src/$1'
   },
 
   snapshotSerializers: [path.resolve(__dirname, './node_modules/@uifabric/jest-serializer-merge-styles')]


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix invalid module mapping that can cause Jest resolver and watcher to fail. This invalid mapping was due to a collision of my mapping changes with Ken's circular module fixes.

#### Focus areas to test

n/a

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5268)

