### PR TITLE
Allow cards to be non draggable with cursor styling

### DIFF
--- a/common/changes/@uifabric/dashboard/drag_2018-07-19-20-12.json
+++ b/common/changes/@uifabric/dashboard/drag_2018-07-19-20-12.json
@@ -1,11 +1,11 @@
-+{
-  +  "changes": [
-  +    {
-  +      "packageName": "@uifabric/dashboard",
-  +      "comment": "Added disable drag prop to card to allow recommendation card to be non draggable",
-  +      "type": "minor"
-  +    }
-  +  ],
-  +  "packageName": "@uifabric/dashboard",
-  +  "email": "saakhta@microsoft.com"
-  +}
+{
+ "changes": [
+   {
+     "packageName": "@uifabric/dashboard",
+     "comment": "Added disable drag prop to card to allow recommendation card to be non draggable",
+     "type": "minor"
+   }
+ ],
+ "packageName": "@uifabric/dashboard",
+ "email": "saakhta@microsoft.com"
+}

--- a/common/changes/@uifabric/dashboard/drag_2018-07-19-20-12.json
+++ b/common/changes/@uifabric/dashboard/drag_2018-07-19-20-12.json
@@ -1,0 +1,11 @@
++{
+  +  "changes": [
+  +    {
+  +      "packageName": "@uifabric/dashboard",
+  +      "comment": "Added disable drag prop to card to allow recommendation card to be non draggable",
+  +      "type": "minor"
+  +    }
+  +  ],
+  +  "packageName": "@uifabric/dashboard",
+  +  "email": "saakhta@microsoft.com"
+  +}

