### PR TITLE
Fix bug #5672 - `getGlobalClassNames` usage in JS styling is a bit of a ticking time bomb

### DIFF
--- a/common/changes/@uifabric/styling/bug5672_2018-07-27-02-48.json
+++ b/common/changes/@uifabric/styling/bug5672_2018-07-27-02-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "getGlobalClassNames - when disabled, now returns a unique classname (modularized) instead of empty string.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/bug5672_2018-08-01-05-13.json
+++ b/common/changes/office-ui-fabric-react/bug5672_2018-08-01-05-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.test.tsx
@@ -80,11 +80,13 @@ describe('Link', () => {
     const NoClassNamesTheme = createTheme({ disableGlobalClassNames: true });
 
     expect(
-      ReactDOM.renderToStaticMarkup(
-        <Customizer settings={{ theme: NoClassNamesTheme }}>
-          <Link href="helloworld.html">My Link</Link>
-        </Customizer>
-      ).indexOf('ms-Link')
-    ).toEqual(-1);
+      /ms-Link($| )/.test(
+        ReactDOM.renderToStaticMarkup(
+          <Customizer settings={{ theme: NoClassNamesTheme }}>
+            <Link href="helloworld.html">My Link</Link>
+          </Customizer>
+        )
+      )
+    ).toBe(false);
   });
 });

--- a/packages/styling/src/styles/getGlobalClassNames.test.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.test.ts
@@ -1,17 +1,49 @@
 import { getGlobalClassNames } from './getGlobalClassNames';
 import { createTheme } from './theme';
