### PR TITLE
Adding custom font size and color prop to Multicount. Change in precision logic.

### DIFF
--- a/common/changes/@uifabric/dashboard/master_2018-08-02-07-38.json
+++ b/common/changes/@uifabric/dashboard/master_2018-08-02-07-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Adding custom font size and color props to Multicount. Changes to the precision logic",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "v-kanuli@microsoft.com"
+}

--- a/packages/dashboard/src/components/MultiCount/MultiCount.tsx
+++ b/packages/dashboard/src/components/MultiCount/MultiCount.tsx
@@ -11,12 +11,24 @@ export class MultiCount extends React.Component<IMultiCountProps, {}> {
   }
 
   public render(): JSX.Element {
-    const multiCountRows = this.props.multiCountRows;
-    const data: JSX.Element[] = this.getGeneratedData(multiCountRows);
+    const { multiCountRows, annotationTextFontSize, annotationTextColor, bodyTextFontSize, bodyTextColor } = this.props;
+    const data: JSX.Element[] = this.getGeneratedData(
+      multiCountRows,
+      annotationTextFontSize,
+      annotationTextColor,
+      bodyTextFontSize,
+      bodyTextColor
+    );
     return <div>{data}</div>;
   }
 
-  public getGeneratedData(rows: IMultiCountRow[]): JSX.Element[] {
+  public getGeneratedData(
+    rows: IMultiCountRow[],
+    annotationTextFontSize?: string,
+    annotationTextColor?: string,
+    bodyTextFontSize?: string,
+    bodyTextColor?: string
+  ): JSX.Element[] {
     const formattedRows: JSX.Element[] = [];
     const units = ['', 'k', 'm', 'b'];
     rows.forEach((row: IMultiCountRow, index: number) => {
@@ -29,11 +41,23 @@ export class MultiCount extends React.Component<IMultiCountProps, {}> {
         indexForUnits++;
         data = data / 1000;
       }
-      const formattedData = data % 1 === 0 ? data : data.toFixed(1);
+      let formattedData = data % 1 === 0 ? data : data.toFixed(1);
+      if (Math.floor(data) >= 100) {
+        formattedData = Math.floor(data);
+      }
       const changeIconIndicator =
-        AnnotationType[row.type] === 'nuetral' ? '' : AnnotationType[row.type] === 'positive' ? 'FlickDown' : 'FlickUp';
+        AnnotationType[row.type] === 'neutral' ? '' : AnnotationType[row.type] === 'positive' ? 'FlickDown' : 'FlickUp';
       const getClassNames = classNamesFunction<IMultiCountProps, IMultiCountStyles>();
-      const classNames = getClassNames(getStyles({ color: row.color, iconName: changeIconIndicator }));
+      const classNames = getClassNames(
+        getStyles({
+          color: row.color,
+          iconName: changeIconIndicator,
+          annotationTextFontSize: annotationTextFontSize,
+          annotationTextColor: annotationTextColor,
+          bodyTextColor: bodyTextColor,
+          bodyTextFontSize: bodyTextFontSize
+        })
+      );
       formattedRows.push(
         <div key={index} className={classNames.root}>
           <div className={classNames.bodyText}>

--- a/packages/dashboard/src/components/MultiCount/MultiCount.types.ts
+++ b/packages/dashboard/src/components/MultiCount/MultiCount.types.ts
@@ -5,6 +5,26 @@ export interface IMultiCountProps {
    * rows of Multicount Dataviz
    */
   multiCountRows: IMultiCountRow[];
+
+  /**
+   * Font size for the annotation text
+   */
+  annotationTextFontSize?: string;
+
+  /**
+   * color for the annotation text
+   */
+  annotationTextColor?: string;
+
+  /**
+   * font size for the body text
+   */
+  bodyTextFontSize?: string;
+
+  /**
+   * color for the body text
+   */
+  bodyTextColor?: string;
 }
 
 export enum AnnotationType {
@@ -27,6 +47,10 @@ export enum AnnotationType {
 export interface IMultiCountStyleProps {
   color: string;
   iconName: string;
+  annotationTextFontSize?: string;
+  annotationTextColor?: string;
+  bodyTextFontSize?: string;
+  bodyTextColor?: string;
 }
 
 export interface IMultiCountRow {

--- a/packages/dashboard/src/components/MultiCount/MultiCountPage.tsx
+++ b/packages/dashboard/src/components/MultiCount/MultiCountPage.tsx
@@ -3,6 +3,7 @@ import { ComponentPage, ExampleCard, IComponentDemoPageProps, PropertiesTableSet
 const MultiCountExampleCode = require('!raw-loader!@uifabric/dashboard/src/components/MultiCount/examples/MultiCount.Example.tsx') as string;
 
 import { MultiCountExample } from './examples/MultiCount.Example';
+import { MultiCountVariantExample } from './examples/MultiCountVariant.Example';
 
 export class MultiCountPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -18,6 +19,14 @@ export class MultiCountPage extends React.Component<IComponentDemoPageProps, {}>
             <ExampleCard title="Multicount" code={MultiCountExampleCode}>
               <div style={style}>
                 <MultiCountExample />
+              </div>
+            </ExampleCard>
+            <ExampleCard
+              title="Multicount Variant. Multicount accepts font size and color as optional attributes."
+              code={MultiCountExampleCode}
+            >
+              <div style={style}>
+                <MultiCountVariantExample />
               </div>
             </ExampleCard>
           </div>

--- a/packages/dashboard/src/components/MultiCount/MultiCountStyles.ts
+++ b/packages/dashboard/src/components/MultiCount/MultiCountStyles.ts
@@ -13,8 +13,9 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
-      fontSize: '28px',
-      flex: 1
+      fontSize: props.bodyTextFontSize ? props.bodyTextFontSize : '28px',
+      flex: 1,
+      color: props.bodyTextColor ? props.bodyTextColor : '#000000'
     },
     data: {
       fontFamily: 'Segoe UI',
@@ -28,7 +29,8 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
     },
     annotationText: {
       marginLeft: '16px',
-      color: '#000000'
+      color: props.annotationTextColor ? props.annotationTextColor : '#000000',
+      fontSize: props.annotationTextFontSize ? props.annotationTextFontSize : '12px'
     },
     icon: {
       width: '12px',

--- a/packages/dashboard/src/components/MultiCount/examples/MultiCountVariant.Example.tsx
+++ b/packages/dashboard/src/components/MultiCount/examples/MultiCountVariant.Example.tsx
@@ -1,23 +1,29 @@
 import * as React from 'react';
 import { AnnotationType, IMultiCountRow, MultiCount } from '@uifabric/dashboard';
-
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 
-export class MultiCountExample extends React.Component<{}, {}> {
+export class MultiCountVariantExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     const rows: IMultiCountRow[] = [
       {
-        data: 109000,
+        data: 13100,
         bodyText: 'Flagged users',
-        annotaionText: 'Annotation Text',
-        color: DefaultPalette.accent,
+        annotaionText: 'Annotation Text ',
+        color: DefaultPalette.blue,
         type: AnnotationType.positive
       },
       {
-        data: 8100000,
+        data: 7100000000,
         bodyText: 'Risky sign-ins',
         annotaionText: 'Decrease in the safety',
-        color: DefaultPalette.green,
+        color: DefaultPalette.blue,
+        type: AnnotationType.negative
+      },
+      {
+        data: 7000000000,
+        bodyText: 'Risky sign-ins',
+        annotaionText: 'Decrease in the safety',
+        color: DefaultPalette.blue,
         type: AnnotationType.negative
       },
       {
@@ -28,6 +34,14 @@ export class MultiCountExample extends React.Component<{}, {}> {
         type: AnnotationType.neutral
       }
     ];
-    return <MultiCount multiCountRows={rows} />;
+    return (
+      <MultiCount
+        multiCountRows={rows}
+        bodyTextFontSize={'16px'}
+        annotationTextColor={DefaultPalette.green}
+        annotationTextFontSize={'12px'}
+        bodyTextColor={DefaultPalette.green}
+      />
+    );
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Adding props for custom font size and color. Changing precision logic so that if the number before the point is three digits, it does not show data after the point.

![image](https://user-images.githubusercontent.com/22408128/43569609-d091c0de-95ec-11e8-832a-0aa1c7031f1a.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5776)

