### PR TITLE
Adding props to gridlist to accept colors for content and icons

### DIFF
--- a/common/changes/@uifabric/dashboard/master_2018-08-04-00-27.json
+++ b/common/changes/@uifabric/dashboard/master_2018-08-04-00-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Adding props that take colors for icon and content in each cell of gridlist",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "v-kanuli@microsoft.com"
+}

--- a/packages/dashboard/src/components/Card/GridList/GridList.styles.ts
+++ b/packages/dashboard/src/components/Card/GridList/GridList.styles.ts
@@ -1,6 +1,6 @@
-import { IGridListStyles } from './GridList.types';
+import { ICustomCssForCells, IGridListStyles } from './GridList.types';
 
-export const getStyles = (): IGridListStyles => {
+export const getStyles = (props: ICustomCssForCells): IGridListStyles => {
   return {
     root: {},
     actionButton: {
@@ -8,7 +8,8 @@ export const getStyles = (): IGridListStyles => {
     },
     imageAlignment: {
       float: 'left',
-      marginRight: '16px'
+      marginRight: '16px',
+      color: props.iconColor ? props.iconColor : ''
     },
     cursonPointer: {
       cursor: 'pointer'
@@ -16,7 +17,7 @@ export const getStyles = (): IGridListStyles => {
     text: {
       fontSize: '14px',
       lineHeight: '16px',
-      color: '#333333'
+      color: props.textColor ? props.textColor : '#333333'
     }
   };
 };

--- a/packages/dashboard/src/components/Card/GridList/GridList.tsx
+++ b/packages/dashboard/src/components/Card/GridList/GridList.tsx
@@ -15,7 +15,7 @@ import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 
 const getClassNames = classNamesFunction<IGridListProps, IGridListStyles>();
-const classNames = getClassNames(getStyles);
+const classNames = getClassNames(getStyles({}));
 
 export class GridList extends React.Component<IGridListProps> {
   constructor(props: IGridListProps) {
@@ -55,6 +55,7 @@ export class GridList extends React.Component<IGridListProps> {
     } else {
       cell = row.c3;
     }
+    const customColorCss = getClassNames(getStyles({ iconColor: cell.iconColor, textColor: cell.textColor }));
     switch (column.key) {
       case 'facepile':
         return (
@@ -62,21 +63,21 @@ export class GridList extends React.Component<IGridListProps> {
             <span className={classNames.imageAlignment}>
               <Image src={cell.facepileImageSrc} width={24} height={24} imageFit={ImageFit.cover} />
             </span>
-            <span className={classNames.text}>{cell.content}</span>
+            <span className={customColorCss.text}>{cell.content}</span>
           </div>
         );
       case 'icon':
         return (
           <div data-selection-invoke={row.isClickable}>
-            <span className={classNames.imageAlignment}>
+            <span className={customColorCss.imageAlignment}>
               <Icon iconName={cell.iconName} />
             </span>
-            <span className={classNames.text}>{cell.content}</span>
+            <span className={customColorCss.text}>{cell.content}</span>
           </div>
         );
       case 'textOnly':
         return (
-          <span className={classNames.text} data-selection-invoke={row.isClickable}>
+          <span className={customColorCss.text} data-selection-invoke={row.isClickable}>
             {cell.content}
           </span>
         );
@@ -111,17 +112,23 @@ export class GridList extends React.Component<IGridListProps> {
         c1: {
           content: gridRow.c1.content,
           facepileImageSrc: gridRow.c1.facepileImageSrc,
-          iconName: gridRow.c1.iconName
+          iconName: gridRow.c1.iconName,
+          textColor: gridRow.c1 !== undefined ? gridRow.c1.textColor : undefined,
+          iconColor: gridRow.c1 !== undefined ? gridRow.c1.iconColor : undefined
         },
         c2: {
           content: gridRow.c2 !== undefined ? gridRow.c2.content : undefined,
           facepileImageSrc: gridRow.c2 !== undefined ? gridRow.c2.facepileImageSrc : undefined,
-          iconName: gridRow.c2 !== undefined ? gridRow.c2.iconName : undefined
+          iconName: gridRow.c2 !== undefined ? gridRow.c2.iconName : undefined,
+          textColor: gridRow.c1 !== undefined ? gridRow.c1.textColor : undefined,
+          iconColor: gridRow.c1 !== undefined ? gridRow.c1.iconColor : undefined
         },
         c3: {
           content: gridRow.c3 !== undefined ? gridRow.c3.content : undefined,
           facepileImageSrc: gridRow.c3 !== undefined ? gridRow.c3.facepileImageSrc : undefined,
-          iconName: gridRow.c3 !== undefined ? gridRow.c3.iconName : undefined
+          iconName: gridRow.c3 !== undefined ? gridRow.c3.iconName : undefined,
+          textColor: gridRow.c1 !== undefined ? gridRow.c1.textColor : undefined,
+          iconColor: gridRow.c1 !== undefined ? gridRow.c1.iconColor : undefined
         }
       };
       rows.push(rowItem);

--- a/packages/dashboard/src/components/Card/GridList/GridList.types.ts
+++ b/packages/dashboard/src/components/Card/GridList/GridList.types.ts
@@ -38,6 +38,21 @@ export interface IGridCellItem {
    * The icon we want to show
    */
   iconName?: string;
+
+  /**
+   * The color for the icon
+   */
+  iconColor?: string;
+
+  /**
+   * The color for text in each cell
+   */
+  textColor?: string;
+}
+
+export interface ICustomCssForCells {
+  iconColor?: string;
+  textColor?: string;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Adding props that take colors for icon and content in each cell of gridlist
![image](https://user-images.githubusercontent.com/22408128/43670627-bd55ea70-9742-11e8-8397-0a2b31bfac3c.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5806)

