### PR TITLE
Expose selectedItems and remove padding on suggestion itemButton

### DIFF
--- a/common/changes/office-ui-fabric-react/amyngu-selectedItemsFixes_2018-07-13-20-32.json
+++ b/common/changes/office-ui-fabric-react/amyngu-selectedItemsFixes_2018-07-13-20-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ExtendedBasePicker: Expose selectedItems, Remove persona suggestion padding in FloatingPicker ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "amyngu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -87,10 +87,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     return this.input.current && this.input.current.inputElement;
   }
 
-  public get selectedItems(): T[] {
-    return this.selectedItemsList.current ? this.selectedItemsList.current.selectedItems() : [];
-  }
-
   public render(): JSX.Element {
     const { className, inputProps, disabled } = this.props;
     const activeDescendant =

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -87,6 +87,10 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     return this.input.current && this.input.current.inputElement;
   }
 
+  public get highlightedItems(): T[] {
+    return this.selectedItemsList.current ? this.selectedItemsList.current.highlightedItems() : [];
+  }
+
   public render(): JSX.Element {
     const { className, inputProps, disabled } = this.props;
     const activeDescendant =

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -87,6 +87,10 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     return this.input.current && this.input.current.inputElement;
   }
 
+  public get selectedItems(): T[] {
+    return this.selectedItemsList.current ? this.selectedItemsList.current.selectedItems() : [];
+  }
+
   public render(): JSX.Element {
     const { className, inputProps, disabled } = this.props;
     const activeDescendant =

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePicker.scss
@@ -27,4 +27,5 @@
   width: 100%;
   justify-content: space-between;
   align-items: center;
+  padding: 7px 12px;
 }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePicker.scss
@@ -27,5 +27,4 @@
   width: 100%;
   justify-content: space-between;
   align-items: center;
-  padding: 7px 12px;
 }

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
@@ -127,7 +127,7 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>>
     this.selection.setAllSelected(false);
   }
 
-  public selectedItems(): T[] {
+  public highlightedItems(): T[] {
     return this.selection.getSelection() as T[];
   }
 

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
@@ -127,6 +127,10 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>>
     this.selection.setAllSelected(false);
   }
 
+  public selectedItems(): T[] {
+    return this.selection.getSelection() as T[];
+  }
+
   public componentWillUpdate(newProps: P, newState: IBaseSelectedItemsListState): void {
     if (newState.items && newState.items !== this.state.items) {
       this.selection.setItems(newState.items);

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.scss
@@ -2,6 +2,8 @@
 
 .resultContent {
   display: table-row;
+
+  padding: 7px 12px;
   .resultItem {
     display: table-cell;
     vertical-align: bottom;
@@ -26,4 +28,6 @@
   width: 100%;
   justify-content: space-between;
   align-items: center;
+
+  padding: 7px 12px;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.scss
@@ -2,8 +2,6 @@
 
 .resultContent {
   display: table-row;
-
-  padding: 7px 12px;
   .resultItem {
     display: table-cell;
     vertical-align: bottom;
@@ -28,6 +26,5 @@
   width: 100%;
   justify-content: space-between;
   align-items: center;
-
   padding: 7px 12px;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -141,6 +141,7 @@
 
 .itemButton.itemButton {
   width: 100%;
+  padding: 0px;
 
   /* once this is converted to js css, then specificity won't be an issue. */
   height: 100%;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -144,7 +144,6 @@
 
   /* once this is converted to js css, then specificity won't be an issue. */
   height: 100%;
-  padding: 7px 12px;
 
   @include high-contrast {
     color: WindowText;

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.scss
@@ -64,4 +64,5 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 60vw;
+    padding: 7px 12px;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Expose selectedItems on ExtendedBasePicker
- Remove padding on suggestion itemButton, to allow consumer to have complete control of suggestion render

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5561)

