### PR TITLE
Command bar deprecate inactive

### DIFF
--- a/common/changes/office-ui-fabric-react/commandBar-deprecate-inactive_2018-07-20-18-07.json
+++ b/common/changes/office-ui-fabric-react/commandBar-deprecate-inactive_2018-07-20-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Deprecated inactive prop as it was no longer being used",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -446,7 +446,8 @@ export interface IContextualMenuItem {
   [propertyName: string]: any;
 
   /**
-   * Optional prop to make an item readonly which is disabled but visitable by keyboard, will apply aria-readonly and some styling. Not supported by all components
+   * This prop is no longer used. All contextual menu items are now focusable when disabled.
+   * @deprecated in 6.38.2 will be removed in 7.0.0
    */
   inactive?: boolean;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5620
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Inactive prop is now deprecated. All contextual menu items are focusable even when disabled. If you want this functionality on the commandBar buttons, you can set allowDisabledFocus to true. 

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5649)

