### PR TITLE
Check: now reflects theme changes.

### DIFF
--- a/common/changes/office-ui-fabric-react/check_2018-07-31-22-13.json
+++ b/common/changes/office-ui-fabric-react/check_2018-07-31-22-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Check: shouldComponentUpdate now resepects theme and classname changes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Check/Check.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.base.tsx
@@ -14,7 +14,11 @@ export class CheckBase extends BaseComponent<ICheckProps, {}> {
   };
 
   public shouldComponentUpdate(newProps: ICheckProps): boolean {
-    return this.props.checked !== newProps.checked;
+    return (
+      this.props.checked !== newProps.checked ||
+      this.props.theme !== newProps.theme ||
+      this.props.className !== newProps.className
+    );
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
The `shouldComponentUpdate` method was not recomputing styles when a new theme was provided.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5750)

