### PR TITLE
Customizer: settings should allow scoping as expected

### DIFF
--- a/common/changes/@uifabric/utilities/customizer-fix2_2018-08-11-01-55.json
+++ b/common/changes/@uifabric/utilities/customizer-fix2_2018-08-11-01-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Customizer should allow for nesting. Right now, `settings` provided have the reverse precendence expected; the outer-most Customizer wins over an inner one. This is completely backwards. Fixing to be correct.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/src/Customizer.test.tsx
+++ b/packages/utilities/src/Customizer.test.tsx
@@ -96,7 +96,7 @@ describe('Customizer', () => {
 
     expect(
       ReactDOM.renderToStaticMarkup(
-        <Customizer scopedSettings={{ Bar: { field: 'field' } }}>
+        <Customizer scopedSettings={{ Bar: { field: 'field', field2: 'oldfield2' } }}>
           <Customizer scopedSettings={{ Bar: { field2: 'field2' } }}>
             <Bar />
           </Customizer>
@@ -144,7 +144,7 @@ describe('Customizer', () => {
     ).toEqual('<div><div>scopedToFoo</div><div>scopedToBar</div></div>');
   });
 
-  it('does not override previously set settings', () => {
+  it('overrides previously set settings', () => {
     expect(
       ReactDOM.renderToStaticMarkup(
         <Customizer settings={{ field: 'field1' }}>
@@ -153,7 +153,7 @@ describe('Customizer', () => {
           </Customizer>
         </Customizer>
       )
-    ).toEqual('<div>field1</div>');
+    ).toEqual('<div>field2</div>');
   });
 
   it('overrides the old settings when the parameter is ignored', () => {

--- a/packages/utilities/src/Customizer.tsx
+++ b/packages/utilities/src/Customizer.tsx
@@ -74,8 +74,7 @@ export class Customizer extends BaseComponent<ICustomizerProps, ICustomizerConte
 
   public static childContextTypes: {
     customizations: PropTypes.Requireable<{}>;
-  } =
-    Customizer.contextTypes;
+  } = Customizer.contextTypes;
 
   // tslint:disable-next-line:no-any
   constructor(props: ICustomizerProps, context: any) {
@@ -126,7 +125,7 @@ function isSettingsFunction(settings?: Settings | SettingsFunction): settings is
 }
 
 function settingsMergeWith(newSettings?: object): (settings: Settings) => Settings {
-  return (settings: Settings) => (newSettings ? { ...newSettings, ...settings } : settings);
+  return (settings: Settings) => (newSettings ? { ...settings, ...newSettings } : settings);
 }
 
 function scopedSettingsMergeWith(scopedSettingsFromProps: Settings = {}): (scopedSettings: Settings) => Settings {


### PR DESCRIPTION
There seems to be some backwards logic added a couple months ago that break nested customizer settings.

This should work:
```
<Customizer settings={{ theme: DefaultTheme }}>
  <App>
    <...stuff/>
    <Customizer settings={{ theme: SpecialTheme }}> 
      <...specialstuff />
    </Customizer>
  </App>
</Customizer>
```

Unfortunately the "specialstuff" above gets the default theme currently. This change makes it so that it gets the special theme.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5911)

