### PR TITLE
Fixes a bug where the DatePicker would only open every other time it gained focus.

### DIFF
--- a/common/changes/office-ui-fabric-react/kisiebel-date-picker-focus-bug_2018-07-16-17-54.json
+++ b/common/changes/office-ui-fabric-react/kisiebel-date-picker-focus-bug_2018-07-16-17-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fixes a bug where the DatePicker would only open every other time it gained focus",
+      "comment": "DatePicker: Fixes a bug where the DatePicker would only open every other time it gained focus.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/kisiebel-date-picker-focus-bug_2018-07-16-17-54.json
+++ b/common/changes/office-ui-fabric-react/kisiebel-date-picker-focus-bug_2018-07-16-17-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes a bug where the DatePicker would only open every other time it gained focus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kisiebel@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -90,13 +90,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   private _calendar = createRef<ICalendar>();
   private _datePickerDiv = createRef<HTMLDivElement>();
   private _textField = createRef<ITextField>();
-  private _preventFocusOpeningPicker: boolean;
 
   constructor(props: IDatePickerProps) {
     super(props);
     this.state = this._getDefaultState();
-
-    this._preventFocusOpeningPicker = false;
   }
 
   public componentWillReceiveProps(nextProps: IDatePickerProps): void {
@@ -287,11 +284,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     }
 
     if (!this.props.allowTextInput) {
-      if (!this._preventFocusOpeningPicker) {
-        this._showDatePickerPopup();
-      } else {
-        this._preventFocusOpeningPicker = false;
-      }
+      this._showDatePickerPopup();
     }
   };
 
@@ -358,7 +351,6 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
   private _showDatePickerPopup(): void {
     if (!this.state.isDatePickerShown) {
-      this._preventFocusOpeningPicker = true;
       this.setState({
         isDatePickerShown: true,
         errorMessage: ''
@@ -380,7 +372,6 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
    * Callback for closing the calendar callout
    */
   private _calendarDismissed = (): void => {
-    this._preventFocusOpeningPicker = true;
     this._dismissDatePickerPopup();
     // don't need to focus the text box, if necessary the focusTrapZone will do it
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Removes a variable that was causing the DatePicker to fail to open every other time it gained focus. I believe the variable was designed to prevent the picker from reopening when it was closed and the button regained focus. However, since focus was already inside the picker before it was closed onFocus was not getting called again when the picker was exited.

#### Focus areas to test

DatePicker keyboard interaction, especially focusing and closing the picker.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5583)

