### PR TITLE
Replace OverflowSet  with button menuprops

### DIFF
--- a/common/changes/@uifabric/dashboard/cardOverFlowIssue_2018-08-17-07-10.json
+++ b/common/changes/@uifabric/dashboard/cardOverFlowIssue_2018-08-17-07-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Replaced the OverflowSet with IconButton and removed the paddingBottom css in ThumbnailList added the  marign Bottom css.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "polu.balakrishna96@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/CardFrame/CardFrame.tsx
+++ b/packages/dashboard/src/components/Card/CardFrame/CardFrame.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { ICardFrameProps, ICardFrameStyles, ICardDropDownOption } from './CardFrame.types';
-import { IconButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { getStyles } from './CardFrame.styles';
 import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
-import { IOverflowSetItemProps, OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
-import { customOverflowStyle } from './CardFrame.styles';
+import { IOverflowSetItemProps } from 'office-ui-fabric-react/lib/OverflowSet';
 
 export class CardFrame extends React.Component<ICardFrameProps, {}> {
   constructor(props: ICardFrameProps) {
@@ -42,10 +41,13 @@ export class CardFrame extends React.Component<ICardFrameProps, {}> {
       <div className={classNames.root}>
         <div className={classNames.cardTitleBox}>
           <div className={classNames.cardTitleEllipsisButton}>
-            <OverflowSet
-              overflowItems={cardDropDownOptions}
-              onRenderOverflowButton={this._onRenderOverflowButton}
-              onRenderItem={this._onRenderItem}
+            <IconButton
+              menuIconProps={{ iconName: 'MoreVertical' }}
+              split={false}
+              aria-roledescription={'More OverflowActions'}
+              menuProps={{
+                items: cardDropDownOptions
+              }}
             />
           </div>
           <div className={classNames.cardTitle}>
@@ -54,29 +56,6 @@ export class CardFrame extends React.Component<ICardFrameProps, {}> {
         </div>
         <div className={classNames.layout}>{this.props.children}</div>
       </div>
-    );
-  }
-
-  private _onRenderItem(item: IOverflowSetItemProps): JSX.Element {
-    return (
-      <IconButton
-        menuIconProps={{ iconName: item.icon }}
-        onClick={item.onClick}
-        title={item.title}
-        ariaLabel={item.ariaLabel}
-      />
-    );
-  }
-
-  private _onRenderOverflowButton(overflowItems: IOverflowSetItemProps[] | undefined): JSX.Element {
-    return (
-      <DefaultButton
-        menuIconProps={{ iconName: 'More' }}
-        menuProps={{ items: overflowItems! }}
-        ariaLabel="Card options"
-        title="Card options"
-        styles={customOverflowStyle}
-      />
     );
   }
 }

--- a/packages/dashboard/src/components/Card/CardFrame/CardFrame.tsx
+++ b/packages/dashboard/src/components/Card/CardFrame/CardFrame.tsx
@@ -42,9 +42,9 @@ export class CardFrame extends React.Component<ICardFrameProps, {}> {
         <div className={classNames.cardTitleBox}>
           <div className={classNames.cardTitleEllipsisButton}>
             <IconButton
-              menuIconProps={{ iconName: 'MoreVertical' }}
+              menuIconProps={{ iconName: 'More' }}
               split={false}
-              aria-roledescription={'More OverflowActions'}
+              aria-label={'More'}
               menuProps={{
                 items: cardDropDownOptions
               }}

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.styles.ts
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.styles.ts
@@ -28,7 +28,7 @@ export const getThumbnailItemStyles = (): IThumbnailItemStyles => {
   return {
     root: {
       overflow: 'hidden',
-      paddingBottom: '16px',
+      marginBottom: '16px',
       minHeight: '52px',
       maxHeight: '52px'
     },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Removed the utilisation of OverflowSet in Dashboard package cardFrame component, Instead we are using IconButton with MenuOptions.

(give an overview)

#### Focus areas to test

(optional)

#### Screenshot
![overflowset_screenshot](https://user-images.githubusercontent.com/21668111/44253071-fdc28300-a21b-11e8-8a48-579567ca8201.PNG)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5955)


