### PR TITLE
add support for commandBarButtonAs to ICommandBarItemProps, and contextualMenuItemAs to IContextualMenuItem

### DIFF
--- a/common/changes/office-ui-fabric-react/nidurak-contextualMenuItemAs_2018-07-19-23-06.json
+++ b/common/changes/office-ui-fabric-react/nidurak-contextualMenuItemAs_2018-07-19-23-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add support for commandBarButtonAs to ICommandBarItemProps, and contextualMenuItemAs to IContextualMenuItem",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nidurak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -154,6 +154,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   private _onRenderItem = (item: ICommandBarItemProps): JSX.Element | React.ReactNode => {
     const { buttonAs: CommandButtonType = CommandBarButton } = this.props;
+    const { commandBarButtonAs: ItemCommandButtonType = CommandButtonType } = item;
 
     const itemText = item.text || item.name;
 
@@ -173,12 +174,12 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     if (item.iconOnly && itemText !== undefined) {
       return (
         <TooltipHost content={itemText}>
-          <CommandButtonType {...commandButtonProps as IButtonProps} />
+          <ItemCommandButtonType {...commandButtonProps as IButtonProps} />
         </TooltipHost>
       );
     }
 
-    return <CommandButtonType {...commandButtonProps as IButtonProps} />;
+    return <ItemCommandButtonType {...commandButtonProps as IButtonProps} />;
   };
 
   private _onRenderOverflowButton = (overflowItems: ICommandBarItemProps[]): JSX.Element => {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -129,6 +129,12 @@ export interface ICommandBarItemProps extends IContextualMenuItem {
    * This value is controlled by the component and useful for adjusting onRender function
    */
   renderedInOverflow?: boolean;
+
+  /**
+   * Method to override the render of the individual command bar button. Note, is not used when rendered in overflow
+   * @default CommandBarButton
+   */
+  commandBarButtonAs?: React.ComponentClass<ICommandBarItemProps> | React.StatelessComponent<ICommandBarItemProps>;
 }
 
 export interface ICommandBarStyleProps {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -455,6 +455,14 @@ export interface IContextualMenuItem {
    * @deprecated Use `text` instead.
    */
   name?: string;
+
+  /**
+   * Method to override the render of the individual menu items
+   * @default ContextualMenuItem
+   */
+  contextualMenuItemAs?:
+    | React.ComponentClass<IContextualMenuItemProps>
+    | React.StatelessComponent<IContextualMenuItemProps>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -26,6 +26,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       dismissMenu
     } = this.props;
 
+    const { contextualMenuItemAs: ItemChildrenRenderer = ChildrenRenderer } = item;
     const subMenuId = this._getSubMenuId(item);
     const ariaLabel = item.ariaLabel || item.text || item.name || '';
 
@@ -81,7 +82,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
             {...itemButtonProperties as React.ButtonHTMLAttributes<HTMLButtonElement>}
             {...keytipAttributes}
           >
-            <ChildrenRenderer
+            <ItemChildrenRenderer
               componentRef={item.componentRef}
               item={item}
               classNames={classNames}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

add support for commandBarButtonAs to ICommandBarItemProps, and contextualMenuItemAs to IContextualMenuItem

#### Focus areas to test

CommandBar and ContextualMenuButton

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5640)

