### PR TITLE
TextField: Fix value clearing on render when value prop is undefined

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-5518-fix-textfield-clearing_2018-07-13-02-13.json
+++ b/common/changes/office-ui-fabric-react/jg-5518-fix-textfield-clearing_2018-07-13-02-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix TextField clearing on render when value prop is undefined.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jason.gore@grabtaxi.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 
 import { TextField } from './TextField';
 
@@ -129,6 +130,30 @@ describe('TextField', () => {
 
     // Assert on the input element.
     expect(inputDOM.defaultValue).toEqual('0');
+  });
+
+  it('should NOT update value when props value remains undefined on props update', () => {
+    const stateValue = 'state value';
+    const textField = mount(<TextField />);
+    expect(textField.state('value')).toEqual('');
+
+    textField.setState({ value: stateValue });
+    expect(textField.state('value')).toEqual(stateValue);
+
+    // Trigger a props update, but value prop remains the same undefined value,
+    //    so state should not be affected.
+    textField.setProps({ id: 'unimportantValue' });
+    expect(textField.state('value')).toEqual(stateValue);
+  });
+
+  it('should update state when props value changes from defined to undefined', () => {
+    const propsValue = 'props value';
+
+    const textField = mount(<TextField value={propsValue} />);
+    expect(textField.state('value')).toEqual(propsValue);
+
+    textField.setProps({ value: undefined });
+    expect(textField.state('value')).toEqual('');
   });
 
   describe('error message', () => {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -132,7 +132,7 @@ describe('TextField', () => {
     expect(inputDOM.defaultValue).toEqual('0');
   });
 
-  it('should NOT update value when props value remains undefined on props update', () => {
+  it('should NOT update state when props value remains undefined on props update', () => {
     const stateValue = 'state value';
     const textField = mount(<TextField />);
     expect(textField.state('value')).toEqual('');

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -122,7 +122,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
   public componentWillReceiveProps(newProps: ITextFieldProps): void {
     const { onBeforeChange } = this.props;
 
-    // If old value prop  was undefined, then component is controlled and we should
+    // If old value prop was undefined, then component is controlled and we should
     //    respect new undefined value and update state accordingly.
     if (newProps.value !== this.state.value && (newProps.value !== undefined || this.props.value !== undefined)) {
       if (onBeforeChange) {
@@ -133,7 +133,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
       this._latestValue = newProps.value;
       this.setState(
         {
-          value: newProps.value ? newProps.value : '',
+          value: newProps.value || '',
           errorMessage: ''
         } as ITextFieldState,
         () => {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -122,7 +122,9 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
   public componentWillReceiveProps(newProps: ITextFieldProps): void {
     const { onBeforeChange } = this.props;
 
-    if (newProps.value !== this.state.value) {
+    // If old value prop  was undefined, then component is controlled and we should
+    //    respect new undefined value and update state accordingly.
+    if (newProps.value !== this.state.value && (newProps.value !== undefined || this.props.value !== undefined)) {
       if (onBeforeChange) {
         onBeforeChange(newProps.value);
       }
@@ -131,7 +133,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
       this._latestValue = newProps.value;
       this.setState(
         {
-          value: newProps.value,
+          value: newProps.value ? newProps.value : '',
           errorMessage: ''
         } as ITextFieldState,
         () => {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.tsx
@@ -16,7 +16,7 @@ import * as stylesImport from './TextField.scss';
 const styles: any = stylesImport;
 import { AnimationClassNames } from '../../Styling';
 export interface ITextFieldState {
-  value?: string | undefined;
+  value: string;
 
   /** Is true when the control has focus. */
   isFocused?: boolean;
@@ -29,6 +29,8 @@ export interface ITextFieldState {
    */
   errorMessage?: string;
 }
+
+const DEFAULT_STATE_VALUE = '';
 
 export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> implements ITextField {
   public static defaultProps: ITextFieldProps = {
@@ -85,7 +87,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
     } else if (props.defaultValue !== undefined) {
       this._latestValue = props.defaultValue;
     } else {
-      this._latestValue = '';
+      this._latestValue = DEFAULT_STATE_VALUE;
     }
 
     this.state = {
@@ -133,7 +135,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
       this._latestValue = newProps.value;
       this.setState(
         {
-          value: newProps.value || '',
+          value: newProps.value || DEFAULT_STATE_VALUE,
           errorMessage: ''
         } as ITextFieldState,
         () => {
@@ -412,7 +414,7 @@ export class TextField extends BaseComponent<ITextFieldProps, ITextFieldState> i
         id={this._id}
         {...inputProps}
         ref={this._textElement}
-        value={this.state.value === undefined ? '' : this.state.value}
+        value={this.state.value}
         onInput={this._onInputChange}
         onChange={this._onInputChange}
         className={this._getTextElementClassName()}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5518
- [x] Include a change request file using `$ npm run change`

#### Description of changes

#5349 was merged to fix #5146 in which changing the *prop* `value` to `undefined` would not update state. However, #5349 swung too far in the other direction, clearing *state* `value` on prop update even if *prop* `value` was previously `undefined`. This change aims to fix #5518 while keeping the fix in place for #5146.

The assumption here is that if *prop* `value` was previously defined, the user intends for the component to be controlled and that therefore the state should be cleared when a *prop* `value` becomes undefined. However, if the *prop* `value` was previously undefined, it should have no effect on state.

I've added tests to ensure both situations remain fixed. (I confirmed one and the other of these tests failed in the conditions before and after #5349 was merged.)

#### Focus areas to test

Test `value` prop effects on state.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5549)

