### PR TITLE
ShimmeredDetailsList: wrapper for DetailsList with Shimmer.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-Ref_DetailsList_Shimmer_2018-06-28-02-01.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-Ref_DetailsList_Shimmer_2018-06-28-02-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ShimmeredDetailsList: adds a new wrapper for DetailsList when needed to be used with Shimmer animation.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -222,7 +222,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   }
 
   public componentWillReceiveProps(newProps: IDetailsListProps): void {
-    const { checkboxVisibility, items, setKey, selectionMode, columns, viewport } = this.props;
+    const { checkboxVisibility, items, setKey, selectionMode, columns, viewport, compact } = this.props;
     const shouldResetSelection = newProps.setKey !== setKey || newProps.setKey === undefined;
     let shouldForceUpdates = false;
 
@@ -245,7 +245,8 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     if (
       newProps.checkboxVisibility !== checkboxVisibility ||
       newProps.columns !== columns ||
-      newProps.viewport!.width !== viewport!.width
+      newProps.viewport!.width !== viewport!.width ||
+      newProps.compact !== compact
     ) {
       shouldForceUpdates = true;
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
@@ -15,9 +15,10 @@ export interface IShimmeredDetailsListProps extends IDetailsListProps {
 }
 
 const SHIMMER_INITIAL_ITEMS = 10;
-
-const DEFAULT_SIDE_PADDING = 8;
 const DEFAULT_SHIMMER_HEIGHT = 7;
+
+// This values are matching values from ./DetailsRow.css
+const DEFAULT_SIDE_PADDING = 8;
 const DEFAULT_ROW_HEIGHT = 42;
 const COMPACT_ROW_HEIGHT = 32;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+
+import { BaseComponent } from '../../Utilities';
+import { IDetailsListProps } from './DetailsList.types';
+import { DetailsList } from './DetailsList';
+import { IDetailsRowProps } from './DetailsRow';
+import { Shimmer, ShimmerElementsGroup, ShimmerElementType, IShimmerElement } from '../Shimmer';
+
+export interface IShimmeredDetailsListProps extends IDetailsListProps {
+  shimmerLines?: number;
+  onRenderCustomPlaceholder?: () => React.ReactNode;
+}
+
+const SHIMMER_INITIAL_ITEMS = 10;
+
+const DEFAULT_SIDE_PADDING = 8;
+const DEFAULT_SHIMMER_HEIGHT = 7;
+const DEFAULT_ROW_HEIGHT = 42;
+const COMPACT_ROW_HEIGHT = 32;
+
+export class ShimmeredDetailsList extends BaseComponent<IShimmeredDetailsListProps, {}> {
+  private _shimmerItems: null[];
+
+  constructor(props: IShimmeredDetailsListProps) {
+    super(props);
+
+    this._shimmerItems = props.shimmerLines ? new Array(props.shimmerLines) : new Array(SHIMMER_INITIAL_ITEMS);
+  }
+
+  public render(): JSX.Element {
+    const { enableShimmer, items } = this.props;
+    const { shimmerLines, onRenderCustomPlaceholder, ...detailsListProps } = this.props;
+
+    return (
+      <DetailsList
+        {...detailsListProps}
+        items={enableShimmer ? this._shimmerItems : items}
+        onRenderMissingItem={this._onRenderShimmerPlaceholder}
+      />
+    );
+  }
+
+  private _onRenderShimmerPlaceholder = (index: number, rowProps: IDetailsRowProps): React.ReactNode => {
+    const { onRenderCustomPlaceholder } = this.props;
+
+    const placeholderElements: React.ReactNode = onRenderCustomPlaceholder
+      ? onRenderCustomPlaceholder()
+      : this._renderDefaultShimmerPlaceholder(rowProps);
+
+    return <Shimmer customElementsGroup={placeholderElements} />;
+  };
+
+  private _renderDefaultShimmerPlaceholder = (rowProps: IDetailsRowProps): React.ReactNode => {
+    const { columns, compact } = rowProps;
+    const shimmerElementsRow: JSX.Element[] = [];
+    const gapHeight: number = compact ? COMPACT_ROW_HEIGHT : DEFAULT_ROW_HEIGHT;
+
+    columns.map((column, columnIdx) => {
+      const shimmerElements: IShimmerElement[] = [];
+      const groupWidth: number = DEFAULT_SIDE_PADDING * 2 + column.calculatedWidth!;
+
+      shimmerElements.push({
+        type: ShimmerElementType.gap,
+        width: DEFAULT_SIDE_PADDING,
+        height: gapHeight
+      });
+
+      if (column.isIconOnly) {
+        shimmerElements.push({
+          type: ShimmerElementType.line,
+          width: column.calculatedWidth!,
+          height: column.calculatedWidth!
+        });
+        shimmerElements.push({
+          type: ShimmerElementType.gap,
+          width: DEFAULT_SIDE_PADDING,
+          height: gapHeight
+        });
+      } else {
+        shimmerElements.push({
+          type: ShimmerElementType.line,
+          width: column.calculatedWidth! - DEFAULT_SIDE_PADDING * 3,
+          height: DEFAULT_SHIMMER_HEIGHT
+        });
+        shimmerElements.push({
+          type: ShimmerElementType.gap,
+          width: DEFAULT_SIDE_PADDING * 4,
+          height: gapHeight
+        });
+      }
+      shimmerElementsRow.push(
+        <ShimmerElementsGroup key={columnIdx} width={`${groupWidth}px`} shimmerElements={shimmerElements} />
+      );
+    });
+    // When resizing the window from narrow to wider, we need to cover the exposed Shimmer wave until the column resizing logic is done.
+    shimmerElementsRow.push(
+      <ShimmerElementsGroup
+        key={'endGap'}
+        width={'100%'}
+        shimmerElements={[{ type: ShimmerElementType.gap, width: '100%', height: gapHeight }]}
+      />
+    );
+    return <div style={{ display: 'flex' }}>{shimmerElementsRow}</div>;
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
@@ -44,18 +44,23 @@ export class ShimmeredDetailsList extends BaseComponent<IShimmeredDetailsListPro
   }
 
   private _onRenderShimmerPlaceholder = (index: number, rowProps: IDetailsRowProps): React.ReactNode => {
-    const { onRenderCustomPlaceholder } = this.props;
+    const { onRenderCustomPlaceholder, compact } = this.props;
+    const { selectionMode, checkboxVisibility } = rowProps;
+    const showCheckbox = selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden;
 
     const placeholderElements: React.ReactNode = onRenderCustomPlaceholder
       ? onRenderCustomPlaceholder()
       : this._renderDefaultShimmerPlaceholder(rowProps);
 
-    return <Shimmer customElementsGroup={placeholderElements} />;
+    return (
+      <div className={css(showCheckbox && styles.shimmerLeftBorder, !compact && styles.shimmerBottomBorder)}>
+        <Shimmer customElementsGroup={placeholderElements} />
+      </div>
+    );
   };
 
   private _renderDefaultShimmerPlaceholder = (rowProps: IDetailsRowProps): React.ReactNode => {
-    const { columns, compact, selectionMode, checkboxVisibility } = rowProps;
-    const showCheckbox = selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden;
+    const { columns, compact } = rowProps;
     const shimmerElementsRow: JSX.Element[] = [];
     const gapHeight: number = compact ? COMPACT_ROW_HEIGHT : DEFAULT_ROW_HEIGHT;
 
@@ -104,13 +109,6 @@ export class ShimmeredDetailsList extends BaseComponent<IShimmeredDetailsListPro
         shimmerElements={[{ type: ShimmerElementType.gap, width: '100%', height: gapHeight }]}
       />
     );
-    return (
-      <div
-        className={css(showCheckbox && styles.shimmerLeftBorder, !compact && styles.shimmerBottomBorder)}
-        style={{ display: 'flex' }}
-      >
-        {shimmerElementsRow}
-      </div>
-    );
+    return <div style={{ display: 'flex' }}>{shimmerElementsRow}</div>;
   };
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 
-import { BaseComponent } from '../../Utilities';
-import { IDetailsListProps } from './DetailsList.types';
+import { BaseComponent, css } from '../../Utilities';
+import { SelectionMode } from '../../utilities/selection/interfaces';
+import { IDetailsListProps, CheckboxVisibility } from './DetailsList.types';
 import { DetailsList } from './DetailsList';
 import { IDetailsRowProps } from './DetailsRow';
 import { Shimmer, ShimmerElementsGroup, ShimmerElementType, IShimmerElement } from '../Shimmer';
+
+import * as styles from './DetailsRow.scss';
 
 export interface IShimmeredDetailsListProps extends IDetailsListProps {
   shimmerLines?: number;
@@ -51,7 +54,8 @@ export class ShimmeredDetailsList extends BaseComponent<IShimmeredDetailsListPro
   };
 
   private _renderDefaultShimmerPlaceholder = (rowProps: IDetailsRowProps): React.ReactNode => {
-    const { columns, compact } = rowProps;
+    const { columns, compact, selectionMode, checkboxVisibility } = rowProps;
+    const showCheckbox = selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden;
     const shimmerElementsRow: JSX.Element[] = [];
     const gapHeight: number = compact ? COMPACT_ROW_HEIGHT : DEFAULT_ROW_HEIGHT;
 
@@ -100,6 +104,13 @@ export class ShimmeredDetailsList extends BaseComponent<IShimmeredDetailsListPro
         shimmerElements={[{ type: ShimmerElementType.gap, width: '100%', height: gapHeight }]}
       />
     );
-    return <div style={{ display: 'flex' }}>{shimmerElementsRow}</div>;
+    return (
+      <div
+        className={css(showCheckbox && styles.shimmerLeftBorder, !compact && styles.shimmerBottomBorder)}
+        style={{ display: 'flex' }}
+      >
+        {shimmerElementsRow}
+      </div>
+    );
   };
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.tsx
@@ -32,8 +32,8 @@ export class ShimmeredDetailsList extends BaseComponent<IShimmeredDetailsListPro
   }
 
   public render(): JSX.Element {
-    const { enableShimmer, items } = this.props;
-    const { shimmerLines, onRenderCustomPlaceholder, ...detailsListProps } = this.props;
+    const { items } = this.props;
+    const { shimmerLines, onRenderCustomPlaceholder, enableShimmer, ...detailsListProps } = this.props;
 
     return (
       <DetailsList

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -4,3 +4,4 @@ export * from './DetailsList';
 export * from './DetailsList.types';
 export * from './DetailsRow';
 export * from './DetailsRowCheck';
+export * from './ShimmeredDetailsList';

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.doc.tsx
@@ -21,7 +21,7 @@ export const ShimmerPageProps: IDocPageProps = {
   title: 'Shimmer',
   componentName: 'ShimmerExample',
   componentUrl:
-    'https://githubcom/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Shimmer',
+    'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Shimmer',
   examples: [
     {
       title: "Shimmer with basic elements using the 'shimmerElements' prop",
@@ -39,7 +39,7 @@ export const ShimmerPageProps: IDocPageProps = {
       view: <ShimmerLoadDataExample />
     },
     {
-      title: 'Details List with 500 items simulating loading data in async manner and having Shimmer enabled.',
+      title: 'Shimmered Details List with 500 items simulating loading data in async manner.',
       code: ShimmerApplicationExampleCode,
       view: <ShimmerApplicationExample />
     },

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
@@ -5,14 +5,15 @@ import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { createListItems } from '../../../utilities/exampleData';
 import {
   IColumn,
-  DetailsList,
+  // DetailsList,
   buildColumns,
   SelectionMode,
-  Toggle,
-  IDetailsRowProps,
-  DetailsRow
+  Toggle
+  // IDetailsRowProps,
+  // DetailsRow
 } from 'office-ui-fabric-react/lib/index';
-import { Shimmer } from 'office-ui-fabric-react/lib/Shimmer';
+// import { Shimmer } from 'office-ui-fabric-react/lib/Shimmer';
+import { ShimmeredDetailsList } from '../../DetailsList';
 
 import * as ShimmerExampleStyles from './Shimmer.Example.scss';
 
@@ -57,7 +58,7 @@ const fileIcons: { name: string }[] = [
 
 const ITEMS_COUNT = 500;
 const ITEMS_BATCH_SIZE = 10;
-const PAGING_DELAY = 2500;
+// const PAGING_DELAY = 2500;
 
 // tslint:disable-next-line:no-any
 let _items: any[];
@@ -71,7 +72,7 @@ export interface IShimmerApplicationExampleState {
 }
 
 export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplicationExampleState> {
-  private _isFetchingItems: boolean;
+  // private _isFetchingItems: boolean;
   private _lastTimeoutId: number;
 
   constructor(props: {}) {
@@ -115,15 +116,15 @@ export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplica
           />
         </div>
         <div>
-          <DetailsList
+          <ShimmeredDetailsList
             setKey="items"
             items={items!}
             columns={columns}
             compact={isCompactMode}
             selectionMode={this.state.isModalSelection ? SelectionMode.multiple : SelectionMode.none}
             onRenderItemColumn={this._onRenderItemColumn}
-            onRenderMissingItem={this._onRenderMissingItem}
-            enableShimmer={true}
+            // onRenderMissingItem={this._onRenderMissingItem}
+            enableShimmer={!isDataLoaded}
             listProps={{ renderedWindowsAhead: 0, renderedWindowsBehind: 0 }}
           />
         </div>
@@ -131,34 +132,34 @@ export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplica
     );
   }
 
-  private _onRenderMissingItem = (index: number, rowProps: IDetailsRowProps): React.ReactNode => {
-    const { isDataLoaded } = this.state;
-    isDataLoaded && this._onDataMiss(index as number);
+  // private _onRenderMissingItem = (index: number, rowProps: IDetailsRowProps): React.ReactNode => {
+  //   const { isDataLoaded } = this.state;
+  //   isDataLoaded && this._onDataMiss(index as number);
 
-    const shimmerRow: JSX.Element = <DetailsRow {...rowProps} shimmer={true} />;
+  //   const shimmerRow: JSX.Element = <DetailsRow {...rowProps} shimmer={true} />;
 
-    return <Shimmer customElementsGroup={shimmerRow} />;
-  };
+  //   return <Shimmer customElementsGroup={shimmerRow} />;
+  // };
 
-  // Simulating asynchronus data loading each 2.5 sec
-  private _onDataMiss = (index: number): void => {
-    index = Math.floor(index / ITEMS_BATCH_SIZE) * ITEMS_BATCH_SIZE;
-    if (!this._isFetchingItems) {
-      this._isFetchingItems = true;
-      this._lastTimeoutId = this._async.setTimeout(() => {
-        this._isFetchingItems = false;
-        // tslint:disable-next-line:no-any
-        const itemsCopy = ([] as any[]).concat(this.state.items);
-        itemsCopy.splice.apply(
-          itemsCopy,
-          [index, ITEMS_BATCH_SIZE].concat(_items.slice(index, index + ITEMS_BATCH_SIZE))
-        );
-        this.setState({
-          items: itemsCopy
-        });
-      }, PAGING_DELAY);
-    }
-  };
+  // // Simulating asynchronus data loading each 2.5 sec
+  // private _onDataMiss = (index: number): void => {
+  //   index = Math.floor(index / ITEMS_BATCH_SIZE) * ITEMS_BATCH_SIZE;
+  //   if (!this._isFetchingItems) {
+  //     this._isFetchingItems = true;
+  //     this._lastTimeoutId = this._async.setTimeout(() => {
+  //       this._isFetchingItems = false;
+  //       // tslint:disable-next-line:no-any
+  //       const itemsCopy = ([] as any[]).concat(this.state.items);
+  //       itemsCopy.splice.apply(
+  //         itemsCopy,
+  //         [index, ITEMS_BATCH_SIZE].concat(_items.slice(index, index + ITEMS_BATCH_SIZE))
+  //       );
+  //       this.setState({
+  //         items: itemsCopy
+  //       });
+  //     }, PAGING_DELAY);
+  //   }
+  // };
 
   private _onLoadData = (checked: boolean): void => {
     if (!_items) {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
@@ -3,16 +3,7 @@ import * as React from 'react';
 /* tslint:enable:no-unused-variable */
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { createListItems } from '../../../utilities/exampleData';
-import {
-  IColumn,
-  // DetailsList,
-  buildColumns,
-  SelectionMode,
-  Toggle
-  // IDetailsRowProps,
-  // DetailsRow
-} from 'office-ui-fabric-react/lib/index';
-// import { Shimmer } from 'office-ui-fabric-react/lib/Shimmer';
+import { IColumn, buildColumns, SelectionMode, Toggle } from 'office-ui-fabric-react/lib/index';
 import { ShimmeredDetailsList } from '../../DetailsList';
 
 import * as ShimmerExampleStyles from './Shimmer.Example.scss';
@@ -57,8 +48,7 @@ const fileIcons: { name: string }[] = [
 ];
 
 const ITEMS_COUNT = 500;
-const ITEMS_BATCH_SIZE = 10;
-// const PAGING_DELAY = 2500;
+const INTERVAL_DELAY = 2500;
 
 // tslint:disable-next-line:no-any
 let _items: any[];
@@ -72,8 +62,8 @@ export interface IShimmerApplicationExampleState {
 }
 
 export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplicationExampleState> {
-  // private _isFetchingItems: boolean;
-  private _lastTimeoutId: number;
+  private _lastIntervalId: number;
+  private _lastIndexWithData: number;
 
   constructor(props: {}) {
     super(props);
@@ -85,6 +75,10 @@ export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplica
       isModalSelection: false,
       isCompactMode: false
     };
+  }
+
+  public componentWillUnmount(): void {
+    this._async.dispose();
   }
 
   public render(): JSX.Element {
@@ -123,7 +117,6 @@ export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplica
             compact={isCompactMode}
             selectionMode={this.state.isModalSelection ? SelectionMode.multiple : SelectionMode.none}
             onRenderItemColumn={this._onRenderItemColumn}
-            // onRenderMissingItem={this._onRenderMissingItem}
             enableShimmer={!isDataLoaded}
             listProps={{ renderedWindowsAhead: 0, renderedWindowsBehind: 0 }}
           />
@@ -132,34 +125,23 @@ export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplica
     );
   }
 
-  // private _onRenderMissingItem = (index: number, rowProps: IDetailsRowProps): React.ReactNode => {
-  //   const { isDataLoaded } = this.state;
-  //   isDataLoaded && this._onDataMiss(index as number);
-
-  //   const shimmerRow: JSX.Element = <DetailsRow {...rowProps} shimmer={true} />;
-
-  //   return <Shimmer customElementsGroup={shimmerRow} />;
-  // };
-
-  // // Simulating asynchronus data loading each 2.5 sec
-  // private _onDataMiss = (index: number): void => {
-  //   index = Math.floor(index / ITEMS_BATCH_SIZE) * ITEMS_BATCH_SIZE;
-  //   if (!this._isFetchingItems) {
-  //     this._isFetchingItems = true;
-  //     this._lastTimeoutId = this._async.setTimeout(() => {
-  //       this._isFetchingItems = false;
-  //       // tslint:disable-next-line:no-any
-  //       const itemsCopy = ([] as any[]).concat(this.state.items);
-  //       itemsCopy.splice.apply(
-  //         itemsCopy,
-  //         [index, ITEMS_BATCH_SIZE].concat(_items.slice(index, index + ITEMS_BATCH_SIZE))
-  //       );
-  //       this.setState({
-  //         items: itemsCopy
-  //       });
-  //     }, PAGING_DELAY);
-  //   }
-  // };
+  private _loadData = (): void => {
+    this._lastIntervalId = this._async.setInterval(() => {
+      const randomQuantity: number = Math.floor(Math.random() * 10) + 1;
+      // tslint:disable-next-line:no-any
+      const itemsCopy = ([] as any[]).concat(this.state.items);
+      itemsCopy.splice.apply(
+        itemsCopy,
+        [this._lastIndexWithData, randomQuantity].concat(
+          _items.slice(this._lastIndexWithData, this._lastIndexWithData + randomQuantity)
+        )
+      );
+      this._lastIndexWithData += randomQuantity;
+      this.setState({
+        items: itemsCopy
+      });
+    }, INTERVAL_DELAY);
+  };
 
   private _onLoadData = (checked: boolean): void => {
     if (!_items) {
@@ -171,11 +153,14 @@ export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplica
     }
 
     let items: IItem[];
+    const randomQuantity: number = Math.floor(Math.random() * 10) + 1;
     if (checked) {
-      items = _items.slice(0, ITEMS_BATCH_SIZE).concat(new Array(ITEMS_COUNT - ITEMS_BATCH_SIZE));
+      items = _items.slice(0, randomQuantity).concat(new Array(ITEMS_COUNT - randomQuantity));
+      this._lastIndexWithData = randomQuantity;
+      this._loadData();
     } else {
       items = new Array();
-      this._async.clearTimeout(this._lastTimeoutId);
+      this._async.clearInterval(this._lastIntervalId);
     }
     this.setState({
       isDataLoaded: checked,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Introduces a wrapper component called ShimmeredDetailsList which can be used in place of regular DetailsList when you want to augment it with the Shimmer placeholder as an alternative to have it integrated internally which was causing a bundle size increase. The purpose of this wrapper is to give a quick default shimmer placeholder to users who don't modify the renderer of each row by just toggling the `enableShimmer` prop, plus the possibility to provide a custom shimmer skeleton through `onRenderCustomPlaceholder` prop when in need. The `shimmerLines` prop gives more control over the default 10 lines when necessary.

#### Focus areas to test
In `DetailsList` I added a conditional to trigger a **`forceUpdate`** as changing the prop `compact` was not propagated to the new wrapper for correct sizes of Shimmer Elements. How expensive is the `forceUpate`?

#### P.S.
There is a bunch of code related to the current implementation of Shimmer in DetailsList, most specifically in the `DetailsRow.scss` plus some props for `DetailsRow` and `DetailsRowFields`. Those will eventually be removed as soon as we have a v6 Fabric bump in our `common` repo and I can change the imports in there to use the Shimmer from Fabric and not from experiments package.
