### PR TITLE
Add unregisterIcons to styling export

### DIFF
--- a/common/changes/@uifabric/styling/keyou-add-unregister-icon-export_2018-07-23-18-24.json
+++ b/common/changes/@uifabric/styling/keyou-add-unregister-icon-export_2018-07-23-18-24.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@uifabric/styling",
       "comment": "Add unregisterIcons to styling export",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@uifabric/styling",

--- a/common/changes/@uifabric/styling/keyou-add-unregister-icon-export_2018-07-23-18-24.json
+++ b/common/changes/@uifabric/styling/keyou-add-unregister-icon-export_2018-07-23-18-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Add unregisterIcons to styling export",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "keyou@microsoft.com"
+}

--- a/packages/styling/src/utilities/index.ts
+++ b/packages/styling/src/utilities/index.ts
@@ -7,6 +7,7 @@ export {
   getIcon,
   registerIcons,
   registerIconAlias,
+  unregisterIcons,
   setIconOptions
 } from './icons';
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

A new function unregisterIcons was added, but wasn't added to the export of the styling package. This PR fixes that

#### Focus areas to test

Verified build

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5657)

