### PR TITLE
Shimmer: change prop use of subcomponents Line, Circle and Gap.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-ShimmerPropDeprecation_2018-07-31-18-23.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ShimmerPropDeprecation_2018-07-31-18-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Deprecating 'borderStyle' prop of Shimmer subcomponents Line, Circle, Gap in favor of leveraging mergeStyles API.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
@@ -12,12 +12,11 @@ export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
-  const styles: IRawStyle = !!borderStyle ? borderStyle : {};
+  const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
 
   return {
     root: [
       classNames.root,
-      styles,
       {
         width: `${height}px`,
         height: `${height}px`,
@@ -31,7 +30,8 @@ export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles
             borderColor: 'Window'
           }
         }
-      }
+      },
+      borderStyles
     ],
     svg: [
       classNames.svg,

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
@@ -10,13 +10,13 @@ export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles
   const { height, borderStyle, theme } = props;
 
   const { palette } = theme;
-  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+  const globalClassNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
 
   return {
     root: [
-      classNames.root,
+      globalClassNames.root,
       {
         width: `${height}px`,
         height: `${height}px`,
@@ -34,7 +34,7 @@ export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles
       borderStyles
     ],
     svg: [
-      classNames.svg,
+      globalClassNames.svg,
       {
         display: 'block',
         fill: palette.white,

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.types.ts
@@ -21,11 +21,6 @@ export interface IShimmerCircleProps extends React.AllHTMLAttributes<HTMLElement
   height?: number;
 
   /**
-   * Used to
-   */
-  borderStyle?: IRawStyle;
-
-  /**
    * Theme provided by High-Order Component.
    */
   theme?: ITheme;
@@ -34,6 +29,12 @@ export interface IShimmerCircleProps extends React.AllHTMLAttributes<HTMLElement
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IShimmerCircleStyleProps, IShimmerCircleStyles>;
+
+  /**
+   * Use to set custom styling of the shimmerCircle borders.
+   * @deprecated Use 'styles' prop to leverage mergeStyle API.
+   */
+  borderStyle?: IRawStyle;
 }
 
 export interface IShimmerCircleStyleProps {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.types.ts
@@ -37,13 +37,38 @@ export interface IShimmerCircleProps extends React.AllHTMLAttributes<HTMLElement
   borderStyle?: IRawStyle;
 }
 
-export interface IShimmerCircleStyleProps {
-  height?: number;
-  borderStyle?: IRawStyle;
+/**
+ * Props needed to construct styles.
+ */
+export type IShimmerCircleStyleProps = {
+  /**
+   * Theme values passed to the component.
+   */
   theme: ITheme;
-}
 
+  /**
+   * Needed to provide a height to the root of the control.
+   */
+  height?: number;
+
+  /**
+   * Styles to override borderStyles with custom ones.
+   * @deprecated in favor of mergeStyles API.
+   */
+  borderStyle?: IRawStyle;
+};
+
+/**
+ * Represents the stylable areas of the control.
+ */
 export interface IShimmerCircleStyles {
+  /**
+   * Root of the ShimmerCircle component.
+   */
   root?: IStyle;
+
+  /**
+   * Style for the circle SVG of the ShimmerCircle component.
+   */
   svg?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
@@ -8,8 +8,11 @@ import {
 import { IRawStyle } from '../../../Styling';
 import { ShimmerElementType, ShimmerElementsDefaultHeights, IShimmerElement } from '../Shimmer.types';
 import { ShimmerLine } from '../ShimmerLine/ShimmerLine';
+import { IShimmerLineStyles } from '../ShimmerLine/ShimmerLine.types';
 import { ShimmerGap } from '../ShimmerGap/ShimmerGap';
+import { IShimmerGapStyles } from '../ShimmerGap/ShimmerGap.types';
 import { ShimmerCircle } from '../ShimmerCircle/ShimmerCircle';
+import { IShimmerCircleStyles } from '../ShimmerCircle/ShimmerCircle.types';
 
 const getClassNames = classNamesFunction<IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles>();
 
@@ -49,24 +52,25 @@ export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGrou
           const { type, ...filteredElem } = elem;
           switch (elem.type) {
             case ShimmerElementType.circle:
-              return (
-                <ShimmerCircle key={index} {...filteredElem} borderStyle={this._getBorderStyles(elem, rowHeight)} />
-              );
+              return <ShimmerCircle key={index} {...filteredElem} styles={this._getBorderStyles(elem, rowHeight)} />;
             case ShimmerElementType.gap:
-              return <ShimmerGap key={index} {...filteredElem} borderStyle={this._getBorderStyles(elem, rowHeight)} />;
+              return <ShimmerGap key={index} {...filteredElem} styles={this._getBorderStyles(elem, rowHeight)} />;
             case ShimmerElementType.line:
-              return <ShimmerLine key={index} {...filteredElem} borderStyle={this._getBorderStyles(elem, rowHeight)} />;
+              return <ShimmerLine key={index} {...filteredElem} styles={this._getBorderStyles(elem, rowHeight)} />;
           }
         }
       )
     ) : (
-      <ShimmerLine height={ShimmerElementsDefaultHeights.line} />
+      <ShimmerLine height={ShimmerElementsDefaultHeights.line} styles={{ root: [{ borderWidth: '0px' }] }} />
     );
 
     return renderedElements;
   };
 
-  private _getBorderStyles = (elem: IShimmerElement, rowHeight?: number): IRawStyle | undefined => {
+  private _getBorderStyles = (
+    elem: IShimmerElement,
+    rowHeight?: number
+  ): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles => {
     const elemHeight: number | undefined = elem.height;
     const dif: number = rowHeight && elemHeight ? rowHeight - elemHeight : 0;
 
@@ -89,7 +93,9 @@ export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGrou
       };
     }
 
-    return borderStyle;
+    return {
+      root: [{ ...borderStyle }]
+    };
   };
 
   /**

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.styles.ts
@@ -9,13 +9,13 @@ export function getStyles(props: IShimmerGapStyleProps): IShimmerGapStyles {
   const { height, borderStyle, theme } = props;
 
   const { palette } = theme;
-  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+  const globalClassNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
 
   return {
     root: [
-      classNames.root,
+      globalClassNames.root,
       {
         backgroundColor: palette.white,
         height: `${height}px`,

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.styles.ts
@@ -11,12 +11,11 @@ export function getStyles(props: IShimmerGapStyleProps): IShimmerGapStyles {
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
-  const styles: IRawStyle = !!borderStyle ? borderStyle : {};
+  const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
 
   return {
     root: [
       classNames.root,
-      styles,
       {
         backgroundColor: palette.white,
         height: `${height}px`,
@@ -30,7 +29,8 @@ export function getStyles(props: IShimmerGapStyleProps): IShimmerGapStyles {
             borderColor: 'Window'
           }
         }
-      }
+      },
+      borderStyles
     ]
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.types.ts
@@ -27,11 +27,6 @@ export interface IShimmerGapProps extends React.AllHTMLAttributes<HTMLElement> {
   width?: number | string;
 
   /**
-   * Sets custom styling of the gap.
-   */
-  borderStyle?: IRawStyle;
-
-  /**
    * Theme provided by High-Order Component.
    */
   theme?: ITheme;
@@ -40,6 +35,12 @@ export interface IShimmerGapProps extends React.AllHTMLAttributes<HTMLElement> {
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IShimmerGapStyleProps, IShimmerGapStyles>;
+
+  /**
+   * Use to set custom styling of the shimmerGap borders.
+   * @deprecated Use 'styles' prop to leverage mergeStyle API.
+   */
+  borderStyle?: IRawStyle;
 }
 
 export interface IShimmerGapStyleProps {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.types.ts
@@ -43,12 +43,33 @@ export interface IShimmerGapProps extends React.AllHTMLAttributes<HTMLElement> {
   borderStyle?: IRawStyle;
 }
 
-export interface IShimmerGapStyleProps {
-  height?: number;
-  borderStyle?: IRawStyle;
+/**
+ * Props needed to construct styles.
+ */
+export type IShimmerGapStyleProps = {
+  /**
+   * Theme values passed to the component.
+   */
   theme: ITheme;
-}
 
+  /**
+   * Needed to provide a height to the root of the control.
+   */
+  height?: number;
+
+  /**
+   * Styles to override borderStyles with custom ones.
+   * @deprecated in favor of mergeStyles API.
+   */
+  borderStyle?: IRawStyle;
+};
+
+/**
+ * Represents the stylable areas of the control.
+ */
 export interface IShimmerGapStyles {
+  /**
+   * Root of the ShimmerGap component.
+   */
   root?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
@@ -15,7 +15,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
-  const borderStyles: IRawStyle = !!borderStyle ? borderStyle : { borderWidth: '0px' };
+  const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
 
   const sharedCornerStyles: IRawStyle = {
     position: 'absolute',

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
@@ -15,7 +15,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
-  const styles: IRawStyle = !!borderStyle ? borderStyle : { borderWidth: '0px' };
+  const borderStyles: IRawStyle = !!borderStyle ? borderStyle : { borderWidth: '0px' };
 
   const sharedCornerStyles: IRawStyle = {
     position: 'absolute',
@@ -25,7 +25,6 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
   return {
     root: [
       classNames.root,
-      styles,
       {
         height: `${height}px`,
         boxSizing: 'content-box',
@@ -43,7 +42,8 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
             }
           }
         }
-      }
+      },
+      borderStyles
     ],
     topLeftCorner: [
       classNames.topLeftCorner,

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
@@ -13,7 +13,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
   const { height, borderStyle, theme } = props;
 
   const { palette } = theme;
-  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+  const globalClassNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
 
@@ -24,7 +24,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
 
   return {
     root: [
-      classNames.root,
+      globalClassNames.root,
       {
         height: `${height}px`,
         boxSizing: 'content-box',
@@ -46,7 +46,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
       borderStyles
     ],
     topLeftCorner: [
-      classNames.topLeftCorner,
+      globalClassNames.topLeftCorner,
       {
         top: '0',
         left: '0'
@@ -54,7 +54,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
       sharedCornerStyles
     ],
     topRightCorner: [
-      classNames.topRightCorner,
+      globalClassNames.topRightCorner,
       {
         top: '0',
         right: '0'
@@ -62,7 +62,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
       sharedCornerStyles
     ],
     bottomRightCorner: [
-      classNames.bottomRightCorner,
+      globalClassNames.bottomRightCorner,
       {
         bottom: '0',
         right: '0'
@@ -70,7 +70,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
       sharedCornerStyles
     ],
     bottomLeftCorner: [
-      classNames.bottomLeftCorner,
+      globalClassNames.bottomLeftCorner,
       {
         bottom: '0',
         left: '0'

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.types.ts
@@ -43,16 +43,53 @@ export interface IShimmerLineProps extends React.AllHTMLAttributes<HTMLElement> 
   borderStyle?: IRawStyle;
 }
 
-export interface IShimmerLineStyleProps {
-  height?: number;
-  borderStyle?: IRawStyle;
+/**
+ * Props needed to construct styles.
+ */
+export type IShimmerLineStyleProps = {
+  /**
+   * Theme values passed to the component.
+   */
   theme: ITheme;
-}
 
+  /**
+   * Needed to provide a height to the root of the control.
+   */
+  height?: number;
+
+  /**
+   * Styles to override borderStyles with custom ones.
+   * @deprecated in favor of mergeStyles API.
+   */
+  borderStyle?: IRawStyle;
+};
+
+/**
+ * Represents the stylable areas of the control.
+ */
 export interface IShimmerLineStyles {
+  /**
+   * Root of the ShimmerLine component.
+   */
   root?: IStyle;
+
+  /**
+   * Top-left corner SVG of the ShimmerLine component.
+   */
   topLeftCorner?: IStyle;
+
+  /**
+   * Top-right corner SVG of the ShimmerLine component.
+   */
   topRightCorner?: IStyle;
+
+  /**
+   * Bottom-right corner SVG of the ShimmerLine component.
+   */
   bottomRightCorner?: IStyle;
+
+  /**
+   * Bottom-left corner SVG of the ShimmerLine component.
+   */
   bottomLeftCorner?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.types.ts
@@ -27,11 +27,6 @@ export interface IShimmerLineProps extends React.AllHTMLAttributes<HTMLElement> 
   width?: number | string;
 
   /**
-   * Sets custom styling of the rectangle.
-   */
-  borderStyle?: IRawStyle;
-
-  /**
    * Theme provided by High-Order Component.
    */
   theme?: ITheme;
@@ -40,6 +35,12 @@ export interface IShimmerLineProps extends React.AllHTMLAttributes<HTMLElement> 
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IShimmerLineStyleProps, IShimmerLineStyles>;
+
+  /**
+   * Use to set custom styling of the shimmerLine borders.
+   * @deprecated Use 'styles' prop to leverage mergeStyle API.
+   */
+  borderStyle?: IRawStyle;
 }
 
 export interface IShimmerLineStyleProps {


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

Removing use of borderStyle prop of Shimmer subcomponents in favor of using mergeStyles API.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5739)

