### PR TITLE
Fix the text is cropped unexpectedly

### DIFF
--- a/common/changes/office-ui-fabric-react/tsekityam-patch-1_2018-07-04-02-36.json
+++ b/common/changes/office-ui-fabric-react/tsekityam-patch-1_2018-07-04-02-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix the text is cropped unexpectedly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "me@kytse.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -43,8 +43,7 @@ export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   /**
    * Used to determine how the image is scaled and cropped to fit the frame.
    *
-   * @defaultvalue If both dimensions are provided, then the image is fit using ImageFit.scale. Otherwise, the
-   * image won't be scaled or cropped.
+   * @defaultvalue If both dimensions are provided, then the image is fit using ImageFit.scale. Otherwise, the image won't be scaled or cropped.
    */
   imageFit?: ImageFit;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The parser we used to generate the doc doesn't read the default value from two lines, as a result, I suggest that we should concat two lines of default value into one until the parser is updated.
![opera snapshot_2018-07-03_152524_developer microsoft com](https://user-images.githubusercontent.com/3814422/42204865-72ae7ee0-7ed5-11e8-97b1-6589ecb2f585.png)


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5429)

