### PR TITLE
SelectionZone, ExtendedPicker: fixes around tabbing

### DIFF
--- a/common/changes/office-ui-fabric-react/amyngu-fixExtendedPickerTabbing_2018-07-30-16-04.json
+++ b/common/changes/office-ui-fabric-react/amyngu-fixExtendedPickerTabbing_2018-07-30-16-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Expose FocusZoneProps on ExtendedBasePicker",
+      "comment": "Fix SelectionZone selectToIndex with Ctrl_Tab, expose FocusZoneProps on ExtendedBasePicker",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/amyngu-fixExtendedPickerTabbing_2018-07-30-16-04.json
+++ b/common/changes/office-ui-fabric-react/amyngu-fixExtendedPickerTabbing_2018-07-30-16-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fix SelectionZone selectToIndex with Ctrl_Tab, expose FocusZoneProps on ExtendedBasePicker",
+      "comment": "Fix SelectionZone selectToIndex with Shift+Tab, expose FocusZoneProps on ExtendedBasePicker",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/amyngu-fixExtendedPickerTabbing_2018-07-30-16-04.json
+++ b/common/changes/office-ui-fabric-react/amyngu-fixExtendedPickerTabbing_2018-07-30-16-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Expose FocusZoneProps on ExtendedBasePicker",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "amyngu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -6,7 +6,7 @@ import * as stylesImport from './BaseExtendedPicker.scss';
 import { IBaseExtendedPickerProps, IBaseExtendedPicker } from './BaseExtendedPicker.types';
 import { IBaseFloatingPickerProps, BaseFloatingPicker } from '../../FloatingPicker';
 import { BaseSelectedItemsList, IBaseSelectedItemsListProps } from '../../SelectedItemsList';
-import { FocusZone, FocusZoneDirection } from '../../FocusZone';
+import { FocusZone, FocusZoneDirection, FocusZoneTabbableElements } from '../../FocusZone';
 import { Selection, SelectionMode, SelectionZone } from '../../Selection';
 // tslint:disable-next-line:no-any
 const styles: any = stylesImport;
@@ -103,10 +103,10 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
         onKeyDown={this.onBackspace}
         onCopy={this.onCopy}
       >
-        <FocusZone direction={FocusZoneDirection.bidirectional}>
+        <FocusZone direction={FocusZoneDirection.bidirectional} handleTabKey={FocusZoneTabbableElements.all}>
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
             <div className={css('ms-BasePicker-text', styles.pickerText)} role={'list'}>
-              {this.props.headerComponent}
+              {this.renderHeader()}
               {this.renderSelectedItemsList()}
               {this.canAddItems() && (
                 <Autofill
@@ -134,6 +134,14 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
         {this.renderSuggestions()}
       </div>
     );
+  }
+
+  protected renderHeader(): JSX.Element | null {
+    return this.props.headerComponent ? (
+      <div data-is-focusable={true} onFocus={this._onHeaderItemFocus}>
+        {this.props.headerComponent}
+      </div>
+    ) : null;
   }
 
   protected onSelectionChange = (): void => {
@@ -292,4 +300,8 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
 
     this.focus();
   }
