### PR TITLE
Default shouldFocusOnMount in BaseButton _onToggleMenu method to respect prop

### DIFF
--- a/common/changes/office-ui-fabric-react/keyou-fix-shouldFocusOnMount-keyboard_2018-06-25-18-21.json
+++ b/common/changes/office-ui-fabric-react/keyou-fix-shouldFocusOnMount-keyboard_2018-06-25-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Default shouldFocusOnMount value in BaseButton _onToggleMenu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -457,10 +457,16 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     const currentMenuProps = this.state.menuProps;
+    let shouldFocusOnMount = true;
+    if (this.props.menuProps && this.props.menuProps.shouldFocusOnMount === false) {
+      shouldFocusOnMount = false;
+    }
     if (this.props.persistMenu) {
-      currentMenuProps && currentMenuProps.hidden ? this._openMenu(shouldFocusOnContainer) : this._dismissMenu();
+      currentMenuProps && currentMenuProps.hidden
+        ? this._openMenu(shouldFocusOnContainer, shouldFocusOnMount)
+        : this._dismissMenu();
     } else {
-      currentMenuProps ? this._dismissMenu() : this._openMenu(shouldFocusOnContainer);
+      currentMenuProps ? this._dismissMenu() : this._openMenu(shouldFocusOnContainer, shouldFocusOnMount);
     }
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5323 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

After adding functionality in PR #5185, opening a menu by keyboarding would not respect the shouldFocusOnMount prop. This PR fixes that by defaulting the value in BaseButton _onToggleMenu

#### Focus areas to test

Tested with button with menuProps in local demo page

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5335)

