### PR TITLE
Fix scrollbar appearing in ActivityItem

### DIFF
--- a/common/changes/office-ui-fabric-react/activity-content-scroll_2018-08-06-18-56.json
+++ b/common/changes/office-ui-fabric-react/activity-content-scroll_2018-08-06-18-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix line height scrollbar issue in ActivityItem",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.styles.ts
@@ -70,7 +70,6 @@ export const getStyles = memoizeFunction(
           display: 'flex',
           justifyContent: 'flex-start',
           alignItems: 'flex-start',
-          lineHeight: '17px',
           boxSizing: 'border-box',
           color: theme.palette.neutralSecondary
         },

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
         font-size: 12px;
         font-weight: 400;
         justify-content: flex-start;
-        line-height: 17px;
       }
   style={undefined}
 >
@@ -175,7 +174,6 @@ exports[`ActivityItem renders compact with an icon correctly 1`] = `
         font-size: 12px;
         font-weight: 400;
         justify-content: flex-start;
-        line-height: 17px;
       }
   style={undefined}
 >
@@ -276,7 +274,6 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
         font-size: 12px;
         font-weight: 400;
         justify-content: flex-start;
-        line-height: 17px;
       }
   style={undefined}
 >
@@ -458,7 +455,6 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
         font-size: 12px;
         font-weight: 400;
         justify-content: flex-start;
-        line-height: 17px;
       }
   style={undefined}
 >
@@ -771,7 +767,6 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
         font-size: 12px;
         font-weight: 400;
         justify-content: flex-start;
-        line-height: 17px;
       }
   style={undefined}
 >
@@ -919,7 +914,6 @@ exports[`ActivityItem renders with an icon correctly 1`] = `
         font-size: 12px;
         font-weight: 400;
         justify-content: flex-start;
-        line-height: 17px;
       }
   style={undefined}
 >
@@ -1017,7 +1011,6 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
         font-size: 12px;
         font-weight: 400;
         justify-content: flex-start;
-        line-height: 17px;
       }
   style={undefined}
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -16,7 +16,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}
@@ -247,7 +246,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}
@@ -407,7 +405,6 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
@@ -16,7 +16,6 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}
@@ -204,7 +203,6 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}
@@ -534,7 +532,6 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}
@@ -639,7 +636,6 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -16,7 +16,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}
@@ -256,7 +255,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}
@@ -675,7 +673,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}
@@ -1099,7 +1096,6 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
           font-size: 12px;
           font-weight: 400;
           justify-content: flex-start;
-          line-height: 17px;
           margin-top: 20px;
         }
     style={undefined}


### PR DESCRIPTION
# Overview

This change fixes an issue in Edge and IE 11 where the `ActivityItem` component would show a scroll bar when rendered in a box exactly equal to the `line-height`. The `overflow-x: hidden` rule causes a vertical scrollbar to appear due to the presence of descenders which extend below the box.
Removing the `line-height` enforcement removes the artificial height enforcement while preserving the visuals, which get the correct line height from the current font size.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5820)

