### PR TITLE
Workaround for IE11 setActive random exceptions from the browser.

### DIFF
--- a/common/changes/office-ui-fabric-react/ie11-fix_2018-07-18-03-40.json
+++ b/common/changes/office-ui-fabric-react/ie11-fix_2018-07-18-03-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding a try/catch when we call setActive in Dropdown/ContextualMenu in IE11.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -851,7 +851,11 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
      * sets the page focus but does not scroll the parent element.
      */
     if ((this._host as any).setActive) {
-      (this._host as any).setActive();
+      try {
+        (this._host as any).setActive();
+      } catch (e) {
+        /* no-op */
+      }
     } else {
       this._host.focus();
     }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.tsx
@@ -629,7 +629,11 @@ export class Dropdown extends BaseComponent<IDropdownInternalProps, IDropdownSta
      */
     if (this._host.current) {
       if ((this._host.current as any).setActive) {
-        (this._host.current as any).setActive();
+        try {
+          (this._host.current as any).setActive();
+        } catch (e) {
+          /* no-op */
+        }
       } else {
         this._host.current.focus();
       }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -241,7 +241,11 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
          * sets the page focus but does not scroll the parent element.
          */
         if ((elements[index] as any).setActive) {
-          (elements[index] as any).setActive();
+          try {
+            (elements[index] as any).setActive();
+          } catch (e) {
+            /* no-op */
+          }
         } else {
           (elements[index] as HTMLElement).focus();
         }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5118
- [X] Include a change request file using `$ npm run change`

#### Description of changes

It seems that in IE11 we're seeing random exceptions thrown when setActive is called. Try/catching to work around.

Addresses this:

![image](https://user-images.githubusercontent.com/1110944/42858183-1450a93a-8a02-11e8-9457-2ad4763c57da.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5611)

