### PR TITLE
Exclude vr-tests from tslint/prettier precommit enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint-staged": "^7.0.5"
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
+    "!(apps/vr-test)/**/*.{ts,tsx}|*.{ts,tsx}": [
       "node ./scripts/lint-staged/prettier",
       "node ./scripts/lint-staged/tslint",
       "git add"


### PR DESCRIPTION
#### Description of changes

tslint enforcement in precommit hooks (and ONLY in precommit hooks) in vr-tests serves no value (too many triggers that require people add tslint-disable all over the place) while introducing a lot of friction.

This change disables tslint enforcement in vr-tests.

#### Focus areas to test

(optional)
