### PR TITLE
Make Styling directly reference utilities modules

### DIFF
--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -1,7 +1,7 @@
 import { fontFace, IFontWeight } from '@uifabric/merge-styles';
 import { IFontStyles } from '../interfaces/index';
 import { createFontStyles, FontWeights, LocalizedFontFamilies, LocalizedFontNames } from './fonts';
-import { getLanguage } from '@uifabric/utilities';
+import { getLanguage } from '@uifabric/utilities/lib/language';
 import { IFabricConfig } from '../interfaces/IFabricConfig';
 
 // Default urls.

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -1,7 +1,7 @@
 import { IRawStyle } from '@uifabric/merge-styles';
 import { ITheme } from '../interfaces/index';
 import { HighContrastSelector } from './CommonStyles';
-import { IsFocusVisibleClassName } from '@uifabric/utilities';
+import { IsFocusVisibleClassName } from '@uifabric/utilities/lib/initializeFocusRects';
 import { ZIndexes } from './zIndexes';
 
 /**

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -1,4 +1,4 @@
-import { Customizations } from '@uifabric/utilities';
+import { Customizations } from '@uifabric/utilities/lib/Customizations';
 import { IPalette, ISemanticColors, ITheme, IPartialTheme } from '../interfaces/index';
 import { DefaultFontStyles } from './DefaultFontStyles';
 import { DefaultPalette } from './DefaultPalette';

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -1,4 +1,5 @@
-import { GlobalSettings, warn } from '@uifabric/utilities';
+import { warn } from '@uifabric/utilities/lib/warn';
+import { GlobalSettings } from '@uifabric/utilities/lib/GlobalSettings';
 import { IRawStyle, IFontFace, fontFace, mergeStyles, Stylesheet } from '@uifabric/merge-styles';
 
 export interface IIconSubset {


### PR DESCRIPTION
This is needed for projects that can't move to build tools that allow tree-shaking yet. Otherwise all of the utilities package is brought in instead of the just the few modules that are actually needed.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5472)

