### PR TITLE
Nidurak/cherrypick spread operator

### DIFF
--- a/common/changes/office-ui-fabric-react/nidurak-cherrypickSpreadOperator_2018-07-17-00-48.json
+++ b/common/changes/office-ui-fabric-react/nidurak-cherrypickSpreadOperator_2018-07-17-00-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Use spread operator in PositioningContainer.styles.ts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nidurak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
@@ -49,12 +49,12 @@ export const getClassNames = memoizeFunction(
         position: 'absolute',
         boxSizing: 'border-box',
         border: '1px solid ${}',
-        selectors: Object.assign(
-          highContrastActive({
+        selectors: {
+          ...highContrastActive({
             border: '1px solid WindowText'
           }),
-          focusClear()
-        )
+          ...focusClear()
+        }
       },
       container: {
         position: 'relative'


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5585 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The Coachmark component uses the PositioningContainer to position the Coachmark. The getClassNames function that is exported from the PositioningContainer.styles.ts file uses Object.assign which does not work in IE. This change replaces Object.assign with the spread operator.

#### Focus areas to test

Coachmark

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5594)

