### PR TITLE
ChoiceGroup: Use .find from utilities

### DIFF
--- a/common/changes/office-ui-fabric-react/mapol-use-find-from-utilities_2018-08-03-08-27.json
+++ b/common/changes/office-ui-fabric-react/mapol-use-find-from-utilities_2018-08-03-08-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix bug in ChoiceGroup that errors on Array.find as it does not exist in IE11",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -7,7 +7,7 @@ import {
   OnChangeCallback
 } from './ChoiceGroupOption/index';
 import { IChoiceGroupOption, IChoiceGroupProps, IChoiceGroupStyleProps, IChoiceGroupStyles } from './ChoiceGroup.types';
-import { BaseComponent, classNamesFunction, createRef, getId } from '../../Utilities';
+import { BaseComponent, classNamesFunction, createRef, getId, find } from '../../Utilities';
 
 const getClassNames = classNamesFunction<IChoiceGroupStyleProps, IChoiceGroupStyles>();
 
@@ -134,7 +134,7 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
     this.changedVars[key]
       ? this.changedVars[key]
       : (this.changedVars[key] = (evt, option: IChoiceGroupOption) => {
-          const { onChanged, onChange, selectedKey, options } = this.props;
+          const { onChanged, onChange, selectedKey, options = [] } = this.props;
 
           // Only manage state in uncontrolled scenarios.
           if (selectedKey === undefined) {
@@ -143,7 +143,7 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
             });
           }
 
-          const originalOption = options!.find((value: IChoiceGroupOption) => value.key === key);
+          const originalOption = find(options, (value: IChoiceGroupOption) => value.key === key);
 
           // TODO: onChanged deprecated, remove else if after 07/17/2017 when onChanged has been removed.
           if (onChange) {
@@ -158,7 +158,9 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
       return props.selectedKey;
     }
 
-    const optionsChecked = props.options!.filter((option: IChoiceGroupOption) => {
+    const { options = [] } = props;
+
+    const optionsChecked = options.filter((option: IChoiceGroupOption) => {
       return option.checked;
     });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5784
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix the `Array.find` does not exist bug in IE11 by using the `find` function from utilities.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5792)

