### PR TITLE
merge-styles: typings tweak to make subcomponentstyles easier to consume

### DIFF
--- a/common/changes/@uifabric/merge-styles/cliffkoh-mergeStyles_2018-07-28-01-09.json
+++ b/common/changes/@uifabric/merge-styles/cliffkoh-mergeStyles_2018-07-28-01-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Change IProcessedStyleSet typings to be easier to consume - subcomponentStyles is now always present so consumers do not have to check for presence even when it is fully expected that it is there.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/cliffkoh-mergeStyles_2018-07-28-01-09.json
+++ b/common/changes/office-ui-fabric-react/cliffkoh-mergeStyles_2018-07-28-01-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Ratings: Minor typings bug fix.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -33,5 +33,5 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
 export type IProcessedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string
 } & {
-  subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, IStyleSet<any>> };
+  subComponentStyles: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, IStyleSet<any>> };
 };

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -94,7 +94,7 @@ describe('mergeStyleSets', () => {
     // he will not be missed.
     const result = mergeStyleSets(undefined, false, null);
 
-    expect(result).toEqual({});
+    expect(result).toEqual({ subComponentStyles: {} });
     expect(_stylesheet.getRules()).toBe('');
   });
 
@@ -122,7 +122,8 @@ describe('mergeStyleSets', () => {
     expect(result).toEqual({
       a: 'a-0',
       b: 'b-1',
-      'c-foo': 'c-foo-2'
+      'c-foo': 'c-foo-2',
+      subComponentStyles: {}
     });
 
     expect(_stylesheet.getRules()).toEqual(
@@ -153,14 +154,16 @@ describe('mergeStyleSets', () => {
 
     expect(styles).toEqual({
       root: 'a root-0',
-      child: 'd child-1'
+      child: 'd child-1',
+      subComponentStyles: {}
     });
     expect(_stylesheet.getRules()).toEqual('.root-0:hover .child-1{background:red;}' + '.child-1{background:green;}');
   });
 
   it('can merge class names', () => {
     expect(mergeStyleSets({ root: ['a', 'b', { background: 'red' }] })).toEqual({
-      root: 'a b root-0'
+      root: 'a b root-0',
+      subComponentStyles: {}
     });
   });
 
@@ -177,7 +180,7 @@ describe('mergeStyleSets', () => {
     const styles: ITestClasses = mergeStyleSets({ root: ['a', { background: 'red' }] });
     const styles1: ITestClasses = mergeStyleSets(styles, styles);
 
-    expect(styles1).toEqual({ root: 'a root-0' });
+    expect(styles1).toEqual({ root: 'a root-0', subComponentStyles: {} });
   });
 
   it('can auto expand a previously registered style embedded in static classname', () => {
@@ -186,10 +189,10 @@ describe('mergeStyleSets', () => {
     const styles3: ITestClasses = mergeStyleSets(styles, { root: ['b', { background: 'purple' }] });
     const styles4: ITestClasses = mergeStyleSets(styles, styles2, styles3, { root: 'c' });
 
-    expect(styles).toEqual({ root: 'a root-0' });
-    expect(styles2).toEqual({ root: 'b a root-0' });
-    expect(styles3).toEqual({ root: 'a b root-1' });
-    expect(styles4).toEqual({ root: 'a b c root-1' });
+    expect(styles).toEqual({ root: 'a root-0', subComponentStyles: {} });
+    expect(styles2).toEqual({ root: 'b a root-0', subComponentStyles: {} });
+    expect(styles3).toEqual({ root: 'a b root-1', subComponentStyles: {} });
+    expect(styles4).toEqual({ root: 'a b c root-1', subComponentStyles: {} });
   });
 
   it('can merge two sets with class names', () => {
@@ -200,7 +203,7 @@ describe('mergeStyleSets', () => {
       root: ['ms-Bar', { background: 'green' }]
     });
 
-    expect(styleSet2).toEqual({ root: 'ms-Foo ms-Bar root-1' });
+    expect(styleSet2).toEqual({ root: 'ms-Foo ms-Bar root-1', subComponentStyles: {} });
     expect(_stylesheet.getRules()).toEqual('.root-0{background:red;}' + '.root-1{background:green;}');
   });
 });

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -95,13 +95,13 @@ export function mergeStyleSets(
   ...styleSets: Array<IStyleSet<any> | undefined | false | null>
 ): IProcessedStyleSet<any> {
   // tslint:disable-next-line:no-any
-  const classNameSet: any = {};
+  const classNameSet: IProcessedStyleSet<any> = { subComponentStyles: {} };
   const classMap: { [key: string]: string } = {};
 
   const styleSet = styleSets[0];
 
   if (!styleSet && styleSets.length <= 1) {
-    return {};
+    return { subComponentStyles: {} };
   }
 
   let concatenatedStyleSet: IConcatenatedStyleSet<any> | IStyleSet<any> =
@@ -117,7 +117,7 @@ export function mergeStyleSets(
   for (const styleSetArea in concatenatedStyleSet) {
     if (concatenatedStyleSet.hasOwnProperty(styleSetArea)) {
       if (styleSetArea === 'subComponentStyles') {
-        classNameSet.subComponentStyles = concatenatedStyleSet.subComponentStyles;
+        classNameSet.subComponentStyles = (concatenatedStyleSet as IConcatenatedStyleSet<any>).subComponentStyles || {};
         continue;
       }
 
@@ -130,7 +130,8 @@ export function mergeStyleSets(
 
       if (registration) {
         classMap[styleSetArea] = registration.className;
-        classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
+        // as any cast not needed in ts >=2.9
+        (classNameSet as any)[styleSetArea] = classes.concat([registration.className]).join(' ');
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -39,7 +39,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
   private _id: string;
   private _min: number;
   private _labelId: string;
-  private _classNames: { [key in keyof IRatingStyles]: string };
+  private _classNames: IProcessedStyleSet<IRatingStyles>;
 
   constructor(props: IRatingProps) {
     super(props);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Consumers no longer have to do a nullability check and can do `<Label styles={this._classNames.subComponentStyles.label} />` for instance without having to check for undefined or use `!`.


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5710)

