### PR TITLE
Phkuo/variants backgrounds

### DIFF
--- a/common/changes/@uifabric/example-app-base/phkuo-variantsBackgrounds_2018-07-14-00-44.json
+++ b/common/changes/@uifabric/example-app-base/phkuo-variantsBackgrounds_2018-07-14-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/phkuo-variantsBackgrounds_2018-07-14-00-44.json
+++ b/common/changes/@uifabric/experiments/phkuo-variantsBackgrounds_2018-07-14-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/file-type-icons/phkuo-variantsBackgrounds_2018-07-14-00-44.json
+++ b/common/changes/@uifabric/file-type-icons/phkuo-variantsBackgrounds_2018-07-14-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/file-type-icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/phkuo-variantsBackgrounds_2018-07-14-00-44.json
+++ b/common/changes/@uifabric/styling/phkuo-variantsBackgrounds_2018-07-14-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Theming: add new semantic slots",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/phkuo-variantsBackgrounds_2018-07-14-00-44.json
+++ b/common/changes/@uifabric/utilities/phkuo-variantsBackgrounds_2018-07-14-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/phkuo-variantsBackgrounds_2018-07-14-00-44.json
+++ b/common/changes/@uifabric/variants/phkuo-variantsBackgrounds_2018-07-14-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/variants",
+      "comment": "Variants: tweak background colors to look better in light and dark, and account for new semantic slots",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "phkuo@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/phkuo-variantsBackgrounds_2018-07-14-00-44.json
+++ b/common/changes/office-ui-fabric-react/phkuo-variantsBackgrounds_2018-07-14-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Theming: new semantic slots, also update MarqueeSelection snapshot to not have the theme in it",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -1,6 +1,7 @@
 /* Base slots */
 $bodyBackgroundColor: "[theme:bodyBackground, default: #ffffff]";
 $bodyFrameBackgroundColor: "[theme:bodyFrameBackground, default: #ffffff]";
+$bodyFrameDividerColor: "[theme:bodyFrameDivider, default: #eaeaea]";
 $bodyTextColor: "[theme:bodyText, default: #333333]";
 $bodyTextCheckedColor: "[theme:bodyTextChecked, default: #000000]";
 $bodySubtextColor: "[theme:bodySubtext, default: #666666]";

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import { MarqueeSelection } from './MarqueeSelection';
 import { Selection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 
@@ -20,7 +19,6 @@ describe('MarqueeSelection', () => {
     component.update();
 
     // Run snapshot test.
-    const tree = toJson(component);
-    expect(tree).toMatchSnapshot();
+    expect(component.getDOMNode()).toMatchSnapshot();
   });
 });

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/__snapshots__/MarqueeSelection.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/__snapshots__/MarqueeSelection.test.tsx.snap
@@ -1,331 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MarqueeSelection renders MarqueeSelection correctly 1`] = `
-<StyledCustomizedMarqueeSelection
-  selection={
-    Selection {
-      "_anchoredIndex": 0,
-      "_canSelectItem": [Function],
-      "_changeEventSuppressionCount": 0,
-      "_exemptedCount": 0,
-      "_exemptedIndices": Object {},
-      "_getKey": [Function],
-      "_isModal": false,
-      "_items": Array [],
-      "_keyToIndexMap": Object {},
-      "_onSelectionChanged": undefined,
-      "_selectedIndices": Array [],
-      "_selectedItems": null,
-      "_unselectableCount": 0,
-      "_unselectableIndices": Object {},
-      "mode": 2,
-    }
-  }
+<div
+  class=
+
+      {
+        cursor: default;
+        position: relative;
+      }
 >
-  <CustomizedMarqueeSelection
-    getStyles={[Function]}
-    isEnabled={true}
-    rootProps={Object {}}
-    rootTagName="div"
-    selection={
-      Selection {
-        "_anchoredIndex": 0,
-        "_canSelectItem": [Function],
-        "_changeEventSuppressionCount": 0,
-        "_exemptedCount": 0,
-        "_exemptedIndices": Object {},
-        "_getKey": [Function],
-        "_isModal": false,
-        "_items": Array [],
-        "_keyToIndexMap": Object {},
-        "_onSelectionChanged": undefined,
-        "_selectedIndices": Array [],
-        "_selectedItems": null,
-        "_unselectableCount": 0,
-        "_unselectableIndices": Object {},
-        "mode": 2,
-      }
-    }
+  <div
+    class=
+
+        {
+          background: rgba(255, 0, 0, 0);
+          bottom: 0px;
+          left: 0px;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background-color: transparent;
+          background: none;
+        }
+  />
+  <div
+    class=
+
+        {
+          border: 1px solid #0078d4;
+          box-sizing: border-box;
+          pointer-events: none;
+          position: absolute;
+          z-index: 10;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border-color: Highlight;
+        }
+    style="left: 0px; top: 0px; width: 100px; height: 100px;"
   >
