### PR TITLE
Pivot: Deprecate unused 'linkIsSelected' style prop

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-pivot-styleprop-deprecation_2018-07-12-18-58.json
+++ b/common/changes/office-ui-fabric-react/jg-pivot-styleprop-deprecation_2018-07-12-18-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Deprecate unused linkIsSelected Pivot style prop.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -90,7 +90,10 @@ export type IPivotStyleProps = Required<Pick<IPivotProps, 'theme'>> &
     rootIsLarge?: boolean;
     /** Indicates whether Pivot has tabbed format. */
     rootIsTabs?: boolean;
-    /** Indicates whether Pivot link is selected. */
+    /**
+     * Indicates whether Pivot link is selected.
+     * @deprecated Is not populated with valid value. Use 'isLinkSelected' styling instead.
+     */
     linkIsSelected?: boolean;
   };
 

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -92,7 +92,7 @@ export type IPivotStyleProps = Required<Pick<IPivotProps, 'theme'>> &
     rootIsTabs?: boolean;
     /**
      * Indicates whether Pivot link is selected.
-     * @deprecated Is not populated with valid value. Use 'isLinkSelected' styling instead.
+     * @deprecated Is not populated with valid value. Specify 'linkIsSelected' styling instead.
      */
     linkIsSelected?: boolean;
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Found issue with `linkIsSelected` style prop not being populated by valid values. It is unused by Pivot styling and redundant with `linkIsSelected` style and is therefore deprecated for removal.

#### Focus areas to test

n/a

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5543)

