### PR TITLE
Address issue #5353

### DIFF
--- a/common/changes/@uifabric/icons/icons.json
+++ b/common/changes/@uifabric/icons/icons.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/icons",
+      "comment": "Republish to address issue #5353",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "cliff.koh@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5353
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There is nothing inherently wrong with icons that amd build will not be generated. Unfortunately because of the time since 6.0.1 was released, we no longer have the build logs. This change file forces a new version of icons to be published.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5359)

