### PR TITLE
merge-styles getInstance reset when window is not what we thought.

### DIFF
--- a/common/changes/@uifabric/merge-styles/mergestyles-fix_2018-07-10-03-12.json
+++ b/common/changes/@uifabric/merge-styles/mergestyles-fix_2018-07-10-03-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "If the singleton `Stylesheet` instance originated from another window, reset the instance. Workaround for an unexplained Chrome issue where the singleton was still accessible after a page refresh.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.test.ts
+++ b/packages/merge-styles/src/Stylesheet.test.ts
@@ -16,4 +16,14 @@ describe('Stylesheet', () => {
     expect(className).toEqual('myCss-0');
     expect(_stylesheet.getRules()).toEqual('.myCss-0{background:red;}');
   });
+
+  it('recreates a new instance when global mismatches', () => {
+    const originalStylesheet = Stylesheet.getInstance();
+
+    expect(Stylesheet.getInstance()).toBe(originalStylesheet);
+
+    originalStylesheet.global = {};
+
+    expect(Stylesheet.getInstance()).not.toBe(originalStylesheet);
+  });
 });

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -66,6 +66,8 @@ let _stylesheet: Stylesheet;
  * @public
  */
 export class Stylesheet {
+  public global?: {};
+
   private _lastStyleElement?: HTMLStyleElement;
   private _styleElement?: HTMLStyleElement;
   private _rules: string[] = [];
@@ -88,11 +90,12 @@ export class Stylesheet {
       typeof window !== 'undefined' ? window : typeof process !== 'undefined' ? process : _fileScopedGlobal;
     _stylesheet = global[STYLESHEET_SETTING] as Stylesheet;
 
-    if (!_stylesheet) {
+    if (!_stylesheet || (_stylesheet.global && _stylesheet.global !== global)) {
       // tslint:disable-next-line:no-string-literal
       const fabricConfig = (global && global['FabricConfig']) || {};
 
       _stylesheet = global[STYLESHEET_SETTING] = new Stylesheet(fabricConfig.mergeStyles);
+      _stylesheet.global = global;
     }
 
     return _stylesheet;


### PR DESCRIPTION
We found a rather difficult to diagnose issue where the singleton `__stylesheet__` instance was not being reset from an F5 in chrome for both mac and pc. No repro in edge.

This will at least work around the potential issue, but it is still unclear as to what's going on in Chrome.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5497)

