### PR TITLE
Addressing Issue #5165 - Using Customizer with Nav Component

### DIFF
--- a/common/changes/office-ui-fabric-react/nav-customizer-5165_2018-06-27-22-41.json
+++ b/common/changes/office-ui-fabric-react/nav-customizer-5165_2018-06-27-22-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added arguments to styled function to allow the Customizer component to affect Nav",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-brgarl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, customizable, divProperties, getNativeProps } from '../../Utilities';
+import { BaseComponent, classNamesFunction, divProperties, getNativeProps } from '../../Utilities';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { ActionButton } from '../../Button';
 import { Icon } from '../../Icon';

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -28,7 +28,6 @@ export interface INavState {
   selectedKey?: string;
 }
 
-@customizable('Nav', ['theme', 'styles'])
 export class NavBase extends BaseComponent<INavProps, INavState> implements INav {
   public static defaultProps: INavProps = {
     groups: null

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -3,4 +3,4 @@ import { INavProps, INavStyleProps, INavStyles } from './Nav.types';
 import { NavBase } from './Nav.base';
 import { getStyles } from './Nav.styles';
 
-export const Nav = styled<INavProps, INavStyleProps, INavStyles>(NavBase, getStyles);
+export const Nav = styled<INavProps, INavStyleProps, INavStyles>(NavBase, getStyles, undefined, { scope: 'Nav' });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5165 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates made to the styles infrastructure now require an extra argument in the use of the `styled()` function in the main component file (e.g. **Nav.tsx**) in lieu of the  **@customizable** decorator used in the past.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5361)

