### PR TITLE
Restore ARIA labeling for DetailsList column headers and status values

### DIFF
--- a/common/changes/office-ui-fabric-react/details-aria-labels_2018-07-31-18-45.json
+++ b/common/changes/office-ui-fabric-react/details-aria-labels_2018-07-31-18-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Restore accessible labels for DetailsList columns and states",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
@@ -55,7 +55,7 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
             headerClassNames.cell,
             column.headerClassName,
             column.columnActionsMode !== ColumnActionsMode.disabled &&
-            'is-actionable ' + headerClassNames.cellIsActionable,
+              'is-actionable ' + headerClassNames.cellIsActionable,
             !column.name && 'is-empty ' + headerClassNames.cellIsEmpty,
             (column.isSorted || column.isGrouped || column.isFiltered) && 'is-icon-visible',
             column.isPadded && headerClassNames.cellWrapperPadded
@@ -82,7 +82,7 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
                   data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
                   role={column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined}
                   aria-describedby={
-                    this.props.onRenderColumnHeaderTooltip || column.ariaLabel
+                    this.props.onRenderColumnHeaderTooltip || this._hasAccessibleLabel()
                       ? `${parentId}-${column.key}-tooltip`
                       : undefined
                   }
@@ -103,32 +103,23 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
                       />
                     )}
 
-                    <span className={column.isIconOnly ? headerClassNames.accessibleLabel : undefined}>
-                      {column.name}
-                    </span>
+                    {column.isIconOnly ? (
+                      <span className={headerClassNames.accessibleLabel}>{column.name}</span>
+                    ) : (
+                      column.name
+                    )}
                   </span>
 
-                  {column.isFiltered && (
-                    <Icon ariaLabel={column.filterAriaLabel} className={headerClassNames.nearIcon} iconName={'Filter'} />
-                  )}
+                  {column.isFiltered && <Icon className={headerClassNames.nearIcon} iconName={'Filter'} />}
 
                   {column.isSorted && (
                     <Icon
-                      ariaLabel={
-                        column.isSortedDescending ? column.sortDescendingAriaLabel : column.sortAscendingAriaLabel
-                      }
                       className={css(headerClassNames.nearIcon, headerClassNames.sortIcon)}
                       iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'}
                     />
                   )}
 
-                  {column.isGrouped && (
-                    <Icon
-                      ariaLabel={column.groupAriaLabel}
-                      className={headerClassNames.nearIcon}
-                      iconName={'GroupedDescending'}
-                    />
-                  )}
+                  {column.isGrouped && <Icon className={headerClassNames.nearIcon} iconName={'GroupedDescending'} />}
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
                     !column.isIconOnly && (
@@ -140,15 +131,7 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
             this._onRenderColumnHeaderTooltip
           )}
         </div>
-        {column.ariaLabel && !this.props.onRenderColumnHeaderTooltip ? (
-          <label
-            key={`${column.key}_label`}
-            id={`${parentId}-${column.key}-tooltip`}
-            className={headerClassNames.accessibleLabel}
-          >
-            {column.ariaLabel}
-          </label>
-        ) : null}
+        {!this.props.onRenderColumnHeaderTooltip ? this._renderAccessibleLabel() : null}
       </>
     );
   }
@@ -239,6 +222,37 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
       onDragEnd: this._onDragEnd
     };
     return options;
+  }
+
+  private _hasAccessibleLabel(): boolean {
+    const { column } = this.props;
+
+    return !!(
+      column.ariaLabel ||
+      column.filterAriaLabel ||
+      column.sortAscendingAriaLabel ||
+      column.sortDescendingAriaLabel ||
+      column.groupAriaLabel
+    );
+  }
+
+  private _renderAccessibleLabel(): JSX.Element | null {
+    const { column, parentId, headerClassNames } = this.props;
+
+    return this._hasAccessibleLabel() && !this.props.onRenderColumnHeaderTooltip ? (
+      <label
+        key={`${column.key}_label`}
+        id={`${parentId}-${column.key}-tooltip`}
+        className={headerClassNames.accessibleLabel}
+      >
+        {column.ariaLabel}
+        {(column.isFiltered && column.filterAriaLabel) || null}
+        {(column.isSorted &&
+          (column.isSortedDescending ? column.sortDescendingAriaLabel : column.sortAscendingAriaLabel)) ||
+          null}
+        {(column.isGrouped && column.groupAriaLabel) || null}
+      </label>
+    ) : null;
   }
 
   private _onDragStart(item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent): void {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
@@ -55,7 +55,7 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
             headerClassNames.cell,
             column.headerClassName,
             column.columnActionsMode !== ColumnActionsMode.disabled &&
-              'is-actionable ' + headerClassNames.cellIsActionable,
+            'is-actionable ' + headerClassNames.cellIsActionable,
             !column.name && 'is-empty ' + headerClassNames.cellIsEmpty,
             (column.isSorted || column.isGrouped || column.isFiltered) && 'is-icon-visible',
             column.isPadded && headerClassNames.cellWrapperPadded
@@ -82,7 +82,9 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
                   data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
                   role={column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined}
                   aria-describedby={
-                    this.props.onRenderColumnHeaderTooltip ? `${parentId}-${column.key}-tooltip` : undefined
+                    this.props.onRenderColumnHeaderTooltip || column.ariaLabel
+                      ? `${parentId}-${column.key}-tooltip`
+                      : undefined
                   }
                   onContextMenu={this._onColumnContextMenu.bind(this, column)}
                   onClick={this._onColumnClick.bind(this, column)}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.tsx
@@ -103,22 +103,37 @@ export class DetailsColumn extends BaseComponent<IDetailsColumnProps> {
                       />
                     )}
 
