### PR TITLE
Callout blur listener and dismissOnBlur 

### DIFF
--- a/common/changes/office-ui-fabric-react/calloutBlurListenerPartTwo_2018-06-22-16-50.json
+++ b/common/changes/office-ui-fabric-react/calloutBlurListenerPartTwo_2018-06-22-16-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout: add blur listener that only dismisses Callout if window loses focus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -251,6 +251,8 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     }
   }
 
+  // We implement a blur listener for the Callout component so that if a page inside inside of an iframe uses a callout,
+  // it can be dismissed when the user clicks outside of the iframe.
   protected _dismissOnBlur(ev: Event) {
     const target = ev.target as HTMLElement;
     const clickedOutsideCallout = this._hostElement.current && !elementContains(this._hostElement.current, target);

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -251,6 +251,23 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     }
   }
 
+  protected _dismissOnBlur(ev: Event) {
+    const target = ev.target as HTMLElement;
+    const clickedOutsideCallout = this._hostElement.current && !elementContains(this._hostElement.current, target);
+    const { preventDismissOnLostFocus } = this.props;
+
+    if (
+      !preventDismissOnLostFocus &&
+      ((!this._target && clickedOutsideCallout) ||
+        (ev.target === this._targetWindow &&
+          clickedOutsideCallout &&
+          ((this._target as MouseEvent).stopPropagation ||
+            (!this._target || (target !== this._target && !elementContains(this._target as HTMLElement, target))))))
+    ) {
+      this.dismiss(ev);
+    }
+  }
+
   protected _setInitialFocus = (): void => {
     if (
       this.props.setInitialFocus &&
@@ -282,6 +299,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     this._async.setTimeout(() => {
       this._events.on(this._targetWindow, 'scroll', this._dismissOnScroll, true);
       this._events.on(this._targetWindow, 'resize', this.dismiss, true);
+      this._events.on(this._targetWindow, 'blur', this._dismissOnBlur, true);
       this._events.on(this._targetWindow.document.documentElement, 'focus', this._dismissOnLostFocus, true);
       this._events.on(this._targetWindow.document.documentElement, 'click', this._dismissOnLostFocus, true);
       this._hasListeners = true;
@@ -291,6 +309,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
   private _removeListeners() {
     this._events.off(this._targetWindow, 'scroll', this._dismissOnScroll, true);
     this._events.off(this._targetWindow, 'resize', this.dismiss, true);
+    this._events.off(this._targetWindow, 'blur', this._dismissOnBlur, true);
     this._events.off(this._targetWindow.document.documentElement, 'focus', this._dismissOnLostFocus, true);
     this._events.off(this._targetWindow.document.documentElement, 'click', this._dismissOnLostFocus, true);
     this._hasListeners = false;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4990  
- [X] Include a change request file using `$ npm run change`

#### Description of changes

My original "fix" for this bug (https://github.com/OfficeDev/office-ui-fabric-react/pull/5107) caused a regression, so it was reverted. The blur listener and implementation of `_dismissOnLostFocus` was causing the callout to be dismissed in weird scenarios. We only want to dismiss the callout when the window is blurred.

Here's another approach.

Instead of using `_dismissOnLostFocus` for both the focus and blur listener, create a separate `_dismissOnBlur` that only dismisses the callout when the window is blurred by additionally checking `ev.target === this._targetWindow`. We think this should fix the issue. Let me know what you think!
