### PR TITLE
Fixing Stack to allow for classNames through Stack.Item

### DIFF
--- a/common/changes/@uifabric/experiments/master_2018-08-03-20-51.json
+++ b/common/changes/@uifabric/experiments/master_2018-08-03-20-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fixing Stack to allow for classNames through Stack.Item",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/experiments/src/components/Stack/Stack.tsx
+++ b/packages/experiments/src/components/Stack/Stack.tsx
@@ -11,19 +11,26 @@ const StackItemType = (<StackItem /> as React.ReactElement<IStackItemProps> &
 const view = (props: IViewComponentProps<IStackProps, IStackStyles>) => {
   const { renderAs: RootType = 'div', classNames, gap, vertical, collapseItems } = props;
 
-  const children: React.ReactChild[] = React.Children.map(
+  const stackChildren: React.ReactChild[] = React.Children.map(
     props.children,
     (child: React.ReactElement<IStackItemProps>, index: number) => {
       const defaultItemProps: IStackItemProps = {
         gap: index > 0 ? gap : 0,
         vertical,
-        collapse: collapseItems
+        collapse: collapseItems,
+        className: child.props ? child.props.className : undefined
       };
 
       if (child.type === StackItemType) {
+        // If child is a StackItem, we need to pass down the className of ITS first child to the StackItem for mergeStylesSet to work
+        const children = child.props ? child.props.children : undefined;
+        const stackItemFirstChildren = React.Children.toArray(children) as React.ReactElement<{ className?: string }>[];
+        const stackItemFirstChild = stackItemFirstChildren && stackItemFirstChildren[0];
+
         return React.cloneElement(child, {
           ...defaultItemProps,
-          ...child.props
+          ...child.props,
+          className: stackItemFirstChild && stackItemFirstChild.props ? stackItemFirstChild.props.className : undefined
         });
       }
 
@@ -31,7 +38,7 @@ const view = (props: IViewComponentProps<IStackProps, IStackStyles>) => {
     }
   );
 
-  return <RootType className={classNames.root}>{children}</RootType>;
+  return <RootType className={classNames.root}>{stackChildren}</RootType>;
 };
 
 const StackStatics = {

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
@@ -8,7 +8,7 @@ const alignMap: { [key: string]: string } = {
 const justifyMap: { [key: string]: string } = {};
 
 export const styles = (props: IThemedProps<IStackItemProps>): IStackItemStyles => {
-  const { grow, collapse, align, justify, gap, vertical } = props;
+  const { grow, collapse, align, justify, gap, vertical, className } = props;
 
   return {
     root: [
@@ -27,7 +27,8 @@ export const styles = (props: IThemedProps<IStackItemProps>): IStackItemStyles =
       },
       !!gap && {
         [vertical ? 'marginTop' : 'marginLeft']: gap
-      }
+      },
+      className
     ]
     // TODO: this cast may be hiding some potential issues with styling and name
     //        lookups and should be removed

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
@@ -13,7 +13,7 @@ describe('Stack Item', () => {
     expect(wrapper.find('div.test').length).toBe(1);
   });
 
-  it('can handle not having a class in a child of an explicit Stack.Item component', () => {
+  it('can handle having a class in a child of an explicit Stack.Item component', () => {
     const wrapper = mount(
       <Stack>
         <Stack.Item>

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { Stack } from '../index';
+
+describe('Stack Item', () => {
+  it('allows className from child component to be rendered', () => {
+    const wrapper = mount(
+      <Stack>
+        <div className="test" />
+      </Stack>
+    );
+
+    expect(wrapper.find('div.test').length).toBe(1);
+  });
+
+  it('can handle not having a class in a child of an explicit Stack.Item component', () => {
+    const wrapper = mount(
+      <Stack>
+        <Stack.Item>
+          <div className="test" />
+        </Stack.Item>
+      </Stack>
+    );
+
+    expect(wrapper.find('div.test').length).toBe(1);
+  });
+
+  it('can handle not having a class', () => {
+    const wrapper = mount(
+      <Stack>
+        <Stack.Item>
+          <div />
+        </Stack.Item>
+      </Stack>
+    );
+
+    expect(wrapper.find('.test').length).toBe(0);
+  });
+});

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -2,7 +2,12 @@ import { IStyle } from '../../../Styling';
 import { IStyleableComponent } from '../../../Foundation';
 
 export interface IStackItemProps extends IStyleableComponent<IStackItemProps, IStackItemStyles> {
+  className?: string;
+
   renderAs?: string | React.ReactType<IStackItemProps>;
+
+  /** @internal Internal use only - gives the Stack component a handle on the children of its Stack.Items */
+  children?: React.ReactElement<IStackItemProps>[] | React.ReactElement<IStackItemProps>;
 
   gap?: number;
   vertical?: boolean;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

I've added a fix for stack so that it passes down className whether Stack.Item is used explicitly or implicitly

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5798)