-                    {!column.isIconOnly ? column.name : undefined}
+                    <span className={column.isIconOnly ? headerClassNames.accessibleLabel : undefined}>
+                      {column.name}
+                    </span>
                   </span>
 
-                  {column.isFiltered && <Icon className={headerClassNames.nearIcon} iconName={'Filter'} />}
+                  {column.isFiltered && (
+                    <Icon ariaLabel={column.filterAriaLabel} className={headerClassNames.nearIcon} iconName={'Filter'} />
+                  )}
 
                   {column.isSorted && (
                     <Icon
+                      ariaLabel={
+                        column.isSortedDescending ? column.sortDescendingAriaLabel : column.sortAscendingAriaLabel
+                      }
                       className={css(headerClassNames.nearIcon, headerClassNames.sortIcon)}
                       iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'}
                     />
                   )}
 
-                  {column.isGrouped && <Icon className={headerClassNames.nearIcon} iconName={'GroupedDescending'} />}
+                  {column.isGrouped && (
+                    <Icon
+                      ariaLabel={column.groupAriaLabel}
+                      className={headerClassNames.nearIcon}
+                      iconName={'GroupedDescending'}
+                    />
+                  )}
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
-                    !column.isIconOnly && <Icon className={headerClassNames.filterChevron} iconName={'ChevronDown'} />}
+                    !column.isIconOnly && (
+                      <Icon aria-hidden={true} className={headerClassNames.filterChevron} iconName={'ChevronDown'} />
+                    )}
                 </span>
               )
             },

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -108,4 +108,50 @@ describe('DetailsHeader', () => {
     header._onSizerMouseUp();
     expect(!!headerBase.state.isSizing).toBe(false);
   });
