### PR TITLE
Added consistent aria levels to any role='heading'

### DIFF
--- a/common/changes/office-ui-fabric-react/update-aria-level_2018-08-02-22-33.json
+++ b/common/changes/office-ui-fabric-react/update-aria-level_2018-08-02-22-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removed unnecessary heading roles, and added aria-level to those requiring them",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1119,7 +1119,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     const { onRenderOption = this._onRenderOptionContent } = this.props;
 
     return (
-      <div key={item.key} className={this._classNames.header} role="heading">
+      <div key={item.key} className={this._classNames.header}>
         {onRenderOption(item, this._onRenderOptionContent)}
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -302,12 +302,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
             onKeyDown={this._onMenuKeyDown}
             onKeyUp={this._onKeyUp}
           >
-            {title && (
-              <div className={this._classNames.title} role="heading" aria-level={1}>
-                {' '}
-                {title}{' '}
-              </div>
-            )}
+            {title && <div className={this._classNames.title}> {title} </div>}
             {items && items.length ? (
               <FocusZone
                 {...this._adjustedFocusZoneProps}
@@ -574,7 +569,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     const { contextualMenuItemAs: ChildrenRenderer = ContextualMenuItem } = this.props;
 
     return (
-      <div className={this._classNames.header} style={item.style} role="heading" aria-level={this.props.title ? 2 : 1}>
+      <div className={this._classNames.header} style={item.style}>
         <ChildrenRenderer
           item={item}
           classNames={classNames}

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -55,11 +55,13 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
     return (
       <div className={classNames.content}>
         <div className={classNames.header}>
-          <p className={classNames.title} id={titleId} role="heading">
+          <p className={classNames.title} id={titleId} role="heading" aria-level={2}>
             {title}
           </p>
           <div className={classNames.topButton}>
-            {this.props.topButtonsProps!.map((props, index) => <IconButton key={props.uniqueId || index} {...props} />)}
+            {this.props.topButtonsProps!.map((props, index) => (
+              <IconButton key={props.uniqueId || index} {...props} />
+            ))}
             {(type === DialogType.close || (showCloseButton && type !== DialogType.largeHeader)) && (
               <IconButton
                 className={classNames.button}

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`Dialog renders Dialog correctly 1`] = `
         }
   >
     <p
+      aria-level={2}
       className=
           ms-Dialog-title
           {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -285,6 +285,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
             className={css('ms-Panel-headerText', styles.headerText, headerClassName)}
             id={headerTextId}
             role="heading"
+            aria-level={2}
           >
             {headerText}
           </p>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5706 Fixes #5481
- [x] Include a change request file using `$ npm run change`

#### Description of changes

As per conversation, level 1 is reserved for page level headings (which our components will rarely be). So I've set everything at a default of 2, unless they are items inside of a component that already has a level 2, in which case it changes to level 3.

This switching behavior was already in contextual menu, so I made combobox consistent.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5782)

