### PR TITLE
Add Callout to the list of components that can be lazily loaded

### DIFF
--- a/common/changes/@uifabric/webpack-utils/chrisgo-delay-load-callout_2018-06-29-23-50.json
+++ b/common/changes/@uifabric/webpack-utils/chrisgo-delay-load-callout_2018-06-29-23-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/webpack-utils",
+      "comment": "Add Callout to the list of components that can be lazy loaded to reduce bundle sizes",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/webpack-utils",
+  "email": "1581488+christiango@users.noreply.github.com"
+}

--- a/packages/webpack-utils/src/fabricAsyncLoaderInclude.ts
+++ b/packages/webpack-utils/src/fabricAsyncLoaderInclude.ts
@@ -5,4 +5,5 @@
  * @param input Webpack loader include function provides the request as input
  */
 export = (input: string) =>
-  input.match(/office-ui-fabric-react[\\/]lib[\\/]components[\\/]ContextualMenu[\\/]ContextualMenu.js/);
+  input.match(/office-ui-fabric-react[\\/]lib[\\/]components[\\/]ContextualMenu[\\/]ContextualMenu.js/) ||
+  input.match(/office-ui-fabric-react[\\/]lib[\\/]components[\\/]Callout[\\/]Callout.js/);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Today, the default configuration for the fabric async loader includes just contextual menus. For many apps this is able to remove some pretty significant chunks of code, like contextual menu and all the menu positioning logic. 

However, for components using combobox, the bundle size reductions aren't as big since it depends directly on callout (which depends on the same menu positioning logic). By async loading callout, consumers of combobox can see the same great improvements in file size!

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5396)

