### PR TITLE
Fix SearchBox background color

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-searchbox-background_2018-07-06-23-38.json
+++ b/common/changes/office-ui-fabric-react/fix-searchbox-background_2018-07-06-23-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "SearchBox: Move background color styling from searchbox input to searchbox root.",
+      "comment": "SearchBox: Move background color styling from searchbox input to searchbox root. Fixes #5477.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/fix-searchbox-background_2018-07-06-23-38.json
+++ b/common/changes/office-ui-fabric-react/fix-searchbox-background_2018-07-06-23-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Move background color from searchbox input to searchbox root.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fix-searchbox-background_2018-07-06-23-38.json
+++ b/common/changes/office-ui-fabric-react/fix-searchbox-background_2018-07-06-23-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Move background color from searchbox input to searchbox root.",
+      "comment": "SearchBox: Move background color styling from searchbox input to searchbox root.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -12,6 +12,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
       normalize,
       {
         color: palette.neutralPrimary,
+        backgroundColor: semanticColors.inputBackground,
         display: 'flex',
         flexDirection: 'row',
         flexWrap: 'nowrap',
@@ -133,7 +134,6 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         fontFamily: 'inherit',
         fontSize: 'inherit',
         color: palette.neutralPrimary,
-        backgroundColor: semanticColors.inputBackground,
         flex: '1 1 0px',
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -121,7 +121,8 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         flexBasis: '32px',
         flexShrink: 0,
         padding: 1,
-        color: palette.themePrimary
+        color: palette.themePrimary,
+        backgroundColor: 'transparent'
       }
     ],
     field: [

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
         align-items: stretch;
+        background-color: #ffffff;
         border: 1px solid #a6a6a6;
         box-shadow: none;
         box-sizing: border-box;
@@ -86,7 +87,6 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
     className=
         ms-SearchBox-field
         {
-          background-color: #ffffff;
           border: none;
           box-shadow: none;
           box-sizing: border-box;
@@ -136,6 +136,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
         align-items: stretch;
+        background-color: #ffffff;
         border: 1px solid #a6a6a6;
         box-shadow: none;
         box-sizing: border-box;
@@ -212,7 +213,6 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
     className=
         ms-SearchBox-field
         {
-          background-color: #ffffff;
           border: none;
           box-shadow: none;
           box-sizing: border-box;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -12,6 +12,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             align-items: stretch;
+            background-color: #ffffff;
             border: 1px solid #a6a6a6;
             box-shadow: none;
             box-sizing: border-box;
@@ -90,7 +91,6 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
         className=
             ms-SearchBox-field
             {
-              background-color: #ffffff;
               border: none;
               box-shadow: none;
               box-sizing: border-box;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -33,6 +33,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             align-items: stretch;
+            background-color: #ffffff;
             border: 1px solid #a6a6a6;
             box-shadow: none;
             box-sizing: border-box;
@@ -111,7 +112,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
         className=
             ms-SearchBox-field
             {
-              background-color: #ffffff;
               border: none;
               box-shadow: none;
               box-sizing: border-box;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -94,7 +94,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
       className=
           ms-SearchBox-field
           {
-            background-color: #ffffff;
             border: none;
             box-shadow: none;
             box-sizing: border-box;
@@ -226,7 +225,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
       className=
           ms-SearchBox-field
           {
-            background-color: #ffffff;
             border: none;
             box-shadow: none;
             box-sizing: border-box;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -11,6 +11,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-items: stretch;
+          background-color: #ffffff;
           border: 1px solid #a6a6a6;
           box-shadow: none;
           box-sizing: border-box;
@@ -89,7 +90,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
       className=
           ms-SearchBox-field
           {
-            background-color: #ffffff;
             border: none;
             box-shadow: none;
             box-sizing: border-box;
@@ -136,6 +136,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-items: stretch;
+          background-color: #ffffff;
           border: 1px solid #a6a6a6;
           box-shadow: none;
           box-sizing: border-box;
@@ -212,7 +213,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
       className=
           ms-SearchBox-field
           {
-            background-color: #ffffff;
             border: none;
             box-shadow: none;
             box-sizing: border-box;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -11,6 +11,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-items: stretch;
+          background-color: #ffffff;
           border: 1px solid #a6a6a6;
           box-shadow: none;
           box-sizing: border-box;
@@ -89,7 +90,6 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
       className=
           ms-SearchBox-field
           {
-            background-color: #ffffff;
             border: none;
             box-shadow: none;
             box-sizing: border-box;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -9,6 +9,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
         align-items: stretch;
+        background-color: #ffffff;
         border-width: 0 0 1px 0;
         border: 1px solid #a6a6a6;
         box-shadow: none;
@@ -88,7 +89,6 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
     className=
         ms-SearchBox-field
         {
-          background-color: #ffffff;
           border: none;
           box-shadow: none;
           box-sizing: border-box;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5477 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Move the `semanticColor` from `input` to `root`, and make the background color of the `input` transparent.

#### Focus areas to test

Does this break contract?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5478)

