### PR TITLE
Dismiss panel when clicking outside of the Panel component.

### DIFF
--- a/common/changes/office-ui-fabric-react/tacambridge-5.0-offsetpanel2_2018-07-09-23-49.json
+++ b/common/changes/office-ui-fabric-react/tacambridge-5.0-offsetpanel2_2018-07-09-23-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dismiss panel when clicking outside of the Panel component. ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tecambri@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -37,6 +37,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     type: PanelType.smallFixedFar,
   };
 
+  private _panel = createRef<HTMLDivElement>();
   private _content = createRef<HTMLDivElement>();
 
   constructor(props: IPanelProps) {
@@ -65,6 +66,14 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
   }
 
   public componentWillReceiveProps(newProps: IPanelProps): void {
+    if (newProps.isBlocking) {
+      if (newProps.isOpen) {
+        this._events.on(document, 'click', this._dismissOnOuterClick);
+      } else {
+        this._events.off(document, 'click', this._dismissOnOuterClick);
+      }
+    }
+
     if (newProps.isOpen !== this.state.isOpen) {
       if (newProps.isOpen) {
         this.open();
@@ -139,6 +148,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
         >
           <div
             { ...nativeProps }
+            ref={ this._panel }
             className={
               css(
                 'ms-Panel',
@@ -318,6 +328,20 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
       this.setState({
         isFooterSticky: height < innerHeight ? true : false
       });
+    }
+  }
+
+  private _dismissOnOuterClick(ev: any): void {
+    const panel = this._panel.current;
+    if (this.state.isOpen && panel) {
+      if (!panel.contains(ev.target)) {
+        if (this.props.onOuterClick) {
+          this.props.onOuterClick();
+          ev.preventDefault();
+        } else {
+          this.dismiss();
+        }
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -145,6 +145,11 @@ export interface IPanelProps extends React.Props<Panel> {
   onLightDismissClick?: () => void;
 
   /**
+   * Optional custom function to handle clicks outside this component
+   */
+  onOuterClick?: () => void;
+
+  /**
    * Optional custom renderer navigation region. Replaces current close button.
    */
   onRenderNavigation?: IRenderFunction<IPanelProps>;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -145,7 +145,7 @@ export interface IPanelProps extends React.Props<Panel> {
   onLightDismissClick?: () => void;
 
   /**
-   * Optional custom function to handle clicks outside this component
+   * Optional custom function to handle clicks outside this component.
    */
   onOuterClick?: () => void;
 

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -145,7 +145,7 @@ export interface IPanelProps extends React.Props<Panel> {
   onLightDismissClick?: () => void;
 
   /**
-   * Optional custom function to handle clicks outside this component.
+   * Optional custom function to handle clicks outside this component
    */
   onOuterClick?: () => void;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Dismiss panel when clicking outside of the Panel component, when it does not take up the whole page (ex. when it has a top offset to not cover any top nav). In this case, we do not stop propagation.

#### Focus areas to test

Panel

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5495)

