### PR TITLE
[Persona] Add prop to show initials when image is loading

### DIFF
--- a/common/changes/office-ui-fabric-react/add-showInitialsUntilImageLoads-props_2018-07-18-18-52.json
+++ b/common/changes/office-ui-fabric-react/add-showInitialsUntilImageLoads-props_2018-07-18-18-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds showInitialsUntilImageLoads property to Persona/PersonaCoin to show initials while the image is loading",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
@@ -58,6 +58,7 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
       onRenderCoin,
       onRenderInitials,
       presence,
+      showInitialsUntilImageLoads,
       showSecondaryText,
       theme
     } = this.props;
@@ -77,6 +78,7 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
       onRenderCoin,
       onRenderInitials,
       presence,
+      showInitialsUntilImageLoads,
       size,
       text: this._getText()
     };

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -113,6 +113,13 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase> {
   showUnknownPersonaCoin?: boolean;
 
   /**
+   * If true renders the initials while the image is loading.
+   * This only applies when an imageUrl is provided.
+   * @defaultvalue false
+   */
+  showInitialsUntilImageLoads?: boolean;
+
+  /**
    * Optional custom persona coin size in pixel.
    */
   coinSize?: number;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -80,6 +80,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
       onRenderCoin = this._onRenderCoin,
       onRenderInitials = this._onRenderInitials,
       presence,
+      showInitialsUntilImageLoads,
       theme
     } = this.props;
 
@@ -103,13 +104,17 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
       showUnknownPersonaCoin
     });
 
+    const shouldRenderInitials = Boolean(
+      (showInitialsUntilImageLoads && imageUrl) || !imageUrl || this.state.isImageError || hideImage
+    );
+
     return (
       <div {...divProps} className={classNames.coin}>
         {// Render PersonaCoin if size is not size10
         size !== PersonaSize.size10 && size !== PersonaSize.tiny ? (
           <div {...coinProps} className={classNames.imageArea} style={coinSizeStyle}>
             {!this.state.isImageLoaded &&
-              (!imageUrl || this.state.isImageError || hideImage) && (
+              shouldRenderInitials && (
                 <div
                   className={mergeStyles(
                     classNames.initials,

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.test.tsx
@@ -35,4 +35,20 @@ describe('PersonaCoin', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders the initials before the image is loaded', () => {
+    const component = renderer.create(
+      <PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} showInitialsUntilImageLoads={true} />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('does not render the initials when showInitialsUntilImageLoads is false', () => {
+    const component = renderer.create(
+      <PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} showInitialsUntilImageLoads={false} />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PersonaCoin does not render the initials when showInitialsUntilImageLoads is false 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  size={13}
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 48px;
+          position: relative;
+          text-align: center;
+          width: 48px;
+        }
+    style={undefined}
+  >
+    <div
+      className=
+          ms-Image
+          ms-Persona-image
+          {
+            border-radius: 50%;
+            border: 0px;
+            height: 100%;
+            left: 0px;
+            margin-right: 10px;
+            overflow: hidden;
+            perspective: 1px;
+            position: absolute;
+            top: 0px;
+            width: 100%;
+          }
+      style={
+        Object {
+          "height": 48,
+          "width": 48,
+        }
+      }
+    >
+      <img
+        alt=""
+        className=
+            ms-Image-image
+            ms-Image-image--cover
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: auto;
+              left: 50% /* @noflip */;
+              opacity: 0;
+              position: absolute;
+              top: 50%;
+              transform: translate(-50%,-50%);
+              width: 100%;
+            }
+        onError={[Function]}
+        onLoad={[Function]}
+        role={undefined}
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII="
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`PersonaCoin renders correctly 1`] = `
 <div
   className=
@@ -395,6 +472,109 @@ exports[`PersonaCoin renders correctly with text 1`] = `
         onLoad={[Function]}
         role={undefined}
         src={undefined}
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
+<div
+  className=
+      ms-Persona-coin
+      ms-Persona--size48
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+  size={13}
+>
+  <div
+    className=
+        ms-Persona-imageArea
+        {
+          flex: 0 0 auto;
+          height: 48px;
+          position: relative;
+          text-align: center;
+          width: 48px;
+        }
+    style={undefined}
+  >
+    <div
+      aria-hidden="true"
+      className=
+          ms-Persona-initials
+          {
+            background-color: #1D1D1D;
+            border-radius: 50%;
+            color: #ffffff;
+            font-size: 17px;
+            font-weight: 400;
+            height: 48px;
+            line-height: 46px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: Window !important;
+            border: 1px solid WindowText;
+            box-sizing: border-box;
+            color: WindowText;
+          }
+      style={undefined}
+    >
+      <span>
+        KL
+      </span>
+    </div>
+    <div
+      className=
+          ms-Image
+          ms-Persona-image
+          {
+            border-radius: 50%;
+            border: 0px;
+            height: 100%;
+            left: 0px;
+            margin-right: 10px;
+            overflow: hidden;
+            perspective: 1px;
+            position: absolute;
+            top: 0px;
+            width: 100%;
+          }
+      style={
+        Object {
+          "height": 48,
+          "width": 48,
+        }
+      }
+    >
+      <img
+        alt=""
+        className=
+            ms-Image-image
+            ms-Image-image--cover
+            ms-Image-image--portrait
+            is-notLoaded
+            is-fadeIn
+            {
+              display: block;
+              height: auto;
+              left: 50% /* @noflip */;
+              opacity: 0;
+              position: absolute;
+              top: 50%;
+              transform: translate(-50%,-50%);
+              width: 100%;
+            }
+        onError={[Function]}
+        onLoad={[Function]}
+        role={undefined}
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII="
       />
     </div>
   </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5601
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds showInitialsUntilImageLoads property to Persona/PersonaCoin to show initials while the image is loading

![](https://www.thedutchies.com/fabric/image-loading-prop.gif)

#### Focus areas to test

Persona / PersonaCoin with images

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5618)

