### PR TITLE
Popup/dont layout if overflow y

### DIFF
--- a/common/changes/office-ui-fabric-react/popup-dontLayoutIfOverflowY_2018-07-20-16-31.json
+++ b/common/changes/office-ui-fabric-react/popup-dontLayoutIfOverflowY_2018-07-20-16-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Popup: Skip scroll computation if style.overflowY is provided.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pablonete@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -124,6 +124,11 @@ export interface ICalloutProps {
   className?: string;
 
   /**
+   * CSS style to apply to the callout.
+   */
+  style?: React.CSSProperties;
+
+  /**
    * Optional callback when the layer content has mounted.
    */
   onLayerMounted?: () => void;

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -140,6 +140,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     let { target } = this.props;
     const {
       styles,
+      style,
       role,
       ariaLabel,
       ariaDescribedBy,
@@ -179,9 +180,12 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
       calloutMaxWidth
     });
 
-    const overflowStyle: React.CSSProperties = overflowYHidden
-      ? { overflowY: 'hidden', maxHeight: contentMaxHeight }
-      : { maxHeight: contentMaxHeight };
+    const overflowStyle: React.CSSProperties = {
+      ...style,
+      maxHeight: contentMaxHeight,
+      ...(overflowYHidden && { overflowY: 'hidden' })
+    };
+
     const visibilityStyle: React.CSSProperties | undefined = this.props.hidden ? { visibility: 'hidden' } : undefined;
     // React.CSSProperties does not understand IRawStyle, so the inline animations will need to be cast as any for now.
     const content = (

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -112,6 +112,11 @@ export class Popup extends BaseComponent<IPopupProps, IPopupState> {
   }
 
   private _getScrollBar(): void {
+    // If overflowY is overriden, don't waste time calculating whether the scrollbar is necessary.
+    if (this.props.style && this.props.style.overflowY) {
+      return;
+    }
+
     let needsVerticalScrollBar = false;
     if (this._root && this._root.current && this._root.current.firstElementChild) {
       // ClientHeight returns the client height of an element rounded to an

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.doc.tsx
@@ -5,6 +5,7 @@ import { IDocPageProps } from '../../common/DocPage.types';
 import { TooltipBasicExample } from './examples/Tooltip.Basic.Example';
 import { TooltipInteractiveExample } from './examples/Tooltip.Interactive.Example';
 import { TooltipOverflowExample } from './examples/Tooltip.Overflow.Example';
+import { TooltipNoScrollExample } from './examples/Tooltip.NoScroll.Example';
 import { TooltipStatus } from './Tooltip.checklist';
 
 import './TooltipPage.global.scss';
@@ -13,6 +14,7 @@ const TooltipBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/
 const TooltipCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx') as string;
 const TooltipInteractiveExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx') as string;
 const TooltipOverflowExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Overflow.Example.tsx') as string;
+const TooltipNoScrollExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx') as string;
 
 export const TooltipPageProps: IDocPageProps = {
   title: 'Tooltip',
@@ -40,6 +42,11 @@ export const TooltipPageProps: IDocPageProps = {
       title: 'Tooltip only on overflow',
       code: TooltipOverflowExampleCode,
       view: <TooltipOverflowExample />
+    },
+    {
+      title: 'Tooltip without scroll (improves performance)',
+      code: TooltipNoScrollExampleCode,
+      view: <TooltipNoScrollExample />
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { BaseComponent, getId } from 'office-ui-fabric-react/lib/Utilities';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+
+export class TooltipNoScrollExample extends BaseComponent<{}> {
+  private readonly tooltipId = getId('text-tooltip');
+
+  public render(): JSX.Element {
+    return (
+      <TooltipHost content="This is the tooltip" id={this.tooltipId} tooltipProps={{ style: { overflowY: 'auto' } }}>
+        <DefaultButton>Tooltip without scroll</DefaultButton>
+      </TooltipHost>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Tooltip.NoScroll.Example.tsx correctly 1`] = `
+<div
+  aria-describedby={undefined}
+  className="ms-TooltipHost"
+  onBlurCapture={[Function]}
+  onFocusCapture={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <button
+    aria-describedby={undefined}
+    aria-disabled={undefined}
+    aria-label={undefined}
+    aria-labelledby={undefined}
+    aria-pressed={undefined}
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
+    data-is-focusable={true}
+    disabled={undefined}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <div
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+    >
+      <div
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__1"
+        >
+          Tooltip without scroll
+        </div>
+      </div>
+    </div>
+  </button>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: No
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Skip layout if overflowY is overriden by style.
Popup always calculates `needsVerticalScrollBar` which is expensive, but if we provide a style with overflowY, this value will overrides the calculated one so we can avoid wasting that time.

I've had to add the style prop to `Callout` because there was no continuity in the composition Tooltip - Callout - Popup.

Added one example on how to avoid the computation of `needsVerticalScrollBar`.

#### Focus areas to test

Popup / Callout / Tooltip
