### PR TITLE
Card: disable dragging everywhere but title bar

### DIFF
--- a/common/changes/@uifabric/experiments/carddrag_2018-07-12-05-28.json
+++ b/common/changes/@uifabric/experiments/carddrag_2018-07-12-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Card: disable dragging of card everywhere but title bar",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "saakhta@microsoft.com"
+}

--- a/packages/experiments/src/components/Card/CardFrame/CardFrame.styles.ts
+++ b/packages/experiments/src/components/Card/CardFrame/CardFrame.styles.ts
@@ -18,7 +18,8 @@ export const getStyles = (props: ICardFrameProps): ICardFrameStyles => {
       height: cardTitleBox,
       overflow: 'hidden',
       borderBottom: '1px solid',
-      borderBottomColor: seperatorColor ? seperatorColor : 'rgba(0,0,0,0.1)'
+      borderBottomColor: seperatorColor ? seperatorColor : 'rgba(0,0,0,0.1)',
+      cursor: 'move'
     },
     cardTitleEllipsisButton: {
       width: 40,

--- a/packages/experiments/src/components/Card/Layout/Layout.tsx
+++ b/packages/experiments/src/components/Card/Layout/Layout.tsx
@@ -37,13 +37,17 @@ export class Layout extends React.Component<ILayoutProps> {
     const headerElement: JSX.Element | null = this._generateHeader(header!);
     const footerElement: JSX.Element | null = this._generateFooter(actions!, classNames.footer);
     return (
-      <div className={classNames.root}>
+      <div className={classNames.root} onMouseDown={this.onMouseDown}>
         {headerElement}
         <div className={classNames.contentAreaLayout}>{content}</div>
         {footerElement}
       </div>
     );
   }
+
+  private onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  };
 
   private _generateContentElement(cardContentList: ICardContentDetails[]): JSX.Element[] {
     const contentArea: JSX.Element[] = [];

--- a/packages/experiments/src/components/Recommendation/__snapshots__/Recommendation.test.tsx.snap
+++ b/packages/experiments/src/components/Recommendation/__snapshots__/Recommendation.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`RecommendationCard renders basic example correctly 1`] = `
             border-bottom: 1px solid;
             height: 40px;
             overflow: hidden;
+            cursor: move;
           }
     >
       <div
@@ -488,6 +489,7 @@ exports[`RecommendationCard renders dlp example correctly 1`] = `
             border-bottom: 1px solid;
             height: 40px;
             overflow: hidden;
+            cursor: move;
           }
     >
       <div
@@ -1235,6 +1237,7 @@ exports[`RecommendationCard renders imageillustration example correctly 1`] = `
             border-bottom: 1px solid;
             height: 40px;
             overflow: hidden;
+            cursor: move;
           }
     >
       <div

--- a/packages/experiments/src/components/Recommendation/__snapshots__/Recommendation.test.tsx.snap
+++ b/packages/experiments/src/components/Recommendation/__snapshots__/Recommendation.test.tsx.snap
@@ -26,9 +26,9 @@ exports[`RecommendationCard renders basic example correctly 1`] = `
           {
             border-bottom-color: rgba(0, 120, 215, 1);
             border-bottom: 1px solid;
+            cursor: move;
             height: 40px;
             overflow: hidden;
-            cursor: move;
           }
     >
       <div
@@ -487,9 +487,9 @@ exports[`RecommendationCard renders dlp example correctly 1`] = `
           {
             border-bottom-color: rgba(0, 120, 215, 1);
             border-bottom: 1px solid;
+            cursor: move;
             height: 40px;
             overflow: hidden;
-            cursor: move;
           }
     >
       <div
@@ -1235,9 +1235,9 @@ exports[`RecommendationCard renders imageillustration example correctly 1`] = `
           {
             border-bottom-color: rgba(0, 120, 215, 1);
             border-bottom: 1px solid;
+            cursor: move;
             height: 40px;
             overflow: hidden;
-            cursor: move;
           }
     >
       <div


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Disabling dragging of the card from content area and only allowing it in title bar, and changing the cursor to show that title bar is draggable

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5532)

