### PR TITLE
expose Nav to more teams not using npm

### DIFF
--- a/common/changes/@uifabric/experiments/master_2018-06-20-19-15.json
+++ b/common/changes/@uifabric/experiments/master_2018-06-20-19-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "expose Nav to teams not using npm",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "yuz@microsoft.com"
+}

--- a/packages/experiments/src/Nav.ts
+++ b/packages/experiments/src/Nav.ts
@@ -1,0 +1,1 @@
+export * from './components/Nav/index';

--- a/packages/experiments/src/index.ts
+++ b/packages/experiments/src/index.ts
@@ -4,3 +4,4 @@ export { Tile } from './Tile';
 export { TilesList } from './TilesList';
 export { Shimmer } from './Shimmer';
 export { Chiclet } from './Chiclet';
+export { ICustomNavLinkGroup, INavLink, NavGroupType, NavToggler } from './Nav';


### PR DESCRIPTION
Description of changes

expose NAV component to more team, including the team (SCC) not using npm for react project
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5271)

