### PR TITLE
Improve regex that is part of autodoc

### DIFF
--- a/common/changes/@uifabric/example-app-base/bug5528_2018-08-07-01-21.json
+++ b/common/changes/@uifabric/example-app-base/bug5528_2018-08-07-01-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Autodoc: improve regex to handle certain edge cases of declaring interfaces.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/parser/Parse.ts
+++ b/packages/example-app-base/src/utilities/parser/Parse.ts
@@ -29,7 +29,8 @@ export function parse(source: string, propsInterfaceOrEnumName?: string): IPrope
 
   if (propsInterfaceOrEnumName) {
     regex = new RegExp(
-      `export (interface|(?:const )?enum) ${propsInterfaceOrEnumName}(?: extends .*?)? \\{(.*[\\r\\n]*)*?\\}`
+      `^export (interface|(?:const )?enum) ${propsInterfaceOrEnumName}(?: extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`,
+      'm'
     );
     let regexResult = regex.exec(source);
     if (regexResult && regexResult.length > 0) {

--- a/packages/example-app-base/src/utilities/parser/Parse.ts
+++ b/packages/example-app-base/src/utilities/parser/Parse.ts
@@ -44,7 +44,7 @@ export function parse(source: string, propsInterfaceOrEnumName?: string): IPrope
       ];
     }
   } else {
-    regex = new RegExp(`export (interface|(?:const )?enum) (\\S*?)(?: extends .*?)? \\{(.*[\\r\\n]*)*?\\}`, 'g');
+    regex = new RegExp(`^export (interface|(?:const )?enum) (\\S*?)(?: extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`, 'gm');
     let regexResult: RegExpExecArray | null;
     let results: Array<IProperty> = [];
     while ((regexResult = regex.exec(source)) !== null) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5528 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
When someone checks in code without Prettier and has
```ts 
export interface ICoachmark { }
``` 

(note the space in `{ }`, it works fine if prettier changes it to `{}`) as part of a larger file, it will crash.

Similarly, it was incorrectly triggering on the following code (less serious because we will never check code like this in - but I fixed it as well since I was in the area):
```ts
// export interface blah {
// }
export type ITextFieldStyleProps = number;
```

Test case:
```ts
import { ICoachmarkStyles, ICoachmarkStyleProps } from './Coachmark.styles';
import { IPositioningContainerProps } from './PositioningContainer/PositioningContainer.types';
import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
import { Coachmark } from './Coachmark';
import { ITeachingBubble } from '../../TeachingBubble';

export interface ICoachmark { }

// export interface blah {
// }
export type ITextFieldStyleProps = number;

/** @deprecated */
export type ICoachmarkTypes = ICoachmarkProps;

export interface ICoachmarkProps extends React.Props<Coachmark> {
  /**
   * Optional callback to access the ICoachmark interface. Use this instead of ref for accessing
   * the public methods and properties of the component.
   */
  componentRef?: IRefObject<ICoachmark>;

  /**
   * Call to provide customized styling that will layer on top of the variant rules
   */
  styles?: IStyleFunctionOrObject<ICoachmarkStyleProps, ICoachmarkStyles>;

  /**
   * The target that the Coachmark should try to position itself based on.
   */
  target: HTMLElement | string | null;

  /**
   * Props to pass to the PositioningContainer component. Specify the `directionalHint` to indicate
   * on which edge the Coachmark/TeachingBubble should be positioned.
   * @default directionalHint: DirectionalHint.bottomAutoEdge
   */
  positioningContainerProps?: IPositioningContainerProps;

  /**
   * Whether or not to force the Coachmark/TeachingBubble content to fit within the window bounds.
   * @default true
   */
  isPositionForced?: boolean;

  /**
   * The starting collapsed state for the Coachmark.  Use isCollapsed instead.
   * @default true
   * @deprecated
   */
  collapsed?: boolean;

  /**
   * The starting collapsed state for the Coachmark.
   * @default true
   */
  isCollapsed?: boolean;

  /**
   * The distance in pixels the mouse is located
   * before opening up the Coachmark.
   * @default 10
   */
  mouseProximityOffset?: number;

  /**
   * Callback when the opening animation begins.
   */
  onAnimationOpenStart?: () => void;

  /**
   * Callback when the opening animation completes.
   */
  onAnimationOpenEnd?: () => void;

  /**
   * The width of the Beak component.
   * @deprecated
   */
  beakWidth?: number;

  /**
   * The height of the Beak component.
   * @deprecated
   */
  beakHeight?: number;

  /**
   * Delay before allowing mouse movements to open the Coachmark.
   * @default 3600
   */
  delayBeforeMouseOpen?: number;

  /**
   * Callback to run when the mouse moves.
   */
  onMouseMove?: (e: MouseEvent) => void;

  /**
   * The width of the Coachmark.
   * @deprecated
   */
  width?: number;

  /**
   * The height of the Coachmark.
   * @deprecated
   */
  height?: number;

  /**
   * Color of the Coachmark/TeachingBubble.
   */
  color?: string;

  /**
   * Beacon color one.
   */
  beaconColorOne?: string;

  /**
   * Beacon color two.
   */
  beaconColorTwo?: string;

  /**
   * Text to announce to screen reader / narrator when Coachmark is displayed
   */
  ariaAlertText?: string;

  /**
   * Ref for TeachingBubble
   */
  teachingBubbleRef?: ITeachingBubble;

  /**
   *  Defines the element id referencing the element containing label text for Coachmark.
   */
  ariaLabelledBy?: string;

  /**
   * Defines the element id referencing the element containing the description for the Coachmark.
   */
  ariaDescribedBy?: string;

  /**
   *  Defines the text content for the ariaLabelledBy element
   */
  ariaLabelledByText?: string;

  /**
   * Defines the text content for the ariaDescribedBy element
   */
  ariaDescribedByText?: string;
}
```

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5830)

