### PR TITLE
FocusZone: Fix Tabbing behavior when in RTL

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-FocusZoneTabRtlFix_2018-08-15-22-34.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-FocusZoneTabRtlFix_2018-08-15-22-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: Fix Tabbing behavior when in RTL",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -395,7 +395,8 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
             ) {
               focusChanged = ev.shiftKey ? this._moveFocusUp() : this._moveFocusDown();
             } else if (direction === FocusZoneDirection.horizontal || direction === FocusZoneDirection.bidirectional) {
-              focusChanged = ev.shiftKey ? this._moveFocusLeft() : this._moveFocusRight();
+              const tabWithDirection = getRTL() ? !ev.shiftKey : ev.shiftKey;
+              focusChanged = tabWithDirection ? this._moveFocusLeft() : this._moveFocusRight();
             }
             this._processingTabKey = false;
             if (focusChanged) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Prior to this change, if tab was enabled on horizontal or bidirectional FocusZone focus would move the incorrect direction horizontally when pressing TAB in RTL

#### Focus areas to test
Verified that TAB works as expected now in RTL and did not change in LTR

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5947)

