### PR TITLE
Make EditSection easier to use.

### DIFF
--- a/common/changes/@uifabric/example-app-base/remove-component-section-enum_2018-07-12-20-47.json
+++ b/common/changes/@uifabric/example-app-base/remove-component-section-enum_2018-07-12-20-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "EditSection: Remove ComponentPageSection enum to make EditSection easier to use.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { css, getDocument } from 'office-ui-fabric-react/lib/Utilities';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { MessageBar } from 'office-ui-fabric-react/lib/MessageBar';
-import { EditSection, ComponentPageSection } from '../EditSection';
+import { EditSection } from '../EditSection';
 import './ComponentPage.scss';
 
 export interface IComponentPageSection {
@@ -95,7 +95,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
                 </h2>
                 <EditSection
                   title={this.props.title}
-                  section={ComponentPageSection.Overview}
+                  section={'Overview'}
                   sectionContent={this.props.overview}
                   url={this._getURL('Overview', this.props.editOverviewUrl)}
                 />
@@ -278,7 +278,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
             <h2 className="ComponentPage-subHeading">Best Practices</h2>
             <EditSection
               title={this.props.title}
-              section={ComponentPageSection.BestPractices}
+              section={'BestPractices'}
               sectionContent={this.props.bestPractices}
               url={this._getURL('BestPractices', this.props.editBestPracticesUrl)}
             />
@@ -296,7 +296,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
               <h3>Do</h3>
               <EditSection
                 title={this.props.title}
-                section={ComponentPageSection.Dos}
+                section={'Dos'}
                 sectionContent={this.props.dos}
                 url={this._getURL('Dos', this.props.editDosUrl)}
               />
@@ -309,7 +309,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
               <h3>Don&rsquo;t</h3>
               <EditSection
                 title={this.props.title}
-                section={ComponentPageSection.Donts}
+                section={'Donts'}
                 sectionContent={this.props.donts}
                 url={this._getURL('Donts', this.props.editDontsUrl)}
               />

--- a/packages/example-app-base/src/components/EditSection/EditSection.tsx
+++ b/packages/example-app-base/src/components/EditSection/EditSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IEditSectionProps, ComponentPageSection } from './EditSection.types';
+import { IEditSectionProps } from './EditSection.types';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 
@@ -11,14 +11,13 @@ export class EditSection extends React.Component<IEditSectionProps, {}> {
       return null;
     }
 
-    const { title, section: sectionIndex, url } = this.props;
-    const section = ComponentPageSection[sectionIndex!];
+    const { section, title, url } = this.props;
     const readableSection = this._getReadableSection();
 
     return (
       <TooltipHost
         key={`${title}-${section}-editButton`}
-        content={`Edit ${title} ${readableSection} on GitHub`}
+        content={`Edit ${title} ${readableSection}`}
         id={`${title}-${section}-editButtonHost`}
       >
         <IconButton
@@ -33,18 +32,16 @@ export class EditSection extends React.Component<IEditSectionProps, {}> {
   }
 
   private _getReadableSection(): string {
-    const { section: sectionIndex, readableSection: readableSectionProp } = this.props;
-    if (readableSectionProp) {
-      return readableSectionProp;
+    if (this.props.readableSection) {
+      return this.props.readableSection;
     }
-
-    const section = ComponentPageSection[sectionIndex!];
+    const { section } = this.props;
     let readableSection = section;
-    switch (sectionIndex) {
-      case ComponentPageSection.BestPractices:
+    switch (section) {
+      case 'BestPractices':
         readableSection = 'Best Practices';
         break;
-      case ComponentPageSection.Donts:
+      case 'Donts':
         readableSection = "Don'ts";
         break;
       default:

--- a/packages/example-app-base/src/components/EditSection/EditSection.types.ts
+++ b/packages/example-app-base/src/components/EditSection/EditSection.types.ts
@@ -1,12 +1,5 @@
 import { EditSection } from './EditSection';
 
-export enum ComponentPageSection {
-  BestPractices,
-  Donts,
-  Dos,
-  Overview
-}
-
 export interface IEditSection {}
 
 export interface IEditSectionProps extends React.HTMLAttributes<EditSection> {
@@ -22,9 +15,9 @@ export interface IEditSectionProps extends React.HTMLAttributes<EditSection> {
   title: string;
 
   /**
-   * The section of the page.
+   * The section id of the page.
    */
-  section: ComponentPageSection;
+  section: string;
 
   /**
    * Pass the prop that has the content of the section.


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Remove `ComponentPageSection` enum
- Replace the `section` prop type with `string`
- Update Components that used the removed enum.

This will allow me to Use the `EditSection` component on more than just the sections defined in `ComponentPage`.

I also removed the "on GitHub" string from the tooltip as we'll soon have .md files hosted on more than just GitHub.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5545)

