### PR TITLE
Ensure SelectionZone sets selection before opening context menu

### DIFF
--- a/common/changes/office-ui-fabric-react/selection-menu_2018-08-14-20-31.json
+++ b/common/changes/office-ui-fabric-react/selection-menu_2018-08-14-20-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Ensure SelectionZone selects item before opening context menu",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -19,7 +19,7 @@
     "build": "node ../../scripts/build.js",
     "clean": "node ../../scripts/clean.js",
     "code-style": "node ../../scripts/code-style.js",
-    "start": "../../apps/fabric-website-resources && npm start",
+    "start": "cd ../../apps/fabric-website-resources && npm start",
     "start-test": "node ../../scripts/start-test.js",
     "update-snapshots": "node ../../scripts/build.js jest -u",
     "codepen": "node ../../scripts/local-codepen.js"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -315,7 +315,8 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       minimumPixelsForDrag,
       getGroupHeight,
       styles,
-      theme
+      theme,
+      cellStyleProps = DEFAULT_CELL_STYLE_PROPS
     } = this.props;
     const { adjustedColumns, isCollapsed, isSizing, isSomeGroupExpanded } = this.state;
     const { _selection: selection, _dragDropHelper: dragDropHelper } = this;
@@ -408,7 +409,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
                   viewport: viewport,
                   columnReorderProps: columnReorderProps,
                   minimumPixelsForDrag: minimumPixelsForDrag,
-                  cellStyleProps: DEFAULT_CELL_STYLE_PROPS
+                  cellStyleProps: cellStyleProps
                 },
                 this._onRenderDetailsHeader
               )}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -408,6 +408,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
       }
     ],
     isMultiline: [
+      defaultCellStyles,
       {
         whiteSpace: 'normal',
         wordBreak: 'break-word',

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -130,12 +130,16 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           checkboxVisibility={checkboxVisibility}
           layoutMode={layoutMode}
           isHeaderVisible={isHeaderVisible}
-          selectionMode={selectionMode}
           constrainMode={constrainMode}
           groupProps={groupProps}
           enterModalSelectionOnTouch={true}
           onItemInvoked={this._onItemInvoked}
           onItemContextMenu={this._onItemContextMenu}
+          selectionZoneProps={{
+            selection: this._selection,
+            disableAutoSelectOnInputElements: true,
+            selectionMode: selectionMode
+          }}
           ariaLabelForListHeader="Column headers. Use menus to perform column operations like sort and filter"
           ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           ariaLabelForSelectionColumn="Toggle selection"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -124,6 +124,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
         <DetailsList
           setKey="items"
           items={items as any[]}
+          selection={this._selection}
           groups={groups}
           columns={columns}
           checkboxVisibility={checkboxVisibility}
@@ -441,10 +442,27 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
   };
 
   private _onItemContextMenu = (item: any, index: number, ev: MouseEvent): boolean => {
-    if ((ev.target as HTMLElement).nodeName === 'A') {
-      return true;
+    const contextualMenuProps: IContextualMenuProps = {
+      target: ev.target as HTMLElement,
+      items: [
+        {
+          key: 'text',
+          name: `${this._selection.getSelectedCount()} selected`
+        }
+      ],
+      onDismiss: () => {
+        this.setState({
+          contextualMenuProps: undefined
+        });
+      }
+    };
+
+    if (index > -1) {
+      this.setState({
+        contextualMenuProps: contextualMenuProps
+      });
     }
-    console.log('Item context menu invoked', item, index);
+
     return false;
   };
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -264,6 +264,9 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
 
       if (itemRoot) {
         const index = this._getItemIndex(itemRoot);
+
+        this._onInvokeMouseDown(ev, index);
+
         const skipPreventDefault = onItemContextMenu(selection.getItems()[index], index, ev.nativeEvent);
 
         // In order to keep back compat, if the value here is undefined, then we should still


### PR DESCRIPTION
# Overview

This change adjusts `onItemContextMenu` in `SelectionZone` so the item being clicked is selected first before the menu callback is invoked. It is assumed that `ContextualMenu` instances spawned from `onItemContextMenu` will attempt to bind to the selected items, so the item that the user right-clicked should be one of those items. The logic mirrors that of OneDrive/SharePoint, the original driver of `DetailsList` and `SelectionZone` behavior requirements.

This change also fixes a CSS precedence issue impacting multi-line text fields, and adds an item context menu to the `DetailsList.Advanced` example.

This is intended to fix #5865.

