### PR TITLE
Add automation identifier to the visible content of ResizeGroup

### DIFF
--- a/common/changes/office-ui-fabric-react/brwatt-resizegroup-id_2018-07-18-22-41.json
+++ b/common/changes/office-ui-fabric-react/brwatt-resizegroup-id_2018-07-18-22-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add automation identifier to the visible content of ResizeGroup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "brwatt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",
@@ -363,6 +364,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",
@@ -735,6 +737,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",
@@ -1007,6 +1010,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",
@@ -1379,6 +1383,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 5 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",
@@ -1671,6 +1676,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 6 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",
@@ -1883,6 +1889,7 @@ exports[`Breadcrumb renders empty breadcrumb 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`CommandBar renders commands correctly 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`CommandBar renders commands correctly 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -365,8 +365,11 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
             </div>
           )}
 
-        <div ref={this._initialHiddenDiv} style={isInitialMeasure ? hiddenDivStyles : undefined}
-          data-automation-id="visibleContent">
+        <div
+          ref={this._initialHiddenDiv}
+          style={isInitialMeasure ? hiddenDivStyles : undefined}
+          data-automation-id="visibleContent"
+        >
           {isInitialMeasure ? onRenderData(dataToMeasure) : renderedData && onRenderData(renderedData)}
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -365,7 +365,8 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
             </div>
           )}
 
-        <div ref={this._initialHiddenDiv} style={isInitialMeasure ? hiddenDivStyles : undefined}>
+        <div ref={this._initialHiddenDiv} style={isInitialMeasure ? hiddenDivStyles : undefined}
+          data-automation-id="visibleContent">
           {isInitialMeasure ? onRenderData(dataToMeasure) : renderedData && onRenderData(renderedData)}
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/__snapshots__/ResizeGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/__snapshots__/ResizeGroup.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`ResizeGroup renders the ResizeGroup correctly 1`] = `
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -33,6 +33,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",
@@ -1044,6 +1045,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",
@@ -1995,6 +1997,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",
@@ -2648,6 +2651,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -17,6 +17,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -11,6 +11,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -11,6 +11,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -13,6 +13,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -17,6 +17,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
         }
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.FlexBox.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.FlexBox.Example.tsx.shot
@@ -10,6 +10,7 @@ exports[`Component Examples renders ResizeGroup.FlexBox.Example.tsx correctly 1`
       }
 >
   <div
+    data-automation-id="visibleContent"
     style={
       Object {
         "position": "fixed",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -15,6 +15,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
     role="tabpanel"
   >
     <div
+      data-automation-id="visibleContent"
       style={
         Object {
           "position": "fixed",


### PR DESCRIPTION
We have automation tests that need to distinguish the real elements of the ResizeGroup from the ones used for measurements. This adds an automation id attribute to the visible content.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5622)

