### PR TITLE
Updated CustomCoinRender example to use imageUrl

### DIFF
--- a/common/changes/office-ui-fabric-react/master20180802_2018-08-02-12-45.json
+++ b/common/changes/office-ui-fabric-react/master20180802_2018-08-02-12-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updated the example to use imageUrl as props instead of hard coding directly into the img tag",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "svaibhav@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.CustomCoinRender.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.CustomCoinRender.Example.tsx
@@ -29,6 +29,7 @@ export class PersonaCustomCoinRenderExample extends React.Component {
           presence={PersonaPresence.online}
           onRenderCoin={this._onRenderCoin}
           imageAlt={'Custom Coin Image'}
+          imageUrl={TestImages.personaMale}
           coinSize={72}
         />
       </div>
@@ -36,8 +37,7 @@ export class PersonaCustomCoinRenderExample extends React.Component {
   }
 
   private _onRenderCoin = (props: IPersonaProps): JSX.Element => {
-    const { coinSize, imageAlt } = props;
-    const imageUrl = TestImages.personaMale;
+    const { coinSize, imageAlt, imageUrl } = props;
     return (
       <div className="customExampleCoin">
         <img src={imageUrl} alt={imageAlt} width={coinSize} height={coinSize} />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
@@ -82,6 +82,16 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
         }
       >
         <div
+          className="customExampleCoin"
+        >
+          <img
+            alt="Custom Coin Image"
+            height={72}
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+            width={72}
+          />
+        </div>
+        <div
           className=
               ms-Persona-presence
               {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

The example was using the imageUrl as a hard coded value directly into the img tag, modified it to pass as a props property.
This was needed as we render PersonaCoin only if we have a valid imageUrl and this check is present in ```PersonaCoin.base.tsx```

(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5777)

