### PR TITLE
Textfield onchange

### DIFF
--- a/common/changes/office-ui-fabric-react/textfield-onchange_2018-08-01-20-04.json
+++ b/common/changes/office-ui-fabric-react/textfield-onchange_2018-08-01-20-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: Add onChange prop and deprecate onChanged",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -19,7 +19,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
   public render(): JSX.Element {
     return (
       <div>
-        <TextField value={String(this.state.hoverDelay)} onChanged={this._onHoverDelayChanged} />
+        <TextField value={String(this.state.hoverDelay)} onChange={this._onHoverDelayChanged} />
         <DefaultButton
           id="ContextualMenuButton2"
           text="Click for ContextualMenu"
@@ -124,7 +124,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
     );
   }
 
-  private _onHoverDelayChanged = (newValue: string) => {
+  private _onHoverDelayChanged = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string) => {
     this.setState({
       hoverDelay: +newValue
     });

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -187,7 +187,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
             onFocus={this._onTextFieldFocus}
             onBlur={this._onTextFieldBlur}
             onClick={this._onTextFieldClick}
-            onChanged={this._onTextFieldChanged}
+            onChange={this._onTextFieldChanged}
             errorMessage={errorMessage}
             placeholder={placeholder}
             borderless={borderless}
@@ -292,7 +292,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     this._validateTextInput();
   };
 
-  private _onTextFieldChanged = (newValue: string): void => {
+  private _onTextFieldChanged = (
+    ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+    newValue: string
+  ): void => {
     if (this.props.allowTextInput) {
       if (this.state.isDatePickerShown) {
         this._dismissDatePickerPopup();

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -119,7 +119,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       <div className="ms-DetailsListAdvancedExample">
         <CommandBar items={this._getCommandItems()} />
 
-        {isGrouped ? <TextField label="Group Item Limit" onChanged={this._onItemLimitChanged} /> : null}
+        {isGrouped ? <TextField label="Group Item Limit" onChange={this._onItemLimitChanged} /> : null}
 
         <DetailsList
           setKey="items"
@@ -218,7 +218,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
     });
   };
 
-  private _onItemLimitChanged = (value: string): void => {
+  private _onItemLimitChanged = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string): void => {
     let newValue = parseInt(value, 10);
     if (isNaN(newValue)) {
       newValue = DEFAULT_ITEM_LIMIT;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -83,7 +83,7 @@ export class DetailsListBasicExample extends React.Component<
             onChange={this._onShowItemIndexInViewChanged}
           />
         </div>
-        <TextField label="Filter by name:" onChanged={this._onChanged} />
+        <TextField label="Filter by name:" onChange={this._onChange} />
         <MarqueeSelection selection={this._selection}>
           <DetailsList
             componentRef={this._detailsList}
@@ -123,7 +123,7 @@ export class DetailsListBasicExample extends React.Component<
     }
   }
 
-  private _onChanged = (text: any): void => {
+  private _onChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: any): void => {
     this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items });
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -123,7 +123,7 @@ export class DetailsListBasicExample extends React.Component<
     }
   }
 
-  private _onChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: any): void => {
+  private _onChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string): void => {
     this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items });
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
@@ -67,7 +67,7 @@ export class DetailsListCompactExample extends React.Component<
     return (
       <div>
         <div>{selectionDetails}</div>
-        <TextField label="Filter by name:" onChanged={this._onChanged} />
+        <TextField label="Filter by name:" onChange={this._onChange} />
         <MarqueeSelection selection={this._selection}>
           <DetailsList
             items={items}
@@ -98,7 +98,7 @@ export class DetailsListCompactExample extends React.Component<
     }
   }
 
-  private _onChanged = (text: any): void => {
+  private _onChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string): void => {
     this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items });
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
@@ -87,7 +87,7 @@ export class DetailsListCustomFooterExample extends React.Component<
             onChange={this._onShowItemIndexInViewChanged}
           />
         </div>
-        <TextField label="Filter by name:" onChanged={this._onChanged} />
+        <TextField label="Filter by name:" onChange={this._onChange} />
         <MarqueeSelection selection={this._selection}>
           <DetailsList
             componentRef={this._detailsList}
@@ -127,7 +127,7 @@ export class DetailsListCustomFooterExample extends React.Component<
     }
   }
 
-  private _onChanged = (text: any): void => {
+  private _onChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string): void => {
     this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items });
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -210,7 +210,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
           offText="Normal"
         />
         <div>{selectionDetails}</div>
-        <TextField label="Filter by name:" onChanged={this._onChangeText} />
+        <TextField label="Filter by name:" onChange={this._onChangeText} />
         <MarqueeSelection selection={this._selection}>
           <DetailsList
             items={items}
@@ -245,7 +245,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
     this.setState({ isModalSelection: checked });
   };
 
-  private _onChangeText = (text: any): void => {
+  private _onChangeText = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string): void => {
     this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items });
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
@@ -74,13 +74,13 @@ export class DetailsListDragDropExample extends React.Component<
           label={'Number of Left frozen columns:'}
           onGetErrorMessage={this._validateNumber}
           value={frozenColumnCountFromStart}