+
+  private _onHeaderItemFocus = () => {
+    this.selection.setAllSelected(false /*isAllSelected*/);
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -103,10 +103,14 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
         onKeyDown={this.onBackspace}
         onCopy={this.onCopy}
       >
-        <FocusZone direction={FocusZoneDirection.bidirectional} handleTabKey={FocusZoneTabbableElements.all}>
+        <FocusZone
+          direction={FocusZoneDirection.bidirectional}
+          shouldInputLoseFocusOnArrowKey={this._shouldInputLoseFocusOnArrowKey}
+          handleTabKey={FocusZoneTabbableElements.all}
+        >
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
             <div className={css('ms-BasePicker-text', styles.pickerText)} role={'list'}>
-              {this.renderHeader()}
+              {this.props.headerComponent}
               {this.renderSelectedItemsList()}
               {this.canAddItems() && (
                 <Autofill
@@ -134,14 +138,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
         {this.renderSuggestions()}
       </div>
     );
-  }
-
-  protected renderHeader(): JSX.Element | null {
-    return this.props.headerComponent ? (
-      <div data-is-focusable={true} onFocus={this._onHeaderItemFocus}>
-        {this.props.headerComponent}
-      </div>
-    ) : null;
   }
 
   protected onSelectionChange = (): void => {
@@ -301,7 +297,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     this.focus();
   }
 
-  private _onHeaderItemFocus = () => {
-    this.selection.setAllSelected(false /*isAllSelected*/);
-  };
+  private _shouldInputLoseFocusOnArrowKey() {
+    return true;
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -6,7 +6,7 @@ import * as stylesImport from './BaseExtendedPicker.scss';
 import { IBaseExtendedPickerProps, IBaseExtendedPicker } from './BaseExtendedPicker.types';
 import { IBaseFloatingPickerProps, BaseFloatingPicker } from '../../FloatingPicker';
 import { BaseSelectedItemsList, IBaseSelectedItemsListProps } from '../../SelectedItemsList';
-import { FocusZone, FocusZoneDirection, FocusZoneTabbableElements } from '../../FocusZone';
+import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { Selection, SelectionMode, SelectionZone } from '../../Selection';
 // tslint:disable-next-line:no-any
 const styles: any = stylesImport;
@@ -90,7 +90,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
   }
 
   public render(): JSX.Element {
-    const { className, inputProps, disabled } = this.props;
+    const { className, inputProps, disabled, focusZoneProps } = this.props;
     const activeDescendant =
       this.floatingPicker.current && this.floatingPicker.current.currentSelectedSuggestionIndex !== -1
         ? 'sug-' + this.floatingPicker.current.currentSelectedSuggestionIndex
@@ -103,11 +103,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
         onKeyDown={this.onBackspace}
         onCopy={this.onCopy}
       >
-        <FocusZone
-          direction={FocusZoneDirection.bidirectional}
-          shouldInputLoseFocusOnArrowKey={this._shouldInputLoseFocusOnArrowKey}
-          handleTabKey={FocusZoneTabbableElements.all}
-        >
+        <FocusZone direction={FocusZoneDirection.bidirectional} {...focusZoneProps}>
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
             <div className={css('ms-BasePicker-text', styles.pickerText)} role={'list'}>
               {this.props.headerComponent}
@@ -295,9 +291,5 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     }
 
     this.focus();
-  }
-
-  private _shouldInputLoseFocusOnArrowKey() {
-    return true;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -4,6 +4,7 @@ import { IInputProps } from '../../Pickers';
 import { IBaseFloatingPickerProps } from '../../FloatingPicker';
 import { IBaseSelectedItemsListProps } from '../../SelectedItemsList';
 import { IRefObject } from '../../Utilities';
+import { IFocusZoneProps } from '../../FocusZone';
 
 export interface IBaseExtendedPicker<T> {
   /** Forces the picker to resolve */
@@ -121,4 +122,9 @@ export interface IBaseExtendedPickerProps<T> {
    * If using as a controlled component use suggestionItems here instead of FloatingPicker
    */
   suggestionItems?: T[];
+
+  /**
+   * Focus zone props
+   */
+  focusZoneProps?: IFocusZoneProps;
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
@@ -196,7 +196,7 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
   };
 
   private _renderHeader(): JSX.Element {
-    return <div>TO:</div>;
+    return <div data-is-focusable={true}>TO:</div>;
   }
 
   private _onRenderFloatingPicker(props: IBaseFloatingPickerProps<IPersonaProps>): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
@@ -20,6 +20,7 @@ import {
   IExtendedPersonaProps
 } from '../../SelectedItemsList';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
 
 import * as stylesImport from './ExtendedPeoplePicker.Basic.Example.scss';
 // tslint:disable-next-line:no-any
@@ -39,6 +40,7 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
   private _picker: ExtendedPeoplePicker;
   private _floatingPickerProps: IBaseFloatingPickerProps<IPersonaProps>;
   private _selectedItemsListProps: ISelectedPeopleProps;
+  private _focusZoneProps: IFocusZoneProps;
   private _suggestionProps: IBaseFloatingPickerSuggestionProps;
 
   constructor(props: {}) {
@@ -155,6 +157,11 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
       onRenderFloatingPicker: this._onRenderFloatingPicker,
       floatingPickerProps: this._floatingPickerProps
     };
+
+    this._focusZoneProps = {
+      shouldInputLoseFocusOnArrowKey: this._shouldInputLoseFocusOnArrowKey,
+      handleTabKey: FocusZoneTabbableElements.all
+    };
   }
 
   public render(): JSX.Element {
@@ -187,6 +194,7 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
         }}
         componentRef={this._setComponentRef}
         headerComponent={this._renderHeader()}
