### PR TITLE
v1.1 changes for GridList,CompounButtonStack. Ref to addition card and lifecycle method for apicalls. 

### DIFF
--- a/common/changes/@uifabric/experiments/master_2018-06-20-23-30.json
+++ b/common/changes/@uifabric/experiments/master_2018-06-20-23-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "CardDidMount callback for making api calls, additional ref incase there is a use case where there is no state, compoundButtonStack  size variation and gridList component v1.1 changes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "v-kanuli@microsoft.com"
+}

--- a/packages/experiments/src/components/Card/ActionBar/ActionBar.tsx
+++ b/packages/experiments/src/components/Card/ActionBar/ActionBar.tsx
@@ -56,9 +56,9 @@ export class ActionBar extends React.Component<IActionBarProps, {}> {
     );
   };
 
-  private _onReduceData = (currentdata: IOverflowSetItemProps): {} => {
+  private _onReduceData = (currentdata: IOverflowSetItemProps): {} | void => {
     if (currentdata.primary.length === 0) {
-      return {};
+      return;
     }
 
     const overflow = [...currentdata.primary.slice(-1), ...currentdata.overflow];
@@ -67,9 +67,9 @@ export class ActionBar extends React.Component<IActionBarProps, {}> {
     return { primary, overflow };
   };
 
-  private _onGrowData = (currentdata: IOverflowSetItemProps): {} => {
+  private _onGrowData = (currentdata: IOverflowSetItemProps): {} | void => {
     if (currentdata.overflow.length === 0) {
-      return {};
+      return;
     }
 
     const overflow = currentdata.overflow.slice(1);

--- a/packages/experiments/src/components/Card/Card.styles.ts
+++ b/packages/experiments/src/components/Card/Card.styles.ts
@@ -1,24 +1,9 @@
-import { memoizeFunction } from '../../Utilities';
-import { mergeStyleSets, IStyle } from '../../Styling';
+import { ICardStyles } from './Card.types';
 
-export interface ICardStyles {
-  /**
-   * Style for the root element in the default enabled/unchecked state.
-   */
-  root?: IStyle;
-}
-
-export interface ICardNames {
-  /**
-   * Root html container for this component.
-   */
-  root?: string;
-}
-
-export const getClassNames = memoizeFunction(
-  (): ICardNames => {
-    return mergeStyleSets({
-      root: []
-    });
-  }
-);
+export const getStyles = (): ICardStyles => {
+  return {
+    root: {
+      backgroundColor: '#ffffff'
+    }
+  };
+};

--- a/packages/experiments/src/components/Card/Card.tsx
+++ b/packages/experiments/src/components/Card/Card.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { ICardProps, ICardState } from './Card.types';
+import { ICardProps, ICardState, ICardStyles } from './Card.types';
 import { CardFrame } from './CardFrame/CardFrame';
 import { Layout } from './Layout/Layout';
+import { getStyles } from './Card.styles';
+import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 
 export class Card extends React.Component<ICardProps, ICardState> {
   constructor(props: ICardProps) {
@@ -11,12 +13,26 @@ export class Card extends React.Component<ICardProps, ICardState> {
     };
   }
 
+  public updateState(): void {
+    this.setState({});
+  }
+
+  public componentDidMount(): void {
+    if (this.props.callOnDidMount !== undefined) {
+      this.props.callOnDidMount();
+    }
+  }
+
   public render(): JSX.Element {
     const { cardFrameContent, header, cardContentList, actions } = this.props;
+    const getClassNames = classNamesFunction<ICardProps, ICardStyles>();
+    const classNames = getClassNames(getStyles);
     return (
-      <CardFrame cardTitle={cardFrameContent.cardTitle} cardDropDownOptions={cardFrameContent.cardDropDownOptions}>
-        <Layout header={header} contentArea={cardContentList} cardSize={this.state.cardSize} actions={actions} />
-      </CardFrame>
+      <div className={classNames.root}>
+        <CardFrame cardTitle={cardFrameContent.cardTitle} cardDropDownOptions={cardFrameContent.cardDropDownOptions}>
+          <Layout header={header} contentArea={cardContentList} cardSize={this.state.cardSize} actions={actions} />
+        </CardFrame>
+      </div>
     );
   }
 }

--- a/packages/experiments/src/components/Card/Card.types.ts
+++ b/packages/experiments/src/components/Card/Card.types.ts
@@ -2,6 +2,7 @@ import { ICardHeaderProps } from './CardHeader/CardHeader.types';
 import { ICardContentDetails } from './Layout/Layout.types';
 import { IAction } from './ActionBar/ActionBar.types';
 import { ICardDropDownOption } from './CardFrame/CardFrame.types';
+import { IStyle } from 'office-ui-fabric-react/lib/Styling';
 
 /**
  * Card size that we want to build.
@@ -105,6 +106,12 @@ export interface ICardProps {
    * The card size (small | medium tall | medium wide | large)
    */
   cardSize: CardSize;
+
+  /**
+   * This props takes in a function that needs to be called upon componentDidMount.
+   * One of its use could be to fetch server data here
+   */
+  callOnDidMount?: VoidFunction;
 }
 
 export interface ICardState {
@@ -112,4 +119,11 @@ export interface ICardState {
    * The card size state
    */
   cardSize: CardSize;
+}
+
+export interface ICardStyles {
+  /**
+   * Styles for root element of the card
+   */
+  root: IStyle;
 }

--- a/packages/experiments/src/components/Card/CompoundButtonStack/CompoundButton.styles.ts
+++ b/packages/experiments/src/components/Card/CompoundButtonStack/CompoundButton.styles.ts
@@ -1,14 +1,16 @@
 import { memoizeFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
+import { ButtonSize } from './CompoundButtonStack.types';
 
 export const getCustomCompoundButtonStyles = memoizeFunction(
-  (): IButtonStyles => {
+  (cardSize: number | undefined): IButtonStyles => {
     return {
       root: {
         width: '100%',
         marginBottom: '16px',
         maxWidth: 'none',
-        minHeight: '68px',
+        minHeight: cardSize === ButtonSize.small ? '40px' : '68px',
+        maxHeight: '68px',
         padding: '14px'
       },
       textContainer: {

--- a/packages/experiments/src/components/Card/CompoundButtonStack/CompoundButtonStack.tsx
+++ b/packages/experiments/src/components/Card/CompoundButtonStack/CompoundButtonStack.tsx
@@ -1,18 +1,31 @@
 import * as React from 'react';
 import { CompoundButton } from 'office-ui-fabric-react/lib/Button';
 import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
-import { ICompoundButtonStackProps, ICompoundButtonStackStyles, ICompoundAction } from './CompoundButtonStack.types';
+import {
+  ICompoundButtonStackProps,
+  ICompoundButtonStackStyles,
+  ICompoundAction,
+  ButtonSize
+} from './CompoundButtonStack.types';
 import { getStyles } from './CompoundButtonStack.styles';
 import { getCustomCompoundButtonStyles } from './CompoundButton.styles';
 
 export class CompoundButtonStack extends React.Component<ICompoundButtonStackProps, {}> {
+  public static defaultProps = {
+    buttonSize: ButtonSize.normal
+  };
+
   public render(): JSX.Element {
     const getClassNames = classNamesFunction<ICompoundButtonStackProps, ICompoundButtonStackStyles>();
     const classNames = getClassNames(getStyles!);
-    const customStyles = getCustomCompoundButtonStyles();
+    const { buttonSize } = this.props;
+    const customStyles = getCustomCompoundButtonStyles(buttonSize);
 
     const renderCompoundButtons = () => {
       return this.props.actions.map((action: ICompoundAction, index: number) => {
+        if (buttonSize === ButtonSize.small) {
+          action.description = '';
+        }
         return (
           <CompoundButton
             key={index}

--- a/packages/experiments/src/components/Card/CompoundButtonStack/CompoundButtonStack.types.ts
+++ b/packages/experiments/src/components/Card/CompoundButtonStack/CompoundButtonStack.types.ts
@@ -1,5 +1,18 @@
 import { IStyle } from 'office-ui-fabric-react/lib/Styling';
 
+export enum ButtonSize {
+  /**
+   *Sets button height to small and does not allow
+   *description in each button(Allows title but not description text in each button)
+   */
+  small,
+
+  /**
+   * Sets the normal height and does allow description in each button
+   */
+  normal
+}
+
 export interface ICompoundButtonStackStyles {
   /**
    * Style set for the compound button component root
@@ -34,4 +47,9 @@ export interface ICompoundButtonStackProps {
    * List of actions this stack is going to support
    */
   actions: ICompoundAction[];
+
+  /**
+   * The  compound button height
+   */
+  buttonSize?: ButtonSize;
 }

--- a/packages/experiments/src/components/Card/GridList/GridList.tsx
+++ b/packages/experiments/src/components/Card/GridList/GridList.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { IGridListProps, IGridListStyles, IGridColumn, IGridRow, GridColumnContentType } from './GridList.types';
-import { DetailsList, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import {
+  DetailsList,
+  IColumn,
+  ColumnActionsMode,
+  DetailsListLayoutMode,
+  ConstrainMode
+} from 'office-ui-fabric-react/lib/DetailsList';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
 import { CheckboxVisibility } from 'office-ui-fabric-react';
@@ -30,6 +36,8 @@ export class GridList extends React.Component<IGridListProps> {
           isHeaderVisible={this.props.isHeaderVisible}
           checkboxVisibility={CheckboxVisibility.hidden}
           onItemInvoked={this._onItemInvoked}
+          layoutMode={DetailsListLayoutMode.justified}
+          constrainMode={ConstrainMode.unconstrained}
         />
         {actionButton}
       </div>
@@ -106,9 +114,9 @@ export class GridList extends React.Component<IGridListProps> {
           iconName: gridRow.c1.iconName
         },
         c2: {
-          content: gridRow.c2.content,
-          facepileImageSrc: gridRow.c2.facepileImageSrc,
-          iconName: gridRow.c2.iconName
+          content: gridRow.c2 !== undefined ? gridRow.c2.content : undefined,
+          facepileImageSrc: gridRow.c2 !== undefined ? gridRow.c2.facepileImageSrc : undefined,
+          iconName: gridRow.c2 !== undefined ? gridRow.c2.iconName : undefined
         },
         c3: {
           content: gridRow.c3 !== undefined ? gridRow.c3.content : undefined,
@@ -128,6 +136,7 @@ export class GridList extends React.Component<IGridListProps> {
       const column: IColumn = {
         key: GridColumnContentType[gridColumn.key],
         name: gridColumn.name,
+        columnActionsMode: ColumnActionsMode.disabled,
         minWidth: 150,
         isResizable: false,
         fieldName: 'c' + (index + 1)

--- a/packages/experiments/src/components/Card/GridList/GridList.types.ts
+++ b/packages/experiments/src/components/Card/GridList/GridList.types.ts
@@ -68,7 +68,7 @@ export interface IGridRow {
   /**
    * Column 2 contents for a single row
    */
-  c2: IGridCellItem;
+  c2?: IGridCellItem;
 
   /**
    * Column 3 content for a single row

--- a/packages/experiments/src/components/Card/Layout/Layout.tsx
+++ b/packages/experiments/src/components/Card/Layout/Layout.tsx
@@ -62,8 +62,8 @@ export class Layout extends React.Component<ILayoutProps> {
                 break;
               }
               case CardContentType.CompoundButtonStack: {
-                const { actions } = cardContent.content as ICompoundButtonStackProps;
-                contentArea.push(<CompoundButtonStack actions={actions} />);
+                const { actions, buttonSize } = cardContent.content as ICompoundButtonStackProps;
+                contentArea.push(<CompoundButtonStack actions={actions} buttonSize={buttonSize} />);
                 break;
               }
               case CardContentType.GridList: {

--- a/packages/experiments/src/components/Card/examples/Card.MediumTall.Basic.Example.tsx
+++ b/packages/experiments/src/components/Card/examples/Card.MediumTall.Basic.Example.tsx
@@ -55,8 +55,7 @@ export class MediumTallCardBasicExample extends React.Component<{}, {}> {
         priority: Priority.Priority2,
         cardContentType: CardContentType.CompoundButtonStack,
         content: {
-          actions: compoundButtonStack,
-          buttonSize: ButtonSize.small
+          actions: compoundButtonStack
         }
       }
     ];

--- a/packages/experiments/src/components/Card/examples/Card.MediumTall.Basic.Example.tsx
+++ b/packages/experiments/src/components/Card/examples/Card.MediumTall.Basic.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ICardProps, CardSize, Priority, CardContentType } from '../Card.types';
 import { Card } from '../Card';
-import { ICompoundAction, ButtonSize } from '../CompoundButtonStack/CompoundButtonStack.types';
+import { ICompoundAction } from '../CompoundButtonStack/CompoundButtonStack.types';
 
 export class MediumTallCardBasicExample extends React.Component<{}, {}> {
   constructor(props: ICardProps) {

--- a/packages/experiments/src/components/Card/examples/Card.MediumTall.Basic.Example.tsx
+++ b/packages/experiments/src/components/Card/examples/Card.MediumTall.Basic.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ICardProps, CardSize, Priority, CardContentType } from '../Card.types';
 import { Card } from '../Card';
-import { ICompoundAction } from '../CompoundButtonStack/CompoundButtonStack.types';
+import { ICompoundAction, ButtonSize } from '../CompoundButtonStack/CompoundButtonStack.types';
 
 export class MediumTallCardBasicExample extends React.Component<{}, {}> {
   constructor(props: ICardProps) {
@@ -55,7 +55,8 @@ export class MediumTallCardBasicExample extends React.Component<{}, {}> {
         priority: Priority.Priority2,
         cardContentType: CardContentType.CompoundButtonStack,
         content: {
-          actions: compoundButtonStack
+          actions: compoundButtonStack,
+          buttonSize: ButtonSize.small
         }
       }
     ];


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
1.Variation of size in CompoundButtonStack
2.GridList header selection lose
3.GridList justify and lose scrolling
4. Added ref to Card, in case someone wants to use the card where they do not have state and lifecycle method for api calls upon component mount.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5279)

