### PR TITLE
FocusTrapZone screener tests

### DIFF
--- a/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
+++ b/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
@@ -2,15 +2,7 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import {
-  Panel,
-  PanelType,
-  Dialog,
-  DialogType,
-  DialogFooter,
-  PrimaryButton,
-  DefaultButton
-} from 'office-ui-fabric-react';
+import { Panel, PanelType, Dialog, DialogType } from 'office-ui-fabric-react';
 
 storiesOf('FocusTrapZones', module)
   .addDecorator(FabricDecorator)

--- a/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
+++ b/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
@@ -10,7 +10,7 @@ storiesOf('FocusTrapZones', module)
     <Screener
       steps={new Screener.Steps()
         .snapshot('default')
-        .click(.'ms-Panel-closeButton')
+        .click('.ms-Panel-closeButton')
         .snapshot('click on panel close button')
         .end()}
     >

--- a/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
+++ b/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { FabricDecorator } from '../utilities';
+import {
+  Panel,
+  PanelType,
+  Dialog,
+  DialogType,
+  DialogFooter,
+  PrimaryButton,
+  DefaultButton
+} from 'office-ui-fabric-react';
+
+storiesOf('FocusTrapZones', module)
+  .addDecorator(FabricDecorator)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default')
+        .click('ms-Panel-closeButton')
+        .snapshot('click on panel close button')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .add('Dialog nested in Panel', () => (
+    <div>
+      <Panel
+        isOpen={true}
+        type={PanelType.smallFixedFar}
+        headerText="This panel makes use of Layer and FocusTrapZone. Focus should be trapped in the panel."
+        closeButtonAriaLabel="Close"
+        hasCloseButton={true}
+      >
+        <Dialog
+          hidden={false}
+          isBlocking={true}
+          dialogContentProps={{
+            type: DialogType.normal,
+            title:
+              'This dialog uses Modal, which also makes use of Layer and FocusTrapZone. Focus should be trapped in the dialog.',
+            subText: "Focus will move back to the panel if you press 'OK' or 'Cancel'."
+          }}
+          modalProps={{
+            titleAriaId: 'myLabelId',
+            subtitleAriaId: 'mySubTextId',
+            isBlocking: false,
+            containerClassName: 'ms-dialogMainOverride'
+          }}
+        >
+          {null}
+        </Dialog>
+      </Panel>
+    </div>
+  ))
+  .add('Panel on its own', () => (
+    <div>
+      <Panel
+        isOpen={true}
+        type={PanelType.smallFixedFar}
+        headerText="This is a panel on its own"
+        closeButtonAriaLabel="Close"
+        hasCloseButton={true}
+      >
+        {null}
+      </Panel>
+    </div>
+  ));

--- a/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
+++ b/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
@@ -10,7 +10,7 @@ storiesOf('FocusTrapZones', module)
     <Screener
       steps={new Screener.Steps()
         .snapshot('default')
-        .click('ms-Panel-closeButton')
+        .click(.'ms-Panel-closeButton')
         .snapshot('click on panel close button')
         .end()}
     >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adding two stories in this PR. The first has a dialog nested in a panel, where the focus should be trapped in the dialog and, therefore, the panel's close button should not be clickable. The second is a panel on its own and its close button should be clickable.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5795)

