### PR TITLE
TextField: Respect validateOnFocus props when props change

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-5813-textfield-validation_2018-08-09-18-29.json
+++ b/common/changes/office-ui-fabric-react/jg-5813-textfield-validation_2018-08-09-18-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: Respect validateOnFocus props when props change.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -148,7 +148,10 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
         }
       );
 
-      this._delayedValidate(newProps.value);
+      const { validateOnFocusIn, validateOnFocusOut } = newProps;
+      if (!(validateOnFocusIn || validateOnFocusOut)) {
+        this._delayedValidate(newProps.value);
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -18,6 +18,10 @@ describe('TextField', () => {
     resetIds();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
     const component = ReactTestUtils.renderIntoDocument(element);
     const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
@@ -318,13 +322,73 @@ describe('TextField', () => {
         return value.length > 3 ? errorMessage : '';
       }
 
+      jest.useFakeTimers();
+
       const textField = mount(<TextField value="initial value" onGetErrorMessage={validator} />);
 
-      delay(20).then(() => assertErrorMessage(textField.getDOMNode(), errorMessage));
+      jest.runOnlyPendingTimers();
+      assertErrorMessage(textField.getDOMNode(), errorMessage);
 
       textField.setProps({ value: '' });
+      jest.runOnlyPendingTimers();
 
-      return delay(250).then(() => assertErrorMessage(textField.getDOMNode(), /* exist */ false));
+      assertErrorMessage(textField.getDOMNode(), /* exist */ false);
+    });
+
+    it('should not validate when receiving props when validating only on focus in', () => {
+      let validationCallCount = 0;
+      const validatorSpy = (value: string) => {
+        validationCallCount++;
+        return value.length > 3 ? errorMessage : '';
+      };
+
+      jest.useFakeTimers();
+
+      const textField = mount(
+        <TextField
+          validateOnFocusIn
+          value="initial value"
+          onGetErrorMessage={validatorSpy}
+          validateOnLoad={false}
+          deferredValidationTime={0}
+        />
+      );
+      expect(validationCallCount).toEqual(0);
+      assertErrorMessage(textField.getDOMNode(), false);
+
+      textField.setProps({ value: 'failValidationValue' });
+      jest.runOnlyPendingTimers();
+
+      expect(validationCallCount).toEqual(0);
+      assertErrorMessage(textField.getDOMNode(), false);
+    });
+
+    it('should not validate when receiving props when validating only on focus out', () => {
+      let validationCallCount = 0;
+      const validatorSpy = (value: string) => {
+        validationCallCount++;
+        return value.length > 3 ? errorMessage : '';
+      };
+
+      jest.useFakeTimers();
+
+      const textField = mount(
+        <TextField
+          validateOnFocusOut
+          value="initial value"
+          onGetErrorMessage={validatorSpy}
+          validateOnLoad={false}
+          deferredValidationTime={0}
+        />
+      );
+      expect(validationCallCount).toEqual(0);
+      assertErrorMessage(textField.getDOMNode(), false);
+
+      textField.setProps({ value: 'failValidationValue' });
+      jest.runOnlyPendingTimers();
+
+      expect(validationCallCount).toEqual(0);
+      assertErrorMessage(textField.getDOMNode(), false);
     });
 
     it('should trigger validation only on focus', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5813 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

#5813 describes an issue where `MaskedTextField` validate callback gets triggered regardless of `validateOnFocus` props specification. `TextField` was not respecting `validateOnFocus` props in its `componentWillReceiveProps` function, causing validate callbacks to be triggered every time a new controlled value is provided.

@Markionium and @dzearing I'm hoping you can confirm that there's no reason to ignore the `validateOnFocus` props in `componentWillReceiveProps`. Thanks!

#### Focus areas to test

Add tests to cover all scenarios of `validateOnFocus` props.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5875)

