### PR TITLE
Link: Fix focus border text clipping

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-5485-link-focus_2018-08-08-22-14.json
+++ b/common/changes/office-ui-fabric-react/jg-5485-link-focus_2018-08-08-22-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Link: Fix focus border text clipping.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -20,7 +20,7 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
   return {
     root: [
       classNames.root,
-      getFocusStyle(theme),
+      getFocusStyle(theme, -2),
       {
         color: semanticColors.link
       },

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -16,13 +16,13 @@ exports[`Link renders Link correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus:after {
         border: 1px solid #ffffff;
-        bottom: 1px;
+        bottom: -1px;
         content: "";
-        left: 1px;
+        left: -1px;
         outline: 1px solid #666666;
         position: absolute;
-        right: 1px;
-        top: 1px;
+        right: -1px;
+        top: -1px;
         z-index: 1;
       }
       &:active, &:hover, &:active:hover {
@@ -77,13 +77,13 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus:after {
         border: 1px solid #ffffff;
-        bottom: 1px;
+        bottom: -1px;
         content: "";
-        left: 1px;
+        left: -1px;
         outline: 1px solid #666666;
         position: absolute;
-        right: 1px;
-        top: 1px;
+        right: -1px;
+        top: -1px;
         z-index: 1;
       }
       @media screen and (-ms-high-contrast: white-on-black){& {
@@ -128,13 +128,13 @@ exports[`Link renders Link with a custom class name 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus:after {
         border: 1px solid #ffffff;
-        bottom: 1px;
+        bottom: -1px;
         content: "";
-        left: 1px;
+        left: -1px;
         outline: 1px solid #666666;
         position: absolute;
-        right: 1px;
-        top: 1px;
+        right: -1px;
+        top: -1px;
         z-index: 1;
       }
       &:active, &:hover, &:active:hover {
@@ -188,13 +188,13 @@ exports[`Link renders Link with no href as a button 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus:after {
         border: 1px solid #ffffff;
-        bottom: 1px;
+        bottom: -1px;
         content: "";
-        left: 1px;
+        left: -1px;
         outline: 1px solid #666666;
         position: absolute;
-        right: 1px;
-        top: 1px;
+        right: -1px;
+        top: -1px;
         z-index: 1;
       }
       @media screen and (-ms-high-contrast: white-on-black){& {
@@ -240,13 +240,13 @@ exports[`Link renders disabled Link correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus:after {
         border: 1px solid #ffffff;
-        bottom: 1px;
+        bottom: -1px;
         content: "";
-        left: 1px;
+        left: -1px;
         outline: 1px solid #666666;
         position: absolute;
-        right: 1px;
-        top: 1px;
+        right: -1px;
+        top: -1px;
         z-index: 1;
       }
       &:link, &:visited {
@@ -295,13 +295,13 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus:after {
         border: 1px solid #ffffff;
-        bottom: 1px;
+        bottom: -1px;
         content: "";
-        left: 1px;
+        left: -1px;
         outline: 1px solid #666666;
         position: absolute;
-        right: 1px;
-        top: 1px;
+        right: -1px;
+        top: -1px;
         z-index: 1;
       }
       @media screen and (-ms-high-contrast: white-on-black){& {
@@ -359,13 +359,13 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
       }
       .ms-Fabric--isFocusVisible &:focus:after {
         border: 1px solid #ffffff;
-        bottom: 1px;
+        bottom: -1px;
         content: "";
-        left: 1px;
+        left: -1px;
         outline: 1px solid #666666;
         position: absolute;
-        right: 1px;
-        top: 1px;
+        right: -1px;
+        top: -1px;
         z-index: 1;
       }
       @media screen and (-ms-high-contrast: white-on-black){& {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -100,13 +100,13 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -180,13 +180,13 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -330,13 +330,13 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -489,13 +489,13 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -558,13 +558,13 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -627,13 +627,13 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -171,13 +171,13 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -472,13 +472,13 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -541,13 +541,13 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -610,13 +610,13 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -961,13 +961,13 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -1030,13 +1030,13 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -1440,13 +1440,13 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {
@@ -1509,13 +1509,13 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: white-on-black){& {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -290,13 +290,13 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
             }
             .ms-Fabric--isFocusVisible &:focus:after {
               border: 1px solid #ffffff;
-              bottom: 1px;
+              bottom: -1px;
               content: "";
-              left: 1px;
+              left: -1px;
               outline: 1px solid #666666;
               position: absolute;
-              right: 1px;
-              top: 1px;
+              right: -1px;
+              top: -1px;
               z-index: 1;
             }
             @media screen and (-ms-high-contrast: white-on-black){& {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -290,13 +290,13 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             }
             .ms-Fabric--isFocusVisible &:focus:after {
               border: 1px solid #ffffff;
-              bottom: 1px;
+              bottom: -1px;
               content: "";
-              left: 1px;
+              left: -1px;
               outline: 1px solid #666666;
               position: absolute;
-              right: 1px;
-              top: 1px;
+              right: -1px;
+              top: -1px;
               z-index: 1;
             }
             @media screen and (-ms-high-contrast: white-on-black){& {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -290,13 +290,13 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
             }
             .ms-Fabric--isFocusVisible &:focus:after {
               border: 1px solid #ffffff;
-              bottom: 1px;
+              bottom: -1px;
               content: "";
-              left: 1px;
+              left: -1px;
               outline: 1px solid #666666;
               position: absolute;
-              right: 1px;
-              top: 1px;
+              right: -1px;
+              top: -1px;
               z-index: 1;
             }
             @media screen and (-ms-high-contrast: white-on-black){& {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -457,13 +457,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -1130,13 +1130,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -1803,13 +1803,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -2476,13 +2476,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -3149,13 +3149,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -3822,13 +3822,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -4495,13 +4495,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -5168,13 +5168,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -5841,13 +5841,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {
@@ -6514,13 +6514,13 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus:after {
                 border: 1px solid #ffffff;
-                bottom: 1px;
+                bottom: -1px;
                 content: "";
-                left: 1px;
+                left: -1px;
                 outline: 1px solid #666666;
                 position: absolute;
-                right: 1px;
-                top: 1px;
+                right: -1px;
+                top: -1px;
                 z-index: 1;
               }
               &:active, &:hover, &:active:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1069,13 +1069,13 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 }
                 .ms-Fabric--isFocusVisible &:focus:after {
                   border: 1px solid #ffffff;
-                  bottom: 1px;
+                  bottom: -1px;
                   content: "";
-                  left: 1px;
+                  left: -1px;
                   outline: 1px solid #666666;
                   position: absolute;
-                  right: 1px;
-                  top: 1px;
+                  right: -1px;
+                  top: -1px;
                   z-index: 1;
                 }
                 &:active, &:hover, &:active:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -22,13 +22,13 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
         }
         .ms-Fabric--isFocusVisible &:focus:after {
           border: 1px solid #ffffff;
-          bottom: 1px;
+          bottom: -1px;
           content: "";
-          left: 1px;
+          left: -1px;
           outline: 1px solid #666666;
           position: absolute;
-          right: 1px;
-          top: 1px;
+          right: -1px;
+          top: -1px;
           z-index: 1;
         }
         &:active, &:hover, &:active:hover {
@@ -82,13 +82,13 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
         }
         .ms-Fabric--isFocusVisible &:focus:after {
           border: 1px solid #ffffff;
-          bottom: 1px;
+          bottom: -1px;
           content: "";
-          left: 1px;
+          left: -1px;
           outline: 1px solid #666666;
           position: absolute;
-          right: 1px;
-          top: 1px;
+          right: -1px;
+          top: -1px;
           z-index: 1;
         }
         @media screen and (-ms-high-contrast: white-on-black){& {
@@ -135,13 +135,13 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
         }
         .ms-Fabric--isFocusVisible &:focus:after {
           border: 1px solid #ffffff;
-          bottom: 1px;
+          bottom: -1px;
           content: "";
-          left: 1px;
+          left: -1px;
           outline: 1px solid #666666;
           position: absolute;
-          right: 1px;
-          top: 1px;
+          right: -1px;
+          top: -1px;
           z-index: 1;
         }
         &:link, &:visited {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -59,13 +59,13 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           .ms-Fabric--isFocusVisible &:focus:after {
             border: 1px solid #ffffff;
-            bottom: 1px;
+            bottom: -1px;
             content: "";
-            left: 1px;
+            left: -1px;
             outline: 1px solid #666666;
             position: absolute;
-            right: 1px;
-            top: 1px;
+            right: -1px;
+            top: -1px;
             z-index: 1;
           }
           @media screen and (-ms-high-contrast: white-on-black){& {
@@ -133,13 +133,13 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           .ms-Fabric--isFocusVisible &:focus:after {
             border: 1px solid #ffffff;
-            bottom: 1px;
+            bottom: -1px;
             content: "";
-            left: 1px;
+            left: -1px;
             outline: 1px solid #666666;
             position: absolute;
-            right: 1px;
-            top: 1px;
+            right: -1px;
+            top: -1px;
             z-index: 1;
           }
           @media screen and (-ms-high-contrast: white-on-black){& {
@@ -207,13 +207,13 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           .ms-Fabric--isFocusVisible &:focus:after {
             border: 1px solid #ffffff;
-            bottom: 1px;
+            bottom: -1px;
             content: "";
-            left: 1px;
+            left: -1px;
             outline: 1px solid #666666;
             position: absolute;
-            right: 1px;
-            top: 1px;
+            right: -1px;
+            top: -1px;
             z-index: 1;
           }
           @media screen and (-ms-high-contrast: white-on-black){& {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5485
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add inset to `getFocusStyle` to prevent focus border from clipping text.

Before:
![linkbefore](https://user-images.githubusercontent.com/26070760/43867380-e1ca8d14-9b1d-11e8-9ce8-a47a0ba211e3.png)

After:
![linkafter](https://user-images.githubusercontent.com/26070760/43867384-e4746c88-9b1d-11e8-8e16-221087fdc556.png)


#### Focus areas to test

n/a

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5859)

