### PR TITLE
Color picker losing value

### DIFF
--- a/common/changes/office-ui-fabric-react/color-picker-losing-value_2018-07-31-22-58.json
+++ b/common/changes/office-ui-fabric-react/color-picker-losing-value_2018-07-31-22-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing an issue where ColorPicker would report invalid color values when tabbing between its Hex and RGBA text inputs.\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "lolynn@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -166,16 +166,22 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
   };
 
   private _onHexChanged = (): void => {
-    this._updateColor(getColorFromString('#' + this._hexText.value));
+    if (this._hexText.current) {
+      this._updateColor(getColorFromString('#' + this._hexText.current.value));
+    }
   };
 
   private _onRGBAChanged = (): void => {
+    if (!this._rText.current || !this._gText.current || !this._bText.current || !this._aText.current) {
+      return;
+    }
+
     this._updateColor(
       getColorFromRGBA({
-        r: Number(this._rText.value),
-        g: Number(this._gText.value),
-        b: Number(this._bText.value),
-        a: Number((this._aText && this._aText.value) || 100)
+        r: Number(this._rText.current.value),
+        g: Number(this._gText.current.value),
+        b: Number(this._bText.current.value),
+        a: Number((this._aText && this._aText.current.value) || 100)
       })
     );
   };

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -143,7 +143,6 @@ describe('ColorPicker', () => {
 
     allInputs.forEach(input => {
       input.simulate('blur');
-      wrapper.update();
 
       expect(colorPickerComponent.state.color.hex).toEqual(colorStringValue);
       expect(colorChangeCalled).toBeFalsy();

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -5,8 +5,8 @@ import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
 import { ColorPicker } from './ColorPicker';
-import { ColorPickerBase } from './ColorPicker.base';
-import { IColorPicker } from './ColorPicker.types';
+import { ColorPickerBase, IColorPickerState } from './ColorPicker.base';
+import { IColorPicker, IColorPickerProps } from './ColorPicker.types';
 
 describe('ColorPicker', () => {
   it('renders ColorPicker correctly', () => {
@@ -109,6 +109,44 @@ describe('ColorPicker', () => {
     const tableHeaders = wrapper.find('.ms-ColorPicker-table > thead > tr > td');
     tableHeaders.forEach((node, index) => {
       expect(node.text()).toEqual(textHeaders[index]);
+    });
+  });
+
+  it('Keeps color value when tabbing between Hex and RGBA text inputs', () => {
+    const colorStringValue = 'ffffff';
+    let colorChangeCalled = false;
+    const onColorChanged = (newColor: string): void => {
+      colorChangeCalled = newColor !== colorStringValue;
+    };
+
+    let colorPickerComponent: any;
+    const setRef = (ref: IColorPicker): void => {
+      colorPickerComponent = ref;
+    };
+
+    const inputClassName = 'input-tab-test';
+    const wrapper = mount<IColorPickerProps, IColorPickerState>(
+      <ColorPicker
+        color={`#${colorStringValue}`}
+        onColorChanged={onColorChanged}
+        componentRef={setRef}
+        styles={{ input: inputClassName }}
+      />
+    );
+
+    expect(colorPickerComponent.state.color.hex).toEqual(colorStringValue);
+    expect(colorChangeCalled).toBeFalsy();
+
+    // Tab between text inputs checking state after each time.
+    const allInputs = wrapper.find(`.${inputClassName} input`);
+    expect(allInputs.length).toBe(5);
+
+    allInputs.forEach(input => {
+      input.simulate('blur');
+      wrapper.update();
+
+      expect(colorPickerComponent.state.color.hex).toEqual(colorStringValue);
+      expect(colorChangeCalled).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5742
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updating ColorPicker input refs' references to pull the value from the text box correctly to prevent NaN from flowing out of ColorPicker when simple tabbing through the Hex and RGBA inputs.

#### Focus areas to test

Color Picker Hex and RGBA inputs.
