### PR TITLE
Allowed state update when hue value changes

### DIFF
--- a/common/changes/office-ui-fabric-react/bugfix-colorpicker-hue-change_2018-08-09-13-28.json
+++ b/common/changes/office-ui-fabric-react/bugfix-colorpicker-hue-change_2018-08-09-13-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fixed an issue #5871",
+      "comment": "ColorPicker: Update color rectangle when hue value changes",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/bugfix-colorpicker-hue-change_2018-08-09-13-28.json
+++ b/common/changes/office-ui-fabric-react/bugfix-colorpicker-hue-change_2018-08-09-13-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed an issue #5871",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "me@vjsrinath.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -193,13 +193,14 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
 
     const { onColorChanged } = this.props;
     const { color } = this.state;
-    if (newColor.h !== color.h || newColor.str !== color.str) {
+    const hasColorStringChanged = newColor.str !== color.str;
+    if (newColor.h !== color.h || hasColorStringChanged) {
       this.setState(
         {
           color: newColor
         } as IColorPickerState,
         () => {
-          if (onColorChanged) {
+          if (hasColorStringChanged && onColorChanged) {
             onColorChanged(newColor.str);
           }
         }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -192,8 +192,8 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
     }
 
     const { onColorChanged } = this.props;
-
-    if (newColor.str !== this.state.color.str) {
+    const { color } = this.state;
+    if (newColor.h !== color.h || newColor.str !== color.str) {
       this.setState(
         {
           color: newColor


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5871 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Color picker component was not updating the state when the hue value is changed. This happens only when the selected color is either black or white.
So added a check to see if the hue value has changed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5873)

