### PR TITLE
Layer: Fix layer customizability regression introduced in #5569 - which also broke the official Layer example.

### DIFF
--- a/common/changes/office-ui-fabric-react/bug5696_2018-08-07-23-18.json
+++ b/common/changes/office-ui-fabric-react/bug5696_2018-08-07-23-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Layer: Fix layer customizability regression introduced in #5569 - which also broke the official Layer example.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
@@ -4,5 +4,6 @@ import { LayerBase } from './Layer.base';
 import { getStyles } from './Layer.styles';
 
 export const Layer = styled<ILayerProps, ILayerStyleProps, ILayerStyles>(LayerBase, getStyles, undefined, {
-  scope: 'Layer'
+  scope: 'Layer',
+  fields: ['hostId', 'theme', 'styles']
 });

--- a/packages/office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx
@@ -59,7 +59,8 @@ export class LayerCustomizedExample extends React.Component<{}, ILayerCustomized
           style={{
             position: 'relative',
             height: '400px',
-            overflow: 'hidden'
+            overflow: 'hidden',
+            border: '1px solid #ccc'
           }}
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -341,6 +341,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
     id="test"
     style={
       Object {
+        "border": "1px solid #ccc",
         "height": "400px",
         "overflow": "hidden",
         "position": "relative",


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5696 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This regression is a result of #5569 which dropped hostId as a customizable aspect of Layer.

##### Fixed:
![image](https://user-images.githubusercontent.com/1003246/43807544-ce613766-9a5d-11e8-8fb8-730f80af0a58.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5843)

