### PR TITLE
faster npm install build

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -17,6 +17,11 @@
       "optionType": "flag",
       "description": "Builds with linting.",
       "associatedCommands": ["build", "rebuild"]
+    },
+    "--npm-install-mode": {
+      "optionType": "flag",
+      "description": "Skips tasks that are irrelevant during npm install",
+      "associatedCommands": ["build", "rebuild"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "scripts": {
     "_rushInstall": "node node_modules/@microsoft/rush/bin/rush install -c",
     "_rushBuild": "node node_modules/@microsoft/rush/bin/rush build",
-    "_rushBuildToFabric": "node node_modules/@microsoft/rush/bin/rush build --to @uifabric/fabric-website-resources --verbose",
+    "_rushBuildToFabric": "node node_modules/@microsoft/rush/bin/rush build --to @uifabric/fabric-website-resources",
     "_rushRebuild": "node node_modules/@microsoft/rush/bin/rush rebuild --production --verbose --lint",
     "_rushRebuildCi": "node node_modules/@microsoft/rush/bin/rush rebuild --verbose --lint",
     "_rushRebuildFast": "node node_modules/@microsoft/rush/bin/rush rebuild",
-    "postinstall": "npm run _rushInstall && npm run _rushBuildToFabric",
+    "postinstall": "npm run _rushInstall && cross-env NPM_INSTALL_MODE=1 npm run _rushBuildToFabric",
     "test": "npm run _rushBuild",
     "vrtest": "cd apps && cd vr-tests && npm run screener",
     "start": "cd apps && cd fabric-website-resources && npm start",
@@ -37,6 +37,7 @@
   "license": "MIT",
   "devDependencies": {
     "@microsoft/rush": "4.3.0",
+    "cross-env": "^5.2.0",
     "husky": "^0.14.3",
     "lint-staged": "^7.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "_rushRebuild": "node node_modules/@microsoft/rush/bin/rush rebuild --production --verbose --lint",
     "_rushRebuildCi": "node node_modules/@microsoft/rush/bin/rush rebuild --verbose --lint",
     "_rushRebuildFast": "node node_modules/@microsoft/rush/bin/rush rebuild",
-    "postinstall": "npm run _rushInstall && cross-env NPM_INSTALL_MODE=1 npm run _rushBuildToFabric",
+    "postinstall": "npm run _rushInstall && npm run _rushBuildToFabric -- --npm-install-mode",
     "test": "npm run _rushBuild",
     "vrtest": "cd apps && cd vr-tests && npm run screener",
     "start": "cd apps && cd fabric-website-resources && npm start",
@@ -37,7 +37,6 @@
   "license": "MIT",
   "devDependencies": {
     "@microsoft/rush": "4.3.0",
-    "cross-env": "^5.2.0",
     "husky": "^0.14.3",
     "lint-staged": "^7.0.5"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -70,13 +70,24 @@ executeTasks(firstTasks)
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 //// Build helper functions
 /////////////////////////////////////////////////////////////////////////////////////////////////////
-
+/**
+ * Disable tasks in one of two ways:
+ * - run `npm run build --npm-install-mode`
+ * - run `npm run build no-jest no-tslint`
+ */
 function getDefaultDisabledTasks() {
   let disabled = package.disabledTasks || [];
 
   if (process.argv.indexOf('--npm-install-mode') > -1) {
     disabled = [...disabled, 'jest', 'tslint', 'lint-imports'];
   }
+
+  (process.argv.filter(tasks => tasks.startsWith('no-')) || []).forEach(task => {
+    const skippedTask = task.replace('no-', '');
+    if (disabled.indexOf(skippedTask) < 0) {
+      disabled.push(skippedTask);
+    }
+  });
 
   return disabled;
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -74,7 +74,7 @@ executeTasks(firstTasks)
 function getDefaultDisabledTasks() {
   let disabled = package.disabledTasks || [];
 
-  if (process.env.NPM_INSTALL_MODE) {
+  if (process.argv.indexOf('--npm-install-mode') > -1) {
     disabled = [...disabled, 'jest', 'tslint', 'lint-imports'];
   }
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -47,7 +47,7 @@ const taskMap = loadTaskFunctions(getAllTasks());
  *  or otherwise
  * the tasks disabled in the package.json.
  */
-const disabledTasks = getDisabledTasks(process, package.disabledTasks);
+const disabledTasks = getDisabledTasks(process, getDefaultDisabledTasks());
 
 // Get the first tasks to execute, these are the tasks without prerequisite.
 const firstTasks = getNextTasks(null, disabledTasks);
@@ -70,6 +70,16 @@ executeTasks(firstTasks)
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 //// Build helper functions
 /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+function getDefaultDisabledTasks() {
+  let disabled = package.disabledTasks || [];
+
+  if (process.env.NPM_INSTALL_MODE) {
+    disabled = [...disabled, 'jest', 'tslint', 'lint-imports'];
+  }
+
+  return disabled;
+}
 
 function executeTasks(tasks) {
   return Promise.all(
@@ -169,9 +179,8 @@ function first(values) {
 }
 
 function getDisabledTasks(process, defaultDisabled = []) {
-  if (process.argv.length >= 3 && process.argv[2].indexOf('--') === -1) {
-    const tasksToRun = process.argv.slice(2);
-
+  const tasksToRun = process.argv.slice(2).filter(tasks => !tasks.startsWith('no-'));
+  if (process.argv.length >= 3 && process.argv[2].indexOf('--') === -1 && tasksToRun.length > 0) {
     return getAllTasks().filter(task => tasksToRun.indexOf(task) === -1);
   }
 


### PR DESCRIPTION
#### Description of changes

Shaves our npm install **build** time by a bit:
On my box, went from 1 minute 22.9 seconds to 54.88 seconds

It accomplishes it by 2 things:
1. got rid of --verbose so we build in parallel
2. get rid of jest & tslint & lint-imports when you're doing npm install

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5939)

