### PR TITLE
Adds the capability to merge/concat StyleFunctions 

### DIFF
--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -58,7 +58,7 @@ The api surfaces consists of 3 methods and a handful of interfaces:
 
 `mergeStyleSet(...args[]: IStyleSet[]): { [key: string]: string }` - Takes in one or more style set objects, each consisting of a set of areas, each which will produce a class name. Using this is analogous to calling mergeStyles for each property in the object, but ensures we maintain the set ordering when multiple style sets are merged.
 
-`concatStyleSet(...args[]: IStyleSet[]): IStyleSet` - In some cases you simply need to combine style sets, without actually generating class names (it is costs in performance to generate class names.) This tool returns a single set merging many together.
+`concatStyleSet(...args[]: IStyleSet[]): IStyleSet` - In some cases you simply need to combine style sets, without actually generating class names (it is costly to generate class names.) This tool returns a single set merging many together.
 
 ## Vocabulary
 

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -1339,6 +1339,12 @@ export interface IRawStyleBase extends IRawFontStyle {
   regionFragment?: ICSSRule | string;
 
   /**
+   * The resize CSS sets whether an element is resizable, and if so, in which direction(s).
+   */
+
+  resize?: ICSSRule | 'none' | 'both' | 'horizontal' | 'vertical' | 'block' | 'inline';
+
+  /**
    * The rest-after property determines how long a speech media agent should pause after
    * presenting an element's main content, before presenting that element's exit cue
    * sound. It may be replaced by the shorthand property rest, which sets rest time

--- a/packages/merge-styles/src/IStyle.ts
+++ b/packages/merge-styles/src/IStyle.ts
@@ -1,4 +1,5 @@
 import { IRawStyleBase } from './IRawStyleBase';
+import { IStyleFunction } from './IStyleFunction';
 
 /**
  * IStyleObject extends a raw style objects, but allows selectors to be defined
@@ -29,3 +30,5 @@ export interface IStyleBaseArray extends Array<IStyle> {}
  * @public
  */
 export type IStyle = IStyleBase | IStyleBaseArray;
+
+export type IStyleOrStyleFunction = IStyle | IStyleFunction<any, any>;

--- a/packages/merge-styles/src/IStyle.ts
+++ b/packages/merge-styles/src/IStyle.ts
@@ -20,7 +20,7 @@ export interface IRawStyle extends IRawStyleBase {
   };
 }
 
-export type IStyleBase = IRawStyle | string | false | null | undefined;
+export type IStyleBase = IRawStyle | string | false | undefined;
 
 export interface IStyleBaseArray extends Array<IStyle> {}
 

--- a/packages/merge-styles/src/IStyleFunction.ts
+++ b/packages/merge-styles/src/IStyleFunction.ts
@@ -1,0 +1,1 @@
+export type IStyleFunction<TStylesProps = {}, TStyles = {}> = (props: TStylesProps) => Partial<TStyles>;

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -1,5 +1,3 @@
-import { IStyle } from './IStyle';
+import { IStyleOrStyleFunction } from './IStyle';
 
-export type IStyleSet = {
-  [key: string]: IStyle;
-};
+export type IStyleSet<TStyles> = { [P in keyof TStyles]?: IStyleOrStyleFunction };

--- a/packages/merge-styles/src/concatStyleSets.test.ts
+++ b/packages/merge-styles/src/concatStyleSets.test.ts
@@ -1,5 +1,6 @@
 import { concatStyleSets } from './concatStyleSets';
 import { IStyle } from './IStyle';
+import { IStyleFunction } from './IStyleFunction';
 
 describe('concatStyleSets', () => {
   it('can concat style sets', () => {
@@ -32,6 +33,53 @@ describe('concatStyleSets', () => {
       ],
       a: [{ background: 'green' }, { background: 'white' }],
       b: { background: 'blue' }
+    });
+  });
+
+  it('can concat style sets with functions on both ends', () => {
+    const fn1 = jest.fn().mockReturnValue({
+      root: { background: 'green', fontSize: 12 }
+    });
+
+    const fn2 = jest.fn().mockReturnValue({
+      root: {
+        background: 'yellow',
+        color: 'pink'
+      }
+    });
+
+    const result = concatStyleSets<{ root?: IStyle; a?: IStyleFunction; b?: IStyle }>(
+      {
+        root: { background: 'red' },
+        a: fn1
+      },
+      {
+        a: fn2,
+        b: { background: 'blue' }
+      },
+      {
+        root: {
+          selectors: {
+            ':hover': { background: 'yellow' }
+          }
+        }
+      }
+    );
+
+    expect(result.root).toEqual([
+      { background: 'red' },
+      {
+        selectors: {
+          ':hover': { background: 'yellow' }
+        }
+      }
+    ]);
+
+    expect(result.b).toEqual({ background: 'blue' });
+    expect(typeof result.a === 'function').toBe(true);
+    const aExpanded = (result.a as IStyleFunction)({});
+    expect(aExpanded).toEqual({
+      root: [{ background: 'green', fontSize: 12 }, { background: 'yellow', color: 'pink' }]
     });
   });
 });

