### PR TITLE
MessageBar: classnames now evaluated in the correct place

### DIFF
--- a/common/changes/office-ui-fabric-react/messagebar-fix_2018-07-05-18-48.json
+++ b/common/changes/office-ui-fabric-react/messagebar-fix_2018-07-05-18-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: class name calculations were not being done in the correct location, and were only valid on initial render. Now ensuring they're evaluated prior to render.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, DelayedRender, getId, customizable, classNamesFunction } from '../../Utilities';
+import { BaseComponent, DelayedRender, getId, classNamesFunction } from '../../Utilities';
 import { IconButton } from '../../Button';
 import { Icon } from '../../Icon';
 import { IMessageBarProps, IMessageBarStyleProps, IMessageBarStyles, MessageBarType } from './MessageBar.types';

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -12,7 +12,6 @@ export interface IMessageBarState {
   expandSingleLine?: boolean;
 }
 
-@customizable('MessageBar', ['theme'])
 export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarState> {
   public static defaultProps: IMessageBarProps = {
     messageBarType: MessageBarType.info,
@@ -40,12 +39,12 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
       showContent: false,
       expandSingleLine: false
     };
-
-    this._classNames = this._getClassNames();
   }
 
   public render(): JSX.Element {
     const { isMultiline } = this.props;
+
+    this._classNames = this._getClassNames();
 
     return isMultiline ? this._renderMultiLine() : this._renderSingleLine();
   }
@@ -132,8 +131,6 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderInnerText(): JSX.Element {
-    this._classNames = this._getClassNames();
-
     return (
       <div className={this._classNames.text} id={this.state.labelId}>
         <span className={this._classNames.innerText} role="status" aria-live={this._getAnnouncementPriority()}>

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.test.tsx
@@ -3,6 +3,7 @@ import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
 import { MessageBar } from './MessageBar';
+import { MessageBarType } from './MessageBar.types';
 
 describe('MessageBar', () => {
   const noop = () => {
@@ -13,6 +14,16 @@ describe('MessageBar', () => {
     const component = renderer.create(<MessageBar>Message</MessageBar>);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('can reflect props changes', () => {
+    const wrapper = mount(<MessageBar messageBarType={MessageBarType.success} />);
+
+    expect(wrapper.find('.ms-MessageBar--success').length).toEqual(1);
+    wrapper.setProps({ messageBarType: MessageBarType.error });
+
+    expect(wrapper.find('.ms-MessageBar--success').length).toEqual(0);
+    expect(wrapper.find('.ms-MessageBar--error').length).toEqual(1);
   });
 
   describe('dismiss', () => {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -7,4 +7,6 @@ export const MessageBar: (props: IMessageBarProps) => JSX.Element = styled<
   IMessageBarProps,
   IMessageBarStyleProps,
   IMessageBarStyles
->(MessageBarBase, getStyles);
+>(MessageBarBase, getStyles, undefined, {
+  scope: 'MessageBar'
+});


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5453 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The classnames were not being evaluated before render. Now they are, which means props changes will be correctly reflected.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5457)

