### PR TITLE
Makes Stack's grow prop to be more flexible like flex-grow

### DIFF
--- a/common/changes/@uifabric/experiments/stack_2018-07-24-23-00.json
+++ b/common/changes/@uifabric/experiments/stack_2018-07-24-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Make stack grow be more flexible",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/experiments/src/components/Stack/Stack.styles.ts
+++ b/packages/experiments/src/components/Stack/Stack.styles.ts
@@ -22,7 +22,7 @@ export const styles = (props: IStyleProps<IStackProps, IStackStyles>): IStackSty
         padding
       },
       grow && {
-        flexGrow: 1,
+        flexGrow: grow === true ? 1 : grow,
         overflow: 'hidden'
       },
       align && {

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -11,7 +11,7 @@ export interface IStackProps {
   inline?: boolean;
   vertical?: boolean;
 
-  grow?: boolean;
+  grow?: boolean | number;
   wrap?: boolean;
 
   gap?: number;

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -11,7 +11,7 @@ export interface IStackProps {
   inline?: boolean;
   vertical?: boolean;
 
-  grow?: boolean | number;
+  grow?: boolean | number | 'inherit' | 'initial' | 'unset';
   wrap?: boolean;
 
   gap?: number;

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
@@ -12,7 +12,7 @@ export const styles = (props: IStyleProps<IStackItemProps, IStackItemStyles>): I
 
   return {
     root: [
-      grow && { flexGrow: 1 },
+      grow && { flexGrow: grow },
       !grow && !collapse && { flexShrink: 0 },
       align && {
         alignSelf: alignMap[align] || align

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
@@ -12,7 +12,7 @@ export const styles = (props: IStyleProps<IStackItemProps, IStackItemStyles>): I
 
   return {
     root: [
-      grow && { flexGrow: grow },
+      grow && { flexGrow: grow === true ? 1 : grow },
       !grow && !collapse && { flexShrink: 0 },
       align && {
         alignSelf: alignMap[align] || align

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -8,7 +8,7 @@ export interface IStackItemProps {
   vertical?: boolean;
   index?: number;
 
-  grow?: boolean;
+  grow?: boolean | number;
   collapse?: boolean;
 
   align?: 'auto' | 'center' | 'start' | 'baseline' | 'stretch' | 'end';

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -8,7 +8,7 @@ export interface IStackItemProps {
   vertical?: boolean;
   index?: number;
 
-  grow?: boolean | number;
+  grow?: boolean | number | 'inherit' | 'initial' | 'unset';
   collapse?: boolean;
 
   align?: 'auto' | 'center' | 'start' | 'baseline' | 'stretch' | 'end';

--- a/packages/experiments/src/components/Stack/examples/Stack.Basic.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Basic.Example.tsx
@@ -29,6 +29,14 @@ export class StackBasicExample extends React.Component<{}, {}> {
         <Stack.Item align="end">
           <Text>I am a stack item!</Text>
         </Stack.Item>
+        <Stack>
+          <Stack.Item grow={5}>
+            <Text>grow is 5</Text>
+          </Stack.Item>
+          <Stack.Item grow={1}>
+            <Text>grow is 1</Text>
+          </Stack.Item>
+        </Stack>
       </Stack>
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Makes Stack's grow prop to be more flexible like flex-grow. It can now be a number, 'inherit', 'initial', or 'unset'

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5674)