+        focusZoneProps={this._focusZoneProps}
       />
     );
   }
@@ -377,5 +385,9 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
       default:
         return [];
     }
+  }
+
+  private _shouldInputLoseFocusOnArrowKey(): boolean {
+    return true;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
@@ -12,15 +12,15 @@ import {
   FloatingPeoplePicker,
   IBaseFloatingPickerProps,
   IBaseFloatingPickerSuggestionProps
-} from '../../FloatingPicker';
+} from 'office-ui-fabric-react/lib/FloatingPicker';
 import {
   IBaseSelectedItemsListProps,
   ISelectedPeopleProps,
   SelectedPeopleList,
   IExtendedPersonaProps
-} from '../../SelectedItemsList';
+} from 'office-ui-fabric-react/lib/SelectedItemsList';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
-import { IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
+import { IFocusZoneProps, FocusZoneTabbableElements } from 'office-ui-fabric-react/lib/FocusZone';
 
 import * as stylesImport from './ExtendedPeoplePicker.Basic.Example.scss';
 // tslint:disable-next-line:no-any

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -33,8 +33,13 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
           className="ms-BasePicker-text"
           role="list"
         >
-          <div>
-            TO:
+          <div
+            data-is-focusable={true}
+            onFocus={[Function]}
+          >
+            <div>
+              TO:
+            </div>
           </div>
           <input
             aria-activedescendant={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -35,11 +35,8 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
         >
           <div
             data-is-focusable={true}
-            onFocus={[Function]}
           >
-            <div>
-              TO:
-            </div>
+            TO:
           </div>
           <input
             aria-activedescendant={undefined}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -65,6 +65,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   private _isCtrlPressed: boolean;
   private _isShiftPressed: boolean;
   private _isMetaPressed: boolean;
+  private _isTabPressed: boolean;
   private _shouldHandleFocus: boolean;
   private _shouldHandleFocusTimeoutId: number | undefined;
   private _isTouch: boolean;
@@ -465,7 +466,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     const selectionMode = this._getSelectionMode();
 
     if (selectionMode === SelectionMode.multiple) {
-      if (this._isShiftPressed) {
+      if (this._isShiftPressed && !this._isTabPressed) {
         selection.selectToIndex(index, !isToggleModifierPressed);
       } else if (isToggleModifierPressed) {
         selection.toggleIndexSelected(index);
@@ -521,6 +522,9 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     this._isShiftPressed = ev.shiftKey;
     this._isCtrlPressed = ev.ctrlKey;
     this._isMetaPressed = ev.metaKey;
+
+    const keyCode = (ev as React.KeyboardEvent<HTMLElement>).keyCode;
+    this._isTabPressed = keyCode ? keyCode === KeyCodes.tab : false;
   }
 
   private _findItemRoot(target: HTMLElement): HTMLElement | undefined {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes
- Expose FocusZoneProps on ExtendedBasePicker to allow consumer to have more control over focus/tab handling
- Change SelectionZone to not selectToIndex when using SHIFT+Tab
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5720)

