### PR TITLE
Replaced black with violet in the personacoin pallette to avoid potential offensive personacoin combinations

### DIFF
--- a/common/changes/office-ui-fabric-react/mariust-personacoin_2018-08-16-13-42.json
+++ b/common/changes/office-ui-fabric-react/mariust-personacoin_2018-08-16-13-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Replaced black with violet in the personacoin pallette to avoid potential offensive personacoin combinations",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mariust@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -383,6 +383,9 @@ export enum PersonaInitialsColor {
   pink = 8,
   magenta = 9,
   purple = 10,
+  /**
+   * Black is a color that can result in offensive persona coins with some initials combinations, so it can only be set with overrides
+   */
   black = 11,
   orange = 12,
   /**
@@ -394,5 +397,6 @@ export enum PersonaInitialsColor {
    * Transparent is not intended to be used with typical initials due to accessibility issues.
    * Its primary use is for overflow buttons, so it is considered a reserved color and can only be set with overrides.
    */
-  transparent = 15
+  transparent = 15,
+  violet = 16
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #2D89EF;
+            background-color: #5E4B8B;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #1D1D1D;
+            background-color: #2D89EF;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -445,7 +445,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #2D89EF;
+              background-color: #5E4B8B;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -1396,7 +1396,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #2D89EF;
+            background-color: #5E4B8B;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;
@@ -1452,7 +1452,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #2D89EF;
+            background-color: #5E4B8B;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -445,7 +445,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #1D1D1D;
+              background-color: #2D89EF;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -1396,7 +1396,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #1D1D1D;
+            background-color: #2D89EF;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;
@@ -1452,7 +1452,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #1D1D1D;
+            background-color: #2D89EF;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
@@ -4,7 +4,7 @@ import { PersonaInitialsColor } from './Persona.types';
 describe('PersonaInitialsColor tests', () => {
   it('renders gets the correct colors if none was provided', () => {
     const colorCode = initialsColorPropToColorCode({ text: 'Kat Larrson' });
-    expect(colorCode).toEqual('#2D89EF');
+    expect(colorCode).toEqual('#5E4B8B');
 
     const colorCode2 = initialsColorPropToColorCode({ text: 'Annie Lindqvist' });
     expect(colorCode2).toEqual('#00A300');

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
@@ -4,7 +4,7 @@ import { PersonaInitialsColor } from './Persona.types';
 describe('PersonaInitialsColor tests', () => {
   it('renders gets the correct colors if none was provided', () => {
     const colorCode = initialsColorPropToColorCode({ text: 'Kat Larrson' });
-    expect(colorCode).toEqual('#5E4B8B');
+    expect(colorCode).toEqual('#2D89EF');
 
     const colorCode2 = initialsColorPropToColorCode({ text: 'Annie Lindqvist' });
     expect(colorCode2).toEqual('#00A300');
@@ -16,7 +16,7 @@ describe('PersonaInitialsColor tests', () => {
   });
 
   it('uses provided string initialsColor if one was specified', () => {
-    const colorCode = initialsColorPropToColorCode({ text: 'Christian Gonzalez', initialsColor: 'blue' });
-    expect(colorCode).toEqual('blue');
+    const colorCode = initialsColorPropToColorCode({ text: 'Christian Gonzalez', initialsColor: 'violet' });
+    expect(colorCode).toEqual('violet');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
@@ -4,7 +4,7 @@ import { PersonaInitialsColor } from './Persona.types';
 describe('PersonaInitialsColor tests', () => {
   it('renders gets the correct colors if none was provided', () => {
     const colorCode = initialsColorPropToColorCode({ text: 'Kat Larrson' });
-    expect(colorCode).toEqual('#1D1D1D');
+    expect(colorCode).toEqual('#5E4B8B');
 
     const colorCode2 = initialsColorPropToColorCode({ text: 'Annie Lindqvist' });
     expect(colorCode2).toEqual('#00A300');

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -44,12 +44,14 @@ function getInitialsColorFromName(displayName: string | undefined): PersonaIniti
   return color;
 }
 
+const blueColor = '#2D89EF';
+
 function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColor): string {
   switch (personaInitialsColor) {
     case PersonaInitialsColor.lightBlue:
       return '#6BA5E7';
     case PersonaInitialsColor.blue:
-      return '#2D89EF';
+      return blueColor;
     case PersonaInitialsColor.darkBlue:
       return '#2B5797';
     case PersonaInitialsColor.teal:
@@ -79,6 +81,8 @@ function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColo
     case PersonaInitialsColor.transparent:
       return 'transparent';
   }
+
+  return blueColor;
 }
 
 export function initialsColorPropToColorCode(props: IPersonaProps): string {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -15,7 +15,7 @@ const COLOR_SWATCHES_LOOKUP: PersonaInitialsColor[] = [
   PersonaInitialsColor.pink,
   PersonaInitialsColor.magenta,
   PersonaInitialsColor.purple,
-  PersonaInitialsColor.black,
+  PersonaInitialsColor.violet,
   PersonaInitialsColor.teal,
   PersonaInitialsColor.blue,
   PersonaInitialsColor.darkBlue,
@@ -44,14 +44,12 @@ function getInitialsColorFromName(displayName: string | undefined): PersonaIniti
   return color;
 }
 
-const blueColor = '#2D89EF';
-
 function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColor): string {
   switch (personaInitialsColor) {
     case PersonaInitialsColor.lightBlue:
       return '#6BA5E7';
     case PersonaInitialsColor.blue:
-      return blueColor;
+      return '#2D89EF';
     case PersonaInitialsColor.darkBlue:
       return '#2B5797';
     case PersonaInitialsColor.teal:
@@ -70,8 +68,8 @@ function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColo
       return '#7E3878';
     case PersonaInitialsColor.purple:
       return '#603CBA';
-    case PersonaInitialsColor.violet:
-      return '#5E4B8B';
+    case PersonaInitialsColor.black:
+      return '#1D1D1D';
     case PersonaInitialsColor.orange:
       return '#DA532C';
     case PersonaInitialsColor.red:
@@ -80,9 +78,9 @@ function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColo
       return '#B91D47';
     case PersonaInitialsColor.transparent:
       return 'transparent';
+    case PersonaInitialsColor.violet:
+      return '#5E4B8B';
   }
-
-  return blueColor;
 }
 
 export function initialsColorPropToColorCode(props: IPersonaProps): string {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -68,8 +68,8 @@ function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColo
       return '#7E3878';
     case PersonaInitialsColor.purple:
       return '#603CBA';
-    case PersonaInitialsColor.black:
-      return '#1D1D1D';
+    case PersonaInitialsColor.violet:
+      return '#5E4B8B';
     case PersonaInitialsColor.orange:
       return '#DA532C';
     case PersonaInitialsColor.red:

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -259,7 +259,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #2D89EF;
+              background-color: #5E4B8B;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -259,7 +259,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #1D1D1D;
+              background-color: #2D89EF;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -445,7 +445,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #2D89EF;
+              background-color: #5E4B8B;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -445,7 +445,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #1D1D1D;
+              background-color: #2D89EF;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -70,7 +70,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #2D89EF;
+                background-color: #5E4B8B;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -70,7 +70,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #1D1D1D;
+                background-color: #2D89EF;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In some cases an offensive personacoin would be generated if the black personacoin color was combined with certain initials. This could for instance happen if a user had initials SS and got a black persona coin. The fix is to replace the black color in the pallette with a new violet color

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5956)

