### PR TITLE
DragDropHelper: Add support for optional onDragOver prop in IDragDropOptions

### DIFF
--- a/common/changes/office-ui-fabric-react/erichdev-onDragOverHelper_2018-06-28-23-26.json
+++ b/common/changes/office-ui-fabric-react/erichdev-onDragOverHelper_2018-06-28-23-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DragDropHelper: Add support for `onDragOver` prop in IDragDropOptions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/DragDropHelper.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/DragDropHelper.tsx
@@ -158,6 +158,10 @@ export class DragDropHelper implements IDragDropHelper {
 
         onDragOver = (event: DragEvent) => {
           event.preventDefault();
+
+          if (dragDropOptions.onDragOver) {
+            dragDropOptions.onDragOver(dragDropOptions.context.data, event);
+          }
         };
 
         this._dragEnterCounts[key] = 0;

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
@@ -43,6 +43,7 @@ export interface IDragDropOptions {
   onDragStart?: (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent) => void;
   onDrop?: (item?: any, event?: DragEvent) => void;
   onDragEnd?: (item?: any, event?: DragEvent) => void;
+  onDragOver?: (item?: any, event?: DragEvent) => void;
 }
 
 export interface IDragDropEvent {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

DragDropHelper: Add support for optional `onDragOver` prop in IDragDropOptions. This is porting into 5.0 just a portion of PR  #4857 that added support for `onDragOver` in 6.0.