### PR TITLE
DetailsList: fixes bugs in single selection mode

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListBugs_2018-08-13-22-33.json
+++ b/common/changes/office-ui-fabric-react/detailsListBugs_2018-08-13-22-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: in single select mode maintain role and index, and remove onclick",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -235,9 +235,9 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
                 key="__checkbox"
                 className={classNames.cellIsCheck}
                 aria-labelledby={`${this._id}-check`}
-                onClick={this._onSelectAllClicked}
-                aria-colindex={!isCheckboxHidden ? 1 : undefined}
-                role={!isCheckboxHidden ? 'columnheader' : undefined}
+                onClick={!isCheckboxHidden ? this._onSelectAllClicked : undefined}
+                aria-colindex={1}
+                role={'columnheader'}
               >
                 {onRenderColumnHeaderTooltip(
                   {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -379,9 +379,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
           aria-label={ariaLabelForGrid}
           aria-rowcount={rowCount}
           aria-colcount={
-            (selectAllVisibility !== SelectAllVisibility.none && selectAllVisibility !== SelectAllVisibility.hidden
-              ? 1
-              : 0) + (adjustedColumns ? adjustedColumns.length : 0)
+            (selectAllVisibility !== SelectAllVisibility.none ? 1 : 0) + (adjustedColumns ? adjustedColumns.length : 0)
           }
           aria-readonly="true"
         >


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5164, #5484 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes extend my changes made in [this PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/5190) where I made the "select all" checkbox in a DetailsList header non-focusable in single selection mode. This new PR maintains that behavior and makes sure that the "select all" checkbox keeps its columnheader role and col-index of 1, so that the column header information associated with cells is correct. 

Thomas Michon and I spoke offline and decided that it makes sense to maintain that column index for the "select all" checkbox when in single selection mode and non-focusable, because it is still a column header, although it alone is not actionable. So, it should be part of column count.

Additionally, these changes ensure that the `onClick` for the DetailsList "select all" checkbox is not defined in single selection mode.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5925)

