### PR TITLE
DetailsList: Fix modal example

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-5829-detailslist-example_2018-08-08-21-11.json
+++ b/common/changes/office-ui-fabric-react/jg-5829-detailslist-example_2018-08-08-21-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "DetailsList: Fix example modal behavior by disabling row renderer.",
+      "comment": "DetailsList: Fix all examples by disabling row renderer optimization.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/jg-5829-detailslist-example_2018-08-08-21-11.json
+++ b/common/changes/office-ui-fabric-react/jg-5829-detailslist-example_2018-08-08-21-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Fix example modal behavior by disabling row renderer.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -139,7 +139,6 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
           onRenderMissingItem={this._onRenderMissingItem}
-          useReducedRowRenderer={true}
         />
 
         {contextualMenuProps && <ContextualMenu {...contextualMenuProps} />}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -96,7 +96,6 @@ export class DetailsListBasicExample extends React.Component<
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
             onItemInvoked={this._onItemInvoked}
-            useReducedRowRenderer={true}
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
@@ -78,7 +78,6 @@ export class DetailsListCompactExample extends React.Component<
             selectionPreservedOnEmptyClick={true}
             onItemInvoked={this._onItemInvoked}
             compact={true}
-            useReducedRowRenderer={true}
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx
@@ -35,7 +35,6 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
         onColumnHeaderClick={this._onColumnClick}
         onItemInvoked={this._onItemInvoked}
         onColumnHeaderContextMenu={this._onColumnHeaderContextMenu}
-        useReducedRowRenderer={true}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
@@ -48,7 +48,6 @@ export class DetailsListCustomGroupHeadersExample extends React.Component {
               </div>
             )
           }}
-          useReducedRowRenderer={true}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
@@ -19,7 +19,7 @@ export class DetailsListCustomRowsExample extends React.Component {
   }
 
   public render() {
-    return <DetailsList items={_items} setKey="set" onRenderRow={this._onRenderRow} useReducedRowRenderer={true} />;
+    return <DetailsList items={_items} setKey="set" onRenderRow={this._onRenderRow} />;
   }
 
   private _onRenderRow = (props: IDetailsRowProps): JSX.Element => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -224,7 +224,6 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
             selectionPreservedOnEmptyClick={true}
             onItemInvoked={this._onItemInvoked}
             enterModalSelectionOnTouch={true}
-            useReducedRowRenderer={true}
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
@@ -94,7 +94,6 @@ export class DetailsListDragDropExample extends React.Component<
             onRenderItemColumn={this._onRenderItemColumn}
             dragDropEvents={this._getDragDropEvents()}
             columnReorderOptions={this.state.isColumnReorderEnabled ? this._getColumnReorderOptions() : undefined}
-            useReducedRowRenderer={true}
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
@@ -119,7 +119,6 @@ export class DetailsListGroupedExample extends BaseComponent<
             showEmptyGroups: true
           }}
           onRenderItemColumn={this._onRenderColumn}
-          useReducedRowRenderer={true}
         />
       </Fabric>
     );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Large.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Large.Example.tsx
@@ -56,7 +56,6 @@ export class DetailsListGroupedLargeExample extends BaseComponent<{}, { items: {
           getGroupHeight={this._getGroupHeight}
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"
-          useReducedRowRenderer={true}
         />
       </Fabric>
     );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.NavigatingFocus.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.NavigatingFocus.Example.tsx
@@ -37,7 +37,6 @@ export class DetailsListNavigatingFocusExample extends React.Component<{}, IDeta
         items={this.state.items}
         columns={this._columns}
         initialFocusedIndex={this.state.initialFocusedIndex}
-        useReducedRowRenderer={true}
       />
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5829
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix DetailsList modal behavior by disabling row render optimization.

Since every DetailsList example has a column resizing issue and almost every example has some issue with rows not refreshing properly, I've decided to disable the row render optimization for all DetailsList examples. #5571 should fix these regressions to examples (or have examples updated to accommodate) before row render optimization is re-enabled.

#### Focus areas to test

n/a

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5855)

