### PR TITLE
Coachmark: Export for use in CodePens

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-export-coachmark_2018-08-13-21-45.json
+++ b/common/changes/office-ui-fabric-react/jg-export-coachmark_2018-08-13-21-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Coachmark: Export from index file for use in CodePens.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -11,6 +11,7 @@ export * from './Callout';
 export * from './Check';
 export * from './Checkbox';
 export * from './ChoiceGroup';
+export * from './Coachmark';
 export * from './ColorPicker';
 export * from './ComboBox';
 export * from './CommandBar';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Found that a partner could not use Coachmark in a CodePen because it is not being exported. This PR fixes that.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5924)