-          onChanged={this._onChangeStartCountText}
+          onChange={this._onChangeStartCountText}
         />
         <TextField
           label={'Number of Right frozen columns:'}
           onGetErrorMessage={this._validateNumber}
           value={frozenColumnCountFromEnd}
-          onChanged={this._onChangeEndCountText}
+          onChange={this._onChangeEndCountText}
         />
         <div>{selectionDetails}</div>
         <MarqueeSelection selection={this._selection}>

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.tsx
@@ -62,7 +62,7 @@ export class ListScrollingExample extends React.Component<IListScrollingExampleP
         />
         <div>
           Scroll item index:
-          <TextField value={this.state.selectedIndex.toString(10)} onChanged={this._onChangeText} />
+          <TextField value={this.state.selectedIndex.toString(10)} onChange={this._onChangeText} />
         </div>
         <div>
           <Checkbox
@@ -102,7 +102,7 @@ export class ListScrollingExample extends React.Component<IListScrollingExampleP
     return h;
   }
 
-  private _onChangeText = (value: any): void => {
+  private _onChangeText = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string): void => {
     this._scroll(parseInt(value, 10) || 0, this.state.scrollToMode);
   };
 

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -90,7 +90,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<
           <TextField
             label="Filter by name:"
             // tslint:disable-next-line:jsx-no-lambda
-            onChanged={text =>
+            onChange={(ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) =>
               this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items })
             }
           />

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -119,7 +119,7 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
         onBlur={this._onBlur}
         onMouseDown={this._onMouseDown}
         onMouseUp={this._onMouseUp}
-        onChanged={this._onInputChange}
+        onChange={this._onInputChange}
         onBeforeChange={this._onBeforeChange}
         onKeyDown={this._onKeyDown}
         onPaste={this._onPaste}
@@ -267,7 +267,11 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
   }
 
   @autobind
