### PR TITLE
Port HoverCard animation fix to 5.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,26 @@
+environment:
+  nodejs_version: "8"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Configure project artifacts.
+artifacts:
+  - path: apps\test-bundle-button\dist\test-bundle-button.json
+    name: SizeAuditor
+    type: json
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+  
+# Don't actually build.
+build: off

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ temp
 lib
 lib-amd
 lib-es2015
+lib-commonjs
 coverage
 dist
 npm-debug.log

--- a/common/changes/office-ui-fabric-react/v-vibr-HoverCard-IEfix_2018-06-05-17-33.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-HoverCard-IEfix_2018-06-05-17-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "HoverCard: Removing unnecessary animation class causing a visual bug in IE browser.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.tsx
@@ -10,7 +10,7 @@ import {
 import { IExpandingCardProps, IExpandingCardStyles, ExpandingCardMode } from './ExpandingCard.types';
 import { Callout, ICallout } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { AnimationStyles, mergeStyles } from '../../Styling';
+import { mergeStyles } from '../../Styling';
 import { FocusTrapZone } from '../../FocusTrapZone';
 import { getStyles } from './ExpandingCard.styles';
 
@@ -78,10 +78,7 @@ export class ExpandingCard extends BaseComponent<IExpandingCardProps, IExpanding
       <Callout
         { ...getNativeProps(this.props, divProperties) }
         componentRef={ this._callout }
-        className={ mergeStyles(
-          AnimationStyles.scaleUpIn100,
-          this._styles.root
-        ) }
+        className={ mergeStyles(this._styles.root) }
         target={ targetElement }
         isBeakVisible={ false }
         directionalHint={ this.props.directionalHint }


### PR DESCRIPTION
Bringing over a bugfix for an animation issue in `HoverCard` impacting IE 11.
Also adding `lib-commonjs` to `.gitignore` to make it easier to switch between branches.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5504)

