### PR TITLE
fixing webpack.config.js to only build production for the UMD / manifest

### DIFF
--- a/common/changes/office-ui-fabric-react/manifestfix_2018-07-06-18-18.json
+++ b/common/changes/office-ui-fabric-react/manifestfix_2018-07-06-18-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fixing webpack.config.js to only build production for the UMD / manifest",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/webpack.config.js
+++ b/packages/office-ui-fabric-react/webpack.config.js
@@ -9,45 +9,56 @@ let entry = {
   [BUNDLE_NAME]: './lib/index.bundle.js'
 };
 
-function createConfig(config) {
-  return resources.createConfig(BUNDLE_NAME, IS_PRODUCTION, {
-    entry,
+function createConfig(config, onlyProduction) {
+  return resources.createConfig(
+    BUNDLE_NAME,
+    IS_PRODUCTION,
+    {
+      entry,
 
-    externals: [
-      {
-        react: 'React'
+      externals: [
+        {
+          react: 'React'
+        },
+        {
+          'react-dom': 'ReactDOM'
+        }
+      ],
+
+      resolve: {
+        alias: {
+          'office-ui-fabric-react/src': path.join(__dirname, 'src'),
+          'office-ui-fabric-react/lib': path.join(__dirname, 'lib'),
+          'Props.ts.js': 'Props',
+          'Example.tsx.js': 'Example'
+        }
       },
-      {
-        'react-dom': 'ReactDOM'
-      }
-    ],
 
-    resolve: {
-      alias: {
-        'office-ui-fabric-react/src': path.join(__dirname, 'src'),
-        'office-ui-fabric-react/lib': path.join(__dirname, 'lib'),
-        'Props.ts.js': 'Props',
-        'Example.tsx.js': 'Example'
-      }
+      ...config
     },
-
-    ...config
-  });
+    onlyProduction
+  );
 }
 
 module.exports = [
-  createConfig({
-    output: {
-      libraryTarget: 'var',
-      library: 'Fabric'
-    }
-  }),
-  createConfig({
-    plugins: [new ManifestServicePlugin()],
-    output: {
-      libraryTarget: 'umd',
-      library: 'Fabric',
-      filename: `${BUNDLE_NAME}.umd.js`
-    }
-  })
+  createConfig(
+    {
+      output: {
+        libraryTarget: 'var',
+        library: 'Fabric'
+      }
+    },
+    false
+  ),
+  createConfig(
+    {
+      plugins: [new ManifestServicePlugin()],
+      output: {
+        libraryTarget: 'umd',
+        library: 'Fabric',
+        filename: `${BUNDLE_NAME}.umd.js`
+      }
+    },
+    true
+  )
 ];


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

fixing webpack.config.js to only build production for the UMD / manifest
currently this bug is blocking publishing

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5470)