+
+  it('renders accessible labels', () => {
+    const columns: IColumn[] = [
+      { key: 'a', name: 'a', fieldName: 'a', minWidth: 200, maxWidth: 400, calculatedWidth: 200, isResizable: true },
+      {
+        key: 'b',
+        name: 'b',
+        fieldName: 'a',
+        minWidth: 200,
+        maxWidth: 400,
+        calculatedWidth: 200,
+        isResizable: true,
+        isSorted: true,
+        sortAscendingAriaLabel: 'Sorted up.',
+        sortDescendingAriaLabel: 'Sorted down.',
+        ariaLabel: 'Click to sort.'
+      },
+      {
+        key: 'c',
+        name: 'c',
+        fieldName: 'c',
+        minWidth: 10,
+        maxWidth: 100,
+        calculatedWidth: 10,
+        isResizable: true,
+        columnActionsMode: ColumnActionsMode.hasDropdown,
+        isIconOnly: false,
+        isFiltered: true,
+        filterAriaLabel: 'Filtered.',
+        isGrouped: true,
+        groupAriaLabel: 'Grouped.',
+        ariaLabel: 'Click to sort, filter, or group.'
+      }
+    ];
+
+    const component = renderer.create(
+      <DetailsHeader
+        selection={_selection}
+        selectionMode={SelectionMode.multiple}
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        columns={columns}
+      />
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -867,3 +867,961 @@ exports[`DetailsHeader can render 1`] = `
   />
 </div>
 `;
+
+exports[`DetailsHeader renders accessible labels 1`] = `
+<div
+  aria-describedby={undefined}
+  aria-label={undefined}
+  aria-labelledby={undefined}
+  className=
+      ms-FocusZone
+      ms-DetailsHeader
+      {
+        background: #ffffff;
+        border-bottom: 1px solid #c8c8c8;
+        box-sizing: content-box;
+        cursor: default;
+        display: inline-block;
+        height: 32px;
+        line-height: 32px;
+        min-width: 100%;
+        padding-bottom: 1px;
+        position: relative;
+        user-select: none;
+        vertical-align: top;
+        white-space: nowrap;
+      }
+      &:hover $check {
+        opacity: 1;
+      }
+      & ms-TooltipHost $checkTooltip {
+        display: block;
+      }
+  data-automationid="DetailsHeader"
+  data-focuszone-id="FocusZone5"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onMouseDownCapture={[Function]}
+  onMouseMove={[Function]}
+  role="row"
+  style={
+    Object {
+      "minWidth": 0,
+    }
+  }
+>
+  <div
+    aria-colindex={1}
+    aria-labelledby="header4-check"
+    className=
+        ms-DetailsHeader-cell
+        ms-DetailsHeader-cellIsCheck
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          border: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: inline-flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          height: 32px;
+          line-height: inherit;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          outline: transparent;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          text-align: left;
+          text-overflow: ellipsis;
+          vertical-align: top;
+          white-space: nowrap;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+    onClick={[Function]}
+    role="columnheader"
+  >
+    <span
+      className=
+
+
+    >
+      <div
+        aria-checked={undefined}
+        aria-describedby="header4-checkTooltip"
+        aria-label={undefined}
+        className=
+            ms-DetailsRow-check
+            ms-DetailsRow-check--isHeader
+            {
+              height: 32px;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              opacity: 1;
+            }
+            {
+              align-items: center;
+              background-color: transparent;
+              background: none;
+              border: none;
+              box-sizing: border-box;
+              cursor: default;
+              display: flex;
+              height: 32px;
+              justify-content: center;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              opacity: 0;
+              outline: transparent;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+              vertical-align: top;
+              width: 40px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:hover {
+              opacity: 1;
+            }
+
+        data-automationid="DetailsRowCheck"
+        data-is-focusable={true}
+        data-selection-toggle={true}
+        id="header4-check"
+        role="checkbox"
+      >
+        <div
+          className=
+              ms-Check
+              {
+                height: 18px;
+                line-height: 1;
+                position: relative;
+                user-select: none;
+                vertical-align: top;
+                width: 18px;
+              }
+              &:before {
+                background: #ffffff;
+                border-radius: 50%;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                opacity: 1;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+              }
+              $checkHost:hover &, $checkHost:focus &, &:hover, &:focus {
+                opacity: 1;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Check-circle
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 18px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: 0px;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+            data-icon-name="CircleRing"
+            role="presentation"
+          >
+            
+          </i>
+          <i
+            aria-hidden={true}
+            className=
+                ms-Check-check
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #c8c8c8;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 18px;
+                  left: .5px;
+                  opacity: 0;
+                  position: absolute;
+                  speak: none;
+                  text-align: center;
+                  top: 0px;
+                  vertical-align: middle;
+                  width: 18px;
+                }
+                &:hover {
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                }
+            data-icon-name="StatusCircleCheckmark"
+            role="presentation"
+          >
+            
+          </i>
+        </div>
+      </div>
+    </span>
+  </div>
+  <div
+    aria-colindex={2}
+    aria-sort="none"
+    className=
+        ms-DetailsHeader-cell
+        is-actionable
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          border: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          height: 32px;
+          line-height: inherit;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 8px;
+          padding-right: 8px;
+          padding-top: 0;
+          position: relative;
+          text-align: left;
+          text-overflow: ellipsis;
+          vertical-align: top;
+          white-space: nowrap;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        &:hover {
+          background: #f4f4f4;
+          color: #333333;
+        }
+        &:active {
+          background: #eaeaea;
+        }
+    data-automationid="ColumnsHeaderColumn"
+    data-is-draggable={false}
+    data-item-key="a"
+    draggable={false}
+    role="columnheader"
+    style={
+      Object {
+        "width": 216,
+      }
+    }
+  >
+    <span
+      className=
+
+          {
+            bottom: 0px;
+            display: block;
+            left: 0px;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+    >
+      <span
+        aria-describedby={undefined}
+        aria-haspopup={false}
+        aria-label={undefined}
+        aria-labelledby="header4-a-name "
+        className=
+            ms-DetailsHeader-cellTitle
+            {
+              align-items: stretch;
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              justify-content: flex-start;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+        data-is-focusable={true}
+        id="header4-a"
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        role="button"
+      >
+        <span
+          className=
+              ms-DetailsHeader-cellName
+              {
+                flex: 0 1 auto;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+          id="header4-a-name"
+        >
+          a
+        </span>
+      </span>
+    </span>
+  </div>
+  <div
+    aria-hidden={true}
+    className=
+        ms-DetailsHeader-cellSizer
+        {
+          background: transparent;
+          bottom: 0px;
+          cursor: ew-resize;
+          display: inline-block;
+          height: inherit;
+          outline: transparent;
+          overflow: hidden;
+          position: relative;
+          top: 0px;
+          width: 16px;
+          z-index: 1;
+        }
+        &::-moz-focus-inner {
+          border: 0px;
+        }
+        &:after {
+          background: #c8c8c8;
+          bottom: 0px;
+          content: "";
+          left: 50%;
+          opacity: 0;
+          position: absolute;
+          top: 0px;
+          width: 1px;
+        }
+        &:focus:after {
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        &:hover:after {
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        &$cellIsResizing:after {
+          box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        {
+          margin-bottom: 0;
+          margin-left: -8px;
+          margin-right: -8px;
+          margin-top: 0;
+        }
+    data-is-focusable={false}
+    data-sizer-index={0}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDoubleClick={[Function]}
+    role="button"
+  />
+  <div
+    aria-colindex={3}
+    aria-sort="ascending"
+    className=
+        ms-DetailsHeader-cell
+        is-actionable
+        is-icon-visible
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          border: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          height: 32px;
+          line-height: inherit;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 8px;
+          padding-right: 8px;
+          padding-top: 0;
+          position: relative;
+          text-align: left;
+          text-overflow: ellipsis;
+          vertical-align: top;
+          white-space: nowrap;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        &:hover {
+          background: #f4f4f4;
+          color: #333333;
+        }
+        &:active {
+          background: #eaeaea;
+        }
+    data-automationid="ColumnsHeaderColumn"
+    data-is-draggable={false}
+    data-item-key="b"
+    draggable={false}
+    role="columnheader"
+    style={
+      Object {
+        "width": 216,
+      }
+    }
+  >
+    <span
+      className=
+
+          {
+            bottom: 0px;
+            display: block;
+            left: 0px;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+    >
+      <span
+        aria-describedby="header4-b-tooltip"
+        aria-haspopup={false}
+        aria-label={undefined}
+        aria-labelledby="header4-b-name "
+        className=
+            ms-DetailsHeader-cellTitle
+            {
+              align-items: stretch;
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              justify-content: flex-start;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+        data-is-focusable={true}
+        id="header4-b"
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        role="button"
+      >
+        <span
+          className=
+              ms-DetailsHeader-cellName
+              {
+                flex: 0 1 auto;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+          id="header4-b-name"
+        >
+          b
+        </span>
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                padding-left: 4px;
+                position: relative;
+                speak: none;
+                top: 1px;
+              }
+          data-icon-name="SortUp"
+          role="presentation"
+        >
+          
+        </i>
+      </span>
+    </span>
+  </div>
+  <label
+    className=
+
+        {
+          border: 0px;
+          height: 1px;
+          margin-bottom: -1px;
+          margin-left: -1px;
+          margin-right: -1px;
+          margin-top: -1px;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: absolute;
+          width: 1px;
+        }
+    id="header4-b-tooltip"
+  >
+    Click to sort.
+    Sorted up.
+  </label>
+  <div
+    aria-hidden={true}
+    className=
+        ms-DetailsHeader-cellSizer
+        {
+          background: transparent;
+          bottom: 0px;
+          cursor: ew-resize;
+          display: inline-block;
+          height: inherit;
+          outline: transparent;
+          overflow: hidden;
+          position: relative;
+          top: 0px;
+          width: 16px;
+          z-index: 1;
+        }
+        &::-moz-focus-inner {
+          border: 0px;
+        }
+        &:after {
+          background: #c8c8c8;
+          bottom: 0px;
+          content: "";
+          left: 50%;
+          opacity: 0;
+          position: absolute;
+          top: 0px;
+          width: 1px;
+        }
+        &:focus:after {
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        &:hover:after {
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        &$cellIsResizing:after {
+          box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        {
+          margin-bottom: 0;
+          margin-left: -8px;
+          margin-right: -8px;
+          margin-top: 0;
+        }
+    data-is-focusable={false}
+    data-sizer-index={1}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDoubleClick={[Function]}
+    role="button"
+  />
+  <div
+    aria-colindex={4}
+    aria-sort="none"
+    className=
+        ms-DetailsHeader-cell
+        is-actionable
+        is-icon-visible
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          border: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          height: 32px;
+          line-height: inherit;
+          margin-bottom: 0;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 0;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 8px;
+          padding-right: 8px;
+          padding-top: 0;
+          position: relative;
+          text-align: left;
+          text-overflow: ellipsis;
+          vertical-align: top;
+          white-space: nowrap;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        &:hover {
+          background: #f4f4f4;
+          color: #333333;
+        }
+        &:active {
+          background: #eaeaea;
+        }
+    data-automationid="ColumnsHeaderColumn"
+    data-is-draggable={false}
+    data-item-key="c"
+    draggable={false}
+    role="columnheader"
+    style={
+      Object {
+        "width": 26,
+      }
+    }
+  >
+    <span
+      className=
+
+          {
+            bottom: 0px;
+            display: block;
+            left: 0px;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+    >
+      <span
+        aria-describedby="header4-c-tooltip"
+        aria-haspopup={true}
+        aria-label={undefined}
+        aria-labelledby="header4-c-name "
+        className=
+            ms-DetailsHeader-cellTitle
+            {
+              align-items: stretch;
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              justify-content: flex-start;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+        data-is-focusable={true}
+        id="header4-c"
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        role="button"
+      >
+        <span
+          className=
+              ms-DetailsHeader-cellName
+              {
+                flex: 0 1 auto;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+          id="header4-c-name"
+        >
+          c
+        </span>
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                padding-left: 8px;
+                speak: none;
+              }
+          data-icon-name="Filter"
+          role="presentation"
+        >
+          
+        </i>
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-6";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 1;
+                padding-left: 8px;
+                speak: none;
+              }
+          data-icon-name="GroupedDescending"
+          role="presentation"
+        >
+          
+        </i>
+        <i
+          aria-hidden={true}
+          className=
+              ms-DetailsHeader-filterChevron
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #a6a6a6;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                padding-left: 4px;
+                speak: none;
+                vertical-align: middle;
+              }
+          data-icon-name="ChevronDown"
+          role="presentation"
+        >
+          
+        </i>
+      </span>
+    </span>
+  </div>
+  <label
+    className=
+
+        {
+          border: 0px;
+          height: 1px;
+          margin-bottom: -1px;
+          margin-left: -1px;
+          margin-right: -1px;
+          margin-top: -1px;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: absolute;
+          width: 1px;
+        }
+    id="header4-c-tooltip"
+  >
+    Click to sort, filter, or group.
+    Filtered.
+    Grouped.
+  </label>
+  <div
+    aria-hidden={true}
+    className=
+        ms-DetailsHeader-cellSizer
+        {
+          background: transparent;
+          bottom: 0px;
+          cursor: ew-resize;
+          display: inline-block;
+          height: inherit;
+          outline: transparent;
+          overflow: hidden;
+          position: relative;
+          top: 0px;
+          width: 16px;
+          z-index: 1;
+        }
+        &::-moz-focus-inner {
+          border: 0px;
+        }
+        &:after {
+          background: #c8c8c8;
+          bottom: 0px;
+          content: "";
+          left: 50%;
+          opacity: 0;
+          position: absolute;
+          top: 0px;
+          width: 1px;
+        }
+        &:focus:after {
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        &:hover:after {
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        &$cellIsResizing:after {
+          box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+          opacity: 1;
+          transition: opacity 0.3s linear;
+        }
+        {
+          margin-bottom: 0px;
+          margin-left: -16px;
+          margin-right: 0px;
+          margin-top: 0px;
+        }
+    data-is-focusable={false}
+    data-sizer-index={2}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDoubleClick={[Function]}
+    role="button"
+  />
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -100,6 +100,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         headerClassName: 'DetailsListExample-header--FileIcon',
         className: 'DetailsListExample-cell--FileIcon',
         iconClassName: 'DetailsListExample-Header-FileTypeIcon',
+        ariaLabel: 'Column operations for File type',
         iconName: 'Page',
         isIconOnly: true,
         fieldName: 'name',
@@ -120,6 +121,8 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         isResizable: true,
         isSorted: true,
         isSortedDescending: false,
+        sortAscendingAriaLabel: 'Sorted A to Z',
+        sortDescendingAriaLabel: 'Sorted Z to A',
         onColumnClick: this._onColumnClick,
         data: 'string',
         isPadded: true


### PR DESCRIPTION
# Overview

This change restores changes to `DetailsColumn` which were inadvertently reverting during drag/drop refactor work. In addition, this change improves upon the original ARIA labeling behavior by ensuring that all labels use `aria-describedby` so they are announced by readers after the column names automatically, and only when focus is within the column headers.

Added a unit test for aria labeling so they don't get removed again.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5740)

