### PR TITLE
tooltip content is not announced by narrator when we use aria-describedby and content is rendered using onRenderContent

### DIFF
--- a/common/changes/office-ui-fabric-react/shaikshavalis-tooltipHostFix_2018-07-27-14-52.json
+++ b/common/changes/office-ui-fabric-react/shaikshavalis-tooltipHostFix_2018-07-27-14-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltip: narrator now announces aria-describedby when using onRenderContent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "shaiksha479@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -71,7 +71,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
         {...{ onBlurCapture: this._hideTooltip }}
         onMouseEnter={this._onTooltipMouseEnter}
         onMouseLeave={this._onTooltipMouseLeave}
-        aria-describedby={setAriaDescribedBy && isTooltipVisible && content ? tooltipId : undefined}
+        aria-describedby={setAriaDescribedBy && isTooltipVisible && isContentPresent ? tooltipId : undefined}
       >
         {children}
         {showTooltip && (

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -62,7 +62,8 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
       (tooltipProps && tooltipProps.onRenderContent && tooltipProps.onRenderContent())
     );
     const showTooltip = isTooltipVisible && isContentPresent;
-
+    const ariaDescribedBy = (setAriaDescribedBy && isTooltipVisible && isContentPresent) ? tooltipId : undefined;
+    
     return (
       <div
         className={css('ms-TooltipHost', styles.host, hostClassName)}
@@ -71,7 +72,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
         {...{ onBlurCapture: this._hideTooltip }}
         onMouseEnter={this._onTooltipMouseEnter}
         onMouseLeave={this._onTooltipMouseLeave}
-        aria-describedby={setAriaDescribedBy && isTooltipVisible && isContentPresent ? tooltipId : undefined}
+        aria-describedby={ariaDescribedBy}
       >
         {children}
         {showTooltip && (

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.tsx
@@ -63,7 +63,7 @@ export class TooltipHost extends BaseComponent<ITooltipHostProps, ITooltipHostSt
     );
     const showTooltip = isTooltipVisible && isContentPresent;
     const ariaDescribedBy = (setAriaDescribedBy && isTooltipVisible && isContentPresent) ? tooltipId : undefined;
-    
+
     return (
       <div
         className={css('ms-TooltipHost', styles.host, hostClassName)}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
tooltip content is not announced by narrator when we have used onRenderContent to render content instead of direct content property.
(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5679)

