### PR TITLE
Checkbox: Apply checked hover styling only to fine pointer devices

### DIFF
--- a/common/changes/@uifabric/styling/jg-5734-add-pointer-selector_2018-08-09-21-13.json
+++ b/common/changes/@uifabric/styling/jg-5734-add-pointer-selector_2018-08-09-21-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Add pointer selectors to aid in detecting touch vs. pointer devices.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-5734-add-pointer-selector_2018-08-09-21-13.json
+++ b/common/changes/office-ui-fabric-react/jg-5734-add-pointer-selector_2018-08-09-21-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Checkbox: Fix sticky hover styling in mobile usage scenarios.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -1,5 +1,5 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
-import { getFocusStyle, FontSizes, HighContrastSelector } from '../../Styling';
+import { getFocusStyle, FontSizes, FinePointerSelector, HighContrastSelector } from '../../Styling';
 
 const MS_CHECKBOX_LABEL_SIZE = '20px';
 const MS_CHECKBOX_TRANSITION_DURATION = '200ms';
@@ -54,9 +54,11 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
             },
             ':focus .ms-Checkbox-checkbox': { borderColor: checkboxBorderHoveredColor },
             ':hover .ms-Checkbox-checkmark': {
-              color: checkmarkFontColorHovered,
-              opacity: '1',
               selectors: {
+                [FinePointerSelector]: {
+                  color: checkmarkFontColorHovered,
+                  opacity: '1'
+                },
                 [HighContrastSelector]: {
                   color: 'Highlight'
                 }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
       &:focus .ms-Checkbox-checkbox {
         border-color: #212121;
       }
-      &:hover .ms-Checkbox-checkmark {
+      @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
         color: #a6a6a6;
         opacity: 1;
       }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -57,7 +57,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.ImplementationExamples.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.ImplementationExamples.tsx.shot
@@ -57,7 +57,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }
@@ -690,7 +690,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }
@@ -854,7 +854,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }
@@ -1019,7 +1019,7 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -63,7 +63,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
           &:focus .ms-Checkbox-checkbox {
             border-color: #212121;
           }
-          &:hover .ms-Checkbox-checkmark {
+          @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
             color: #a6a6a6;
             opacity: 1;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -62,7 +62,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
           &:focus .ms-Checkbox-checkbox {
             border-color: #212121;
           }
-          &:hover .ms-Checkbox-checkmark {
+          @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
             color: #a6a6a6;
             opacity: 1;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -87,7 +87,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
           &:focus .ms-Checkbox-checkbox {
             border-color: #212121;
           }
-          &:hover .ms-Checkbox-checkmark {
+          @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
             color: #a6a6a6;
             opacity: 1;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -78,7 +78,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 2`] = `
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -65,7 +65,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }
@@ -229,7 +229,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -197,7 +197,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }
@@ -381,7 +381,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3162,7 +3162,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:focus .ms-Checkbox-checkbox {
             border-color: #212121;
           }
-          &:hover .ms-Checkbox-checkmark {
+          @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
             color: #a6a6a6;
             opacity: 1;
           }
@@ -3326,7 +3326,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:focus .ms-Checkbox-checkbox {
             border-color: #212121;
           }
-          &:hover .ms-Checkbox-checkmark {
+          @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
             color: #a6a6a6;
             opacity: 1;
           }
@@ -3490,7 +3490,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:focus .ms-Checkbox-checkbox {
             border-color: #212121;
           }
-          &:hover .ms-Checkbox-checkmark {
+          @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
             color: #a6a6a6;
             opacity: 1;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -58,7 +58,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
         &:focus .ms-Checkbox-checkbox {
           border-color: #212121;
         }
-        &:hover .ms-Checkbox-checkmark {
+        @media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none){&:hover .ms-Checkbox-checkmark {
           color: #a6a6a6;
           opacity: 1;
         }

--- a/packages/styling/src/styles/CommonStyles.ts
+++ b/packages/styling/src/styles/CommonStyles.ts
@@ -14,6 +14,16 @@ export const ScreenWidthMaxLarge = ScreenWidthMinXLarge - 1;
 export const ScreenWidthMaxXLarge = ScreenWidthMinXXLarge - 1;
 export const ScreenWidthMaxXXLarge = ScreenWidthMinXXXLarge - 1;
 
+/**
+ * Selectors for determining primary input mechanism.
+ * Useful for detecting mouse/stylus (fine) vs. touch (coarse) input.
+ * Since IE11 doesn't support pointer media queries, it's detected via other means
+ * and always assumed to have a fine input mechanism.
+ */
+export const CoarsePointerSelector = '@media (pointer:coarse), (-moz-touch-enabled: 1)';
+export const FinePointerSelector =
+  '@media (pointer:fine), (-moz-touch-enabled: 0), screen and (-ms-high-contrast: active), (-ms-high-contrast: none)';
+
 export function getScreenSelector(min: number, max: number): string {
   return `@media only screen and (min-width: ${min}px) and (max-width: ${max}px)`;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5734
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Create two new selectors to aid in identifying fine pointer devices (mouse, stylus) vs. coarse pointer devices (touch). Apply to hover checkmark styling in Checkbox to fix the issue described in #5734.

#### Focus areas to test

Tested FinePointerSelector on Chrome, Firefox, Edge, IE11, Chrome on Android, and Safari on iOS.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5882)

