### PR TITLE
Bump variants and file-type-icons packages to restore amd build output

### DIFF
--- a/common/changes/@uifabric/file-type-icons/brwatt-amd_2018-07-02-21-21.json
+++ b/common/changes/@uifabric/file-type-icons/brwatt-amd_2018-07-02-21-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Bump variants and file-type-icons packages to restore amd build output",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "brwatt@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/brwatt-amd_2018-07-02-21-21.json
+++ b/common/changes/@uifabric/variants/brwatt-amd_2018-07-02-21-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/variants",
+      "comment": "Bump variants and file-type-icons packages to restore amd build output",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "brwatt@microsoft.com"
+}

--- a/packages/file-type-icons/package.json
+++ b/packages/file-type-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/file-type-icons",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Office UI Fabric file type icon set.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/file-type-icons/package.json
+++ b/packages/file-type-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/file-type-icons",
-  "version": "6.0.1",
+  "version": "6.0.0",
   "description": "Office UI Fabric file type icon set.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/variants/package.json
+++ b/packages/variants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/variants",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Office UI Fabric subtheme generator.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/variants/package.json
+++ b/packages/variants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/variants",
-  "version": "6.0.5",
+  "version": "6.0.4",
   "description": "Office UI Fabric subtheme generator.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
PR #5255 fixed the build, but didn't trigger builds for all of the packages. So the latest versions of variants and file-type-icons still do not contain amd output.

This just bumps those packages so we can get a new version with amd output.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5420)

