### PR TITLE
Fix import paths to use relative paths in product code

### DIFF
--- a/common/changes/office-ui-fabric-react/fixImportPaths_2018-06-25-22-09.json
+++ b/common/changes/office-ui-fabric-react/fixImportPaths_2018-06-25-22-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix import paths to use relative paths for office-ui-fabric-react",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Beak/Beak.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Beak/Beak.tsx
@@ -3,7 +3,7 @@ import { BaseComponent, css, classNamesFunction } from '../../../Utilities';
 import { IBeakProps } from './Beak.types';
 import { getStyles, IBeakStyles } from './Beak.styles';
 import { IBeakStylesProps } from './Beak.types';
-import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
+import { RectangleEdge } from '../../../utilities/positioning';
 
 export const BEAK_HEIGHT = 10;
 export const BEAK_WIDTH = 18;

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Beak/Beak.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Beak/Beak.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Beak } from './Beak';
-import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
+import { RectangleEdge } from '../../../utilities/positioning';
 
 export interface IBeak {}
 

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
@@ -2,12 +2,12 @@
 import * as React from 'react';
 import { BaseComponent, IRectangle, classNamesFunction, createRef, shallowCompare } from '../../Utilities';
 import { DefaultPalette } from '../../Styling';
-import { IPositionedData, RectangleEdge, getOppositeEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
+import { IPositionedData, RectangleEdge, getOppositeEdge } from '../../utilities/positioning';
 
 // Component Dependencies
 import { PositioningContainer, IPositioningContainer } from './PositioningContainer/index';
 import { Beak, BEAK_HEIGHT, BEAK_WIDTH } from './Beak/Beak';
-import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
+import { DirectionalHint } from '../../common/DirectionalHint';
 
 // Coachmark
 import { ICoachmarkTypes } from './Coachmark.types';

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { IPositioningContainerTypes } from './PositioningContainer.types';
 import { getClassNames } from './PositioningContainer.styles';
-import { Layer } from 'office-ui-fabric-react/lib/Layer';
+import { Layer } from './../../Layer';
 
 // Utilites/Helpers
-import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
+import { DirectionalHint } from '../../../common/DirectionalHint';
 import {
   BaseComponent,
   IPoint,
@@ -19,13 +19,13 @@ import {
 } from '../../../Utilities';
 
 import {
-  IPositionProps,
   getMaxHeight,
   positionElement,
   IPositionedData,
-  RectangleEdge,
-  IPosition
-} from 'office-ui-fabric-react/lib/utilities/positioning';
+  IPositionProps,
+  IPosition,
+  RectangleEdge
+} from '../../../utilities/positioning';
 
 import { AnimationClassNames, mergeStyles } from '../../../Styling';
 

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IPositioningContainerTypes } from './PositioningContainer.types';
 import { getClassNames } from './PositioningContainer.styles';
-import { Layer } from './../../Layer';
+import { Layer } from '../../Layer';
 
 // Utilites/Helpers
 import { DirectionalHint } from '../../../common/DirectionalHint';

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { PositioningContainer } from './PositioningContainer';
-import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
+import { DirectionalHint } from '../../../common/DirectionalHint';
 import { IPoint, IRectangle } from '../../../Utilities';
-import { IPositionedData } from 'office-ui-fabric-react/lib/utilities/positioning';
+import { IPositionedData } from '../../../utilities/positioning';
 
 export interface IPositioningContainer {}
 

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
@@ -6,7 +6,7 @@ import { FloatingPeoplePicker, IBaseFloatingPickerProps } from '../../../../Floa
 import { ISelectedPeopleItemProps } from '../SelectedPeopleList';
 import { IExtendedPersonaProps } from '../SelectedPeopleList';
 import { IPeoplePickerItemState } from './ExtendedSelectedItem';
-import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
+import { IPersonaProps } from '../../../Persona';
 
 import * as stylesImport from './EditingItem.scss';
 

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 /* tslint:enable */
 import { css } from '../../../../Utilities';
 import { Persona, PersonaSize, IPersonaProps, PersonaPresence } from '../../../../Persona';
-import { IBasePickerSuggestionsProps, ISuggestionItemProps } from 'office-ui-fabric-react/lib/Pickers';
+import { IBasePickerSuggestionsProps, ISuggestionItemProps } from '../../../../Pickers';
 import * as stylesImport from '../PeoplePicker.scss';
 const styles: any = stylesImport;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix import paths in product code to point to relative paths instead of 'office-ui-fabric-react/lib...' paths

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5338)

