### PR TITLE
Fix button that has inner html

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-button-that-has-inner-html_2018-08-03-18-49.json
+++ b/common/changes/office-ui-fabric-react/fix-button-that-has-inner-html_2018-08-03-18-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button should not have any html tag as children. In IE the inner html, would not render. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xiameng@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
@@ -30,7 +30,7 @@ export class SuggestionsHeaderFooterItem extends BaseComponent<ISuggestionsHeade
   public render(): JSX.Element {
     const { renderItem, onExecute, isSelected, id } = this.props;
     return onExecute ? (
-      <button
+      <div
         id={id}
         onClick={onExecute}
         className={css('ms-Suggestions-sectionButton', styles.actionButton, {
@@ -38,7 +38,7 @@ export class SuggestionsHeaderFooterItem extends BaseComponent<ISuggestionsHeade
         })}
       >
         {renderItem()}
-      </button>
+      </div>
     ) : (
       <div id={id} className={css('ms-Suggestions-section', styles.suggestionsTitle)}>
         {renderItem()}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes
Button should not have any html tag as children. In IE the inner html, would not render.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5796)

