### PR TITLE
ScrollablePane: allow initialScrollPosition === 0

### DIFF
--- a/common/changes/office-ui-fabric-react/initialscrollposition-undefined_2018-07-10-17-54.json
+++ b/common/changes/office-ui-fabric-react/initialscrollposition-undefined_2018-07-10-17-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ScrollablePane: allow initialScrollPosition === 0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "spelliot@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -157,7 +157,11 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
   public componentDidUpdate(prevProps: IScrollablePaneProps, prevState: IScrollablePaneState) {
     const initialScrollPosition = this.props.initialScrollPosition;
-    if (this.contentContainer && initialScrollPosition && prevProps.initialScrollPosition !== initialScrollPosition) {
+    if (
+      this.contentContainer &&
+      typeof initialScrollPosition === 'number' &&
+      prevProps.initialScrollPosition !== initialScrollPosition
+    ) {
       this.contentContainer.scrollTop = initialScrollPosition;
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Previously, if the `initialScrollPosition` prop changed to 0, the
content container scroll position was prevented from updating. By
explicitly checking that `initialScrollPosition` is a number, 0 becomes
an allowed value.

#### Focus areas to test

Pass `initialScrollPosition=0` as a prop to an already-mounted ScrollablePane, and observe that the scroll position is updated to the top of the container.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5507)

