### PR TITLE
Adding role="grid" to CalendarDay so that VoiceOver within Safari works

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-08-10-01-58.json
+++ b/common/changes/office-ui-fabric-react/master_2018-08-10-01-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding role=\"Grid\" so that VoiceOver within Safari works for Calendar and DatePicker",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "github@woofton.net"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -207,6 +207,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
             aria-multiselectable="false"
             aria-labelledby={monthAndYearId}
             aria-activedescendant={activeDescendantId}
+            role="grid"
           >
             <thead>
               <tr>

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -119,6 +119,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                 aria-multiselectable="false"
                 aria-readonly="true"
                 className="ms-DatePicker-table"
+                role="grid"
               >
                 <thead>
                   <tr>


### PR DESCRIPTION
for Calendar and DatePicker

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5726 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adding role=\"Grid\" so that VoiceOver within Safari works for Calendar and DatePicker

#### Focus areas to test

Use VoiceOver to navigate between the various days in the Calendar and make sure that VoiceOver announces the days.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5890)

