### PR TITLE
Don't hide close button icon from aria in Panel

### DIFF
--- a/common/changes/office-ui-fabric-react/maxlus-closeButtonAria_2018-07-23-18-36.json
+++ b/common/changes/office-ui-fabric-react/maxlus-closeButtonAria_2018-07-23-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Don't hide close button icon from aria in Panel",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "maxlus@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -263,7 +263,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
             onClick={this._onPanelClick}
             ariaLabel={closeButtonAriaLabel}
             data-is-visible={true}
-            iconProps={{ iconName: 'Cancel' }}
+            iconProps={{ iconName: 'Cancel', ariaLabel: closeButtonAriaLabel }}
           />
         </div>
       );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5608
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The close button in Panel wasn't passing the aria label into the icon, causing the icon to have "Aria-Hidden=True” & Role=Presentation" as attributes. This effectively hides the icon from Narrator in scan mode. By passing the aria label through to the icon, it fixes this issue.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5659)

