### PR TITLE
Respect the getMenuClassNames property on Contextual Menu

### DIFF
--- a/common/changes/office-ui-fabric-react/chrisgo-fix-menu_2018-07-11-22-56.json
+++ b/common/changes/office-ui-fabric-react/chrisgo-fix-menu_2018-07-11-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Respect the getMenuClassNames property on ContextualMenu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "1581488+christiango@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -8,7 +8,7 @@ import {
 } from './ContextualMenu.types';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { FocusZone, FocusZoneDirection, IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
-import { IMenuItemClassNames, getContextualMenuClassNames, getItemClassNames } from './ContextualMenu.classNames';
+import { IMenuItemClassNames, getItemClassNames } from './ContextualMenu.classNames';
 import {
   assign,
   BaseComponent,
@@ -83,8 +83,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     shouldFocusOnMount: true,
     gapSpace: 0,
     directionalHint: DirectionalHint.bottomAutoEdge,
-    beakWidth: 16,
-    getMenuClassNames: getContextualMenuClassNames
+    beakWidth: 16
   };
 
   private _host: HTMLElement;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -204,13 +204,16 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
       theme,
       calloutProps,
       onRenderSubMenu = this._onRenderSubMenu,
-      focusZoneProps
+      focusZoneProps,
+      getMenuClassNames
     } = this.props;
 
-    this._classNames = getClassNames(styles, {
-      theme: theme!,
-      className: className
-    });
+    this._classNames = getMenuClassNames
+      ? getMenuClassNames(theme!, className)
+      : getClassNames(styles, {
+          theme: theme!,
+          className: className
+        });
 
     const hasIcons = itemsHaveIcons(items);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5526
- [x] Include a change request file using `$ npm run change`

#### Description of changes
After the conversion of ContextualMenus to merge styles, the getMenuClassNames property is no longer working. This is important, because it enables you to completely override the default styles of a contextual menu when invoked from a base button


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5529)

