### PR TITLE
Jest tests: Config Independent Time/Date Output

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-fix-jest-date-output_2018-07-02-16-33.json
+++ b/common/changes/office-ui-fabric-react/jg-fix-jest-date-output_2018-07-02-16-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Jest Date output to be consistent regardless of machine locale and time zone config.",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
@@ -97,10 +97,20 @@ describe('Component Examples', () => {
   const glob = require('glob');
   const path = require('path');
   const realDate = Date;
-  const constantDate = new Date('2017-06-13T04:41:20');
+  const realToLocaleTimeString = global.Date.prototype.toLocaleTimeString;
+  const realToLocaleDateString = global.Date.prototype.toLocaleDateString;
+  const constantDate = new Date(Date.UTC(2017, 13, 6, 4, 41, 20));
   const files: string[] = glob.sync(path.resolve(process.cwd(), 'src/components/**/examples/*Example*.tsx'));
 
   beforeAll(() => {
+    // Ensure test output is consistent across machine locale and time zone config.
+    global.Date.prototype.toLocaleTimeString = () => {
+      return constantDate.toUTCString();
+    };
+    global.Date.prototype.toLocaleDateString = () => {
+      return constantDate.toUTCString();
+    };
+
     // Prevent random and time elements from failing repeated tests.
     global.Date = class {
       public static now() {
@@ -123,6 +133,8 @@ describe('Component Examples', () => {
   afterAll(() => {
     jest.restoreAllMocks();
     global.Date = realDate;
+    global.Date.prototype.toLocaleTimeString = realToLocaleTimeString;
+    global.Date.prototype.toLocaleDateString = realToLocaleDateString;
 
     snapshotsStateMap.forEach(snapshotState => {
       if (snapshotState.getUncheckedCount() > 0) {
@@ -162,7 +174,10 @@ describe('Component Examples', () => {
           });
         } catch (e) {
           console.warn(
-            'TEST NOTE: Failure with ' +
+            'ERROR: ' +
+              e +
+              ', ' +
+              'TEST NOTE: Failure with ' +
               componentFile +
               '. ' +
               'Have you recently added a component? If so, please see notes in ComponentExamples.test.tsx.'

--- a/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
@@ -97,6 +97,7 @@ describe('Component Examples', () => {
   const glob = require('glob');
   const path = require('path');
   const realDate = Date;
+  const realToLocaleString = global.Date.prototype.toLocaleString;
   const realToLocaleTimeString = global.Date.prototype.toLocaleTimeString;
   const realToLocaleDateString = global.Date.prototype.toLocaleDateString;
   const constantDate = new Date(Date.UTC(2017, 13, 6, 4, 41, 20));
@@ -104,12 +105,13 @@ describe('Component Examples', () => {
 
   beforeAll(() => {
     // Ensure test output is consistent across machine locale and time zone config.
-    global.Date.prototype.toLocaleTimeString = () => {
+    const mockToLocaleString = () => {
       return constantDate.toUTCString();
     };
-    global.Date.prototype.toLocaleDateString = () => {
-      return constantDate.toUTCString();
-    };
+
+    global.Date.prototype.toLocaleString = mockToLocaleString;
+    global.Date.prototype.toLocaleTimeString = mockToLocaleString;
+    global.Date.prototype.toLocaleDateString = mockToLocaleString;
 
     // Prevent random and time elements from failing repeated tests.
     global.Date = class {
@@ -133,6 +135,7 @@ describe('Component Examples', () => {
   afterAll(() => {
     jest.restoreAllMocks();
     global.Date = realDate;
+    global.Date.prototype.toLocaleString = realToLocaleString;
     global.Date.prototype.toLocaleTimeString = realToLocaleTimeString;
     global.Date.prototype.toLocaleDateString = realToLocaleDateString;
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -5,7 +5,7 @@ exports[`Component Examples renders DatePicker.Bounded.Example.tsx correctly 1`]
   className="docs-DatePickerExample"
 >
   <p>
-    When date boundaries are set (via minDate and maxDate props) the DatePicker will not allow out-of-bounds dates to be picked or entered. In this example, the allowed dates are 2018-5-13-2018-5-13
+    When date boundaries are set (via minDate and maxDate props) the DatePicker will not allow out-of-bounds dates to be picked or entered. In this example, the allowed dates are Sun, 06 Jan 2019 04:41:20 GMT-Sun, 06 Jan 2019 04:41:20 GMT
   </p>
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -15,7 +15,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
     className="LayerExample-textContent"
   />
   <div>
-    04:41:20
+    Sun, 06 Jan 2019 04:41:20 GMT
   </div>
 </div>
 `;
@@ -194,7 +194,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 2`] = `
       Hello world.
     </div>
     <div>
-      04:41:20
+      Sun, 06 Jan 2019 04:41:20 GMT
     </div>
   </div>
 </div>


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Override Date prototypes to ensure consistent output regardless of a machine's locale and time zone configuration. (Issue found in #5397)

#### Focus areas to test

n/a

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5402)

