### PR TITLE
Specify dir attribute to make grid work in newer versions

### DIFF
--- a/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.tsx
@@ -146,7 +146,7 @@ export class LayoutPage extends React.Component<any, any> {
             devices. The columns in a row should add up to 12 for each device size.
           </p>
           <p>
-              Newer versions of Office Fabric require the <code>dir</code> attribute to be set to specify how the content should be rendered (whether left-to-right, <code>ltr</code>, or right-to-left, <code>rtl</code>).
+              Newer versions of Fabric require the <code>dir</code> attribute to be set to specify how the content should be rendered (whether left-to-right, <code>ltr</code>, or right-to-left, <code>rtl</code>).
           </p>
         </div>
         <CodeBlock language="html" isLightTheme={true}>

--- a/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.tsx
@@ -145,9 +145,12 @@ export class LayoutPage extends React.Component<any, any> {
             (ms-Grid-col). Utility classes (ms-sm6) specify how large each column should be on small, medium, and large
             devices. The columns in a row should add up to 12 for each device size.
           </p>
+          <p>
+              Newer versions of Office Fabric require the <code>dir</code> attribute to be set to specify how the content should be rendered (whether left-to-right, <code>ltr</code>, or right-to-left, <code>rtl</code>).
+          </p>
         </div>
         <CodeBlock language="html" isLightTheme={true}>
-          {`<div class="ms-Grid">
+          {`<div class="ms-Grid" dir="ltr">
   <div class="ms-Grid-row">
     <div class="ms-Grid-col ms-sm6 ms-md4 ms-lg2">A</div>
     <div class="ms-Grid-col ms-sm6 ms-md8 ms-lg10">B</div>

--- a/common/changes/@uifabric/fabric-website/patch-1_2018-07-05-17-24.json
+++ b/common/changes/@uifabric/fabric-website/patch-1_2018-07-05-17-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Update documentation regarding dir attribute.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "jagore@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://github.com/OfficeDev/office-ui-fabric-core/issues/1123
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Updated docs to mention the `dir` attribute as discussed with @mikewheaton here: https://github.com/OfficeDev/office-ui-fabric-core/issues/1123. 

I don't know exactly to which versions this change applies (tested with v9.6.0), that's why I say "newer" - would be better to specify exactly what that means. 

#### Focus areas to test

Docs...
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5430)

