### PR TITLE
Put back ShimmerTile in @uifabric/experiments for 5.0 compat

### DIFF
--- a/common/changes/@uifabric/experiments/experiments-shimmer_2018-06-22-13-04.json
+++ b/common/changes/@uifabric/experiments/experiments-shimmer_2018-06-22-13-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Re-export ShimmerTile in its original location for 5.0 compat",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.tsx
@@ -1,1 +1,2 @@
+// Remove this in 7.0.0
 export * from '../../Tile/ShimmerTile/ShimmerTile';

--- a/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerTile/ShimmerTile.tsx
@@ -1,0 +1,1 @@
+export * from '../../Tile/ShimmerTile/ShimmerTile';


### PR DESCRIPTION
Similar to `CommandBar`, this change re-exports `ShimmerTile` from its location from 5.x so that component libraries may be able to support 5.0 and 6.0 interchangeably when necessary.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5311)

