### PR TITLE
merge-styles: resetting instance on ownerDocument changes.

### DIFF
--- a/common/changes/@uifabric/merge-styles/mergestyles-fix_2018-07-10-19-46.json
+++ b/common/changes/@uifabric/merge-styles/mergestyles-fix_2018-07-10-19-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Refining the merge-styles fix from yesterday to check for ownerDocument changes, which is a more correct comparison to work around the Chrome \"window not resetting\" issue.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.test.ts
+++ b/packages/merge-styles/src/Stylesheet.test.ts
@@ -22,7 +22,8 @@ describe('Stylesheet', () => {
 
     expect(Stylesheet.getInstance()).toBe(originalStylesheet);
 
-    originalStylesheet.global = {};
+    // tslint:disable-next-line:no-any
+    (originalStylesheet as any)._lastStyleElement = { ownerDocument: {} };
 
     expect(Stylesheet.getInstance()).not.toBe(originalStylesheet);
   });

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -66,8 +66,6 @@ let _stylesheet: Stylesheet;
  * @public
  */
 export class Stylesheet {
-  public global?: {};
-
   private _lastStyleElement?: HTMLStyleElement;
   private _styleElement?: HTMLStyleElement;
   private _rules: string[] = [];
@@ -90,12 +88,11 @@ export class Stylesheet {
       typeof window !== 'undefined' ? window : typeof process !== 'undefined' ? process : _fileScopedGlobal;
     _stylesheet = global[STYLESHEET_SETTING] as Stylesheet;
 
-    if (!_stylesheet || (_stylesheet.global && _stylesheet.global !== global)) {
+    if (!_stylesheet || (_stylesheet._lastStyleElement && _stylesheet._lastStyleElement.ownerDocument !== document)) {
       // tslint:disable-next-line:no-string-literal
       const fabricConfig = (global && global['FabricConfig']) || {};
 
       _stylesheet = global[STYLESHEET_SETTING] = new Stylesheet(fabricConfig.mergeStyles);
-      _stylesheet.global = global;
     }
 
     return _stylesheet;


### PR DESCRIPTION
This change undoes the fix from yesterday and replaces with a more robust solution to resetting the stylesheet singleton instance when the ownerdocument changes.