### PR TITLE
Stackitem merge classnames

### DIFF
--- a/common/changes/@uifabric/experiments/stackitem-merge-classnames_2018-08-07-23-44.json
+++ b/common/changes/@uifabric/experiments/stackitem-merge-classnames_2018-08-07-23-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Stack: merge the className of a StackItem with the className of its first child",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/experiments/src/components/Stack/Stack.tsx
+++ b/packages/experiments/src/components/Stack/Stack.tsx
@@ -4,6 +4,7 @@ import StackItem from './StackItem/StackItem';
 import { IStackItemProps, IStackItemStyles } from './StackItem/StackItem.types';
 import { IStackProps, IStackStyles } from './Stack.types';
 import { styles } from './Stack.styles';
+import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
 const StackItemType = (<StackItem /> as React.ReactElement<IStackItemProps> &
   IStyleableComponent<IStackItemProps, IStackItemStyles>).type;
@@ -27,10 +28,16 @@ const view = (props: IViewComponentProps<IStackProps, IStackStyles>) => {
         const stackItemFirstChildren = React.Children.toArray(children) as React.ReactElement<{ className?: string }>[];
         const stackItemFirstChild = stackItemFirstChildren && stackItemFirstChildren[0];
 
+        // pass down both the className on the StackItem as well as the className on its first child
+        let mergedClassName = defaultItemProps.className;
+        if (stackItemFirstChild && stackItemFirstChild.props && stackItemFirstChild.props.className) {
+          mergedClassName = mergeStyles(mergedClassName, stackItemFirstChild.props.className);
+        }
+
         return React.cloneElement(child, {
           ...defaultItemProps,
           ...child.props,
-          className: stackItemFirstChild && stackItemFirstChild.props ? stackItemFirstChild.props.className : undefined
+          className: mergedClassName
         });
       }
 

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
@@ -36,4 +36,23 @@ describe('Stack Item', () => {
 
     expect(wrapper.find('.test').length).toBe(0);
   });
+
+  it('includes the classNames on both a StackItem and its child', () => {
+    const stackItemClassName = 'stackItemClass';
+    const childClassName = 'childClass';
+
+    const wrapper = mount(
+      <Stack>
+        <Stack.Item className={stackItemClassName}>
+          <span className={childClassName} />
+        </Stack.Item>
+      </Stack>
+    );
+
+    const child = wrapper.find('span').at(0);
+    const childClass = child.props().className;
+
+    expect(childClass).toContain(stackItemClassName);
+    expect(childClass).toContain(childClassName);
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This change fixes a bug where the className property of a StackItem was not being passed through to the StackItem view, since it was overridden with the className of its first child. Now, a StackItem will include both its own className property as well as the className property of its first child.

The className of the first child takes precedence. E.g.

`<Stack.Item className={mergeStyles({border: '1px solid red'})}><Text className=mergeStyles({border: '1px solid green'})}>Hello world</Text></Stack.Item>`

will have a green border, not a red border.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5844)

