### PR TITLE
Fix element containment check for Panel light-dismiss

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-dismiss_2018-07-13-13-03.json
+++ b/common/changes/office-ui-fabric-react/panel-dismiss_2018-07-13-13-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix check for Panel light-dismiss",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}


### PR DESCRIPTION
# Overview
Fixing a blocking bug in `<Panel>` light-dismiss that was recently introduced.

When testing whether events occur 'inside' elements, such checks need to use the virtual-hierarchy-aware `elementContains` function from `@uifabric/utilities` because `<Panel>` is inside a `<Layer>`. Otherwise clicking in a dropdown inside a panel will dismiss the panel!
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5552)

