### PR TITLE
FormDropdown: allow "options" prop to flow to the underlying Dropdown component.

### DIFF
--- a/common/changes/@uifabric/experiments/master_2018-07-26-23-52.json
+++ b/common/changes/@uifabric/experiments/master_2018-07-26-23-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "FormDropdown: allow options prop to flow to the underlying Dropdown component.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "nerios@microsoft.com"
+}

--- a/packages/experiments/src/components/Form/inputs/dropdown/FormDropdown.tsx
+++ b/packages/experiments/src/components/Form/inputs/dropdown/FormDropdown.tsx
@@ -35,12 +35,12 @@ export class FormDropdown extends FormBaseInput<
   public render(): JSX.Element {
     return (
       <Dropdown
+        options={[]}
         {...this.props.dropdownProps}
         // These props cannot be overridden
         key={this.props.inputKey}
         onChanged={this._onChanged}
         selectedKey={this.state.currentValue}
-        options={[]}
       />
     );
   }


### PR DESCRIPTION
**Pull request checklist**

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using $ npm run change

**Description of changes**

The experimental FormDropdown component was not allowing the "options" prop to flow to the underlying Dropdown component. This PR fixes that problem.