### PR TITLE
Remove ShimmeredDetailsList from the DetailsList export

### DIFF
--- a/common/changes/office-ui-fabric-react/shimmer-bundle_2018-07-06-16-52.json
+++ b/common/changes/office-ui-fabric-react/shimmer-bundle_2018-07-06-16-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove ShimmeredDetailsList from the DetailsList 'bundle'",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/ShimmeredDetailsList.ts
+++ b/packages/office-ui-fabric-react/src/ShimmeredDetailsList.ts
@@ -1,0 +1,1 @@
+export * from './components/DetailsList/ShimmeredDetailsList';

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Shimmer.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Shimmer.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DetailsListLayoutMode, IColumn } from 'office-ui-fabric-react/lib/components/DetailsList';
-import { ShimmeredDetailsList } from 'office-ui-fabric-react/lib/components/DetailsList/ShimmeredDetailsList';
+import { ShimmeredDetailsList } from 'office-ui-fabric-react/lib/ShimmeredDetailsList';
 import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
 import './DetailsListExample.scss';
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -6,5 +6,4 @@ export * from './DetailsRow';
 export * from './DetailsRow.types';
 export * from './DetailsRowCheck';
 export * from './DetailsRowCheck.types';
-export * from './ShimmeredDetailsList';
 export * from './DetailsFooter.types';

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { createListItems } from 'office-ui-fabric-react/lib/utilities/exampleData';
 import { IColumn, buildColumns, SelectionMode, Toggle } from 'office-ui-fabric-react/lib/index';
-import { ShimmeredDetailsList } from 'office-ui-fabric-react/lib/DetailsList';
+import { ShimmeredDetailsList } from 'office-ui-fabric-react/lib/ShimmeredDetailsList';
 import * as ShimmerExampleStyles from './Shimmer.Example.scss';
 
 export interface IItem {


### PR DESCRIPTION
PR #5374 incorrectly added `ShimmeredDetailsList` to the `DetailsList` export root, defeating the purpose of factoring it into its own component to reduce bundle cost.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5468)

