### PR TITLE
Panel dismiss

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-dismiss_2018-08-15-22-52.json
+++ b/common/changes/office-ui-fabric-react/panel-dismiss_2018-08-15-22-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: change click listener to mousedown listener so that Panels aren't dismissed on mouseup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -61,7 +61,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     this._events.on(window, 'resize', this._updateFooterPosition);
 
     if (this._shouldListenForOuterClick(this.props)) {
-      this._events.on(document.body, 'click', this._dismissOnOuterClick, true);
+      this._events.on(document.body, 'mousedown', this._dismissOnOuterClick, true);
     }
 
     if (this.props.isOpen) {
@@ -74,9 +74,9 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     const previousShouldListenOnOuterClick = this._shouldListenForOuterClick(previousProps);
 
     if (shouldListenOnOuterClick && !previousShouldListenOnOuterClick) {
-      this._events.on(document.body, 'click', this._dismissOnOuterClick, true);
+      this._events.on(document.body, 'mousedown', this._dismissOnOuterClick, true);
     } else if (!shouldListenOnOuterClick && previousShouldListenOnOuterClick) {
-      this._events.off(document.body, 'click', this._dismissOnOuterClick, true);
+      this._events.off(document.body, 'mousedown', this._dismissOnOuterClick, true);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5935 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Panel now listens for mousedown events on the body rather than click. This prevents Panels from being unintentionally dismissed on mouseup events (e.g. in the onSelectionChanged callback of a Selection component).

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5948)

