### PR TITLE
MessageBar: add aria-expanded property

### DIFF
--- a/common/changes/office-ui-fabric-react/messageBarExpandCollapse_2018-08-02-03-09.json
+++ b/common/changes/office-ui-fabric-react/messageBarExpandCollapse_2018-08-02-03-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: add aria-expanded",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -118,7 +118,10 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
 
   private _renderSingleLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
     return (
-      <div className={this._classNames.root}>
+      <div
+        className={this._classNames.root}
+        aria-expanded={!this.props.actions && this.props.truncated ? this.state.expandSingleLine : undefined}
+      >
         <div className={this._classNames.content}>
           {this._getIconSpan()}
           {this._renderInnerText()}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/examples/MessageBar.Basic.Example.tsx
@@ -36,7 +36,7 @@ export const MessageBarBasicExample = () => (
       onDismiss={log('test')}
       dismissButtonAriaLabel="Close"
       truncated={true}
-      overflowButtonAriaLabel="Overflow"
+      overflowButtonAriaLabel="See more"
     >
       Blocked lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio
       augue pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae
@@ -156,9 +156,7 @@ export const MessageBarBasicExample = () => (
       <Link href="www.bing.com">Visit our website.</Link>
     </MessageBar>
 
-    <Label>
-      Blocked, single line, with dismiss button and truncated text - custom styles
-    </Label>
+    <Label>Blocked, single line, with dismiss button and truncated text - custom styles</Label>
     <MessageBar
       styles={{
         root: {
@@ -193,13 +191,13 @@ export const MessageBarBasicExample = () => (
       onDismiss={log('test')}
       dismissButtonAriaLabel="Close"
       truncated={true}
-      overflowButtonAriaLabel="Overflow"
+      overflowButtonAriaLabel="See more"
     >
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio
-      augue pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae
-      orci nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac
-      placerat erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu
-      ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi a, fermentum suscipit
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio augue
+      pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae orci
+      nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac placerat
+      erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu ante
+      commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi a, fermentum suscipit
       magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris.{' '}
       <Link href="www.bing.com">Visit our website.</Link>
     </MessageBar>
@@ -283,7 +281,7 @@ export const MessageBarBasicExample = () => (
           background: 'rgba(0, 188, 242, 0.4)'
         },
         dismissal: {
-          border: '1px solid #00188f',
+          border: '1px solid #00188f'
         },
         actions: {
           border: '1px solid #0078d4',
@@ -301,11 +299,11 @@ export const MessageBarBasicExample = () => (
         </div>
       }
     >
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio
-      augue pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae
-      orci nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac
-      placerat erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu
-      ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi a, fermentum suscipit
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio augue
+      pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae orci
+      nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac placerat
+      erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu ante
+      commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi a, fermentum suscipit
       magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris.<Link href="www.bing.com">
         Visit our website.
       </Link>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5717
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes add an aria-expanded property to MessageBars that have an overflow button. Before, all the screen reader had was an overflow button with a single, static aria-label that did not change for when the message bar was expanded vs. when it was collapsed. 

@betrue-final-final and I discussed an approach to this issue, and I think it makes the most sense to add an aria-collapsed property. We seem to see more of these scenarios with expanded/collapsed as states.

This PR also changes the aria-label of "Overflow" to "See more" in the MessageBar demo page.
