### PR TITLE
ScrollablePane: Add notifySubscribers in mutationObserver

### DIFF
--- a/common/changes/office-ui-fabric-react/fixStickyFooterDetailsList_2018-07-12-23-23.json
+++ b/common/changes/office-ui-fabric-react/fixStickyFooterDetailsList_2018-07-12-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ScrollablePane: Add notifySubscribers in mutationObserver",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -101,6 +101,8 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     if ('MutationObserver' in window) {
       this._mutationObserver = new MutationObserver(mutation => {
         // Function to check if mutation is occuring in stickyAbove or stickyBelow
+        console.log(mutation, 'mutation');
+
         function checkIfMutationIsSticky(mutationRecord: MutationRecord): boolean {
           if (this.stickyAbove !== null && this.stickyBelow !== null) {
             return this.stickyAbove.contains(mutationRecord.target) || this.stickyBelow.contains(mutationRecord.target);
@@ -112,7 +114,10 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
         if (mutation.some(checkIfMutationIsSticky.bind(this))) {
           this.updateStickyRefHeights();
         } else {
-          // Else if mutation occurs in scrollable region, then find sticky it belongs to and force update
+          // Notify subscribers again to re-check whether Sticky should be Sticky'd or not
+          this.notifySubscribers();
+
+          // If mutation occurs in scrollable region, then find Sticky it belongs to and force update
           const stickyList: Sticky[] = [];
           this._stickies.forEach(sticky => {
             if (sticky.root && sticky.root.contains(mutation[0].target)) {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -101,8 +101,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     if ('MutationObserver' in window) {
       this._mutationObserver = new MutationObserver(mutation => {
         // Function to check if mutation is occuring in stickyAbove or stickyBelow
-        console.log(mutation, 'mutation');
-
         function checkIfMutationIsSticky(mutationRecord: MutationRecord): boolean {
           if (this.stickyAbove !== null && this.stickyBelow !== null) {
             return this.stickyAbove.contains(mutationRecord.target) || this.stickyBelow.contains(mutationRecord.target);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5547
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds notifySubscriber in the mutationObserver to have Sticky components re-check status and distance from top of ScrollablePane

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5548)

