### PR TITLE
TextField: For uncontrolled scenarios, update value when defaultValue changes

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-1564-textfield-defaultvalue-changes_2018-08-10-20-35.json
+++ b/common/changes/office-ui-fabric-react/jg-1564-textfield-defaultvalue-changes_2018-08-10-20-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: For uncontrolled scenarios, update value when defaultValue changes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -137,21 +137,17 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
       }
 
       this._id = newProps.id || this._id;
-      this._latestValue = newProps.value;
-      this.setState(
-        {
-          value: newProps.value || DEFAULT_STATE_VALUE,
-          errorMessage: ''
-        } as ITextFieldState,
-        () => {
-          this._adjustInputHeight();
-        }
-      );
+      this._setValue(newProps.value);
 
       const { validateOnFocusIn, validateOnFocusOut } = newProps;
       if (!(validateOnFocusIn || validateOnFocusOut)) {
         this._delayedValidate(newProps.value);
       }
+    }
+
+    // If component is not currently controlled and defaultValue changes, set value to new defaultValue.
+    if (newProps.defaultValue !== this.props.defaultValue && newProps.value === undefined) {
+      this._setValue(newProps.defaultValue);
     }
   }
 
@@ -301,6 +297,19 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     if (this._textElement.current) {
       (this._textElement.current as HTMLInputElement).setSelectionRange(start, end);
     }
+  }
+
+  private _setValue(value?: string) {
+    this._latestValue = value;
+    this.setState(
+      {
+        value: value || DEFAULT_STATE_VALUE,
+        errorMessage: ''
+      } as ITextFieldState,
+      () => {
+        this._adjustInputHeight();
+      }
+    );
   }
 
   private _onFocus(ev: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -495,6 +495,41 @@ describe('TextField', () => {
     expect(textField.getDOMNode().querySelector('textarea')!.value).toEqual('initial value');
   });
 
+  it('should update value when defaultValue changes and value prop is not set', () => {
+    const defaultValue1 = 'default value 1';
+    const defaultValue2 = 'default value 2';
+
+    const textField = mount(<TextField defaultValue={defaultValue1} />);
+    expect(textField.getDOMNode().querySelector('input')).toBeTruthy();
+    expect(textField.getDOMNode().querySelector('input')!.value).toEqual(defaultValue1);
+
+    textField.setProps({ defaultValue: defaultValue2 });
+    expect(textField.getDOMNode().querySelector('input')).toBeTruthy();
+    expect(textField.getDOMNode().querySelector('input')!.value).toEqual(defaultValue2);
+
+    textField.setProps({ defaultValue: undefined });
+    expect(textField.getDOMNode().querySelector('input')).toBeTruthy();
+    expect(textField.getDOMNode().querySelector('input')!.value).toEqual('');
+  });
+
+  it('should not update value when defaultValue changes and value prop is set', () => {
+    const defaultValue1 = 'default value 1';
+    const defaultValue2 = 'default value 2';
+    const testValue = 'test value';
+
+    const textField = mount(<TextField defaultValue={defaultValue1} />);
+    expect(textField.getDOMNode().querySelector('input')).toBeTruthy();
+    expect(textField.getDOMNode().querySelector('input')!.value).toEqual(defaultValue1);
+
+    textField.setProps({ value: testValue, defaultValue: defaultValue2 });
+    expect(textField.getDOMNode().querySelector('input')).toBeTruthy();
+    expect(textField.getDOMNode().querySelector('input')!.value).toEqual(testValue);
+
+    textField.setProps({ defaultValue: undefined });
+    expect(textField.getDOMNode().querySelector('input')).toBeTruthy();
+    expect(textField.getDOMNode().querySelector('input')!.value).toEqual(testValue);
+  });
+
   it('can render description text', () => {
     const testDescription = 'A custom description';
     const textField = mount(<TextField description={testDescription} />);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1564
- [x] Include a change request file using `$ npm run change`

#### Description of changes

For uncontrolled scenarios (when `value` prop is `undefined`), update `value` when `defaultValue` prop changes.

#### Focus areas to test

Add tests to make sure `value` is updated (or not) depending on controlled and uncontrolled scenarios.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5903)

