### PR TITLE
Column drag drop changes - Added 2 callback functions to notify the dragStart and dragEnd events

### DIFF
--- a/common/changes/office-ui-fabric-react/laxmika-ColumnDragDropCallbacks_2018-08-02-15-03.json
+++ b/common/changes/office-ui-fabric-react/laxmika-ColumnDragDropCallbacks_2018-08-02-15-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "' Added 2 callback functions for dragstart and drag end events to get the telemetry logs in ODSP-Next'",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "laxmika@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -32,6 +32,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
     this._onDragStart = this._onDragStart.bind(this);
     this._onDragEnd = this._onDragEnd.bind(this);
     this._onRootMouseDown = this._onRootMouseDown.bind(this);
+    this._updateHeaderDragInfo = this._updateHeaderDragInfo.bind(this);
   }
 
   public render(): JSX.Element {
@@ -265,19 +266,23 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
 
   private _onDragStart(item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent): void {
     const classNames = this._classNames;
-
-    if (itemIndex && this.props.updateDragInfo) {
-      this.props.updateDragInfo(itemIndex);
+    if (itemIndex) {
+      this._updateHeaderDragInfo(itemIndex);
       this._root.current.classList.add(classNames.borderWhileDragging);
     }
   }
 
   private _onDragEnd(item?: any, event?: MouseEvent): void {
     const classNames = this._classNames;
+    this._root.current.classList.remove(classNames.borderWhileDragging);
+  }
 
+  private _updateHeaderDragInfo(itemIndex: number, event?: MouseEvent) {
+    if (this.props.setDraggedItemIndex) {
+      this.props.setDraggedItemIndex(itemIndex);
+    }
     if (this.props.updateDragInfo) {
-      this.props.updateDragInfo(-1, event);
-      this._root.current.classList.remove(classNames.borderWhileDragging);
+      this.props.updateDragInfo({ itemIndex }, event);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -266,8 +266,8 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
   private _onDragStart(item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent): void {
     const classNames = this._classNames;
 
-    if (itemIndex && this.props.setDraggedItemIndex) {
-      this.props.setDraggedItemIndex(itemIndex);
+    if (itemIndex && this.props.updateDragInfo) {
+      this.props.updateDragInfo(itemIndex);
       this._root.current.classList.add(classNames.borderWhileDragging);
     }
   }
@@ -275,8 +275,8 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
   private _onDragEnd(item?: any, event?: MouseEvent): void {
     const classNames = this._classNames;
 
-    if (this.props.setDraggedItemIndex) {
-      this.props.setDraggedItemIndex(-1);
+    if (this.props.updateDragInfo) {
+      this.props.updateDragInfo(-1, event);
       this._root.current.classList.remove(classNames.borderWhileDragging);
     }
   }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
@@ -18,7 +18,9 @@ export interface IDetailsColumnProps extends React.Props<DetailsColumnBase> {
   onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => void;
   dragDropHelper?: IDragDropHelper | null;
   isDraggable?: boolean;
+  // @deprecated, use updateDragInfo
   setDraggedItemIndex?: (itemIndex: number) => void;
+  updateDragInfo?: (props: { itemIndex: number }, event?: MouseEvent) => void;
   isDropped?: boolean;
   cellStyleProps?: ICellStyleProps;
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -34,12 +34,9 @@ const _columns: IColumn[] = [
     isIconOnly: false
   }
 ];
-
 const _columnReorderProps = {
-  columnReorderOptions: {
-    frozenColumnCountFromStart: 1,
-    handleColumnReorder: this._dummyFunction
-  }
+  frozenColumnCountFromStart: 1,
+  handleColumnReorder: this._dummyFunction
 };
 
 _selection.setItems(_items);

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -34,9 +34,12 @@ const _columns: IColumn[] = [
     isIconOnly: false
   }
 ];
-const _columnReorderOptions = {
-  frozenColumnCountFromStart: 1,
-  handleColumnReorder: this._dummyFunction
+
+const _columnReorderProps = {
+  columnReorderOptions: {
+    frozenColumnCountFromStart: 1,
+    handleColumnReorder: this._dummyFunction
+  }
 };
 
 _selection.setItems(_items);
@@ -69,7 +72,7 @@ describe('DetailsHeader', () => {
         layoutMode={DetailsListLayoutMode.fixedColumns}
         columns={_columns}
         onColumnResized={onColumnResized}
-        columnReorderOptions={_columnReorderOptions}
+        columnReorderProps={_columnReorderProps}
       />
     );
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -85,10 +85,7 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase> {
   viewport?: IViewport;
 
   /** Column reordering options */
-  columnReorderOptions?: IColumnReorderOptions | null;
-
-  /** callback to notify the column dragEnd event */
-  onColumnDragEnd?: (event: MouseEvent, onHeader: boolean) => void;
+  columnReorderProps?: IColumnReorderProps;
 
   /** Minimum pixels to be moved before dragging is registered */
   minimumPixelsForDrag?: number;
@@ -117,6 +114,16 @@ export interface IColumnResizeDetails {
   columnIndex: number;
   originX?: number;
   columnMinWidth: number;
+}
+
+export interface IColumnReorderProps {
+  columnReorderOptions: IColumnReorderOptions;
+
+  /** Callback to notify the column dragEnd event to List
+   * Need this to check whether the dragEnd has happened on
+   * corresponding list or outside of the list
+   */
+  onColumnDragEnd?: (event: MouseEvent, onHeader: boolean) => void;
 }
 
 export interface IDropHintDetails {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -6,7 +6,7 @@ import { IViewport } from '../../utilities/decorators/withViewport';
 import { ISelection, SelectionMode } from '../../utilities/selection/interfaces';
 import { ITheme, IStyle } from '../../Styling';
 import { DetailsHeaderBase } from './DetailsHeader.base';
-import { IColumn, DetailsListLayoutMode, IColumnReorderOptions } from './DetailsList.types';
+import { IColumn, DetailsListLayoutMode, IColumnReorderOptions, ColumnDragEndLocation } from './DetailsList.types';
 import { ICellStyleProps } from './DetailsRow.types';
 
 export interface IDetailsHeader {
@@ -85,7 +85,10 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase> {
   viewport?: IViewport;
 
   /** Column reordering options */
-  columnReorderProps?: IColumnReorderProps;
+  columnReorderOptions?: IColumnReorderOptions;
+
+  /** Column reordering options */
+  columnReorderProps?: IColumnReorderHeaderProps;
 
   /** Minimum pixels to be moved before dragging is registered */
   minimumPixelsForDrag?: number;
@@ -116,14 +119,12 @@ export interface IColumnResizeDetails {
   columnMinWidth: number;
 }
 
-export interface IColumnReorderProps {
-  columnReorderOptions: IColumnReorderOptions;
-
+export interface IColumnReorderHeaderProps extends IColumnReorderOptions {
   /** Callback to notify the column dragEnd event to List
    * Need this to check whether the dragEnd has happened on
    * corresponding list or outside of the list
    */
-  onColumnDragEnd?: (event: MouseEvent, onHeader: boolean) => void;
+  onColumnDragEnd?: (props: { dropLocation?: ColumnDragEndLocation }, event: MouseEvent) => void;
 }
 
 export interface IDropHintDetails {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -87,6 +87,9 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase> {
   /** Column reordering options */
   columnReorderOptions?: IColumnReorderOptions | null;
 
+  /** callback to notify the column dragEnd event */
+  onColumnDragEnd?: (event: MouseEvent, onHeader: boolean) => void;
+
   /** Minimum pixels to be moved before dragging is registered */
   minimumPixelsForDrag?: number;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -114,6 +114,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
     this._onContentKeyDown = this._onContentKeyDown.bind(this);
     this._onRenderCell = this._onRenderCell.bind(this);
     this._onGroupExpandStateChanged = this._onGroupExpandStateChanged.bind(this);
+    this._onColumnDragEnd = this._onColumnDragEnd.bind(this);
 
     this.state = {
       focusedItemIndex: -1,
@@ -402,6 +403,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
                   collapseAllVisibility: groupProps && groupProps.collapseAllVisibility,
                   viewport: viewport,
                   columnReorderOptions: columnReorderOptions,
+                  onColumnDragEnd: this._onColumnDragEnd,
                   minimumPixelsForDrag: minimumPixelsForDrag,
                   cellStyleProps: DEFAULT_CELL_STYLE_PROPS
                 },
@@ -646,6 +648,24 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
     });
     if (this._groupedList.current) {
       this._groupedList.current.toggleCollapseAll(collapsed);
+    }
+  }
+
+  private _onColumnDragEnd(event: MouseEvent, onHeader: boolean): void {
+    if (onHeader) {
+      this.props.columnReorderOptions!.onColumnDragEnd!(0);
+    } else {
+      const clientRect = this._root.current!.getBoundingClientRect();
+      if (
+        event.clientX > clientRect.left &&
+        event.clientX < clientRect.right &&
+        event.clientY > clientRect.top &&
+        event.clientY < clientRect.bottom
+      ) {
+        this.props.columnReorderOptions!.onColumnDragEnd!(1);
+      } else {
+        this.props.columnReorderOptions!.onColumnDragEnd!(2);
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -496,10 +496,63 @@ export interface IColumnReorderOptions {
   frozenColumnCountFromEnd?: number;
 
   /**
+   * Callback to handle the column dragstart
+   * draggedStarted indicates that the column drag has been started on DetailsHeader
+   */
+  onColumnDragStart?: (dragStarted: boolean) => void;
+
+  /**
+   * Callback to handle the column reorder
+   * draggedIndex is the source column index, that need to be placed in targetIndex
+   * Use oncolumnDrop instead of this
+   * @deprecated
+   */
+  handleColumnReorder?: (draggedIndex: number, targetIndex: number) => void;
+
+  /**
    * Callback to handle the column reorder
    * draggedIndex is the source column index, that need to be placed in targetIndex
    */
-  handleColumnReorder: (draggedIndex: number, targetIndex: number) => void;
+  onColumnDrop?: (dragDropDetails: IColumnDragDropDetails) => void;
+
+  /**
+   * Callback to handle the column reorder
+   */
+  onColumnDragEnd?: (columnDropLocationDetails: ColumnDragEndLocation) => void;
+}
+
+export interface IColumnDragDropDetails {
+  /**
+   * Specifies the source column index
+   * @default -1
+   */
+  draggedIndex: number;
+
+  /**
+   * Specifies the target column index
+   * @default -1
+   */
+  targetIndex: number;
+}
+
+/**
+ * Enum to describe where the column has been dropped, after starting the drag
+ */
+export enum ColumnDragEndLocation {
+  /**
+   * Drag ended on Header
+   */
+  onHeader = 0,
+
+  /**
+   * Drag ended on current List
+   */
+  onList = 1,
+
+  /**
+   * Drag ended outside of current list
+   */
+  outsideList = 2
 }
 
 export enum DetailsListLayoutMode {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -540,19 +540,19 @@ export interface IColumnDragDropDetails {
  */
 export enum ColumnDragEndLocation {
   /**
-   * Drag ended on Header
+   * Drag ended outside of current list
    */
-  onHeader = 0,
+  outside = 0,
 
   /**
    * Drag ended on current List
    */
-  onList = 1,
+  surface = 1,
 
   /**
-   * Drag ended outside of current list
+   * Drag ended on Header
    */
-  outsideList = 2
+  header = 2
 }
 
 export enum DetailsListLayoutMode {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -611,5 +611,4 @@ export interface IDetailsGroupDividerProps extends IGroupDividerProps {
   columns?: IColumn[];
   groupNestingDepth?: number;
   selection?: ISelection;
-  jhcja?: number;
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -518,7 +518,7 @@ export interface IColumnReorderOptions {
   /**
    * Callback to handle the column reorder
    */
-  onColumnDragEnd?: (columnDropLocationDetails: ColumnDragEndLocation) => void;
+  onDragEnd?: (columnDropLocationDetails: ColumnDragEndLocation) => void;
 }
 
 export interface IColumnDragDropDetails {
@@ -611,4 +611,5 @@ export interface IDetailsGroupDividerProps extends IGroupDividerProps {
   columns?: IColumn[];
   groupNestingDepth?: number;
   selection?: ISelection;
+  jhcja?: number;
 }


### PR DESCRIPTION
Added 2 callback functions to notify the dragstart and end events.
Added onColumnDrop to deprecate the handleColumnReorder. Will remove this once the ODSP-Next changes are done.
Callbacks will be used in ODSP-Next to log the events for telemetry.
ColumnDragEndLocation  is added to get exactly dragend details, whether its ended on header or list or outside of the list
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5779)

