### PR TITLE
TextField render value undefined as empty string

### DIFF
--- a/common/changes/office-ui-fabric-react/textFieldValueUndefined_2018-06-26-23-59.json
+++ b/common/changes/office-ui-fabric-react/textFieldValueUndefined_2018-06-26-23-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: render undefined as empty string in renderInput",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -409,7 +409,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         id={this._id}
         {...inputProps}
         ref={this._textElement}
-        value={this.state.value ? this.state.value : ''}
+        value={this.state.value === undefined ? '' : this.state.value}
         onInput={this._onInputChange}
         onChange={this._onInputChange}
         className={this._getTextElementClassName()}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -122,7 +122,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
   public componentWillReceiveProps(newProps: ITextFieldProps): void {
     const { onBeforeChange } = this.props;
 
-    if (newProps.value !== undefined && newProps.value !== this.state.value) {
+    if (newProps.value !== this.state.value) {
       if (onBeforeChange) {
         onBeforeChange(newProps.value);
       }
@@ -409,7 +409,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         id={this._id}
         {...inputProps}
         ref={this._textElement}
-        value={this.state.value}
+        value={this.state.value ? this.state.value : ''}
         onInput={this._onInputChange}
         onChange={this._onInputChange}
         className={this._getTextElementClassName()}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5146 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

If a **TextField** value is undefined, make sure **_renderInput** gets executed and render the value as an empty string. 
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5349)

