### PR TITLE
Add menuAs to button to support functional custom menus

### DIFF
--- a/common/changes/office-ui-fabric-react/button-menuAs_2018-07-11-23-16.json
+++ b/common/changes/office-ui-fabric-react/button-menuAs_2018-07-11-23-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button: Added menuAs to better support custom contextual menus",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -411,6 +411,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   private _onRenderMenu = (menuProps: IContextualMenuProps): JSX.Element => {
     const { onDismiss = this._dismissMenu } = menuProps;
 
+    const MenuType = this.props.menuAs || (ContextualMenu as React.ReactType<IContextualMenuProps>);
+
     // the accessible menu label (accessible name) has a relationship to the button.
     // If the menu props do not specify an explicit value for aria-label or aria-labelledBy,
     // AND the button has text, we'll set the menu aria-labelledBy to the text element id.
@@ -419,7 +421,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     return (
-      <ContextualMenu
+      <MenuType
         id={this._labelId + '-menu'}
         directionalHint={DirectionalHint.bottomLeftEdge}
         {...menuProps}

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -3,7 +3,7 @@ import { BaseButton } from './BaseButton';
 import { Button } from './Button';
 import { IButtonClassNames } from './BaseButton.classNames';
 import { ISplitButtonClassNames } from './SplitButton/SplitButton.classNames';
-import { IRenderFunction, KeyCodes } from '../../Utilities';
+import { IRenderFunction, KeyCodes, IComponentAs } from '../../Utilities';
 import { IContextualMenuProps } from '../../ContextualMenu';
 import { IIconProps } from '../../Icon';
 import { IStyle, ITheme } from '../../Styling';
@@ -179,9 +179,15 @@ export interface IButtonProps
   onRenderMenuIcon?: IRenderFunction<IButtonProps>;
 
   /**
-   * Custom render function for button menu
+   * Deprecated at v6.3.2, to be removed at >= v7.0.0. Use menuAs instead.
+   * @deprecated
    */
   onRenderMenu?: IRenderFunction<IContextualMenuProps>;
+
+  /**
+   * Render a custom menu in place of the normal one.
+   */
+  menuAs?: IComponentAs<IContextualMenuProps>;
 
   /**
    * Description of the action this button takes.

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DefaultButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { IContextualMenuProps, ContextualMenu } from 'office-ui-fabric-react/lib/ContextualMenu';
 
 export class ButtonContextualMenuExample extends React.Component<IButtonProps, {}> {
   public render(): JSX.Element {
@@ -13,6 +14,7 @@ export class ButtonContextualMenuExample extends React.Component<IButtonProps, {
             disabled={disabled}
             checked={checked}
             iconProps={{ iconName: 'Add' }}
+            menuAs={this._getMenu}
             text="New"
             // tslint:disable-next-line:jsx-no-lambda
             onMenuClick={ev => {
@@ -38,4 +40,9 @@ export class ButtonContextualMenuExample extends React.Component<IButtonProps, {
       </div>
     );
   }
+
+  private _getMenu = (menuProps: IContextualMenuProps): JSX.Element => {
+    // Customize contextual menu with menuAs
+    return <ContextualMenu {...menuProps} />;
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -6,7 +6,7 @@ import { IIconProps } from '../Icon/Icon.types';
 import { ICalloutProps } from '../../Callout';
 import { ITheme, IStyle } from '../../Styling';
 import { IButtonStyles } from '../../Button';
-import { IPoint, IRectangle, IRenderFunction, IStyleFunction } from '../../Utilities';
+import { IPoint, IRectangle, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
 import { IContextualMenuClassNames, IMenuItemClassNames } from './ContextualMenu.classNames';
 export { DirectionalHint } from '../../common/DirectionalHint';
@@ -36,7 +36,7 @@ export interface IContextualMenuProps extends React.Props<ContextualMenuBase>, I
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  styles?: IStyleFunction<IContextualMenuStyleProps, IContextualMenuStyles>;
+  styles?: IStyleFunctionOrObject<IContextualMenuStyleProps, IContextualMenuStyles>;
 
   /**
    * Theme provided by High-Order Component.


### PR DESCRIPTION
#### Pull request checklist

onRenderMenu didn't work due to not getting target prop. menuAs is a much better approach. 

- [ ] Addresses an existing issue: Fixes #5527
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5531)