+import { Stylesheet } from '@uifabric/merge-styles';
+
+const styleSheet = Stylesheet.getInstance();
 
 describe('getGlobalClassNames', () => {
-  it('returns an empty string when the global styles are disabled', () => {
-    const theme = createTheme({ disableGlobalClassNames: true });
-
-    expect(getGlobalClassNames({ root: 'ms-Link' }, theme)).toEqual({});
+  beforeEach(() => {
+    styleSheet.reset();
   });
 
-  it('returns the correct classNames when global classes are enabled', () => {
-    const theme = createTheme({ disableGlobalClassNames: false });
+  it('returns a generated classname when the global styles are disabled', () => {
+    const theme = createTheme({ disableGlobalClassNames: true });
 
-    expect(getGlobalClassNames({ root: 'ms-Link' }, theme)).toEqual({ root: 'ms-Link' });
+    expect(getGlobalClassNames({ root: 'ms-Link', label: 'ms-Label' }, theme)).toEqual({
+      root: '__global-class-name__-0',
+      label: '__global-class-name__-1'
+    });
+  });
+
+  describe('calls are memoized', () => {
+    let theme, globalClassnames;
+    beforeAll(() => {
+      theme = createTheme({ disableGlobalClassNames: true });
+      globalClassnames = { root: 'ms-Memoized' };
+    });
+
+    it('multiple calls with the same instance of classnames return the same set of global classnames', () => {
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
+    });
+
+    it('calls with different arguments returns a different set of global classnames', () => {
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
+      expect(getGlobalClassNames(globalClassnames, theme, true)).toEqual({ root: '__global-class-name__-1' });
+      expect(getGlobalClassNames({ ...globalClassnames }, theme)).toEqual({ root: '__global-class-name__-2' });
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
+      expect(getGlobalClassNames(globalClassnames, { ...theme })).toEqual({ root: '__global-class-name__-3' });
+    });
+  });
+
+  it('returns the correct classNames when global classes are enabled; also disableGlobalClassNames argument has priority', () => {
+    const theme = createTheme({ disableGlobalClassNames: true });
+
+    expect(getGlobalClassNames({ root: 'ms-Link' }, theme, false)).toEqual({ root: 'ms-Link' });
   });
 
   it('works for multiple global classes', () => {

--- a/packages/styling/src/styles/getGlobalClassNames.test.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.test.ts
@@ -13,8 +13,8 @@ describe('getGlobalClassNames', () => {
     const theme = createTheme({ disableGlobalClassNames: true });
 
     expect(getGlobalClassNames({ root: 'ms-Link', label: 'ms-Label' }, theme)).toEqual({
-      root: '__global-class-name__-0',
-      label: '__global-class-name__-1'
+      root: 'ms-Link-0',
+      label: 'ms-Label-1'
     });
   });
 
@@ -26,17 +26,17 @@ describe('getGlobalClassNames', () => {
     });
 
     it('multiple calls with the same instance of classnames return the same set of global classnames', () => {
-      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
-      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
-      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
     });
 
     it('calls with different arguments returns a different set of global classnames', () => {
-      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
-      expect(getGlobalClassNames(globalClassnames, theme, true)).toEqual({ root: '__global-class-name__-1' });
-      expect(getGlobalClassNames({ ...globalClassnames }, theme)).toEqual({ root: '__global-class-name__-2' });
-      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: '__global-class-name__-0' });
-      expect(getGlobalClassNames(globalClassnames, { ...theme })).toEqual({ root: '__global-class-name__-3' });
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
+      expect(getGlobalClassNames(globalClassnames, theme, true)).toEqual({ root: 'ms-Memoized-1' });
+      expect(getGlobalClassNames({ ...globalClassnames }, theme)).toEqual({ root: 'ms-Memoized-2' });
+      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
+      expect(getGlobalClassNames(globalClassnames, { ...theme })).toEqual({ root: 'ms-Memoized-3' });
     });
   });
 

--- a/packages/styling/src/styles/getGlobalClassNames.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.ts
@@ -29,7 +29,7 @@ export const getGlobalClassNames: <T>(
     if (disableGlobalClassNames || (disableGlobalClassNames === undefined && theme.disableGlobalClassNames)) {
       // disable global classnames
       return Object.keys(classNames).reduce((acc: {}, className: string) => {
-        acc[className] = styleSheet.getClassName('__global-class-name__');
+        acc[className] = styleSheet.getClassName(classNames[className]);
         return acc;
       }, {});
     }

--- a/packages/styling/src/styles/getGlobalClassNames.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.ts
@@ -1,17 +1,40 @@
 import { ITheme } from '../interfaces/index';
 
+import { Stylesheet } from '@uifabric/merge-styles';
+import { memoizeFunction } from '@uifabric/utilities';
+
 export type GlobalClassNames<IStyles> = Record<keyof IStyles, string>;
 
 /**
  * Checks for the `disableGlobalClassNames` property on the `theme` to determine if it should return `classNames`
+ * Note that calls to this function are memoized.
  *
+ * @param classNames The collection of global class names that apply when the flag is false. Make sure to pass in
+ * the same instance on each call to benefit from memoization.
  * @param theme The theme to check the flag on
- * @param classNames The global class names that apply when the flag is false
+ * @param disableGlobalClassNames Optional. Explicitly opt in/out of disabling global classnames. Defaults to false.
  */
-export function getGlobalClassNames<T>(classNames: GlobalClassNames<T>, theme: ITheme): Partial<GlobalClassNames<T>> {
-  if (theme.disableGlobalClassNames) {
-    return {};
-  }
+export const getGlobalClassNames: <T>(
+  classNames: GlobalClassNames<T>,
+  theme: ITheme,
+  disableGlobalClassNames?: boolean
+) => Partial<GlobalClassNames<T>> = memoizeFunction(
+  <T>(
+    classNames: GlobalClassNames<T>,
+    theme: ITheme,
+    disableGlobalClassNames?: boolean
+  ): Partial<GlobalClassNames<T>> => {
+    const styleSheet = Stylesheet.getInstance();
 
-  return classNames;
-}
+    if (disableGlobalClassNames || (disableGlobalClassNames === undefined && theme.disableGlobalClassNames)) {
+      // disable global classnames
+      return Object.keys(classNames).reduce((acc: {}, className: string) => {
+        acc[className] = styleSheet.getClassName('__global-class-name__');
+        return acc;
+      }, {});
+    }
+
+    // use global classnames
+    return classNames;
+  }
+);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5672 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

getGlobalClassNames - when disabled, now returns a unique classname (modularized) instead of empty string.

Also added a new optional third argument that takes priority.

#### Focus areas to test

I have tested to ensure it does not result in a severe perf degradation when we disable global classnames.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5702)

