### PR TITLE
ColumnDragDrop - Update drag info on DragEnd event

### DIFF
--- a/common/changes/office-ui-fabric-react/laxmika-ColumnDragDropBugFix_2018-08-10-11-17.json
+++ b/common/changes/office-ui-fabric-react/laxmika-ColumnDragDropBugFix_2018-08-10-11-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding updateDragInfo for DragEnd event",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "laxmika@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -274,6 +274,9 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
 
   private _onDragEnd(item?: any, event?: MouseEvent): void {
     const classNames = this._classNames;
+    if (event) {
+      this._updateHeaderDragInfo(-1, event);
+    }
     this._root.current.classList.remove(classNames.borderWhileDragging);
   }
 


### PR DESCRIPTION
This change is related to https://github.com/OfficeDev/office-ui-fabric-react/pull/5779
UpdateDragInfo needs to be called for dragEnd event also
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5895)

