### PR TITLE
Make FloatingPicker a controlled component

### DIFF
--- a/common/changes/office-ui-fabric-react/amyngu-makeFloatingPickerAControlledComponent_2018-06-27-23-27.json
+++ b/common/changes/office-ui-fabric-react/amyngu-makeFloatingPickerAControlledComponent_2018-06-27-23-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow FloatingPicker to be a controlled component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "amyngu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -111,7 +111,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
               {this.canAddItems() && (
                 <Autofill
                   {...inputProps as IInputProps}
-                  tabIndex={-1}
                   className={css('ms-BasePicker-input', styles.pickerInput)}
                   ref={this.input}
                   onFocus={this.onInputFocus}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -13,6 +13,7 @@ const styles: any = stylesImport;
 
 export interface IBaseExtendedPickerState<T> {
   selectedItems: T[] | null;
+  suggestionItems: T[] | null;
 }
 
 export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
@@ -33,6 +34,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     this.selection = new Selection({ onSelectionChanged: () => this.onSelectionChange() });
 
     this.state = {
+      suggestionItems: this.props.suggestionItems ? (this.props.suggestionItems as T[]) : null,
       selectedItems: this.props.defaultSelectedItems
         ? (this.props.defaultSelectedItems as T[])
         : this.props.selectedItems
@@ -109,6 +111,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
               {this.canAddItems() && (
                 <Autofill
                   {...inputProps as IInputProps}
+                  tabIndex={-1}
                   className={css('ms-BasePicker-input', styles.pickerInput)}
                   ref={this.input}
                   onFocus={this.onInputFocus}
@@ -150,6 +153,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
       onChange: this._onSuggestionSelected,
       inputElement: this.input.current ? this.input.current.inputElement : undefined,
       selectedItems: this.items,
+      suggestionItems: this.props.suggestionItems ? this.props.suggestionItems : undefined,
       ...this.floatingPickerProps
     });
   }
@@ -159,7 +163,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     return onRenderSelectedItems({
       componentRef: this.selectedItemsList,
       selection: this.selection,
-      selectedItems: this.state.selectedItems ? this.state.selectedItems : undefined,
+      selectedItems: this.props.selectedItems ? this.props.selectedItems : undefined,
       onItemsDeleted: this.props.selectedItems ? this.props.onItemsRemoved : undefined,
       ...this.selectedItemsListProps
     });

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -114,7 +114,7 @@ export interface IBaseExtendedPickerProps<T> {
   selectedItems?: T[];
 
   /**
-   * If using as a controlled component use suggestionITems here instead of FloatingPicker
+   * If using as a controlled component use suggestionItems here instead of FloatingPicker
    */
   suggestionItems?: T[];
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -112,4 +112,9 @@ export interface IBaseExtendedPickerProps<T> {
    * If using as a controlled component use selectedItems here instead of the SelectedItemsList
    */
   selectedItems?: T[];
+
+  /**
+   * If using as a controlled component use suggestionITems here instead of FloatingPicker
+   */
+  suggestionItems?: T[];
 }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.test.tsx
@@ -87,6 +87,8 @@ describe('Pickers', () => {
       input.value = '';
       picker.onQueryStringChanged('');
 
+      input.click();
+
       expect(picker.suggestions.length).toEqual(4);
 
       ReactDOM.unmountComponentAtNode(root);

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.test.tsx
@@ -83,11 +83,8 @@ describe('Pickers', () => {
       input.value = 'a';
       picker.onQueryStringChanged('a');
 
-      // Change input to be empty string
       input.value = '';
       picker.onQueryStringChanged('');
-
-      input.click();
 
       expect(picker.suggestions.length).toEqual(4);
 

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -193,7 +193,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
 
   protected updateSuggestionWithZeroState(): void {
     if (this.props.onZeroQuerySuggestion) {
-      this._updateSuggestionsVisible(true);
+      this._updateSuggestionsVisible(true /*shouldShow*/);
       const onEmptyInputFocus = this.props.onZeroQuerySuggestion as (selectedItems?: T[]) => T[] | PromiseLike<T[]>;
       const suggestions: T[] | PromiseLike<T[]> = onEmptyInputFocus(this.props.selectedItems);
       this.updateSuggestionsList(suggestions);
@@ -231,7 +231,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
 
   protected onSuggestionClick = (ev: React.MouseEvent<HTMLElement>, item: T, index: number): void => {
     this.onChange(item);
-    this._updateSuggestionsVisible(false);
+    this._updateSuggestionsVisible(false /*shouldShow*/);
   };
 
   protected onSuggestionRemove = (ev: React.MouseEvent<HTMLElement>, item: T, index: number): void => {
@@ -306,7 +306,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
       this.props.selectedItems
     );
 
-    this._updateSuggestionsVisible(true);
+    this._updateSuggestionsVisible(true /*shouldShow*/);
     if (suggestions !== null) {
       this.updateSuggestionsList(suggestions, updatedValue);
     }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, createRef } from '../../Utilities';
+import * as stylesImport from './BaseFloatingPicker.scss';
+import { BaseComponent, createRef, css, KeyCodes } from '../../Utilities';
 import { Callout, DirectionalHint } from '../../Callout';
-import { ISuggestionModel } from '../../Pickers';
 import {
   IBaseFloatingPicker,
   IBaseFloatingPickerProps,
   IBaseFloatingPickerSuggestionProps
 } from './BaseFloatingPicker.types';
+import { ISuggestionModel } from '../../Pickers';
 import { ISuggestionsControlProps } from './Suggestions/Suggestions.types';
 import { SuggestionsControl } from './Suggestions/SuggestionsControl';
 import { SuggestionsStore } from './Suggestions/SuggestionsStore';
-import * as stylesImport from './BaseFloatingPicker.scss';
 // tslint:disable-next-line:no-any
 const styles: any = stylesImport;
 
@@ -31,7 +31,6 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
   protected SuggestionsControlOfProperType: new (props: ISuggestionsControlProps<T>) => SuggestionsControl<
     T
   > = SuggestionsControl as new (props: ISuggestionsControlProps<T>) => SuggestionsControl<T>;
-  protected loadingTimer: number | undefined;
   // tslint:disable-next-line:no-any
   protected currentPromise: PromiseLike<any>;
 
@@ -76,7 +75,11 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
         queryString: queryString
       });
 
-      this.showPicker(true /*updateValue*/);
+      if (this.props.onInputChanged) {
+        (this.props.onInputChanged as (filter: string) => void)(queryString);
+      }
+
+      this.updateValue(queryString);
     }
   };
 
@@ -100,13 +103,9 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
     });
 
     // Update the suggestions if updateValue == true
+    const value = this.props.inputElement ? this.props.inputElement.value : '';
     if (updateValue) {
-      const value = this.props.inputElement ? this.props.inputElement.value : '';
-      if (value === '') {
-        this.updateSuggestionWithZeroState();
-      } else {
-        this.updateValue(value);
-      }
+      this.updateValue(value);
     }
   };
 
@@ -122,6 +121,12 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
 
   public componentWillUnmount(): void {
     this._unbindFromInputElement();
+  }
+
+  public componentWillReceiveProps(newProps: P): void {
+    if (newProps.suggestionItems) {
+      this.updateSuggestions(newProps.suggestionItems);
+    }
   }
 
   public completeSuggestion = (): void => {
@@ -179,15 +184,16 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
   }
 
   protected updateValue(updatedValue: string): void {
-    if (this.props.onInputChanged) {
-      (this.props.onInputChanged as (filter: string) => void)(updatedValue);
+    if (updatedValue === '') {
+      this.updateSuggestionWithZeroState();
+    } else {
+      this._onResolveSuggestions(updatedValue);
     }
-
-    this._onResolveSuggestions(updatedValue);
   }
 
   protected updateSuggestionWithZeroState(): void {
     if (this.props.onZeroQuerySuggestion) {
+      this._updateSuggestionsVisible(true);
       const onEmptyInputFocus = this.props.onZeroQuerySuggestion as (selectedItems?: T[]) => T[] | PromiseLike<T[]>;
       const suggestions: T[] | PromiseLike<T[]> = onEmptyInputFocus(this.props.selectedItems);
       this.updateSuggestionsList(suggestions);
@@ -204,36 +210,17 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
     // If the returned value is not an array then check to see if it's a promise or PromiseLike. If it is then resolve it asynchronously.
     if (Array.isArray(suggestionsArray)) {
       if (updatedValue !== undefined) {
-        this.resolveNewValue(updatedValue, suggestionsArray);
-      } else {
-        this.updateSuggestions(suggestionsArray, true /*forceUpdate*/);
+        this.updateSuggestions(suggestionsArray);
       }
     } else if (suggestionsPromiseLike && suggestionsPromiseLike.then) {
-      this._updateSuggestionsVisible(updatedValue !== undefined && updatedValue !== '');
-
       // Ensure that the promise will only use the callback if it was the most recent one.
       const promise: PromiseLike<T[]> = (this.currentPromise = suggestionsPromiseLike);
       promise.then((newSuggestions: T[]) => {
         if (promise === this.currentPromise) {
-          if (updatedValue !== undefined) {
-            this.resolveNewValue(updatedValue, newSuggestions);
-          } else {
-            this.updateSuggestions(newSuggestions);
-
-            this._updateSuggestionsVisible(newSuggestions.length > 0);
-          }
-          if (this.loadingTimer) {
-            this._async.clearTimeout(this.loadingTimer);
-            this.loadingTimer = undefined;
-          }
+          this.updateSuggestions(newSuggestions, true /*forceUpdate*/);
         }
       });
     }
-  }
-
-  protected resolveNewValue(updatedValue: string, suggestions: T[]): void {
-    this.updateSuggestions(suggestions);
-    this._updateSuggestionsVisible(updatedValue !== '');
   }
 
   protected onChange(item: T): void {
@@ -244,6 +231,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
 
   protected onSuggestionClick = (ev: React.MouseEvent<HTMLElement>, item: T, index: number): void => {
     this.onChange(item);
+    this._updateSuggestionsVisible(false);
   };
 
   protected onSuggestionRemove = (ev: React.MouseEvent<HTMLElement>, item: T, index: number): void => {
@@ -318,6 +306,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
       this.props.selectedItems
     );
 
+    this._updateSuggestionsVisible(true);
     if (suggestions !== null) {
       this.updateSuggestionsList(suggestions, updatedValue);
     }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -202,16 +202,14 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
     }
   }
 
-  protected updateSuggestionsList(suggestions: T[] | PromiseLike<T[]>, updatedValue?: string): void {
+  protected updateSuggestionsList(suggestions: T[] | PromiseLike<T[]>): void {
     const suggestionsArray: T[] = suggestions as T[];
     const suggestionsPromiseLike: PromiseLike<T[]> = suggestions as PromiseLike<T[]>;
 
     // Check to see if the returned value is an array, if it is then just pass it into the next function.
     // If the returned value is not an array then check to see if it's a promise or PromiseLike. If it is then resolve it asynchronously.
     if (Array.isArray(suggestionsArray)) {
-      if (updatedValue !== undefined) {
-        this.updateSuggestions(suggestionsArray, true /*forceUpdate*/);
-      }
+      this.updateSuggestions(suggestionsArray, true /*forceUpdate*/);
     } else if (suggestionsPromiseLike && suggestionsPromiseLike.then) {
       // Ensure that the promise will only use the callback if it was the most recent one.
       const promise: PromiseLike<T[]> = (this.currentPromise = suggestionsPromiseLike);
@@ -308,7 +306,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
 
     this._updateSuggestionsVisible(true /*shouldShow*/);
     if (suggestions !== null) {
-      this.updateSuggestionsList(suggestions, updatedValue);
+      this.updateSuggestionsList(suggestions);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -210,7 +210,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
     // If the returned value is not an array then check to see if it's a promise or PromiseLike. If it is then resolve it asynchronously.
     if (Array.isArray(suggestionsArray)) {
       if (updatedValue !== undefined) {
-        this.updateSuggestions(suggestionsArray);
+        this.updateSuggestions(suggestionsArray, true /*forceUpdate*/);
       }
     } else if (suggestionsPromiseLike && suggestionsPromiseLike.then) {
       // Ensure that the promise will only use the callback if it was the most recent one.

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
@@ -40,9 +40,9 @@ export interface IBaseFloatingPickerProps<T> extends React.Props<any> {
   suggestionsStore: SuggestionsStore<T>;
 
   /**
-   * The suggestions to show on zero query
+   * The suggestions to show on zero query, return null if using as a controlled component
    */
-  onZeroQuerySuggestion?: (selectedItems?: T[]) => T[] | PromiseLike<T[]>;
+  onZeroQuerySuggestion?: (selectedItems?: T[]) => T[] | PromiseLike<T[]> | null;
 
   /**
    * The input element to listen on events
@@ -58,6 +58,7 @@ export interface IBaseFloatingPickerProps<T> extends React.Props<any> {
    * A callback for what should happen when a person types text into the input.
    * Returns the already selected items so the resolver can filter them out.
    * If used in conjunction with resolveDelay this will ony kick off after the delay throttle.
+   * Return null if using as a controlled component
    */
   onResolveSuggestions: (filter: string, selectedItems?: T[]) => T[] | PromiseLike<T[]> | null;
 
@@ -134,6 +135,11 @@ export interface IBaseFloatingPickerProps<T> extends React.Props<any> {
    * The callback that should be called when the suggestions are hiden
    */
   onSuggestionsHidden?: () => void;
+
+  /**
+   * If using as a controlled component, the items to show in the suggestion list
+   */
+  suggestionItems?: T[];
 }
 
 export interface IBaseFloatingPickerSuggestionProps {


### PR DESCRIPTION

#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes
- Allow FloatingPicker to be used as a controlled component (suggestions to be passed in via props)
- Cleaned up some private methods in BaseFloatingPicker
- Change so that zero query suggestions are only shown if user explicitly clicks into the input
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5363)

