### PR TITLE
Scoped focus style to only affect teaching bubble button

### DIFF
--- a/common/changes/office-ui-fabric-react/teachingBubble-style-fix_2018-07-05-16-10.json
+++ b/common/changes/office-ui-fabric-react/teachingBubble-style-fix_2018-07-05-16-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TeachingBubble: Fixed unscoped focus style",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -305,7 +305,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
               color: palette.white
             }
           ],
-          ':hover, &:focus': {
+          '&:hover, &:focus': {
             backgroundColor: palette.themeDarkAlt,
             borderColor: palette.white
           },

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -305,7 +305,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
               color: palette.white
             }
           ],
-          ':hover, :focus': {
+          ':hover, &:focus': {
             backgroundColor: palette.themeDarkAlt,
             borderColor: palette.white
           },

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -517,7 +517,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
               font-size: 14px;
               font-weight: 400;
             }
-            &:hover, :focus {
+            &:hover, &:focus {
               background-color: #106ebe;
               border-color: #ffffff;
             }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5449
- [x] Include a change request file using `$ npm run change`

#### Description of changes
it appears that the first pseudo selector is properly scoped, but subsequent ones are global styles. Being explicit about the connection to selector appears to be necessary right now. This is probably a bug in styling? @dzearing - what's the expected behavior for chained selectors? 

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5455)

