### PR TITLE
Link: Link as button hc colors

### DIFF
--- a/common/changes/@uifabric/styling/link-button-hc_2018-06-29-18-52.json
+++ b/common/changes/@uifabric/styling/link-button-hc_2018-06-29-18-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "New selectors for high contrast white and black modes.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "lynam.emily@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/link-button-hc_2018-06-29-18-52.json
+++ b/common/changes/office-ui-fabric-react/link-button-hc_2018-06-29-18-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Link: HC color for link rendered as a button.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lynam.emily@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -1,4 +1,10 @@
-import { getFocusStyle, getGlobalClassNames, HighContrastSelector } from '../../Styling';
+import {
+  getFocusStyle,
+  getGlobalClassNames,
+  HighContrastSelector,
+  HighContrastSelectorWhite,
+  HighContrastSelectorBlack
+} from '../../Styling';
 import { ILinkStyleProps, ILinkStyles } from './Link.types';
 
 const GlobalClassNames = {
@@ -30,7 +36,15 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
         padding: 0,
         textAlign: 'left',
         textOverflow: 'inherit',
-        userSelect: 'text'
+        userSelect: 'text',
+        selectors: {
+          [HighContrastSelectorBlack]: {
+            color: '#FFFF00'
+          },
+          [HighContrastSelectorWhite]: {
+            color: '#00009F'
+          }
+        }
       },
       !isButton && {
         textDecoration: 'none'

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -37,12 +37,17 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
         textAlign: 'left',
         textOverflow: 'inherit',
         userSelect: 'text',
+        borderBottom: '1px solid transparent', // For Firefox high contrast mode
         selectors: {
           [HighContrastSelectorBlack]: {
             color: '#FFFF00'
           },
           [HighContrastSelectorWhite]: {
             color: '#00009F'
+          },
+          '@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)': {
+            // For IE high contrast mode
+            borderBottom: 'none'
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
       {
         background-color: transparent;
         background: none;
+        border-bottom: 1px solid transparent;
         border: none;
         color: #0078d4;
         cursor: pointer;
@@ -90,6 +91,9 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
       }
       @media screen and (-ms-high-contrast: black-on-white){& {
         color: #00009F;
+      }
+      @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+        border-bottom: none;
       }
       &:active, &:hover, &:active:hover {
         color: #004578;
@@ -158,6 +162,7 @@ exports[`Link renders Link with no href as a button 1`] = `
       {
         background-color: transparent;
         background: none;
+        border-bottom: 1px solid transparent;
         border: none;
         color: #0078d4;
         cursor: pointer;
@@ -197,6 +202,9 @@ exports[`Link renders Link with no href as a button 1`] = `
       }
       @media screen and (-ms-high-contrast: black-on-white){& {
         color: #00009F;
+      }
+      @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+        border-bottom: none;
       }
       &:active, &:hover, &:active:hover {
         color: #004578;
@@ -261,6 +269,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       {
         background-color: transparent;
         background: none;
+        border-bottom: 1px solid transparent;
         border: none;
         color: #a6a6a6;
         cursor: default;
@@ -301,6 +310,9 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       @media screen and (-ms-high-contrast: black-on-white){& {
         color: #00009F;
       }
+      @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+        border-bottom: none;
+      }
       &:link, &:visited {
         pointer-events: none;
       }
@@ -321,6 +333,7 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
       {
         background-color: transparent;
         background: none;
+        border-bottom: 1px solid transparent;
         border: none;
         color: #0078d4;
         cursor: pointer;
@@ -360,6 +373,9 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
       }
       @media screen and (-ms-high-contrast: black-on-white){& {
         color: #00009F;
+      }
+      @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+        border-bottom: none;
       }
       &:active, &:hover, &:active:hover {
         color: #004578;

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -85,6 +85,12 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
         top: 1px;
         z-index: 1;
       }
+      @media screen and (-ms-high-contrast: white-on-black){& {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){& {
+        color: #00009F;
+      }
       &:active, &:hover, &:active:hover {
         color: #004578;
       }
@@ -186,6 +192,12 @@ exports[`Link renders Link with no href as a button 1`] = `
         top: 1px;
         z-index: 1;
       }
+      @media screen and (-ms-high-contrast: white-on-black){& {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){& {
+        color: #00009F;
+      }
       &:active, &:hover, &:active:hover {
         color: #004578;
       }
@@ -283,6 +295,12 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
         top: 1px;
         z-index: 1;
       }
+      @media screen and (-ms-high-contrast: white-on-black){& {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){& {
+        color: #00009F;
+      }
       &:link, &:visited {
         pointer-events: none;
       }
@@ -336,6 +354,12 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
         right: 1px;
         top: 1px;
         z-index: 1;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){& {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){& {
+        color: #00009F;
       }
       &:active, &:hover, &:active:hover {
         color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -74,6 +74,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -114,6 +115,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -150,6 +154,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -190,6 +195,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -297,6 +305,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -337,6 +346,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -453,6 +465,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -493,6 +506,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -518,6 +534,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -558,6 +575,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -583,6 +603,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -623,6 +644,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -109,6 +109,12 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 top: 1px;
                 z-index: 1;
               }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
+              }
               &:active, &:hover, &:active:hover {
                 color: #004578;
               }
@@ -178,6 +184,12 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 right: 1px;
                 top: 1px;
                 z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -319,6 +331,12 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 right: 1px;
                 top: 1px;
                 z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -470,6 +488,12 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 top: 1px;
                 z-index: 1;
               }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
+              }
               &:active, &:hover, &:active:hover {
                 color: #004578;
               }
@@ -529,6 +553,12 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 top: 1px;
                 z-index: 1;
               }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
+              }
               &:active, &:hover, &:active:hover {
                 color: #004578;
               }
@@ -587,6 +617,12 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 right: 1px;
                 top: 1px;
                 z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -180,6 +180,12 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 top: 1px;
                 z-index: 1;
               }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
+              }
               &:active, &:hover, &:active:hover {
                 color: #004578;
               }
@@ -519,6 +525,12 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 top: 1px;
                 z-index: 1;
               }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
+              }
               &:active, &:hover, &:active:hover {
                 color: #004578;
               }
@@ -578,6 +590,12 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 top: 1px;
                 z-index: 1;
               }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
+              }
               &:active, &:hover, &:active:hover {
                 color: #004578;
               }
@@ -636,6 +654,12 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 right: 1px;
                 top: 1px;
                 z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -1026,6 +1050,12 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 top: 1px;
                 z-index: 1;
               }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
+              }
               &:active, &:hover, &:active:hover {
                 color: #004578;
               }
@@ -1084,6 +1114,12 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 right: 1px;
                 top: 1px;
                 z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -1580,6 +1616,12 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 top: 1px;
                 z-index: 1;
               }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
+              }
               &:active, &:hover, &:active:hover {
                 color: #004578;
               }
@@ -1638,6 +1680,12 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 right: 1px;
                 top: 1px;
                 z-index: 1;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){& {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){& {
+                color: #00009F;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -145,6 +145,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -185,6 +186,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -490,6 +494,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -530,6 +535,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -555,6 +563,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -595,6 +604,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -620,6 +632,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -660,6 +673,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -1015,6 +1031,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -1055,6 +1072,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -1080,6 +1100,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -1120,6 +1141,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -1581,6 +1605,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -1621,6 +1646,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;
@@ -1646,6 +1674,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               {
                 background-color: transparent;
                 background: none;
+                border-bottom: 1px solid transparent;
                 border: none;
                 color: #0078d4;
                 cursor: pointer;
@@ -1686,6 +1715,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
+              }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-bottom: none;
               }
               &:active, &:hover, &:active:hover {
                 color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -108,6 +108,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -152,6 +153,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -263,6 +267,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -307,6 +312,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -418,6 +426,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -462,6 +471,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -573,6 +585,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -617,6 +630,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -728,6 +744,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -772,6 +789,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -883,6 +903,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -927,6 +948,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1095,6 +1119,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -1139,6 +1164,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1238,6 +1266,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -1282,6 +1311,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1381,6 +1413,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -1425,6 +1458,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1524,6 +1560,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -1568,6 +1605,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1667,6 +1707,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -1711,6 +1752,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1810,6 +1854,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -1854,6 +1899,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -147,6 +147,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       top: 1px;
                       z-index: 1;
                     }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
+                    }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
                     }
@@ -295,6 +301,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       right: 1px;
                       top: 1px;
                       z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -445,6 +457,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       top: 1px;
                       z-index: 1;
                     }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
+                    }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
                     }
@@ -593,6 +611,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       right: 1px;
                       top: 1px;
                       z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -743,6 +767,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       top: 1px;
                       z-index: 1;
                     }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
+                    }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
                     }
@@ -891,6 +921,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       right: 1px;
                       top: 1px;
                       z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1098,6 +1134,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       top: 1px;
                       z-index: 1;
                     }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
+                    }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
                     }
@@ -1234,6 +1276,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       right: 1px;
                       top: 1px;
                       z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1372,6 +1420,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       top: 1px;
                       z-index: 1;
                     }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
+                    }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
                     }
@@ -1508,6 +1562,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       right: 1px;
                       top: 1px;
                       z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -1646,6 +1706,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       top: 1px;
                       z-index: 1;
                     }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
+                    }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
                     }
@@ -1782,6 +1848,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       right: 1px;
                       top: 1px;
                       z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -271,6 +271,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -315,6 +316,9 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -426,6 +430,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -470,6 +475,9 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
@@ -581,6 +589,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       background: none;
+                      border-bottom: 1px solid transparent;
                       border: none;
                       color: #333333;
                       cursor: pointer;
@@ -625,6 +634,9 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     }
                     @media screen and (-ms-high-contrast: black-on-white){& {
                       color: #00009F;
+                    }
+                    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                      border-bottom: none;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -310,6 +310,12 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       top: 1px;
                       z-index: 1;
                     }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
+                    }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
                     }
@@ -459,6 +465,12 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       top: 1px;
                       z-index: 1;
                     }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
+                    }
                     &:active, &:hover, &:active:hover {
                       color: #004578;
                     }
@@ -607,6 +619,12 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       right: 1px;
                       top: 1px;
                       z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: white-on-black){& {
+                      color: #FFFF00;
+                    }
+                    @media screen and (-ms-high-contrast: black-on-white){& {
+                      color: #00009F;
                     }
                     &:active, &:hover, &:active:hover {
                       color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -212,6 +212,12 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
               top: 1px;
               z-index: 1;
             }
+            @media screen and (-ms-high-contrast: white-on-black){& {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){& {
+              color: #00009F;
+            }
             &:active, &:hover, &:active:hover {
               color: #004578;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -178,6 +178,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
             {
               background-color: transparent;
               background: none;
+              border-bottom: 1px solid transparent;
               border: none;
               color: #0078d4;
               cursor: pointer;
@@ -217,6 +218,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
             }
             @media screen and (-ms-high-contrast: black-on-white){& {
               color: #00009F;
+            }
+            @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+              border-bottom: none;
             }
             &:active, &:hover, &:active:hover {
               color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -212,6 +212,12 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
               top: 1px;
               z-index: 1;
             }
+            @media screen and (-ms-high-contrast: white-on-black){& {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){& {
+              color: #00009F;
+            }
             &:active, &:hover, &:active:hover {
               color: #004578;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -178,6 +178,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             {
               background-color: transparent;
               background: none;
+              border-bottom: 1px solid transparent;
               border: none;
               color: #0078d4;
               cursor: pointer;
@@ -217,6 +218,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: black-on-white){& {
               color: #00009F;
+            }
+            @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+              border-bottom: none;
             }
             &:active, &:hover, &:active:hover {
               color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -212,6 +212,12 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
               top: 1px;
               z-index: 1;
             }
+            @media screen and (-ms-high-contrast: white-on-black){& {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){& {
+              color: #00009F;
+            }
             &:active, &:hover, &:active:hover {
               color: #004578;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -178,6 +178,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
             {
               background-color: transparent;
               background: none;
+              border-bottom: 1px solid transparent;
               border: none;
               color: #0078d4;
               cursor: pointer;
@@ -217,6 +218,9 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
             }
             @media screen and (-ms-high-contrast: black-on-white){& {
               color: #00009F;
+            }
+            @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+              border-bottom: none;
             }
             &:active, &:hover, &:active:hover {
               color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -90,6 +90,12 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           top: 1px;
           z-index: 1;
         }
+        @media screen and (-ms-high-contrast: white-on-black){& {
+          color: #FFFF00;
+        }
+        @media screen and (-ms-high-contrast: black-on-white){& {
+          color: #00009F;
+        }
         &:active, &:hover, &:active:hover {
           color: #004578;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -56,6 +56,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
         {
           background-color: transparent;
           background: none;
+          border-bottom: 1px solid transparent;
           border: none;
           color: #0078d4;
           cursor: pointer;
@@ -95,6 +96,9 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
         }
         @media screen and (-ms-high-contrast: black-on-white){& {
           color: #00009F;
+        }
+        @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+          border-bottom: none;
         }
         &:active, &:hover, &:active:hover {
           color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -67,6 +67,12 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             top: 1px;
             z-index: 1;
           }
+          @media screen and (-ms-high-contrast: white-on-black){& {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){& {
+            color: #00009F;
+          }
           &:active, &:hover, &:active:hover {
             color: #004578;
           }
@@ -131,6 +137,12 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             top: 1px;
             z-index: 1;
           }
+          @media screen and (-ms-high-contrast: white-on-black){& {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){& {
+            color: #00009F;
+          }
           &:active, &:hover, &:active:hover {
             color: #004578;
           }
@@ -194,6 +206,12 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             right: 1px;
             top: 1px;
             z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){& {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){& {
+            color: #00009F;
           }
           &:active, &:hover, &:active:hover {
             color: #004578;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -33,6 +33,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           {
             background-color: transparent;
             background: none;
+            border-bottom: 1px solid transparent;
             border: none;
             color: #0078d4;
             cursor: pointer;
@@ -72,6 +73,9 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
+          }
+          @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+            border-bottom: none;
           }
           &:active, &:hover, &:active:hover {
             color: #004578;
@@ -103,6 +107,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           {
             background-color: transparent;
             background: none;
+            border-bottom: 1px solid transparent;
             border: none;
             color: #0078d4;
             cursor: pointer;
@@ -142,6 +147,9 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
+          }
+          @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+            border-bottom: none;
           }
           &:active, &:hover, &:active:hover {
             color: #004578;
@@ -173,6 +181,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           {
             background-color: transparent;
             background: none;
+            border-bottom: 1px solid transparent;
             border: none;
             color: #0078d4;
             cursor: pointer;
@@ -212,6 +221,9 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
+          }
+          @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+            border-bottom: none;
           }
           &:active, &:hover, &:active:hover {
             color: #004578;

--- a/packages/styling/src/styles/CommonStyles.ts
+++ b/packages/styling/src/styles/CommonStyles.ts
@@ -1,4 +1,6 @@
 export const HighContrastSelector = '@media screen and (-ms-high-contrast: active)';
+export const HighContrastSelectorWhite = '@media screen and (-ms-high-contrast: black-on-white)';
+export const HighContrastSelectorBlack = '@media screen and (-ms-high-contrast: white-on-black)';
 
 export const ScreenWidthMinSmall = 320;
 export const ScreenWidthMinMedium = 480;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5371 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The 'Hyperlink' system color used in high contrast mode is not available in css. When we don't give links an href, they render as a button and the browser doesn't know to apply the Hyperlink color to them. 

To account for this special case, I added new selectors for HC White and Black and hard coded the hex values in for these two modes. 

HCBlack:
![linkasbutton-hcblack](https://user-images.githubusercontent.com/16619843/42109674-4f2cfe3c-7b93-11e8-9d84-b7b033c31e39.PNG)

HCWhite:
![linkasbutton-hcwhite](https://user-images.githubusercontent.com/16619843/42109681-52e762c4-7b93-11e8-8730-48d186db959b.PNG)


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5392)

