### PR TITLE
Fixing Detailscolumn render return type issue

### DIFF
--- a/common/changes/office-ui-fabric-react/laxmika-DetailsColumnRenderFix_2018-07-25-11-43.json
+++ b/common/changes/office-ui-fabric-react/laxmika-DetailsColumnRenderFix_2018-07-25-11-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing the Detailscolumn render return type to return a single JSX element, instead of an array",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "laxmika@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
@@ -39,96 +39,101 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
     this._onRootMouseDown = this._onRootMouseDown.bind(this);
   }
 
-  public render() {
+  public render(): JSX.Element {
     const { column, columnIndex, parentId, isDraggable, headerClassNames } = this.props;
     const { onRenderColumnHeaderTooltip = this._onRenderColumnHeaderTooltip } = this.props;
 
-    return [
-      <div
-        key={column.key}
-        ref={this._root}
-        role={'columnheader'}
-        aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
-        aria-colindex={columnIndex}
-        className={css(
-          headerClassNames.cell,
-          column.headerClassName,
-          column.columnActionsMode !== ColumnActionsMode.disabled &&
-            'is-actionable ' + headerClassNames.cellIsActionable,
-          !column.name && 'is-empty ' + headerClassNames.cellIsEmpty,
-          (column.isSorted || column.isGrouped || column.isFiltered) && 'is-icon-visible',
-          column.isPadded && headerClassNames.cellWrapperPadded
-        )}
-        data-is-draggable={isDraggable}
-        draggable={isDraggable}
-        style={{ width: column.calculatedWidth! + INNER_PADDING + (column.isPadded ? ISPADDED_WIDTH : 0) }}
-        data-automationid={'ColumnsHeaderColumn'}
-        data-item-key={column.key}
-      >
-        {isDraggable && <Icon iconName={'GripperBarVertical'} className={headerClassNames.gripperBarVerticalStyle} />}
-        {onRenderColumnHeaderTooltip(
-          {
-            hostClassName: headerClassNames.cellTooltip,
-            id: `${parentId}-${column.key}-tooltip`,
-            setAriaDescribedBy: false,
-            content: column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '',
-            children: (
-              <span
-                id={`${parentId}-${column.key}`}
-                aria-label={column.isIconOnly ? column.name : undefined}
-                aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name `}
-                className={headerClassNames.cellTitle}
-                data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
-                role={column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined}
-                aria-describedby={
-                  this.props.onRenderColumnHeaderTooltip ? `${parentId}-${column.key}-tooltip` : undefined
-                }
-                onContextMenu={this._onColumnContextMenu.bind(this, column)}
-                onClick={this._onColumnClick.bind(this, column)}
-                aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown}
-              >
+    return (
+      <>
+        <div
+          key={column.key}
+          ref={this._root}
+          role={'columnheader'}
+          aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
+          aria-colindex={columnIndex}
+          className={css(
+            headerClassNames.cell,
+            column.headerClassName,
+            column.columnActionsMode !== ColumnActionsMode.disabled &&
+              'is-actionable ' + headerClassNames.cellIsActionable,
+            !column.name && 'is-empty ' + headerClassNames.cellIsEmpty,
+            (column.isSorted || column.isGrouped || column.isFiltered) && 'is-icon-visible',
+            column.isPadded && headerClassNames.cellWrapperPadded
+          )}
+          data-is-draggable={isDraggable}
+          draggable={isDraggable}
+          style={{ width: column.calculatedWidth! + INNER_PADDING + (column.isPadded ? ISPADDED_WIDTH : 0) }}
+          data-automationid={'ColumnsHeaderColumn'}
+          data-item-key={column.key}
+        >
+          {isDraggable && <Icon iconName={'GripperBarVertical'} className={headerClassNames.gripperBarVerticalStyle} />}
+          {onRenderColumnHeaderTooltip(
+            {
+              hostClassName: headerClassNames.cellTooltip,
+              id: `${parentId}-${column.key}-tooltip`,
+              setAriaDescribedBy: false,
+              content: column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '',
+              children: (
                 <span
-                  id={`${parentId}-${column.key}-name`}
-                  className={css(headerClassNames.cellName, {
-                    [headerClassNames.iconOnlyHeader]: column.isIconOnly
-                  })}
+                  id={`${parentId}-${column.key}`}
+                  aria-label={column.isIconOnly ? column.name : undefined}
+                  aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name `}
+                  className={headerClassNames.cellTitle}
+                  data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
+                  role={column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined}
+                  aria-describedby={
+                    this.props.onRenderColumnHeaderTooltip ? `${parentId}-${column.key}-tooltip` : undefined
+                  }
+                  onContextMenu={this._onColumnContextMenu.bind(this, column)}
+                  onClick={this._onColumnClick.bind(this, column)}
+                  aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown}
                 >
-                  {(column.iconName || column.iconClassName) && (
-                    <Icon className={css(headerClassNames.nearIcon, column.iconClassName)} iconName={column.iconName} />
+                  <span
+                    id={`${parentId}-${column.key}-name`}
+                    className={css(headerClassNames.cellName, {
+                      [headerClassNames.iconOnlyHeader]: column.isIconOnly
+                    })}
+                  >
+                    {(column.iconName || column.iconClassName) && (
+                      <Icon
+                        className={css(headerClassNames.nearIcon, column.iconClassName)}
+                        iconName={column.iconName}
+                      />
+                    )}
+
+                    {!column.isIconOnly ? column.name : undefined}
+                  </span>
+
+                  {column.isFiltered && <Icon className={headerClassNames.nearIcon} iconName={'Filter'} />}
+
+                  {column.isSorted && (
+                    <Icon
+                      className={css(headerClassNames.nearIcon, headerClassNames.sortIcon)}
+                      iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'}
+                    />
                   )}
 
-                  {!column.isIconOnly ? column.name : undefined}
+                  {column.isGrouped && <Icon className={headerClassNames.nearIcon} iconName={'GroupedDescending'} />}
+
+                  {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
+                    !column.isIconOnly && <Icon className={headerClassNames.filterChevron} iconName={'ChevronDown'} />}
                 </span>
-
-                {column.isFiltered && <Icon className={headerClassNames.nearIcon} iconName={'Filter'} />}
-
-                {column.isSorted && (
-                  <Icon
-                    className={css(headerClassNames.nearIcon, headerClassNames.sortIcon)}
-                    iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'}
-                  />
-                )}
-
-                {column.isGrouped && <Icon className={headerClassNames.nearIcon} iconName={'GroupedDescending'} />}
-
-                {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
-                  !column.isIconOnly && <Icon className={headerClassNames.filterChevron} iconName={'ChevronDown'} />}
-              </span>
-            )
-          },
-          this._onRenderColumnHeaderTooltip
-        )}
-      </div>,
-      column.ariaLabel && !this.props.onRenderColumnHeaderTooltip ? (
-        <label
-          key={`${column.key}_label`}
-          id={`${parentId}-${column.key}-tooltip`}
-          className={headerClassNames.accessibleLabel}
-        >
-          {column.ariaLabel}
-        </label>
-      ) : null
-    ];
+              )
+            },
+            this._onRenderColumnHeaderTooltip
+          )}
+        </div>
+        {column.ariaLabel && !this.props.onRenderColumnHeaderTooltip ? (
+          <label
+            key={`${column.key}_label`}
+            id={`${parentId}-${column.key}-tooltip`}
+            className={headerClassNames.accessibleLabel}
+          >
+            {column.ariaLabel}
+          </label>
+        ) : null}
+      </>
+    );
   }
 
   public componentDidMount(): void {


### PR DESCRIPTION
Addresses an existing issue: Fixes #5629 

#### Description of changes

Changed the return type of render to return single element instead of an array

#### Focus areas to test

DetailsList rendering
