### PR TITLE
Popup/dont layout if overflow y 5.0

### DIFF
--- a/common/changes/office-ui-fabric-react/popup-dontLayoutIfOverflowY_2018-07-20-16-31.json
+++ b/common/changes/office-ui-fabric-react/popup-dontLayoutIfOverflowY_2018-07-20-16-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Popup: Skip scroll computation if style.overflowY is provided.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pablonete@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -131,6 +131,11 @@ export interface ICalloutProps {
   className?: string;
 
   /**
+   * CSS style to apply to the callout.
+   */
+  style?: React.CSSProperties;
+
+  /**
    * Optional callback when the layer content has mounted.
    */
   onLayerMounted?: () => void;

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -153,6 +153,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     } = this.props;
     const {
       getStyles,
+      style,
       role,
       ariaLabel,
       ariaDescribedBy,
@@ -190,7 +191,12 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
       }
     );
 
-    const overflowStyle: React.CSSProperties = overflowYHidden ? { overflowY: 'hidden', maxHeight: contentMaxHeight } : { maxHeight: contentMaxHeight };
+    const overflowStyle: React.CSSProperties = {
+      ...style,
+      maxHeight: contentMaxHeight,
+      ...(overflowYHidden && { overflowY: 'hidden' })
+    };
+
     const visibilityStyle: React.CSSProperties | undefined = this.props.hidden ? { visibility: 'hidden' } : undefined;
     // React.CSSProperties does not understand IRawStyle, so the inline animations will need to be cast as any for now.
     const content = (

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -113,6 +113,11 @@ export class Popup extends BaseComponent<IPopupProps, IPopupState> {
   }
 
   private _getScrollBar(): void {
+    // If overflowY is overriden, don't waste time calculating whether the scrollbar is necessary.
+    if (this.props.style && this.props.style.overflowY) {
+      return;
+    }
+
     let needsVerticalScrollBar = false;
     if (this._root && this._root.current && this._root.current.firstElementChild) {
       // ClientHeight returns the client height of an element rounded to an

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipPage.tsx
@@ -11,6 +11,7 @@ import { TooltipCustomExample } from './examples/Tooltip.Custom.Example';
 import { TooltipBasicExample } from './examples/Tooltip.Basic.Example';
 import { TooltipInteractiveExample } from './examples/Tooltip.Interactive.Example';
 import { TooltipOverflowExample } from './examples/Tooltip.Overflow.Example';
+import { TooltipNoScrollExample } from './examples/Tooltip.NoScroll.Example';
 import { ComponentStatus } from '../../demo/ComponentStatus/ComponentStatus';
 import { TooltipStatus } from './Tooltip.checklist';
 
@@ -20,6 +21,7 @@ const TooltipBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/
 const TooltipCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx') as string;
 const TooltipInteractiveExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx') as string;
 const TooltipOverflowExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Overflow.Example.tsx') as string;
+const TooltipNoScrollExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx') as string;
 
 export class TooltipPage extends React.Component<IComponentDemoPageProps, any> {
   public render(): JSX.Element {
@@ -30,43 +32,61 @@ export class TooltipPage extends React.Component<IComponentDemoPageProps, any> {
         componentUrl='https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Tooltip'
         exampleCards={
           <LayerHost>
-            <ExampleCard title='Default Tooltip' code={ TooltipBasicExampleCode }>
+            <ExampleCard title='Default Tooltip' code={TooltipBasicExampleCode}>
               <TooltipBasicExample />
             </ExampleCard>
 
-            <ExampleCard title='Tooltip with list' code={ TooltipCustomExampleCode }>
+            <ExampleCard
+              title='Tooltip with list'
+              code={TooltipCustomExampleCode}
+            >
               <TooltipCustomExample />
             </ExampleCard>
 
-            <ExampleCard title='Tooltip with a closing delay' code={ TooltipInteractiveExampleCode }>
+            <ExampleCard
+              title='Tooltip with a closing delay'
+              code={TooltipInteractiveExampleCode}
+            >
               <TooltipInteractiveExample />
             </ExampleCard>
 
-            <ExampleCard title='Tooltip only on overflow' code={ TooltipOverflowExampleCode }>
+            <ExampleCard
+              title='Tooltip only on overflow'
+              code={TooltipOverflowExampleCode}
+            >
               <TooltipOverflowExample />
+            </ExampleCard>
+
+            <ExampleCard
+              title='Tooltip without scrollbar (may improve performance)'
+              code={TooltipNoScrollExampleCode}
+            >
+              <TooltipNoScrollExample />
             </ExampleCard>
           </LayerHost>
         }
-        allowNativeProps={ true }
+        allowNativeProps={true}
         propertiesTables={
           <PropertiesTableSet
-            sources={ [
-              require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts'),
-              require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts')
-            ] }
+            sources={[
+              require<
+                string
+              >('!raw-loader!office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts'),
+              require<
+                string
+              >('!raw-loader!office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts')
+            ]}
           />
         }
         overview={
           <PageMarkdown>
-            { require<string>('!raw-loader!office-ui-fabric-react/src/components/Tooltip/docs/TooltipOverview.md') }
+            {require<
+              string
+            >('!raw-loader!office-ui-fabric-react/src/components/Tooltip/docs/TooltipOverview.md')}
           </PageMarkdown>
         }
-        isHeaderVisible={ this.props.isHeaderVisible }
-        componentStatus={
-          <ComponentStatus
-            { ...TooltipStatus }
-          />
-        }
+        isHeaderVisible={this.props.isHeaderVisible}
+        componentStatus={<ComponentStatus {...TooltipStatus} />}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { BaseComponent, getId } from 'office-ui-fabric-react/lib/Utilities';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+
+export class TooltipNoScrollExample extends BaseComponent<{}> {
+  private readonly tooltipId = getId('text-tooltip');
+
+  public render(): JSX.Element {
+    return (
+      <TooltipHost
+        content='This is the tooltip'
+        id={this.tooltipId}
+        tooltipProps={{ style: { overflowY: 'auto' } }}
+      >
+        <DefaultButton>Tooltip without scroll</DefaultButton>
+      </TooltipHost>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Tooltip.NoScroll.Example.tsx correctly 1`] = `
+<div
+  aria-describedby={undefined}
+  className="ms-TooltipHost"
+  onBlurCapture={[Function]}
+  onFocusCapture={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <button
+    aria-describedby={undefined}
+    aria-disabled={undefined}
+    aria-label={undefined}
+    aria-labelledby={undefined}
+    aria-pressed={undefined}
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #000000;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
+    data-is-focusable={true}
+    disabled={undefined}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <div
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+    >
+      <div
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__1"
+        >
+          Tooltip without scroll
+        </div>
+      </div>
+    </div>
+  </button>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Cherry pick to 5.0 of #5646 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Skip expensive layout if overflowY is overriden by inline style.
More details in #5646

#### Focus areas to test

Popup / Callout / Tooltip 5.0
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5654)

