### PR TITLE
Fixing dialog overflow issue for IE11

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-07-03-06-50.json
+++ b/common/changes/office-ui-fabric-react/master_2018-07-03-06-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dialog: Fixing layout issue for IE11",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "manishda@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
@@ -25,7 +25,8 @@ export const getStyles = (props: IDialogContentStyleProps): IDialogContentStyles
       isLargeHeader && classNames.contentLgHeader,
       isClose && classNames.close,
       {
-        flexGrow: 1
+        flexGrow: 1,
+        overflowY: 'auto' // required for IE11
       },
       className
     ],

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Dialog renders Dialog correctly 1`] = `
 
       {
         flex-grow: 1;
+        overflow-y: auto;
       }
 >
   <div


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5427 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
For IE11, Dialog content doesn't honor the flex-grow style and it overflows if there is some complex component is contained within the dialog. Check #5427 for details.

Fix:
Explicitly adding `overflow-y: auto` fixes the flexbox for IE11 and content container is able to calculate the required height.

#### Focus areas to test

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5428)

