### PR TITLE
Cherry-pick fix for Object.assign ie bug (#5585) from PR #5589

### DIFF
--- a/common/changes/@uifabric/fabric-website/nidurak-cherryPickSpread_2018-07-17-01-26.json
+++ b/common/changes/@uifabric/fabric-website/nidurak-cherryPickSpread_2018-07-17-01-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "nidurak@microsoft.com"
+}

--- a/common/changes/@uifabric/icons/nidurak-cherryPickSpread_2018-07-17-01-26.json
+++ b/common/changes/@uifabric/icons/nidurak-cherryPickSpread_2018-07-17-01-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "nidurak@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/nidurak-cherryPickSpread_2018-07-17-01-26.json
+++ b/common/changes/@uifabric/styling/nidurak-cherryPickSpread_2018-07-17-01-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "nidurak@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/nidurak-cherryPickSpread_2018-07-17-01-26.json
+++ b/common/changes/@uifabric/variants/nidurak-cherryPickSpread_2018-07-17-01-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/variants",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "nidurak@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/nidurak-cherryPickSpread_2018-07-17-01-26.json
+++ b/common/changes/office-ui-fabric-react/nidurak-cherryPickSpread_2018-07-17-01-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "fix Object.assign ie bug",
+      "comment": "Coachmark: Cherry fix from 6.0 which fixes an Object.assign IE bug.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/nidurak-cherryPickSpread_2018-07-17-01-26.json
+++ b/common/changes/office-ui-fabric-react/nidurak-cherryPickSpread_2018-07-17-01-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fix Object.assign ie bug",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nidurak@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/nidurak-cherryPickSpread_2018-07-17-17-29.json
+++ b/common/changes/office-ui-fabric-react/nidurak-cherryPickSpread_2018-07-17-17-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Cherry pick #5589 which fixes an Object.assign ie bug.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nidurak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
@@ -50,7 +50,7 @@ export const getClassNames = memoizeFunction((): IPositioningContainerNames => {
       border: '1px solid ${}',
       selectors: {
         ...highContrastActive({
-          border: "1px solid WindowText"
+          border: '1px solid WindowText'
         }),
         ...focusClear()
       }

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
@@ -1,11 +1,11 @@
-import { memoizeFunction } from '../../../Utilities';
-import { mergeStyleSets } from '../../../Styling';
-import { IStyle } from '../../../Styling';
+import { memoizeFunction } from "../../../Utilities";
+import { mergeStyleSets } from "../../../Styling";
+import { IStyle } from "../../../Styling";
 
 export interface IPositioningContainerStyles {
   /**
-  * Style for the root element in the default enabled/unchecked state.
-  */
+   * Style for the root element in the default enabled/unchecked state.
+   */
   root?: IStyle;
 }
 
@@ -26,43 +26,48 @@ export interface IPositioningContainerNames {
 /* tslint:disable */
 export function highContrastActive(styles: IStyle): any {
   return {
-    '@media screen and (-ms-high-contrast: active)': styles
+    "@media screen and (-ms-high-contrast: active)": styles
   };
 }
 
 export function focusClear(): any {
   return {
-    '&::-moz-focus-inner': {
+    "&::-moz-focus-inner": {
       border: 0
     },
-    '&': {
-      outline: 'transparent'
+    "&": {
+      outline: "transparent"
     }
-  }
+  };
 }
 /* tslint:enable */
 
-export const getClassNames = memoizeFunction((): IPositioningContainerNames => {
-  return mergeStyleSets({
-    root: {
-      position: 'absolute',
-      boxSizing: 'border-box',
-      border: '1px solid ${}',
-      selectors: Object.assign(highContrastActive({
-        border: '1px solid WindowText',
-      }), focusClear()),
-    },
-    container: {
-      position: 'relative'
-    },
-    main: {
-      backgroundColor: '#ffffff',
-      overflowX: 'hidden',
-      overflowY: 'hidden',
-      position: 'relative'
-    },
-    overFlowYHidden: {
-      overflowY: 'hidden'
-    }
-  });
-});
+export const getClassNames = memoizeFunction(
+  (): IPositioningContainerNames => {
+    return mergeStyleSets({
+      root: {
+        position: "absolute",
+        boxSizing: "border-box",
+        border: "1px solid ${}",
+        selectors: {
+          ...highContrastActive({
+            border: "1px solid WindowText"
+          }),
+          ...focusClear()
+        }
+      },
+      container: {
+        position: "relative"
+      },
+      main: {
+        backgroundColor: "#ffffff",
+        overflowX: "hidden",
+        overflowY: "hidden",
+        position: "relative"
+      },
+      overFlowYHidden: {
+        overflowY: "hidden"
+      }
+    });
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.styles.ts
@@ -1,11 +1,11 @@
-import { memoizeFunction } from "../../../Utilities";
-import { mergeStyleSets } from "../../../Styling";
-import { IStyle } from "../../../Styling";
+import { memoizeFunction } from '../../../Utilities';
+import { mergeStyleSets } from '../../../Styling';
+import { IStyle } from '../../../Styling';
 
 export interface IPositioningContainerStyles {
   /**
-   * Style for the root element in the default enabled/unchecked state.
-   */
+  * Style for the root element in the default enabled/unchecked state.
+  */
   root?: IStyle;
 }
 
@@ -26,48 +26,46 @@ export interface IPositioningContainerNames {
 /* tslint:disable */
 export function highContrastActive(styles: IStyle): any {
   return {
-    "@media screen and (-ms-high-contrast: active)": styles
+    '@media screen and (-ms-high-contrast: active)': styles
   };
 }
 
 export function focusClear(): any {
   return {
-    "&::-moz-focus-inner": {
+    '&::-moz-focus-inner': {
       border: 0
     },
-    "&": {
-      outline: "transparent"
+    '&': {
+      outline: 'transparent'
     }
-  };
+  }
 }
 /* tslint:enable */
 
-export const getClassNames = memoizeFunction(
-  (): IPositioningContainerNames => {
-    return mergeStyleSets({
-      root: {
-        position: "absolute",
-        boxSizing: "border-box",
-        border: "1px solid ${}",
-        selectors: {
-          ...highContrastActive({
-            border: "1px solid WindowText"
-          }),
-          ...focusClear()
-        }
-      },
-      container: {
-        position: "relative"
-      },
-      main: {
-        backgroundColor: "#ffffff",
-        overflowX: "hidden",
-        overflowY: "hidden",
-        position: "relative"
-      },
-      overFlowYHidden: {
-        overflowY: "hidden"
+export const getClassNames = memoizeFunction((): IPositioningContainerNames => {
+  return mergeStyleSets({
+    root: {
+      position: 'absolute',
+      boxSizing: 'border-box',
+      border: '1px solid ${}',
+      selectors: {
+        ...highContrastActive({
+          border: "1px solid WindowText"
+        }),
+        ...focusClear()
       }
-    });
-  }
-);
+    },
+    container: {
+      position: 'relative'
+    },
+    main: {
+      backgroundColor: '#ffffff',
+      overflowX: 'hidden',
+      overflowY: 'hidden',
+      position: 'relative'
+    },
+    overFlowYHidden: {
+      overflowY: 'hidden'
+    }
+  });
+});


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5585 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The Coachmark component uses the PositioningContainer to position the Coachmark. The getClassNames function that is exported from the PositioningContainer.styles.ts file uses Object.assign which does not work in IE. This change replaces Object.assign with the spread operator.
#### Focus areas to test

Coachmark

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5596)

