### PR TITLE
HoverCard: new prop openHotKey.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-HoverCard_hotKey_2018-07-06-01-39.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-HoverCard_hotKey_2018-07-06-01-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "HoverCard: Adds new prop 'openHotKey' to allow user to change the default key used to open the hover card when tabbing to it.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.tsx
@@ -19,7 +19,8 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
     cardDismissDelay: 100,
     expandedCardOpenDelay: 1500,
     instantOpenOnClick: false,
-    setInitialFocus: false
+    setInitialFocus: false,
+    openHotKey: KeyCodes.c
   };
 
   // The wrapping div that gets the hover events
@@ -131,7 +132,7 @@ export class HoverCard extends BaseComponent<IHoverCardProps, IHoverCardState> {
 
   // Show HoverCard
   private _cardOpen = (ev: MouseEvent): void => {
-    if (this._shouldBlockHoverCard() || (ev.type === 'keydown' && !(ev.which === KeyCodes.c))) {
+    if (this._shouldBlockHoverCard() || (ev.type === 'keydown' && !(ev.which === this.props.openHotKey))) {
       return;
     }
     this._async.clearTimeout(this._dismissTimerId);

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { HoverCard } from './HoverCard';
 import { IExpandingCardProps } from './ExpandingCard.types';
 import { IStyle } from '../../Styling';
+import { KeyCodes } from '../../Utilities';
 
 export interface IHoverCard {}
 
@@ -90,6 +91,8 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement | H
    * Set first focus into hover card, default should be true
    */
   setInitialFocus?: boolean;
+
+  openHotKey?: KeyCodes;
 }
 
 export interface IHoverCardStyles {

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -88,10 +88,15 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement | H
   shouldBlockHoverCard?: () => void;
 
   /**
-   * Set first focus into hover card, default should be true
+   * Set first focus into hover card.
+   * @default false
    */
   setInitialFocus?: boolean;
 
+  /**
+   * HotKey used for opening the HoverCard when tabbed to target.
+   * @default 'C'
+   */
   openHotKey?: KeyCodes;
 }
 

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -95,7 +95,7 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement | H
 
   /**
    * HotKey used for opening the HoverCard when tabbed to target.
-   * @default 'C'
+   * @default 'KeyCodes.c'
    */
   openHotKey?: KeyCodes;
 }

--- a/packages/office-ui-fabric-react/src/components/HoverCard/examples/HoverCard.Target.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/examples/HoverCard.Target.Example.tsx
@@ -5,6 +5,7 @@ import { DetailsList, buildColumns, IColumn } from 'office-ui-fabric-react/lib/D
 import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
 import { createListItems } from '../../../utilities/exampleData';
 import './HoverCard.Example.scss';
+import { KeyCodes } from '@uifabric/utilities';
 
 let _items: any[];
 
@@ -47,6 +48,7 @@ class HoverCardField extends BaseComponent<IHoverCardFieldProps, IHoverCardField
             onCardVisible={this._log('onCardVisible')}
             onCardHide={this._log('onCardHide')}
             trapFocus={true}
+            openHotKey={KeyCodes.enter}
           />
         )}
       </div>


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Adding a new prop to HoverCard allowing the user to change the default key used for opening the HoverCard when tabbing to it.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5465)