-  private _onInputChange(value: string) {
+  private _onInputChange(ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) {
+    if (this.props.onChange) {
+      this.props.onChange(ev, value);
+    }
+
     if (this.props.onChanged) {
       this.props.onChanged(value);
     }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -42,7 +42,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     autoAdjustHeight: false,
     underlined: false,
     borderless: false,
-    onChanged: () => {
+    onChange: () => {
       /* noop */
     },
     onBeforeChange: () => {
@@ -76,7 +76,8 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     this._warnDeprecations({
       iconClass: 'iconProps',
       addonString: 'prefix',
-      onRenderAddon: 'onRenderPrefix'
+      onRenderAddon: 'onRenderPrefix',
+      onChanged: 'onChange'
     });
 
     this._warnMutuallyExclusive({
@@ -418,6 +419,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
   }
 
   private _onInputChange(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>): void {
+    event.persist();
     const element: HTMLInputElement = event.target as HTMLInputElement;
     const value: string = element.value;
 
@@ -433,6 +435,10 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
       } as ITextFieldState,
       () => {
         this._adjustInputHeight();
+
+        if (this.props.onChange) {
+          this.props.onChange(event, value);
+        }
 
         if (this.props.onChanged) {
           this.props.onChanged(value);

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.deprecated.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import * as WarnUtil from '@uifabric/utilities/lib-commonjs/warn';
+import * as ReactTestUtils from 'react-dom/test-utils';
+import { mount } from 'enzyme';
 
 import { resetIds } from '../../Utilities';
 import { TextField } from './TextField';
@@ -21,9 +23,59 @@ describe('TextField deprecated', () => {
     resetIds();
   });
 
+  function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
+    const target: EventTarget = { value: targetValue } as HTMLInputElement;
+    const event: ReactTestUtils.SyntheticEventData = { target };
+
+    return event;
+  }
+
   it('renders with deprecated props affecting styling', () => {
     const component = renderer.create(<TextField addonString={'test addonString'} iconClass={'test-iconClass'} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('should call deprecated onChanged handler for input change', () => {
+    let callCount = 0;
+    const onChangedSpy = (value: string) => {
+      callCount++;
+    };
+
+    const textField = mount(
+      <TextField
+        defaultValue="initial value"
+        onChanged={onChangedSpy}
+        // tslint:disable-next-line:jsx-no-lambda
+        onGetErrorMessage={value => (value.length > 0 ? '' : 'error')}
+      />
+    );
+
+    expect(callCount).toEqual(0);
+    const inputDOM = textField.getDOMNode().querySelector('input') as Element;
+
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('value change'));
+    ReactTestUtils.Simulate.change(inputDOM, mockEvent('value change'));
+    expect(callCount).toEqual(1);
+
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent(''));
+    ReactTestUtils.Simulate.change(inputDOM, mockEvent(''));
+    expect(callCount).toEqual(2);
+  });
+
+  it('should not call deprecated onChanged when initial value is undefined and input change is an empty string', () => {
+    let callCount = 0;
+    const onChangedSpy = (value: string) => {
+      callCount++;
+    };
+
+    const textField = mount(<TextField onChanged={onChangedSpy} />);
+
+    expect(callCount).toEqual(0);
+    const inputDOM = textField.getDOMNode().querySelector('input') as Element;
+
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent(''));
+    ReactTestUtils.Simulate.change(inputDOM, mockEvent(''));
+    expect(callCount).toEqual(0);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -494,6 +494,28 @@ describe('TextField', () => {
     expect(callCount).toEqual(0);
   });
 
+  it('should call onChange with a persisted event', () => {
+    let textFieldTarget: any = null;
+    const onChangeSpy = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
+      textFieldTarget = ev.target;
+    };
+
+    const textFieldOne = mount(<TextField onChange={onChangeSpy} />);
+    const textFieldTwo = mount(<TextField onChange={onChangeSpy} />);
+
+    const inputDOMOne = textFieldOne.getDOMNode().querySelector('input') as Element;
+    const inputDOMTwo = textFieldTwo.getDOMNode().querySelector('input') as Element;
+
+    const valueOne = 'textfield one';
+    const valueTwo = 'textfield two';
+
+    ReactTestUtils.Simulate.input(inputDOMOne, mockEvent(valueOne));
+    expect(textFieldTarget!.value).toEqual(valueOne);
+
+    ReactTestUtils.Simulate.change(inputDOMTwo, mockEvent(valueTwo));
+    expect(textFieldTarget!.value).toEqual(valueTwo);
+  });
+
   it('should select a range of text', () => {
     const initialValue = 'initial value';
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -451,16 +451,16 @@ describe('TextField', () => {
     expect(callCount).toEqual(1);
   });
 
-  it('should call onChanged handler for input change', () => {
+  it('should call onChange handler for input change', () => {
     let callCount = 0;
-    const onChangedSpy = (value: string) => {
+    const onChangeSpy = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
       callCount++;
     };
 
     const textField = mount(
       <TextField
         defaultValue="initial value"
-        onChanged={onChangedSpy}
+        onChange={onChangeSpy}
         // tslint:disable-next-line:jsx-no-lambda
         onGetErrorMessage={value => (value.length > 0 ? '' : 'error')}
       />
@@ -478,13 +478,13 @@ describe('TextField', () => {
     expect(callCount).toEqual(2);
   });
 
-  it('should not call onChanged when initial value is undefined and input change is an empty string', () => {
+  it('should not call onChange when initial value is undefined and input change is an empty string', () => {
     let callCount = 0;
-    const onChangedSpy = (value: string) => {
+    const onChangeSpy = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
       callCount++;
     };
 
-    const textField = mount(<TextField onChanged={onChangedSpy} />);
+    const textField = mount(<TextField onChange={onChangeSpy} />);
 
     expect(callCount).toEqual(0);
     const inputDOM = textField.getDOMNode().querySelector('input') as Element;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -159,7 +159,12 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   errorMessage?: string;
 
   /**
-   * Callback for the onChanged event.
+   * Callback for when the input value changes.
+   */
+  onChange?: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
+
+  /**
+   * @deprecated Use onChange instead.
    */
   onChanged?: (newValue: any) => void;
 

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/NumberTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/NumberTextField.tsx
@@ -16,7 +16,7 @@ export class NumberTextField extends React.Component<INumberTextFieldProps, INum
     super(props);
 
     this._restore = this._restore.bind(this);
-    this._onChanged = this._onChanged.bind(this);
+    this._onChange = this._onChange.bind(this);
     this._validateNumber = this._validateNumber.bind(this);
 
     this.state = {
@@ -31,7 +31,7 @@ export class NumberTextField extends React.Component<INumberTextFieldProps, INum
           className="NumberTextField-textField"
           label={this.props.label}
           value={this.state.value}
-          onChanged={this._onChanged}
+          onChange={this._onChange}
           onGetErrorMessage={this._validateNumber}
         />
         <div className="NumberTextField-restoreButton">
@@ -45,7 +45,7 @@ export class NumberTextField extends React.Component<INumberTextFieldProps, INum
     return isNaN(Number(value)) ? `The value should be a number, actual is ${value}.` : '';
   }
 
-  private _onChanged(value: string): void {
+  private _onChange(ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string): void {
     return this.setState({
       value
     });

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Icon.Example.tsx
@@ -6,12 +6,12 @@ export class TextFieldIconExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
       <div className="docs-TextFieldExample">
-        <TextField label="TextField with an icon" iconProps={{ iconName: 'Calendar' }} onChanged={this._onChanged} />
+        <TextField label="TextField with an icon" iconProps={{ iconName: 'Calendar' }} onChange={this._onChange} />
       </div>
     );
   }
 
-  private _onChanged = (text: string): void => {
+  private _onChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string): void => {
     console.log(text);
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5391 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add an `onChange` prop to TextField that exposes both the event and the new value. Deprecate the TextField `onChanged` prop.

(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5764)

