### PR TITLE
Fix issue #5224

### DIFF
--- a/common/changes/office-ui-fabric-react/cliffkoh-checkbox-bug_2018-06-25-23-38.json
+++ b/common/changes/office-ui-fabric-react/cliffkoh-checkbox-bug_2018-06-25-23-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Checkbox: Fix layout bug that causes `overflow`/`text-overflow` in Checkbox label to not take effect (#5224)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -88,7 +88,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
     label: [
       'ms-Checkbox-label',
       {
-        display: 'inline-flex',
+        display: 'flex',
         margin: '0 -4px',
         alignItems: 'center',
         cursor: disabled ? 'default' : 'pointer',

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
         {
           align-items: center;
           cursor: pointer;
-          display: inline-flex;
+          display: flex;
           margin-bottom: 0;
           margin-left: -4px;
           margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -93,7 +93,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
             {
               align-items: center;
               cursor: pointer;
-              display: inline-flex;
+              display: flex;
               margin-bottom: 0;
               margin-left: -4px;
               margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -80,7 +80,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.ImplementationExamples.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.ImplementationExamples.tsx.shot
@@ -80,7 +80,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;
@@ -249,7 +249,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;
@@ -393,7 +393,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
           {
             align-items: center;
             cursor: default;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;
@@ -534,7 +534,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
           {
             align-items: center;
             cursor: default;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;
@@ -691,7 +691,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;
@@ -847,7 +847,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             flex-direction: row-reverse;
             justify-content: flex-end;
             margin-bottom: 0;
@@ -1004,7 +1004,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -86,7 +86,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
             {
               align-items: center;
               cursor: pointer;
-              display: inline-flex;
+              display: flex;
               margin-bottom: 0;
               margin-left: -4px;
               margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -110,7 +110,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
             {
               align-items: center;
               cursor: pointer;
-              display: inline-flex;
+              display: flex;
               margin-bottom: 0;
               margin-left: -4px;
               margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -648,7 +648,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
             {
               align-items: center;
               cursor: pointer;
-              display: inline-flex;
+              display: flex;
               margin-bottom: 0;
               margin-left: -4px;
               margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -101,7 +101,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 2`] = `
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -95,7 +95,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;
@@ -263,7 +263,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -219,7 +219,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;
@@ -395,7 +395,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
@@ -95,7 +95,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -89,7 +89,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             {
               align-items: center;
               cursor: pointer;
-              display: inline-flex;
+              display: flex;
               margin-bottom: 0;
               margin-left: -4px;
               margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3184,7 +3184,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             {
               align-items: center;
               cursor: pointer;
-              display: inline-flex;
+              display: flex;
               margin-bottom: 0;
               margin-left: -4px;
               margin-right: -4px;
@@ -3340,7 +3340,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             {
               align-items: center;
               cursor: pointer;
-              display: inline-flex;
+              display: flex;
               margin-bottom: 0;
               margin-left: -4px;
               margin-right: -4px;
@@ -3496,7 +3496,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             {
               align-items: center;
               cursor: pointer;
-              display: inline-flex;
+              display: flex;
               margin-bottom: 0;
               margin-left: -4px;
               margin-right: -4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -81,7 +81,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
           {
             align-items: center;
             cursor: pointer;
-            display: inline-flex;
+            display: flex;
             margin-bottom: 0;
             margin-left: -4px;
             margin-right: -4px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5224
- [x] Include a change request file using `$ npm run change`

#### Description of changes

That the label was inline-flex was causing the `overflow`/`text-overflow` css properties to not correctly take effect because of incorrect block formatting context.

The only concern is whether there was a reason for this to be `inline-flex` in the first place... However, given that each option for the checkbox is never rendered inline, it is very counter-intuitive in the first place to use `inline-flex`.



##### Before
![image](https://user-images.githubusercontent.com/1003246/41880916-7eea8884-7895-11e8-9a75-2e9496985519.png)

##### After
![image](https://user-images.githubusercontent.com/1003246/41880936-9ea23d48-7895-11e8-8ed2-4ec8e7455bd5.png)

#### Focus areas to test

Visual regressions...

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5341)

