### PR TITLE
ShimmeredDetailsList: modify some math logic

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-ShimmeredDetailsListFix_2018-08-06-22-41.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ShimmeredDetailsListFix_2018-08-06-22-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ShimmeredDetailsList: replace a hard coded multiplier with a ratio constant and modify some math logic.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.base.tsx
@@ -21,6 +21,7 @@ const getClassNames = classNamesFunction<IShimmeredDetailsListStyleProps, IShimm
 
 const SHIMMER_INITIAL_ITEMS = 10;
 const DEFAULT_SHIMMER_HEIGHT = 7;
+const SHIMMER_LINE_VS_CELL_WIDTH_RATIO = 0.95;
 
 // This values are matching values from ./DetailsRow.css
 const DEFAULT_ROW_HEIGHT = 42;
@@ -130,12 +131,15 @@ export class ShimmeredDetailsListBase extends BaseComponent<IShimmeredDetailsLis
       } else {
         shimmerElements.push({
           type: ShimmerElementType.line,
-          width: column.calculatedWidth! - cellStyleProps.cellRightPadding * 3,
+          width: column.calculatedWidth! * SHIMMER_LINE_VS_CELL_WIDTH_RATIO,
           height: DEFAULT_SHIMMER_HEIGHT
         });
         shimmerElements.push({
           type: ShimmerElementType.gap,
-          width: cellStyleProps.cellRightPadding * 4,
+          width:
+            cellStyleProps.cellRightPadding +
+            (column.calculatedWidth! - column.calculatedWidth! * SHIMMER_LINE_VS_CELL_WIDTH_RATIO) +
+            (column.isPadded ? cellStyleProps.cellExtraRightPadding : 0),
           height: gapHeight
         });
       }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes a misaligned ShimmeredDetailsList
- [X] Include a change request file using `$ npm run change`

#### Description of changes
ShimmeredDetailsList was not taking into consideration the isPadded property of the column so had to adjust some widths of shimmer elements plus took advantage to replace a hard coded multiplier with a constant ratio.

**This is how it looks misaligned:** 
![screen shot 2018-08-06 at 12 27 11 pm](https://user-images.githubusercontent.com/29514833/43744663-dd477d18-998f-11e8-9df0-991297e3d764.png)

**This is how it looks after the fix:**
![screen shot 2018-08-06 at 3 46 24 pm](https://user-images.githubusercontent.com/29514833/43744679-f2a2014c-998f-11e8-8ecb-7843f40823c9.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5824)

