### PR TITLE
DetailsList: remove demo page broken links

### DIFF
--- a/common/changes/office-ui-fabric-react/fixDetailsListDemoPage_2018-08-15-17-56.json
+++ b/common/changes/office-ui-fabric-react/fixDetailsListDemoPage_2018-08-15-17-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: remove related section from demo page",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.doc.tsx
@@ -37,7 +37,6 @@ import { DetailsListNavigatingFocusExample } from './examples/DetailsList.Naviga
 const DetailsListNavigatingFocusExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.NavigatingFocus.Example.tsx') as string;
 
 import { DetailsListShimmerExample } from './examples/DetailsList.Shimmer.Example';
-import { Link } from '../../Link';
 const DetailsListShimmerExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Shimmer.Example.tsx') as string;
 
 import { DetailsListCustomFooterExample } from './examples/DetailsList.CustomFooter.Example';
@@ -56,39 +55,6 @@ export const DetailsListPageProps: IDocPageProps = {
       view: <DetailsListDocumentsExample />
     }
   ],
-  related: (
-    <div>
-      <ul className="ComponentPage-variantsList">
-        <li>
-          <Link href="/#/components/detailslist/basic">Basic</Link>
-        </li>
-        <li>
-          <Link href="/#/components/detailslist/compact">Compact</Link>
-        </li>
-        <li>
-          <Link href="/#/components/detailslist/grouped">Grouped</Link>
-        </li>
-        <li>
-          <Link href="/#/components/detailslist/customitemcolumns">Custom Item Columns</Link>
-        </li>
-        <li>
-          <Link href="/#/components/detailslist/customitemrows">Custom Item Rows</Link>
-        </li>
-        <li>
-          <Link href="/#/components/detailslist/customgroupheaders">Custom Group Headers</Link>
-        </li>
-        <li>
-          <Link href="/#/components/detailslist/variablerowheights">Variable Row Heights</Link>
-        </li>
-        <li>
-          <Link href="/#/components/detailslist/draganddrop">Drag &amp; Drop</Link>
-        </li>
-        <li>
-          <Link href="/#/components/detailslist/innernavigation">Inner Navigation</Link>
-        </li>
-      </ul>
-    </div>
-  ),
   propertiesTablesSources: [
     require<string>('!raw-loader!office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts')
   ],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Before, the "Also available in" links were broken for the DetailsList demo page, as shown below:

![detailslist broken link 1](https://user-images.githubusercontent.com/14134000/44164169-24e14f00-a07a-11e8-8868-012c779fea22.gif)


@kenotron and I discussed offline that perhaps it would be best to just remove this section, as it makes the pages very text heavy.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5940)

