### PR TITLE
Added root `npm run start-exp` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "npm run _rushBuild",
     "vrtest": "cd apps && cd vr-tests && npm run screener",
     "start": "cd apps && cd fabric-website-resources && npm start",
+    "start-exp": "cd packages && cd experiments && npm start",
     "build": "npm run _rushRebuild",
     "buildci": "npm run _rushRebuildCi",
     "buildfast": "npm run _rushBuild",


### PR DESCRIPTION
Added `start-exp` command in root **package.json** to allow experiments `npm start` command to be run from root.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5606)

