### PR TITLE
Fix minor accessibility bugs in DetailsList

### DIFF
--- a/common/changes/office-ui-fabric-react/details-accessibility_2018-06-20-22-18.json
+++ b/common/changes/office-ui-fabric-react/details-accessibility_2018-06-20-22-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix minor accessibility bugs in DetailsList",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Check/Check.scss
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.scss
@@ -66,7 +66,7 @@ $checkBoxHeight: 18px;
 }
 
 .circle {
-  color: $ms-color-neutralTertiaryAlt;
+  color: $ms-color-neutralSecondary;
 
   @include high-contrast {
     color: WindowText;
@@ -78,7 +78,7 @@ $checkBoxHeight: 18px;
 }
 
 .check {
-  color: $ms-color-neutralTertiaryAlt;
+  color: $ms-color-neutralSecondary;
   font-size: 16px;
   left: .5px;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
@@ -49,7 +49,6 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
         ref={this._root}
         role={'columnheader'}
         aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
-        aria-disabled={column.columnActionsMode === ColumnActionsMode.disabled}
         aria-colindex={columnIndex}
         className={css(
           'ms-DetailsHeader-cell',

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -136,7 +136,6 @@ exports[`DetailsHeader can render 1`] = `
   </div>
   <div
     aria-colindex={2}
-    aria-disabled={false}
     aria-sort="none"
     className="ms-DetailsHeader-cell is-actionable undefined"
     data-automationid="ColumnsHeaderColumn"
@@ -186,7 +185,6 @@ exports[`DetailsHeader can render 1`] = `
   />
   <div
     aria-colindex={3}
-    aria-disabled={false}
     aria-sort="none"
     className="ms-DetailsHeader-cell is-actionable undefined"
     data-automationid="ColumnsHeaderColumn"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -162,7 +162,6 @@ exports[`DetailsList renders List correctly 1`] = `
           </div>
           <div
             aria-colindex={2}
-            aria-disabled={false}
             aria-sort="none"
             className="ms-DetailsHeader-cell is-actionable undefined"
             data-automationid="ColumnsHeaderColumn"


### PR DESCRIPTION
Adjusted the contrast of the Check component.
Removed `aria-disabled` from column headers.

This fixes #4142, #4269, and #5076.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5278)