-    <MarqueeSelectionBase
-      getStyles={[Function]}
-      isEnabled={true}
-      rootProps={Object {}}
-      rootTagName="div"
-      selection={
-        Selection {
-          "_anchoredIndex": 0,
-          "_canSelectItem": [Function],
-          "_changeEventSuppressionCount": 0,
-          "_exemptedCount": 0,
-          "_exemptedIndices": Object {},
-          "_getKey": [Function],
-          "_isModal": false,
-          "_items": Array [],
-          "_keyToIndexMap": Object {},
-          "_onSelectionChanged": undefined,
-          "_selectedIndices": Array [],
-          "_selectedItems": null,
-          "_unselectableCount": 0,
-          "_unselectableIndices": Object {},
-          "mode": 2,
-        }
-      }
-      theme={
-        Object {
-          "disableGlobalClassNames": false,
-          "fonts": Object {
-            "large": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "17px",
-              "fontWeight": 300,
-            },
-            "medium": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "14px",
-              "fontWeight": 400,
-            },
-            "mediumPlus": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "15px",
-              "fontWeight": 400,
-            },
-            "mega": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "72px",
-              "fontWeight": 100,
-            },
-            "small": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "12px",
-              "fontWeight": 400,
-            },
-            "smallPlus": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "13px",
-              "fontWeight": 400,
-            },
-            "superLarge": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "42px",
-              "fontWeight": 100,
-            },
-            "tiny": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "10px",
-              "fontWeight": 600,
-            },
-            "xLarge": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "21px",
-              "fontWeight": 100,
-            },
-            "xSmall": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "11px",
-              "fontWeight": 400,
-            },
-            "xxLarge": Object {
-              "MozOsxFontSmoothing": "grayscale",
-              "WebkitFontSmoothing": "antialiased",
-              "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
-              "fontSize": "28px",
-              "fontWeight": 100,
-            },
-          },
-          "isInverted": false,
-          "palette": Object {
-            "accent": "#0078d4",
-            "black": "#000000",
-            "blackTranslucent40": "rgba(0,0,0,.4)",
-            "blue": "#0078d4",
-            "blueDark": "#002050",
-            "blueLight": "#00bcf2",
-            "blueMid": "#00188f",
-            "green": "#107c10",
-            "greenDark": "#004b1c",
-            "greenLight": "#bad80a",
-            "magenta": "#b4009e",
-            "magentaDark": "#5c005c",
-            "magentaLight": "#e3008c",
-            "neutralDark": "#212121",
-            "neutralLight": "#eaeaea",
-            "neutralLighter": "#f4f4f4",
-            "neutralLighterAlt": "#f8f8f8",
-            "neutralPrimary": "#333333",
-            "neutralPrimaryAlt": "#3c3c3c",
-            "neutralQuaternary": "#d0d0d0",
-            "neutralQuaternaryAlt": "#dadada",
-            "neutralSecondary": "#666666",
-            "neutralTertiary": "#a6a6a6",
-            "neutralTertiaryAlt": "#c8c8c8",
-            "orange": "#d83b01",
-            "orangeLight": "#ea4300",
-            "orangeLighter": "#ff8c00",
-            "purple": "#5c2d91",
-            "purpleDark": "#32145a",
-            "purpleLight": "#b4a0ff",
-            "red": "#e81123",
-            "redDark": "#a80000",
-            "teal": "#008272",
-            "tealDark": "#004b50",
-            "tealLight": "#00b294",
-            "themeDark": "#005a9e",
-            "themeDarkAlt": "#106ebe",
-            "themeDarker": "#004578",
-            "themeLight": "#c7e0f4",
-            "themeLighter": "#deecf9",
-            "themeLighterAlt": "#eff6fc",
-            "themePrimary": "#0078d4",
-            "themeSecondary": "#2b88d8",
-            "themeTertiary": "#71afe5",
-            "white": "#ffffff",
-            "whiteTranslucent40": "rgba(255,255,255,.4)",
-            "yellow": "#ffb900",
-            "yellowLight": "#fff100",
-          },
-          "semanticColors": Object {
-            "blockingBackground": "rgba(234, 67, 0, .2)",
-            "bodyBackground": "#ffffff",
-            "bodyDivider": "#c8c8c8",
-            "bodyFrameBackground": "#ffffff",
-            "bodySubtext": "#666666",
-            "bodyText": "#333333",
-            "bodyTextChecked": "#000000",
-            "buttonBackground": "#f4f4f4",
-            "buttonBackgroundChecked": "#c8c8c8",
-            "buttonBackgroundCheckedHovered": "#eaeaea",
-            "buttonBackgroundHovered": "#eaeaea",
-            "buttonBorder": "transparent",
-            "buttonText": "#333333",
-            "buttonTextChecked": "#212121",
-            "buttonTextCheckedHovered": "#000000",
-            "buttonTextHovered": "#000000",
-            "disabledBackground": "#f4f4f4",
-            "disabledBodyText": "#c8c8c8",
-            "disabledSubtext": "#d0d0d0",
-            "disabledText": "#a6a6a6",
-            "errorBackground": "rgba(232, 17, 35, .2)",
-            "errorText": "#a80000",
-            "focusBorder": "#000000",
-            "inputBackground": "#ffffff",
-            "inputBackgroundChecked": "#0078d4",
-            "inputBackgroundCheckedHovered": "#106ebe",
-            "inputBorder": "#a6a6a6",
-            "inputBorderHovered": "#212121",
-            "inputFocusBorderAlt": "#0078d4",
-            "inputForegroundChecked": "#ffffff",
-            "inputPlaceholderText": "#666666",
-            "link": "#0078d4",
-            "linkHovered": "#004578",
-            "listBackground": "#ffffff",
-            "listHeaderBackgroundHovered": "#f4f4f4",
-            "listHeaderBackgroundPressed": "#eaeaea",
-            "listItemBackgroundChecked": "#eaeaea",
-            "listItemBackgroundCheckedHovered": "#dadada",
-            "listItemBackgroundHovered": "#f4f4f4",
-            "listText": "#333333",
-            "listTextColor": "#333333",
-            "menuHeader": "#0078d4",
-            "menuIcon": "#0078d4",
-            "menuItemBackgroundChecked": "#eaeaea",
-            "menuItemBackgroundHovered": "#f4f4f4",
-            "smallInputBorder": "#666666",
-            "successBackground": "rgba(186, 216, 10, .2)",
-            "warningBackground": "rgba(255, 185, 0, .2)",
-            "warningHighlight": "#ffb900",
-            "warningText": "#333333",
-          },
-        }
-      }
-    >
-      <div
-        className=
+    <div
+      class=
 
