### PR TITLE
improve DetailsList row performance

### DIFF
--- a/common/changes/office-ui-fabric-react/feat_reducedrowrenderer_2018-07-14-19-43.json
+++ b/common/changes/office-ui-fabric-react/feat_reducedrowrenderer_2018-07-14-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add shouldComponentUpdate to detailsrow to improve performance",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "daniel.gut@outlook.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -494,7 +494,8 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       getRowAriaDescribedBy,
       checkButtonAriaLabel,
       checkboxCellClassName,
-      groupProps
+      groupProps,
+      useReducedRowRenderer
     } = this.props;
     const collapseAllVisibility = groupProps && groupProps.collapseAllVisibility;
     const selection = this._selection;
@@ -521,7 +522,8 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       getRowAriaLabel: getRowAriaLabel,
       getRowAriaDescribedBy: getRowAriaDescribedBy,
       checkButtonAriaLabel: checkButtonAriaLabel,
-      checkboxCellClassName: checkboxCellClassName
+      checkboxCellClassName: checkboxCellClassName,
+      useReducedRowRenderer: useReducedRowRenderer
     };
 
     if (!item) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -268,6 +268,12 @@ export interface IDetailsListProps extends React.Props<DetailsListBase>, IWithVi
    * avoiding the scroll jumping issue.
    */
   getGroupHeight?: (group: IGroup, groupIndex: number) => number;
+
+  /**
+   * Rerender DetailsRow only when props changed. Might cause regression when depending on external updates.
+   * @default false
+   */
+  useReducedRowRenderer?: boolean;
 }
 
 export interface IColumn {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -156,7 +156,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
           return true;
         }
       }
-      return !shallowCompare(this.props, nextProps);
+      return shallowCompare(this.props, nextProps);
     } else {
       return true;
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -148,6 +148,20 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
     });
   }
 
+  public shouldComponentUpdate(nextProps: IDetailsRowProps, nextState: IDetailsRowState): boolean {
+    if (this.props.useReducedRowRenderer) {
+      if (this.state.selectionState) {
+        const newSelectionState = this._getSelectionState(nextProps);
+        if (this.state.selectionState.isSelected !== newSelectionState.isSelected) {
+          return true;
+        }
+      }
+      return !shallowCompare(this.props, nextProps);
+    } else {
+      return true;
+    }
+  }
+
   public render(): JSX.Element {
     const {
       className,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -150,6 +150,12 @@ export interface IDetailsRowProps extends React.Props<DetailsRowBase> {
    * Whether to render shimmer
    */
   shimmer?: boolean;
+
+  /**
+   * Rerender DetailsRow only when props changed. Might cause regression when depending on external updates.
+   * @default false
+   */
+  useReducedRowRenderer?: boolean;
 }
 
 export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme'>> & {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -139,6 +139,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
           onRenderMissingItem={this._onRenderMissingItem}
+          useReducedRowRenderer={true}
         />
 
         {contextualMenuProps && <ContextualMenu {...contextualMenuProps} />}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -96,6 +96,7 @@ export class DetailsListBasicExample extends React.Component<
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
             onItemInvoked={this._onItemInvoked}
+            useReducedRowRenderer={true}
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
@@ -78,6 +78,7 @@ export class DetailsListCompactExample extends React.Component<
             selectionPreservedOnEmptyClick={true}
             onItemInvoked={this._onItemInvoked}
             compact={true}
+            useReducedRowRenderer={true}
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx
@@ -35,6 +35,7 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
         onColumnHeaderClick={this._onColumnClick}
         onItemInvoked={this._onItemInvoked}
         onColumnHeaderContextMenu={this._onColumnHeaderContextMenu}
+        useReducedRowRenderer={true}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
@@ -48,6 +48,7 @@ export class DetailsListCustomGroupHeadersExample extends React.Component {
               </div>
             )
           }}
+          useReducedRowRenderer={true}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
@@ -19,7 +19,7 @@ export class DetailsListCustomRowsExample extends React.Component {
   }
 
   public render() {
-    return <DetailsList items={_items} setKey="set" onRenderRow={this._onRenderRow} />;
+    return <DetailsList items={_items} setKey="set" onRenderRow={this._onRenderRow} useReducedRowRenderer={true} />;
   }
 
   private _onRenderRow = (props: IDetailsRowProps): JSX.Element => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -221,6 +221,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
             selectionPreservedOnEmptyClick={true}
             onItemInvoked={this._onItemInvoked}
             enterModalSelectionOnTouch={true}
+            useReducedRowRenderer={true}
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
@@ -94,6 +94,7 @@ export class DetailsListDragDropExample extends React.Component<
             onRenderItemColumn={this._onRenderItemColumn}
             dragDropEvents={this._getDragDropEvents()}
             columnReorderOptions={this.state.isColumnReorderEnabled ? this._getColumnReorderOptions() : undefined}
+            useReducedRowRenderer={true}
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
@@ -119,6 +119,7 @@ export class DetailsListGroupedExample extends BaseComponent<
             showEmptyGroups: true
           }}
           onRenderItemColumn={this._onRenderColumn}
+          useReducedRowRenderer={true}
         />
       </Fabric>
     );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Large.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Large.Example.tsx
@@ -56,6 +56,7 @@ export class DetailsListGroupedLargeExample extends BaseComponent<{}, { items: {
           getGroupHeight={this._getGroupHeight}
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
+          useReducedRowRenderer={true}
         />
       </Fabric>
     );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.NavigatingFocus.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.NavigatingFocus.Example.tsx
@@ -37,6 +37,7 @@ export class DetailsListNavigatingFocusExample extends React.Component<{}, IDeta
         items={this.state.items}
         columns={this._columns}
         initialFocusedIndex={this.state.initialFocusedIndex}
+        useReducedRowRenderer={true}
       />
     );
   }


### PR DESCRIPTION
this PR replaces #4858. needed to create a new branch to fix merge issues.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3853 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

added shouldComponentUpdate to detailsrow to only render the row when the props change

#### Focus areas to test

any edge cases where rows should render again when not changing the props
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5571)