--- a/packages/merge-styles/src/concatStyleSets.test.ts
+++ b/packages/merge-styles/src/concatStyleSets.test.ts
@@ -4,7 +4,7 @@ import { IStyleFunction } from './IStyleFunction';
 
 describe('concatStyleSets', () => {
   it('can concat style sets', () => {
-    const result = concatStyleSets<{ root?: IStyle; a?: IStyle; b?: IStyle }>(
+    const result = concatStyleSets(
       {
         root: { background: 'red' },
         a: { background: 'green' }
@@ -48,7 +48,7 @@ describe('concatStyleSets', () => {
       }
     });
 
-    const result = concatStyleSets<{ root?: IStyle; a?: IStyleFunction; b?: IStyle }>(
+    const result = concatStyleSets(
       {
         root: { background: 'red' },
         a: fn1

--- a/packages/merge-styles/src/concatStyleSets.ts
+++ b/packages/merge-styles/src/concatStyleSets.ts
@@ -1,9 +1,11 @@
+import { IStyleSet } from './IStyleSet';
+import { IStyleOrStyleFunction } from './IStyle';
+
 /**
  * Combine a set of styles together (but does not register css classes.)
  * @public
  */
-export function concatStyleSets<T extends object>(...args: (T | false | null | undefined)[]): T {
-  // tslint:disable-next-line:no-any
+export function concatStyleSets(...args: (IStyleSet<any> | false | null | undefined)[]): IStyleSet<any> {
   const mergedSet = {} as any;
 
   for (const currentSet of args) {
@@ -11,20 +13,38 @@ export function concatStyleSets<T extends object>(...args: (T | false | null | u
       for (const prop in currentSet) {
         if (currentSet.hasOwnProperty(prop)) {
           const mergedValue = mergedSet[prop];
-          const currentValue = currentSet[prop];
+          const currentValue: IStyleOrStyleFunction = currentSet[prop];
 
           if (mergedValue === undefined) {
             mergedSet[prop] = currentValue;
           } else {
-            mergedSet[prop] = [
-              ...(Array.isArray(mergedValue) ? mergedValue : [mergedValue]),
-              ...(Array.isArray(currentValue) ? currentValue : [currentValue])
-            ];
+            if (typeof currentValue === 'function') {
+              // if it is a function, we need special handling.
+              mergedSet[prop] = (props: any) => {
+                if (typeof mergedValue === 'function') {
+                  return concatStyleSets(mergedValue(props), currentValue(props));
+                } else {
+                  // our typings will not allow this scenario to happen.
+                  // it is probably return concatStyleSets(mergedValue, currentValue(props));
+                  // however, if we wanted to support this scenario, we should update the typings to allow.
+                  // We just throw a type error for now (but this should never happen for anyone using TypeScript).
+
+                  throw new TypeError(
+                    `The area ${props} in the stylesets being concatenated has inconsistent typing (mix of style functions and objects). `
+                  );
+                }
+              };
+            } else {
+              mergedSet[prop] = [
+                ...(Array.isArray(mergedValue) ? mergedValue : [mergedValue]),
+                ...(Array.isArray(currentValue) ? currentValue : [currentValue])
+              ];
+            }
           }
         }
       }
     }
   }
 
-  return mergedSet as T;
+  return mergedSet as IStyleSet<any>;
 }

--- a/packages/merge-styles/src/extractStyleParts.ts
+++ b/packages/merge-styles/src/extractStyleParts.ts
@@ -6,7 +6,7 @@ import { Stylesheet } from './Stylesheet';
  * args are auto expanded into objects.
  */
 export function extractStyleParts(
-  ...args: (IStyle | IStyle[] | false | null | undefined)[]
+  ...args: (IStyle | IStyle[] | false | undefined)[]
 ): { classes: string[]; objects: IStyle[] } {
   const classes: string[] = [];
   const objects: {}[] = [];

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -1,4 +1,4 @@
-export { IRawStyle, IStyle } from './IStyle';
+export { IRawStyle, IStyle, IStyleOrStyleFunction } from './IStyle';
 
 export { IStyleFunction } from './IStyleFunction';
 
@@ -8,7 +8,7 @@ export { IFontFace, IFontWeight } from './IRawStyleBase';
 
 export { mergeStyles } from './mergeStyles';
 
-export { mergeStyleSets } from './mergeStyleSets';
+export { mergeStyleSets, IClassNameOrStyleFunction } from './mergeStyleSets';
 
 export { concatStyleSets } from './concatStyleSets';
 

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -1,5 +1,7 @@
 export { IRawStyle, IStyle } from './IStyle';
 
+export { IStyleFunction } from './IStyleFunction';
+
 export { IStyleSet } from './IStyleSet';
 
 export { IFontFace, IFontWeight } from './IRawStyleBase';

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -1,10 +1,11 @@
-import { mergeStyleSets } from './mergeStyleSets';
+import { mergeStyleSets, IClassNameOrStyleFunction } from './mergeStyleSets';
 import { Stylesheet, InjectionMode } from './Stylesheet';
+import { IStyle } from './IStyle';
 
 const _stylesheet: Stylesheet = Stylesheet.getInstance();
 
 interface ITestClasses {
-  root: string;
+  root?: IClassNameOrStyleFunction;
 }
 
 _stylesheet.setConfig({ injectionMode: InjectionMode.none });
@@ -16,7 +17,7 @@ describe('mergeStyleSets', () => {
 
   it('can merge style sets', () => {
     const empty: { c?: string } = {};
-    const result: { root: string; a: string; b: string } = mergeStyleSets(
+    const result = mergeStyleSets(
       empty,
       {
         root: { background: 'red' },
@@ -114,7 +115,7 @@ describe('mergeStyleSets', () => {
 
   it('can auto expand a previously registered style', () => {
     const styles: ITestClasses = mergeStyleSets({ root: { background: 'red' } });
-    const styles2: ITestClasses = mergeStyleSets({ root: [{ background: 'purple' }, styles.root] });
+    const styles2: ITestClasses = mergeStyleSets({ root: [{ background: 'purple' }, styles.root as IStyle] });
 
     expect(styles.root).toEqual(styles2.root);
 

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -1,6 +1,6 @@
 import { extractStyleParts } from './extractStyleParts';
 import { concatStyleSets } from './concatStyleSets';
-import { IStyleOrStyleFunction } from './IStyle';
+import { IStyleOrStyleFunction, IStyle } from './IStyle';
 import { styleToRegistration, applyRegistration } from './styleToClassName';
 import { IStyleFunction } from './IStyleFunction';
 import { IStyleSet } from './IStyleSet';
@@ -15,7 +15,9 @@ export type IClassNameOrStyleFunction<TStyleProps = any, TStyles = any> = string
  *
  * @param styleSet1 The first style set to be merged.
  */
-export function mergeStyleSets<T>(styleSet: IStyleSet<T>): { [P in keyof T]?: IClassNameOrStyleFunction };
+export function mergeStyleSets<T>(
+  styleSet: IStyleSet<T>
+): { [P in keyof T]?: T[P] extends Function ? IStyleFunction<any, any> : string };
 
 /**
  * Takes in one or more style set objects, each consisting of a set of areas,
@@ -29,7 +31,7 @@ export function mergeStyleSets<T>(styleSet: IStyleSet<T>): { [P in keyof T]?: IC
 export function mergeStyleSets<T, U>(
   styleSet1: IStyleSet<T>,
   styleSet2: IStyleSet<U>
-): { [P in keyof (T & U)]?: IClassNameOrStyleFunction };
+): { [P in keyof (T & U)]?: (T & U)[P] extends Function ? IStyleFunction<any, any> : string };
 
 /**
  * Takes in one or more style set objects, each consisting of a set of areas,

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -1,43 +1,111 @@
 import { extractStyleParts } from './extractStyleParts';
 import { concatStyleSets } from './concatStyleSets';
-import { IStyle } from './IStyle';
+import { IStyleOrStyleFunction } from './IStyle';
 import { styleToRegistration, applyRegistration } from './styleToClassName';
+import { IStyleFunction } from './IStyleFunction';
+import { IStyleSet } from './IStyleSet';
+
+export type IClassNameOrStyleFunction<TStyleProps = any, TStyles = any> = string | IStyleFunction<TStyleProps, TStyles>;
 
 /**
- * Allows you to pass in 1 or more sets of areas which will return a merged
- * set of classes.
+ * Takes in one or more style set objects, each consisting of a set of areas,
+ * each which will produce a class name. Using this is analogous to calling
+ * `mergeStyles` for each property in the object, but ensures we maintain the
+ * set ordering when multiple style sets are merged.
  *
- * @public
+ * @param styleSet1 The first style set to be merged.
  */
-export function mergeStyleSets<K extends string>(
-  ...cssSets: ({ [P in K]?: IStyle } | null | undefined)[]
-): { [P in K]: string } {
+export function mergeStyleSets<T>(styleSet: IStyleSet<T>): { [P in keyof T]?: IClassNameOrStyleFunction };
+
+/**
+ * Takes in one or more style set objects, each consisting of a set of areas,
+ * each which will produce a class name. Using this is analogous to calling
+ * `mergeStyles` for each property in the object, but ensures we maintain the
+ * set ordering when multiple style sets are merged.
+ *
+ * @param styleSet1 The first style set to be merged.
+ * @param styleSet2 The second style set to be merged.
+ */
+export function mergeStyleSets<T, U>(
+  styleSet1: IStyleSet<T>,
+  styleSet2: IStyleSet<U>
+): { [P in keyof (T & U)]?: IClassNameOrStyleFunction };
+
+/**
+ * Takes in one or more style set objects, each consisting of a set of areas,
+ * each which will produce a class name. Using this is analogous to calling
+ * `mergeStyles` for each property in the object, but ensures we maintain the
+ * set ordering when multiple style sets are merged.
+ *
+ * @param styleSet1 The first style set to be merged.
+ * @param styleSet2 The second style set to be merged.
+ * @param styleSet3 The third style set to be merged.
+ */
+export function mergeStyleSets<T, U, V>(
+  styleSet1: IStyleSet<T>,
+  styleSet2: IStyleSet<U>,
+  styleSet3: IStyleSet<V>
+): { [P in keyof (T & U & V)]?: IClassNameOrStyleFunction };
+
+/**
+ * Takes in one or more style set objects, each consisting of a set of areas,
+ * each which will produce a class name. Using this is analogous to calling
+ * `mergeStyles` for each property in the object, but ensures we maintain the
+ * set ordering when multiple style sets are merged.
+ *
+ * @param styleSet1 The first style set to be merged.
+ * @param styleSet2 The second style set to be merged.
+ * @param styleSet3 The third style set to be merged.
+ * @param styleSet4 The fourth style set to be merged.
+ */
+export function mergeStyleSets<T, U, V, W>(
+  styleSet1: IStyleSet<T>,
+  styleSet2: IStyleSet<U>,
+  styleSet3: IStyleSet<V>,
+  styleSet4: IStyleSet<W>
+): { [P in keyof (T & U & V & W)]?: IClassNameOrStyleFunction };
+
+/**
+ * Takes in one or more style set objects, each consisting of a set of areas,
+ * each which will produce a class name. Using this is analogous to calling
+ * `mergeStyles` for each property in the object, but ensures we maintain the
+ * set ordering when multiple style sets are merged.
+ *
+ * @param styleSets One or more style sets to be merged.
+ */
+export function mergeStyleSets(
+  ...styleSets: (IStyleSet<any> | null | undefined)[]
+): { [area: string]: string | IStyleFunction<any, any> } {
   // tslint:disable-next-line:no-any
   const classNameSet: any = {};
   const classMap: { [key: string]: string } = {};
 
-  let cssSet = cssSets[0];
+  let styleSet = styleSets[0];
 
-  if (cssSet) {
-    if (cssSets.length > 1) {
-      cssSet = concatStyleSets(...cssSets);
+  if (styleSet) {
+    if (styleSets.length > 1) {
+      styleSet = concatStyleSets(...styleSets);
     }
 
     const registrations = [];
 
-    for (const prop in cssSet) {
-      if (cssSet.hasOwnProperty(prop)) {
-        const args: IStyle = cssSet[prop];
+    for (const styleSetArea in styleSet) {
+      if (styleSet.hasOwnProperty(styleSetArea)) {
+        const styles: IStyleOrStyleFunction = styleSet[styleSetArea];
 
-        // tslint:disable-next-line:no-any
-        const { classes, objects } = extractStyleParts(args as any);
-        const registration = styleToRegistration({ displayName: prop }, objects);
+        if (typeof styles === 'function') {
+          classNameSet[styleSetArea] = styles;
+          continue;
+        }
+
+        const { classes, objects } = extractStyleParts(styles);
+        const registration = styleToRegistration({ displayName: styleSetArea }, objects);
 
         registrations.push(registration);
 
         if (registration) {
-          classMap[prop] = registration.className;
-          classNameSet[prop] = classes.concat([registration.className]).join(' ');
+          classMap[styleSetArea] = registration.className;
+          classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
         }
       }
     }

--- a/packages/merge-styles/src/mergeStyles.test.ts
+++ b/packages/merge-styles/src/mergeStyles.test.ts
@@ -41,11 +41,11 @@ describe('mergeStyles', () => {
   });
 
   it('can join strings', () => {
-    expect(mergeStyles('a', false, null, undefined, 'b')).toEqual('a b');
+    expect(mergeStyles('a', false, undefined, undefined, 'b')).toEqual('a b');
   });
 
   it('can join arrays of strings', () => {
-    expect(mergeStyles(['a', 'b', 'c'], false, null, undefined)).toEqual('a b c');
+    expect(mergeStyles(['a', 'b', 'c'], false, undefined, undefined)).toEqual('a b c');
   });
 
   it('can join an object and style', () => {

--- a/packages/merge-styles/src/mergeStyles.ts
+++ b/packages/merge-styles/src/mergeStyles.ts
@@ -7,7 +7,7 @@ import { extractStyleParts } from './extractStyleParts';
  *
  * @public
  */
-export function mergeStyles(...args: (IStyle | IStyle[] | false | null | undefined)[]): string {
+export function mergeStyles(...args: (IStyle | IStyle[] | false | undefined)[]): string {
   const { classes, objects } = extractStyleParts(args);
 
   if (objects.length) {

--- a/packages/merge-styles/src/server.test.ts
+++ b/packages/merge-styles/src/server.test.ts
@@ -4,7 +4,7 @@ import { mergeStyleSets } from './mergeStyleSets';
 describe('staticRender', () => {
   it('can render content', () => {
     const { html, css } = renderStatic(() => {
-      const classNames: { root: string } = mergeStyleSets({
+      const classNames = mergeStyleSets({
         root: {
           background: 'red'
         }
@@ -19,7 +19,7 @@ describe('staticRender', () => {
 
   it('can namespace things', () => {
     const { html, css } = renderStatic(() => {
-      const classNames: { root: string } = mergeStyleSets({
+      const classNames = mergeStyleSets({
         root: {
           background: 'red'
         }

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -74,7 +74,7 @@ describe('styleToClassName', () => {
 
   it('can merge rules', () => {
     let className = styleToClassName(
-      null,
+      undefined,
       false,
       undefined,
       { backgroundColor: 'red', color: 'white' },

--- a/packages/merge-styles/tslint.json
+++ b/packages/merge-styles/tslint.json
@@ -1,4 +1,6 @@
 {
   "extends": ["office-ui-fabric-react-tslint"],
-  "rules": {}
+  "rules": {
+    "no-any": false
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/Keytip/Keytip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Keytip/Keytip.styles.ts
@@ -72,6 +72,6 @@ export const getCalloutOffsetStyles = (
           marginTop: offset.y
         }
       ]
-    });
+    }) as ICalloutContentStyles;
   };
 };

--- a/packages/utilities/src/IClassNames.ts
+++ b/packages/utilities/src/IClassNames.ts
@@ -1,1 +1,5 @@
-export type IClassNames<T> = { [key in keyof T]: string };
+import { IStyleFunction } from '@uifabric/merge-styles';
+
+export type IClassNames<TStyleProps, TStyles> = {
+  [key in keyof TStyles]?: TStyles[key] extends Function ? IStyleFunction<TStyleProps, TStyles> : string
+};

--- a/packages/utilities/src/IStyleFunction.ts
+++ b/packages/utilities/src/IStyleFunction.ts
@@ -1,1 +1,1 @@
-export type IStyleFunction<TStylesProps, TStyles> = (props: TStylesProps) => Partial<TStyles>;
+export { IStyleFunction } from '@uifabric/merge-styles';

--- a/packages/utilities/src/classNamesFunction.ts
+++ b/packages/utilities/src/classNamesFunction.ts
@@ -1,17 +1,27 @@
-import { mergeStyleSets, IStyle } from '@uifabric/merge-styles';
+import { mergeStyleSets, IStyleOrStyleFunction, IStyleSet } from '@uifabric/merge-styles';
 import { IClassNames } from './IClassNames';
-import { IStyleFunction } from './IStyleFunction';
 import { IStyleFunctionOrObject } from './styled';
 
 /**
  * Creates a getClassNames function which calls getStyles given the props, and injects them
  * into mergeStyleSets.
  */
-export function classNamesFunction<TStyleProps extends {}, TStyles extends { [P in keyof TStyles]: IStyle }>(): (
+export function classNamesFunction<TStyleProps extends {}, TStyles extends IStyleSet<TStyles>>(): (
   getStyles?: IStyleFunctionOrObject<TStyleProps, TStyles>,
   styleProps?: TStyleProps
-) => IClassNames<TStyles> {
+) => IClassNames<TStyleProps, TStyles> {
   // TODO: memoize.
-  return (getStyles?: IStyleFunctionOrObject<TStyleProps, TStyles>, styleProps?: TStyleProps): IClassNames<TStyles> =>
-    mergeStyleSets(getStyles && (typeof getStyles === 'function' ? getStyles(styleProps!) : getStyles));
+  return (
+    getStyles?: IStyleFunctionOrObject<TStyleProps, TStyles>,
+    styleProps?: TStyleProps
+  ): IClassNames<TStyleProps, TStyles> => {
+    const styleSet = getStyles && (typeof getStyles === 'function' ? getStyles(styleProps!) : getStyles);
+
+    // styleSet might be undefined if getStyles is undefined, but getStyles should never
+    // ordinarily be undefined (it would hardly make any sense).
+    // However, because we usually use `props.styles` as the argument to an invocation of this method, and
+    // `props.styles` itself is defined as optional, this avoids the need to use `!` at all invocation points.
+
+    return styleSet ? (mergeStyleSets(styleSet) as IClassNames<TStyleProps, TStyles>) : {};
+  };
 }

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { concatStyleSets } from '@uifabric/merge-styles';
+import { concatStyleSets, IStyleSet } from '@uifabric/merge-styles';
 import { IStyleFunction } from './IStyleFunction';
 import { CustomizableContextTypes } from './customizable';
 import { Customizations, ICustomizations } from './Customizations';
@@ -74,10 +74,16 @@ export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TSt
   return Wrapped as (props: TComponentProps) => JSX.Element;
 }
 
-function _resolve<TStyleProps, TStyles>(
+/**
+ * This helper function takes any given number of `styles` function or objects, resolves them if necessary, and combines them
+ * into a single style set.
+ * @param styleProps Style props that we pass into the "getStyles" function.
+ * @param allStyles All the "getStyles" functions or objects to be resolved and combined.
+ */
+function _resolve<TStyleProps, TStyles extends IStyleSet<TStyles>>(
   styleProps: TStyleProps,
   ...allStyles: (IStyleFunctionOrObject<TStyleProps, Partial<TStyles>> | undefined)[]
-): Partial<TStyles> | undefined {
+): IStyleSet<TStyles> | undefined {
   const result: Partial<TStyles>[] = [];
 
   for (const styles of allStyles) {
@@ -85,8 +91,9 @@ function _resolve<TStyleProps, TStyles>(
       result.push(typeof styles === 'function' ? styles(styleProps) : styles);
     }
   }
+
   if (result.length) {
-    return concatStyleSets(...result);
+    return concatStyleSets(...result) as IStyleSet<TStyles>;
   }
 
   return undefined;


### PR DESCRIPTION
#### Description of changes

This change adds support for IStyleFunctions (in addition to IStyle which primarily dealt with arrays and objects), and logic to merge them correctly.

This will allow `IComponentStyles` props to take in `StyleFunction`s for their subcomponents (while still intuitively identifying them as an area). Additionally, as with everything else in `IStyle`, a component can provide a base StyleFunction and additional style functions provided through customizer or props will be merged in correctly.

I also tightened the typings... which technically is a breaking change but based on offline discussions, we can treat tightening of typings as a minor bump (kind of like with Typescript itself) if it helps catch more errors... (from JS's POV - the API surface did not otherwise change).

TODO before merge:
1. Add more unit tests
2. Fix the typings in downstream packages (might make the PR very big and messy).
3. Change files


TODO after merge:
1. Update documentation.
2. More general improving code quality of merge-styles package in general.

#### Focus areas to test
Check typing..

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5306)