-            {
-              cursor: default;
-              position: relative;
-            }
-      >
-        <div
-          className=
-
-              {
-                background: rgba(255, 0, 0, 0);
-                bottom: 0px;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                background-color: transparent;
-                background: none;
-              }
-        />
-        <div
-          className=
-
-              {
-                border: 1px solid #0078d4;
-                box-sizing: border-box;
-                pointer-events: none;
-                position: absolute;
-                z-index: 10;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                border-color: Highlight;
-              }
-          style={
-            Object {
-              "height": 100,
-              "left": 0,
-              "top": 0,
-              "width": 100,
-            }
+          {
+            background-color: #0078d4;
+            bottom: 0px;
+            box-sizing: border-box;
+            left: 0px;
+            opacity: 0.1;
+            position: absolute;
+            right: 0px;
+            top: 0px;
           }
-        >
-          <div
-            className=
-
-                {
-                  background-color: #0078d4;
-                  bottom: 0px;
-                  box-sizing: border-box;
-                  left: 0px;
-                  opacity: 0.1;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  background-color: transparent;
-                  background: none;
-                }
-          />
-        </div>
-      </div>
-    </MarqueeSelectionBase>
-  </CustomizedMarqueeSelection>
-</StyledCustomizedMarqueeSelection>
+          @media screen and (-ms-high-contrast: active){& {
+            background-color: transparent;
+            background: none;
+          }
+    />
+  </div>
+</div>
 `;

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -57,11 +57,20 @@ export interface ISemanticColors {
   bodyBackground: string;
 
   /**
-   * A special semantic slot that will always be the same or darker (not necessarily stronger) than the bodyBackground slot, even in
-   * an inverted theme. This is used for zones near the edge of the page, to provide a vignetting effect. This is especially effective
-   * with zones near the edge of the page in stronger themes or if it uses a variant theme.
+   * The color for chrome adjacent to an area with bodyBackground.
+   * This can be used to provide visual separation of zones when using stronger colors, when using a divider line is not desired.
+   * In most themes, this should match the color of bodyBackground.
+   * See also: bodyFrameDivider
    */
   bodyFrameBackground: string;
+
+  /**
+   * Used as the border between a zone with bodyFrameBackground and a zone with bodyBackground.
+   * If bodyBackground and bodyFrameBackground are different, this should be the same color as bodyFrameBackground
+   * in order to visually disappear.
+   * See also: bodyFrameBackground
+   */
+  bodyFrameDivider: string;
 
   /**
    * The default color for text.
@@ -157,8 +166,8 @@ export interface ISemanticColors {
   inputBorder: string;
 
   /** The border of a small input control in its resting unchecked state; e.g. the box of an unchecked checkbox.
-  *
-  */
+   *
+   */
   smallInputBorder: string;
 
   /**

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -5,12 +5,8 @@ import {
   ITheme,
   IPartialTheme
 } from '../interfaces/index';
-import {
-  DefaultFontStyles
-} from './DefaultFontStyles';
-import {
-  DefaultPalette
-} from './DefaultPalette';
+import { DefaultFontStyles } from './DefaultFontStyles';
+import { DefaultPalette } from './DefaultPalette';
 import { loadTheme as legacyLoadTheme } from '@microsoft/load-themed-styles';
 
 let _theme: ITheme = {
@@ -18,7 +14,7 @@ let _theme: ITheme = {
   semanticColors: _makeSemanticColorsFromPalette(DefaultPalette, false, false),
   fonts: DefaultFontStyles,
   isInverted: false,
-  disableGlobalClassNames: false,
+  disableGlobalClassNames: false
 };
 let _onThemeChangeCallbacks: Array<(theme: ITheme) => void> = [];
 
@@ -28,7 +24,11 @@ if (!Customizations.getSettings([ThemeSettingName]).theme) {
   let win = typeof window !== 'undefined' ? window : undefined;
 
   // tslint:disable:no-string-literal no-any
-  if (win && (win as any)['FabricConfig'] && (win as any)['FabricConfig'].theme) {
+  if (
+    win &&
+    (win as any)['FabricConfig'] &&
+    (win as any)['FabricConfig'].theme
+  ) {
     _theme = createTheme((win as any)['FabricConfig'].theme);
   }
   // tslint:enable:no-string-literal no-any
@@ -53,7 +53,9 @@ export function getTheme(depComments: boolean = false): ITheme {
  * This should only be used when the component cannot automatically get theme changes through its state.
  * This will not register duplicate callbacks.
  */
-export function registerOnThemeChangeCallback(callback: (theme: ITheme) => void): void {
+export function registerOnThemeChangeCallback(
+  callback: (theme: ITheme) => void
+): void {
   if (_onThemeChangeCallbacks.indexOf(callback) === -1) {
     _onThemeChangeCallbacks.push(callback);
   }
@@ -63,7 +65,9 @@ export function registerOnThemeChangeCallback(callback: (theme: ITheme) => void)
  * See registerOnThemeChangeCallback().
  * Removes previously registered callbacks.
  */
-export function removeOnThemeChangeCallback(callback: (theme: ITheme) => void): void {
+export function removeOnThemeChangeCallback(
+  callback: (theme: ITheme) => void
+): void {
   const i = _onThemeChangeCallbacks.indexOf(callback);
   if (i === -1) {
     return;
@@ -77,7 +81,10 @@ export function removeOnThemeChangeCallback(callback: (theme: ITheme) => void): 
  * @param {object} theme - Partial theme object.
  * @param {boolean} depComments - Whether to include deprecated tags as comments for deprecated slots.
  */
-export function loadTheme(theme: IPartialTheme, depComments: boolean = false): ITheme {
+export function loadTheme(
+  theme: IPartialTheme,
+  depComments: boolean = false
+): ITheme {
   _theme = createTheme(theme, depComments);
 
   // Invoke the legacy method of theming the page as well.
@@ -101,7 +108,10 @@ export function loadTheme(theme: IPartialTheme, depComments: boolean = false): I
  * @param {object} theme - Partial theme object.
  * @param {boolean} depComments - Whether to include deprecated tags as comments for deprecated slots.
  */
-export function createTheme(theme: IPartialTheme, depComments: boolean = false): ITheme {
+export function createTheme(
+  theme: IPartialTheme,
+  depComments: boolean = false
+): ITheme {
   let newPalette = { ...DefaultPalette, ...theme.palette };
 
   if (!theme.palette || !theme.palette.accent) {
@@ -109,7 +119,14 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
   }
 
   // mix in custom overrides with good slots first, since custom overrides might be used in fixing deprecated slots
-  let newSemanticColors = { ..._makeSemanticColorsFromPalette(newPalette, !!theme.isInverted, depComments), ...theme.semanticColors };
+  let newSemanticColors = {
+    ..._makeSemanticColorsFromPalette(
+      newPalette,
+      !!theme.isInverted,
+      depComments
+    ),
+    ...theme.semanticColors
+  };
 
   return {
     palette: newPalette,
@@ -119,16 +136,21 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
     },
     semanticColors: newSemanticColors,
     isInverted: !!theme.isInverted,
-    disableGlobalClassNames: !!theme.disableGlobalClassNames,
+    disableGlobalClassNames: !!theme.disableGlobalClassNames
   };
 }
 
 // Generates all the semantic slot colors based on the Fabric palette.
 // We'll use these as fallbacks for semantic slots that the passed in theme did not define.
-function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean, depComments: boolean): ISemanticColors {
+function _makeSemanticColorsFromPalette(
+  p: IPalette,
+  isInverted: boolean,
+  depComments: boolean
+): ISemanticColors {
   let toReturn: ISemanticColors = {
     bodyBackground: p.white,
     bodyFrameBackground: p.white,
+    bodyFrameDivider: p.neutralLight,
     bodyText: p.neutralPrimary,
     bodyTextChecked: p.black,
     bodySubtext: p.neutralSecondary,
@@ -143,11 +165,19 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean, depCom
 
     errorText: !isInverted ? p.redDark : '#ff5f5f',
     warningText: !isInverted ? '#333333' : '#ffffff',
-    errorBackground: !isInverted ? 'rgba(232, 17, 35, .2)' : 'rgba(232, 17, 35, .5)',
-    blockingBackground: !isInverted ? 'rgba(234, 67, 0, .2)' : 'rgba(234, 67, 0, .5)',
-    warningBackground: !isInverted ? 'rgba(255, 185, 0, .2)' : 'rgba(255, 251, 0, .6)',
+    errorBackground: !isInverted
+      ? 'rgba(232, 17, 35, .2)'
+      : 'rgba(232, 17, 35, .5)',
+    blockingBackground: !isInverted
+      ? 'rgba(234, 67, 0, .2)'
+      : 'rgba(234, 67, 0, .5)',
+    warningBackground: !isInverted
+      ? 'rgba(255, 185, 0, .2)'
+      : 'rgba(255, 251, 0, .6)',
     warningHighlight: !isInverted ? '#ffb900' : '#fff100',
-    successBackground: !isInverted ? 'rgba(186, 216, 10, .2)' : 'rgba(186, 216, 10, .4)',
+    successBackground: !isInverted
+      ? 'rgba(186, 216, 10, .2)'
+      : 'rgba(186, 216, 10, .4)',
 
     inputBorder: p.neutralTertiary,
     inputBorderHovered: p.neutralDark,
@@ -193,7 +223,10 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean, depCom
   return _fixDeprecatedSlots(toReturn, depComments!);
 }
 
-function _fixDeprecatedSlots(s: ISemanticColors, depComments: boolean): ISemanticColors {
+function _fixDeprecatedSlots(
+  s: ISemanticColors,
+  depComments: boolean
+): ISemanticColors {
   // Add @deprecated tag as comment if enabled
   let dep = '';
   if (depComments === true) {

--- a/packages/variants/src/variants.ts
+++ b/packages/variants/src/variants.ts
@@ -9,12 +9,13 @@ import {
 function makeThemeFromPartials(
   originalTheme: IPartialTheme,
   partialPalette: Partial<IPalette>,
-  partialSemantic: Partial<ISemanticColors>): ITheme {
+  partialSemantic: Partial<ISemanticColors>
+): ITheme {
   return createTheme({
     ...originalTheme,
     ...{
       palette: { ...originalTheme.palette, ...partialPalette },
-      semanticColors: { ...originalTheme.semanticColors, ...partialSemantic },
+      semanticColors: { ...originalTheme.semanticColors, ...partialSemantic }
     }
   });
 }
@@ -33,16 +34,16 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
   // commented lines are unchanged, but left in for tracking purposes
   // in a neutral variant, most colors remain unchanged
   const partialPalette: Partial<IPalette> = {
-    // theme
-    // themeDarker: '#004578',
-    // themeDark: '#005a9e',
-    // themeDarkAlt: '#106ebe',
-    // themePrimary: '#0078d4',
-    // themeSecondary: '#2b88d8',
-    // themeTertiary: '#71afe5',
-    // themeLight: '#c7e0f4',
-    // themeLighter: '#deecf9',
-    // themeLighterAlt: '#eff6fc',
+    // theme - shifts a shade stronger to account for contrast against stronger background
+    // themeDarker: '#004578', // can't go darker, stays the same
+    themeDark: p.themeDarker,
+    themeDarkAlt: p.themeDark,
+    themePrimary: p.themeDarkAlt,
+    themeSecondary: p.themePrimary,
+    themeTertiary: p.themeSecondary,
+    themeLight: p.themeTertiary,
+    themeLighter: p.themeLight,
+    themeLighterAlt: p.themeLighterAlt,
 
     // foregrounds
     // black: '#000000',
@@ -51,21 +52,20 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
     // neutralPrimaryAlt: '#3c3c3c',
     // neutralSecondary: '#666666',
     // neutralTertiary: '#a6a6a6',
-
-    // backgrounds
+    // backgrounds - background is still the same scale, just squish it a bit
     // neutralTertiaryAlt: '#c8c8c8',
-    // neutralQuaternary: '#d0d0d0',
-    // neutralQuaternaryAlt: '#dadada',
+    neutralQuaternary: p.neutralTertiaryAlt,
+    neutralQuaternaryAlt: p.neutralQuaternary,
     neutralLight: p.neutralQuaternaryAlt,
     neutralLighter: p.neutralLight,
     neutralLighterAlt: p.neutralLight,
     white: p.neutralLighter
-    // squish the backgrounds a bit
   };
 
   const partialSemantic: Partial<ISemanticColors> = {
     bodyBackground: p.neutralLighter,
-    bodyFrameBackground: !fullTheme.isInverted ? p.neutralLight : p.neutralLighterAlt
+    bodyFrameBackground: !fullTheme.isInverted ? p.neutralLight : p.neutralLighter,
+    bodyFrameDivider: !fullTheme.isInverted ? p.neutralLight : p.neutralQuaternary
   };
 
   return makeThemeFromPartials(theme, partialPalette, partialSemantic);
@@ -85,16 +85,16 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
   // commented lines are unchanged, but left in for tracking purposes
   // in a soft variant, most colors remain unchanged
   const partialPalette: Partial<IPalette> = {
-    // theme
-    // themeDarker: '#004578',
-    // themeDark: '#005a9e',
-    // themeDarkAlt: '#106ebe',
-    // themePrimary: '#0078d4',
-    // themeSecondary: '#2b88d8',
-    // themeTertiary: '#71afe5',
-    // themeLight: '#c7e0f4',
-    // themeLighter: '#deecf9',
-    // themeLighterAlt: '#eff6fc',
+    // theme - shifts a shade stronger to account for contrast against stronger background
+    // themeDarker: '#004578', // can't go darker, stays the same
+    themeDark: p.themeDarker,
+    themeDarkAlt: p.themeDark,
+    themePrimary: p.themeDarkAlt,
+    themeSecondary: p.themePrimary,
+    themeTertiary: p.themeSecondary,
+    themeLight: p.themeTertiary,
+    themeLighter: p.themeLight,
+    themeLighterAlt: p.themeLighter,
 
     // foregrounds
     // black: '#000000',
@@ -103,27 +103,30 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     // neutralPrimaryAlt: '#3c3c3c',
     // neutralSecondary: '#666666',
     // neutralTertiary: '#a6a6a6',
-
-    // backgrounds
-    neutralTertiaryAlt: p.themeDark,
-    neutralQuaternary: p.themeDarkAlt,
-    neutralQuaternaryAlt: p.themePrimary,
-    neutralLight: p.themeSecondary,
-    neutralLighter: p.themeTertiary,
-    neutralLighterAlt: p.themeLight,
-    white: p.themeLighter
+    // backgrounds - page background starts at themeLighterAlt or themeLight, depending on inverted theme or not,
+    // then gets steps stronger from there
+    neutralTertiaryAlt: !fullTheme.isInverted ? p.themeDarkAlt : p.themeDarker,
+    neutralQuaternary: !fullTheme.isInverted ? p.themePrimary : p.themeDark,
+    neutralQuaternaryAlt: !fullTheme.isInverted
+      ? p.themeSecondary
+      : p.themeDarkAlt,
+    neutralLight: !fullTheme.isInverted ? p.themeTertiary : p.themePrimary,
+    neutralLighter: !fullTheme.isInverted ? p.themeLight : p.themeSecondary,
+    neutralLighterAlt: !fullTheme.isInverted ? p.themeLighter : p.themeTertiary,
+    white: !fullTheme.isInverted ? p.themeLighterAlt : p.themeLight
   };
 
   const partialSemantic: Partial<ISemanticColors> = {
-    bodyBackground: p.themeLighter,
-    bodyFrameBackground: !fullTheme.isInverted ? p.themeLight : p.themeLighterAlt,
+    bodyBackground: !fullTheme.isInverted ? p.themeLighterAlt : p.themeLight,
+    bodyFrameBackground: !fullTheme.isInverted ? p.themeLighter : p.themeLight,
+    bodyFrameDivider: !fullTheme.isInverted ? p.themeLighter : p.themeTertiary,
 
     inputBorder: p.themeLighter,
     // inputBorderHovered: p.neutralPrimary,
     inputBackground: p.themeLighter,
     // inputBackgroundChecked: p.themePrimary,
     // inputBackgroundCheckedHovered: p.themeDarkAlt,
-    inputForegroundChecked: p.themeLighter,
+    inputForegroundChecked: p.themeLighter
     // inputFocusBorderAlt: p.themePrimary,
   };
 
@@ -181,7 +184,10 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
 
   const partialSemantic: Partial<ISemanticColors> = {
     bodyBackground: p.themePrimary,
-    bodyFrameBackground: !fullTheme.isInverted ? p.themeDarkAlt : p.themeSecondary,
+    bodyFrameBackground: !fullTheme.isInverted
+      ? p.themeDarkAlt
+      : p.themePrimary,
+    bodyFrameDivider: !fullTheme.isInverted ? p.themeDarkAlt : p.themeTertiary,
 
     bodyText: p.white,
     bodySubtext: p.white,
@@ -191,7 +197,7 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
     inputBackground: p.themeDark,
     inputBackgroundChecked: p.white,
     // inputBackgroundCheckedHovered: p.themePrimary,
-    inputForegroundChecked: p.themeDark,
+    inputForegroundChecked: p.themeDark
     // inputFocusBorderAlt: p.themePrimary,
   };
 

--- a/packages/variants/src/variants.ts
+++ b/packages/variants/src/variants.ts
@@ -52,6 +52,7 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
     // neutralPrimaryAlt: '#3c3c3c',
     // neutralSecondary: '#666666',
     // neutralTertiary: '#a6a6a6',
+
     // backgrounds - background is still the same scale, just squish it a bit
     // neutralTertiaryAlt: '#c8c8c8',
     neutralQuaternary: p.neutralTertiaryAlt,
@@ -103,6 +104,7 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     // neutralPrimaryAlt: '#3c3c3c',
     // neutralSecondary: '#666666',
     // neutralTertiary: '#a6a6a6',
+
     // backgrounds - page background starts at themeLighterAlt or themeLight, depending on inverted theme or not,
     // then gets steps stronger from there
     neutralTertiaryAlt: !fullTheme.isInverted ? p.themeDarkAlt : p.themeDarker,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

1) Ports over some changes from the 6.0 branch.
2) Add new semantic slot: bodyFrameDivider
3) Tweaks variant-generating algorithms, particularly for backgrounds.
4) Fix MarqueeSelection snapshot test to stop including the theme in it!! So I don't have to update-snapshots every time I make a change.

Note that prettier/tslint had a lot of fun with some of the files here.
I will port these changes to 6.0 next week.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5567)

