### PR TITLE
Panel: When isHiddenOnDismiss and closed, forceFocusInsideTrap set to false

### DIFF
--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Panel, PanelType } from 'office-ui-fabric-react';
+import { Panel, PanelType, SearchBox } from 'office-ui-fabric-react';
 
 Panel.defaultProps = {
   isOpen: true,
@@ -12,58 +12,35 @@ Panel.defaultProps = {
 
 storiesOf('Panel', module)
   .addDecorator(FabricDecorator)
+  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default').end()}>{story()}</Screener>)
+  .add('Small left w/ close button', () => <Panel hasCloseButton type={PanelType.smallFixedNear} headerText="Small" />)
+  .add('Small fixed right w/ close button', () => (
+    <Panel hasCloseButton type={PanelType.smallFixedFar} headerText="Small fixed" />
+  ))
+  .add('Small fluid right', () => <Panel type={PanelType.smallFluid} headerText="Small fluid" />)
+  .add('Medium right', () => <Panel type={PanelType.medium} headerText="Medium" />)
+  .add('Large right', () => <Panel type={PanelType.large} headerText="Large" />)
+  .add('Large fixed right', () => <Panel type={PanelType.largeFixed} headerText="Large fixed" />)
+  .add('Extra large right', () => <Panel type={PanelType.extraLarge} headerText="Extra Large" />);
+
+storiesOf('Panel', module)
+  .addDecorator(FabricDecorator)
   .addDecorator(story => (
     <Screener
-      steps={ new Screener.Steps()
+      steps={new Screener.Steps()
         .snapshot('default')
-        .end()
-      }
+        .click('.ms-SearchBox-field')
+        .snapshot('default')
+        .end()}
     >
-      { story() }
+      {story()}
     </Screener>
   ))
-  .add('Small left w/ close button', () => (
-    <Panel
-      hasCloseButton
-      type={ PanelType.smallFixedNear }
-      headerText='Small'
-    />
-  ))
-  .add('Small fixed right w/ close button', () => (
-    <Panel
-      hasCloseButton
-      type={ PanelType.smallFixedFar }
-      headerText='Small fixed'
-    />
-  ))
-  .add('Small fluid right', () => (
-    <Panel
-      type={ PanelType.smallFluid }
-      headerText='Small fluid'
-    />
-  ))
-  .add('Medium right', () => (
-    <Panel
-      type={ PanelType.medium }
-      headerText='Medium'
-    />
-  ))
-  .add('Large right', () => (
-    <Panel
-      type={ PanelType.large }
-      headerText='Large'
-    />
-  ))
-  .add('Large fixed right', () => (
-    <Panel
-      type={ PanelType.largeFixed }
-      headerText='Large fixed'
-    />
-  ))
-  .add('Extra large right', () => (
-    <Panel
-      type={ PanelType.extraLarge }
-      headerText='Extra Large'
-    />
-  ))
-  ;
+  .add('SearchBox and Right Panel', () => (
+    <div>
+      <SearchBox placeholder="Search" />
+      <Panel isOpen={false} type={PanelType.medium} headerClassName="" headerText={'Header'} isHiddenOnDismiss>
+        {null}
+      </Panel>
+    </div>
+  ));

--- a/common/changes/office-ui-fabric-react/searchBoxAndPanel_2018-08-03-23-59.json
+++ b/common/changes/office-ui-fabric-react/searchBoxAndPanel_2018-08-03-23-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Don't force focus in trap if isHiddenOnDismiss is set and panel is closed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -173,7 +173,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
             {overlay}
             <FocusTrapZone
               ignoreExternalFocusing={ignoreExternalFocusing}
-              forceFocusInsideTrap={isHiddenOnDismiss ? false : forceFocusInsideTrap}
+              forceFocusInsideTrap={isHiddenOnDismiss && !isOpen ? false : forceFocusInsideTrap}
               firstFocusableSelector={firstFocusableSelector}
               {...focusTrapZoneProps}
               className={css(

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -173,7 +173,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
             {overlay}
             <FocusTrapZone
               ignoreExternalFocusing={ignoreExternalFocusing}
-              forceFocusInsideTrap={forceFocusInsideTrap}
+              forceFocusInsideTrap={isHiddenOnDismiss ? false : forceFocusInsideTrap}
               firstFocusableSelector={firstFocusableSelector}
               {...focusTrapZoneProps}
               className={css(

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -42,6 +42,7 @@ export interface IPanelProps extends React.Props<Panel> {
 
   /**
    * Whether the panel is hidden on dismiss, instead of destroyed in the DOM.
+   * Protects the contents from being destroyed when the panel is dismissed.
    * @default false
    */
   isHiddenOnDismiss?: boolean;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5704
- [X] Include a change request file using `$ npm run change`

#### Description of changes

** TODO **: write tests

These changes set `forceFocusInsideTrap` to false on two conditions:
1. the panel's prop `isHiddenOnDismiss` is true
2. the panel is closed (`isOpen` is false)

This makes sure that the panel is not stealing focus away from other elements on the page when it is closed (although technically just hiding). The `forceFocusInsideTrap` returns to its correct value when the panel is opened again.

Now, as we can see below, the panel won't steal focus from the SearchBox and block the animations.

Before (no SearchBox animations):

![searchbox animations not working with panel](https://user-images.githubusercontent.com/14134000/43670505-4d862fa8-9741-11e8-851d-d3915e70cfa8.gif)


After (SearchBox animations working):

![searchbox animations working with panel](https://user-images.githubusercontent.com/14134000/43670507-4f576374-9741-11e8-8c19-0198bbaa87e3.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5805)

