### PR TITLE
Add high contrast styles to disabled contextual menu items

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-06-21-12-35.json
+++ b/common/changes/office-ui-fabric-react/master_2018-06-21-12-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add high contrast styles to disabled contextual menu items",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "thomabr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -68,7 +68,13 @@ export const getMenuItemStyles = memoizeFunction(
       rootDisabled: {
         color: semanticColors.disabledBodyText,
         cursor: 'default',
-        pointerEvents: 'none'
+        pointerEvents: 'none',
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'GrayText',
+            opacity: 1
+          }
+        }
       },
       rootHovered: {
         backgroundColor: ContextualMenuItemBackgroundHoverColor,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

There was a change a month ago to remove the disabled attribute from contextual menu items so that they could be focusable. This prevents the browser from automatically showing the control as disabled in HC mode. This fix explicitly sets the HC selector for the disabled state.

#### Focus areas to test

High Contrast
disabled contextual menu items

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5291)