--- a/packages/dashboard/src/components/Card/Card.tsx
+++ b/packages/dashboard/src/components/Card/Card.tsx
@@ -24,7 +24,7 @@ export class Card extends React.Component<ICardProps, ICardState> {
   }
 
   public render(): JSX.Element {
-    const { cardFrameContent, header, cardContentList, actions } = this.props;
+    const { cardFrameContent, header, cardContentList, actions, disableDrag } = this.props;
     const getClassNames = classNamesFunction<ICardProps, ICardStyles>();
     const classNames = getClassNames(getStyles);
     return (
@@ -33,6 +33,7 @@ export class Card extends React.Component<ICardProps, ICardState> {
           cardTitle={cardFrameContent.cardTitle}
           cardDropDownOptions={cardFrameContent.cardDropDownOptions}
           href={cardFrameContent.href}
+          disableDrag={disableDrag === undefined ? false : disableDrag}
         >
           <Layout header={header} contentArea={cardContentList} cardSize={this.state.cardSize} actions={actions} />
         </CardFrame>

--- a/packages/dashboard/src/components/Card/Card.types.ts
+++ b/packages/dashboard/src/components/Card/Card.types.ts
@@ -122,6 +122,12 @@ export interface ICardProps {
    * One of its use could be to fetch server data here
    */
   callOnDidMount?: VoidFunction;
+
+  /**
+   * Whether the card is draggable or not
+   * @default false
+   */
+  disableDrag?: boolean;
 }
 
 export interface ICardState {

--- a/packages/dashboard/src/components/Card/CardFrame/CardFrame.styles.ts
+++ b/packages/dashboard/src/components/Card/CardFrame/CardFrame.styles.ts
@@ -4,7 +4,7 @@ import { IButtonStyles } from 'office-ui-fabric-react';
 const cardTitleBox = 40;
 
 export const getStyles = (props: ICardFrameProps): ICardFrameStyles => {
-  const { titleTextColor, fontFamily, fontSize, seperatorColor, href } = props;
+  const { titleTextColor, fontFamily, fontSize, seperatorColor, href, disableDrag } = props;
 
   return {
     root: {
@@ -21,7 +21,7 @@ export const getStyles = (props: ICardFrameProps): ICardFrameStyles => {
       borderBottomColor: seperatorColor ? seperatorColor : 'rgba(0,0,0,0.1)',
       borderTopLeftRadius: '2px',
       borderTopRightRadius: '2px',
-      cursor: 'move',
+      cursor: disableDrag ? '' : 'move',
       transition: 'background-color .2s,color .2s,margin .2s,padding .2s,border-color .2s',
       selectors: {
         ':hover': {

--- a/packages/dashboard/src/components/Card/CardFrame/CardFrame.tsx
+++ b/packages/dashboard/src/components/Card/CardFrame/CardFrame.tsx
@@ -13,14 +13,15 @@ export class CardFrame extends React.Component<ICardFrameProps, {}> {
 
   public render(): JSX.Element {
     const getClassNames = classNamesFunction<ICardFrameProps, ICardFrameStyles>();
-    const { fontFamily, fontSize, cardTitle, seperatorColor, titleTextColor, href } = this.props;
+    const { fontFamily, fontSize, cardTitle, seperatorColor, titleTextColor, href, disableDrag } = this.props;
     const classNames = getClassNames(getStyles, {
       cardTitle,
       fontFamily,
       fontSize,
       seperatorColor,
       titleTextColor,
-      href
+      href,
+      disableDrag
     });
     const overflowItems: ICardDropDownOption[] | undefined = this.props.cardDropDownOptions;
     const cardDropDownOptions: IOverflowSetItemProps[] = [];

--- a/packages/dashboard/src/components/Card/CardFrame/CardFrame.types.ts
+++ b/packages/dashboard/src/components/Card/CardFrame/CardFrame.types.ts
@@ -62,6 +62,12 @@ export interface ICardFrameProps {
    * Hyperlink URL for title
    */
   href?: string;
+
+  /**
+   * Whether the card is draggable or not
+   * @default false
+   */
+  disableDrag?: boolean;
 }
 
 export interface ICardFrameStyles {

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayout.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayout.tsx
@@ -72,9 +72,9 @@ export class DashboardGridLayout extends React.Component<IDashboardGridLayoutPro
       y: layoutProp.y,
       w: sizes[layoutProp.size].w,
       h: sizes[layoutProp.size].h,
-      static: layoutProp.static || false,
-      isDraggable: layoutProp.isDraggable || true,
-      isResizable: layoutProp.isResizable || true
+      static: layoutProp.static === undefined ? false : layoutProp.static,
+      isDraggable: layoutProp.disableDrag === undefined ? true : !layoutProp.disableDrag,
+      isResizable: layoutProp.isResizable === undefined ? true : layoutProp.isResizable
     };
   }
 

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayout.types.ts
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayout.types.ts
@@ -67,9 +67,9 @@ export interface IDashboardCardLayout {
 
   /**
    * Whether cards in this grid are allowed to drag
-   * @default true
+   * @default false
    */
-  isDraggable?: boolean;
+  disableDrag?: boolean;
 
   /**
    * Whether cards in this grid are allowed to get resized

--- a/packages/dashboard/src/components/DashboardGridLayout/examples/DashboardGridLayout.Card.Example.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/examples/DashboardGridLayout.Card.Example.tsx
@@ -182,6 +182,7 @@ export class DashboardGridLayoutCardExample extends React.Component<{}, {}> {
             header={header}
             cardContentList={contentAreaList}
             cardSize={CardSize.small}
+            disableDrag={true}
           />
         </div>
         <div key="1">
@@ -226,7 +227,7 @@ export class DashboardGridLayoutCardExample extends React.Component<{}, {}> {
   private _generateLayout(): DashboardGridBreakpointLayouts {
     return {
       lg: [
-        { i: '0', y: 0, x: 0, size: Size.small },
+        { i: '0', y: 0, x: 0, size: Size.small, disableDrag: true },
         { i: '1', y: 0, x: 1, size: Size.mediumTall },
         { i: '2', y: 1, x: 0, size: Size.small },
         { i: '3', y: 0, x: 2, size: Size.mediumWide },

--- a/packages/dashboard/src/components/Recommendation/Recommendation.tsx
+++ b/packages/dashboard/src/components/Recommendation/Recommendation.tsx
@@ -60,6 +60,7 @@ export class Recommendation extends React.Component<IRecommendationProps, {}> {
         seperatorColor={CardComponentStyles.separatorColor}
         titleTextColor={CardComponentStyles.frameHeaderColor}
         cardDropDownOptions={this.recommendationMenuItems}
+        disableDrag={true}
       >
         <div className={classNames.recommendationContainer}>
           <div className={classNames.recommendationTextContainer}>

--- a/packages/dashboard/src/components/Recommendation/__snapshots__/Recommendation.test.tsx.snap
+++ b/packages/dashboard/src/components/Recommendation/__snapshots__/Recommendation.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`RecommendationCard renders basic example correctly 1`] = `
             border-bottom: 1px solid;
             border-top-left-radius: 2px;
             border-top-right-radius: 2px;
-            cursor: move;
+            cursor: ;
             height: 40px;
             overflow: hidden;
             transition: background-color .2s,color .2s,margin .2s,padding .2s,border-color .2s;
@@ -504,7 +504,7 @@ exports[`RecommendationCard renders dlp example correctly 1`] = `
             border-bottom: 1px solid;
             border-top-left-radius: 2px;
             border-top-right-radius: 2px;
-            cursor: move;
+            cursor: ;
             height: 40px;
             overflow: hidden;
             transition: background-color .2s,color .2s,margin .2s,padding .2s,border-color .2s;
@@ -1267,7 +1267,7 @@ exports[`RecommendationCard renders imageillustration example correctly 1`] = `
             border-bottom: 1px solid;
             border-top-left-radius: 2px;
             border-top-right-radius: 2px;
-            cursor: move;
+            cursor: ;
             height: 40px;
             overflow: hidden;
             transition: background-color .2s,color .2s,margin .2s,padding .2s,border-color .2s;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added a disable drag prop to card to allow non draggable cards like Recommendation card have normal cursor and other css

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5641)

