### PR TITLE
Column Drag Drop: Drop hint Icon fix

### DIFF
--- a/common/changes/office-ui-fabric-react/laxmika-DropHintIconFix_2018-08-07-16-02.json
+++ b/common/changes/office-ui-fabric-react/laxmika-DropHintIconFix_2018-08-07-16-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Changing the drophint ICON",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "laxmika@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -532,12 +532,13 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
     const classNames = this._classNames;
     return (
       <div key={'dropHintKey'} className={classNames.dropHintStyle} id={`columnDropHint_${dropHintIndex}`}>
-        <div
-          key={`dropHintCircleKey`}
+        <Icon
+          key={`dropHintCaretKey`}
           aria-hidden={true}
           data-is-focusable={false}
           data-sizer-index={dropHintIndex}
-          className={classNames.dropHintCircleStyle}
+          className={classNames.dropHintCaretStyle}
+          iconName={'CaretUpSolid8'}
         />
         <div
           key={`dropHintLineKey`}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -293,7 +293,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
         position: 'absolute',
         top: 22,
         left: -9,
-        fontSize: 18,
+        fontSize: 16,
         color: palette.themePrimary,
         overflow: 'visible',
         zIndex: 10

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -25,7 +25,7 @@ const GlobalClassNames = {
   isResizingColumn: 'is-resizingColumn',
   cellSizer: 'ms-DetailsHeader-cellSizer',
   isResizing: 'is-resizing',
-  dropHintCircleStyle: 'ms-DetailsHeader-dropHintCircleStyle',
+  dropHintCaretStyle: 'ms-DetailsHeader-dropHintCaretStyle',
   dropHintLineStyle: 'ms-DetailsHeader-dropHintLineStyle',
   cellTitle: 'ms-DetailsHeader-cellTitle',
   cellName: 'ms-DetailsHeader-cellName',
@@ -285,22 +285,18 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
 
     accessibleLabel: [hiddenContentStyle],
 
-    dropHintCircleStyle: [
-      classNames.dropHintCircleStyle,
+    dropHintCaretStyle: [
+      classNames.dropHintCaretStyle,
       {
         display: 'inline-block',
         visibility: 'hidden',
         position: 'absolute',
-        bottom: 0,
-        height: 9,
-        width: 9,
-        borderRadius: '50%',
-        marginLeft: -5,
-        top: 34,
+        top: 22,
+        left: -9,
+        fontSize: 18,
+        color: palette.themePrimary,
         overflow: 'visible',
-        zIndex: 10,
-        border: `1px solid ${palette.themePrimary}`,
-        background: palette.white
+        zIndex: 10
       }
     ],
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -25,6 +25,7 @@ const GlobalClassNames = {
   isResizingColumn: 'is-resizingColumn',
   cellSizer: 'ms-DetailsHeader-cellSizer',
   isResizing: 'is-resizing',
+  dropHintCircleStyle: 'ms-DetailsHeader-dropHintCircleStyle',
   dropHintCaretStyle: 'ms-DetailsHeader-dropHintCaretStyle',
   dropHintLineStyle: 'ms-DetailsHeader-dropHintLineStyle',
   cellTitle: 'ms-DetailsHeader-cellTitle',
@@ -284,6 +285,25 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
     ],
 
     accessibleLabel: [hiddenContentStyle],
+
+    dropHintCircleStyle: [
+      classNames.dropHintCircleStyle,
+      {
+        display: 'inline-block',
+        visibility: 'hidden',
+        position: 'absolute',
+        bottom: 0,
+        height: 9,
+        width: 9,
+        borderRadius: '50%',
+        marginLeft: -5,
+        top: 34,
+        overflow: 'visible',
+        zIndex: 10,
+        border: `1px solid ${palette.themePrimary}`,
+        background: palette.white
+      }
+    ],
 
     dropHintCaretStyle: [
       classNames.dropHintCaretStyle,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -292,7 +292,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
         visibility: 'hidden',
         position: 'absolute',
         top: 22,
-        left: -9,
+        left: -7.5,
         fontSize: 16,
         color: palette.themePrimary,
         overflow: 'visible',

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -161,6 +161,7 @@ export interface IDetailsHeaderStyles {
   collapseButton: IStyle;
   checkTooltip: IStyle;
   sizingOverlay: IStyle;
+  dropHintCircleStyle: IStyle;
   dropHintCaretStyle: IStyle;
   dropHintLineStyle: IStyle;
   dropHintStyle: IStyle;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -161,7 +161,7 @@ export interface IDetailsHeaderStyles {
   collapseButton: IStyle;
   checkTooltip: IStyle;
   sizingOverlay: IStyle;
-  dropHintCircleStyle: IStyle;
+  dropHintCaretStyle: IStyle;
   dropHintLineStyle: IStyle;
   dropHintStyle: IStyle;
   accessibleLabel: IStyle;


### PR DESCRIPTION
Changing the drophint ICON for column reorder to carat instead of circle as per the new spec

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5835)

