### PR TITLE
Typography customize

### DIFF
--- a/common/changes/@uifabric/styling/typography-customize_2018-08-01-00-03.json
+++ b/common/changes/@uifabric/styling/typography-customize_2018-08-01-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Styling: make typography properties optional in Partial<ITheme>",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/styling/src/interfaces/ITheme.ts
+++ b/packages/styling/src/interfaces/ITheme.ts
@@ -1,7 +1,7 @@
 import { IPalette } from './IPalette';
 import { IFontStyles } from './IFontStyles';
 import { ISemanticColors } from './ISemanticColors';
-import { ITypography } from './ITypography';
+import { ITypography, IPartialTypography } from './ITypography';
 
 export interface ITheme {
   palette: IPalette;
@@ -32,5 +32,5 @@ export interface IPartialTheme {
   semanticColors?: Partial<ISemanticColors>;
   isInverted?: boolean;
   disableGlobalClassNames?: boolean;
-  typography?: Partial<ITypography>;
+  typography?: IPartialTypography;
 }

--- a/packages/styling/src/interfaces/ITheme.ts
+++ b/packages/styling/src/interfaces/ITheme.ts
@@ -26,11 +26,10 @@ export interface ITheme {
   typography: ITypography;
 }
 
-export interface IPartialTheme {
-  palette?: Partial<IPalette>;
-  fonts?: Partial<IFontStyles>;
-  semanticColors?: Partial<ISemanticColors>;
-  isInverted?: boolean;
-  disableGlobalClassNames?: boolean;
-  typography?: IPartialTypography;
-}
+export type IPartialTheme = {
+  [P in keyof Pick<
+    ITheme,
+    'palette' | 'fonts' | 'semanticColors' | 'isInverted' | 'disableGlobalClassNames'
+  >]?: Partial<ITheme[P]>
+} &
+  { [P in keyof Pick<ITheme, 'typography'>]?: IPartialTypography };

--- a/packages/styling/src/interfaces/ITypography.ts
+++ b/packages/styling/src/interfaces/ITypography.ts
@@ -50,9 +50,7 @@ export interface ITypography {
   types: IFontTypes;
 }
 
-export interface IPartialTypography {
-  families?: Partial<IFontFamilies>;
-  sizes?: Partial<IFontSizes>;
-  weights?: Partial<IFontWeights>;
-  types?: Partial<IFontTypes>;
-}
+/**
+ * Used in IPartialTheme so that user-defined themes can override selected typography properties
+ */
+export type IPartialTypography = { [P in keyof ITypography]?: Partial<ITypography[P]> };

--- a/packages/styling/src/interfaces/ITypography.ts
+++ b/packages/styling/src/interfaces/ITypography.ts
@@ -49,3 +49,10 @@ export interface ITypography {
   weights: IFontWeights;
   types: IFontTypes;
 }
+
+export interface IPartialTypography {
+  families?: Partial<IFontFamilies>;
+  sizes?: Partial<IFontSizes>;
+  weights?: Partial<IFontWeights>;
+  types?: Partial<IFontTypes>;
+}

--- a/packages/styling/src/styles/theme.test.ts
+++ b/packages/styling/src/styles/theme.test.ts
@@ -1,4 +1,5 @@
 import * as theme from './theme';
+import { DefaultTypography } from './DefaultTypography';
 
 describe('registerOnThemeChangeCallback', () => {
   /*let counter = 0;
@@ -38,5 +39,73 @@ describe('registerOnThemeChangeCallback', () => {
   it('didnt pass null to the callback', () => {
     expect(callback.mock.calls[0][0]).toBeTruthy();
     expect(callback.mock.calls[1][0]).toBeTruthy();
+  });
+});
+
+describe('loadTheme', () => {
+  describe('typography', () => {
+    it('preserves the default typography when given an empty theme', () => {
+      const userTheme = {};
+      theme.loadTheme(userTheme);
+      const newTheme = theme.getTheme();
+      expect(newTheme.typography).toEqual(DefaultTypography);
+    });
+
+    it('preserves the default typography when given a theme with no typography', () => {
+      const userTheme = {
+        palette: {
+          themePrimary: 'red'
+        }
+      };
+      theme.loadTheme(userTheme);
+      const newTheme = theme.getTheme();
+      expect(newTheme.typography).toEqual(DefaultTypography);
+    });
+
+    it('preserves the default typography sizes when given a theme with no typography sizes', () => {
+      const userTheme = {
+        typography: {
+          weights: {
+            light: 100
+          }
+        }
+      };
+      theme.loadTheme(userTheme);
+      const newTheme = theme.getTheme();
+      expect(newTheme.typography.sizes).toEqual(DefaultTypography.sizes);
+    });
+
+    it('preserves the default typography sizes when given a theme with empty typography sizes', () => {
+      const userTheme = {
+        typography: {
+          sizes: {}
+        }
+      };
+      theme.loadTheme(userTheme);
+      const newTheme = theme.getTheme();
+      expect(newTheme.typography.sizes).toEqual(DefaultTypography.sizes);
+    });
+
+    it('overrides the given font sizes and preserves the default sizes', () => {
+      const userTheme = {
+        typography: {
+          sizes: {
+            tiny: '12px',
+            large: '24px'
+          }
+        }
+      };
+      theme.loadTheme(userTheme);
+      const newTheme = theme.getTheme();
+      expect(newTheme.typography.sizes.tiny).toEqual(userTheme.typography.sizes.tiny);
+      expect(newTheme.typography.sizes.large).toEqual(userTheme.typography.sizes.large);
+      expect(newTheme.typography.sizes.xSmall).toEqual(DefaultTypography.sizes.xSmall);
+      expect(newTheme.typography.sizes.small).toEqual(DefaultTypography.sizes.small);
+      expect(newTheme.typography.sizes.medium).toEqual(DefaultTypography.sizes.medium);
+      expect(newTheme.typography.sizes.xLarge).toEqual(DefaultTypography.sizes.xLarge);
+      expect(newTheme.typography.sizes.xxLarge).toEqual(DefaultTypography.sizes.xxLarge);
+      expect(newTheme.typography.sizes.xxxLarge).toEqual(DefaultTypography.sizes.xxxLarge);
+      expect(newTheme.typography.sizes.mega).toEqual(DefaultTypography.sizes.mega);
+    });
   });
 });

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -108,7 +108,7 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
     ...theme.semanticColors
   };
 
-  let typography = { ...DefaultTypography };
+  let typography = DefaultTypography;
   if (theme.typography) {
     typography = {
       families: { ...DefaultTypography.families, ...theme.typography.families },

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -1,10 +1,10 @@
 import { Customizations } from '@uifabric/utilities';
 import { IPalette, ISemanticColors, ITheme, IPartialTheme } from '../interfaces/index';
+import { ITypography } from '../interfaces/ITypography';
 import { DefaultFontStyles } from './DefaultFontStyles';
 import { DefaultPalette } from './DefaultPalette';
 import { DefaultTypography } from './DefaultTypography';
 import { loadTheme as legacyLoadTheme } from '@microsoft/load-themed-styles';
-import { IFontType } from '../interfaces/ITypography';
 
 let _theme: ITheme = {
   palette: DefaultPalette,
@@ -108,21 +108,30 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
     ...theme.semanticColors
   };
 
-  const typography = { ...DefaultTypography, ...theme.typography };
+  let typography = { ...DefaultTypography };
+  if (theme.typography) {
+    typography = {
+      families: { ...DefaultTypography.families, ...theme.typography.families },
+      weights: { ...DefaultTypography.weights, ...theme.typography.weights },
+      sizes: { ...DefaultTypography.sizes, ...theme.typography.sizes },
+      types: { ...DefaultTypography.types, ...theme.typography.types }
+    } as ITypography;
+  }
 
   const { types } = typography;
   for (const typeName in types) {
     if (types.hasOwnProperty(typeName)) {
       const type = types[typeName];
-
-      if (type.fontFamily && typography.families[type.fontFamily]) {
-        type.fontFamily = typography.families[type.fontFamily];
-      }
-      if (type.fontSize && typography.sizes[type.fontSize]) {
-        type.fontSize = typography.sizes[type.fontSize];
-      }
-      if (type.fontWeight && typography.families[type.fontWeight]) {
-        type.fontWeight = typography.families[type.fontWeight];
+      if (type) {
+        if (type.fontFamily && typography.families[type.fontFamily]) {
+          type.fontFamily = typography.families[type.fontFamily];
+        }
+        if (type.fontSize && typography.sizes[type.fontSize]) {
+          type.fontSize = typography.sizes[type.fontSize];
+        }
+        if (type.fontWeight && typography.families[type.fontWeight]) {
+          type.fontWeight = typography.families[type.fontWeight];
+        }
       }
     }
   }
@@ -136,7 +145,7 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
     semanticColors: newSemanticColors,
     isInverted: !!theme.isInverted,
     disableGlobalClassNames: !!theme.disableGlobalClassNames,
-    typography: typography
+    typography: typography as ITypography
   };
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This change allows the user to pass in a theme with a partial typography property to the `loadTheme` function. Without this change, the following would result in a compiler error:

`loadTheme({typography: {sizes: {tiny: '12px'}}});`

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5756)

