### PR TITLE
Make uifabric/webpack-utils compatible with safari 9

### DIFF
--- a/common/changes/@uifabric/webpack-utils/chrisgo-fabric-const_2018-07-13-23-08.json
+++ b/common/changes/@uifabric/webpack-utils/chrisgo-fabric-const_2018-07-13-23-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/webpack-utils",
+      "comment": "Use var instead of const in the ui fabric plugin to make it compatible with Safari 9",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/webpack-utils",
+  "email": "1581488+christiango@users.noreply.github.com"
+}

--- a/packages/webpack-utils/src/fabricAsyncLoader.ts
+++ b/packages/webpack-utils/src/fabricAsyncLoader.ts
@@ -49,7 +49,7 @@ module.exports.pitch = function(remainingRequest: string, precedingRequest: stri
 
   return [
     "import Loadable from 'react-loadable';",
-    `export const ${moduleName} = Loadable({`,
+    `export var ${moduleName} = Loadable({`,
     `  loader: function() { return import(${getMagicComments(
       options
     )} ${request}).then(function(m) { return m.${moduleName}; }); },`,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Office Online deployed a build containing the webpack utils plugin. We noticed a spike in JavaScript exceptions coming from Safari 9 around the usage of the const keyword. This PR switches to use a var instead of a const to make the generated code compatible with Safari 9
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5564)

