### PR TITLE
Panel custom align

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-custom-align_2018-08-16-17-13.json
+++ b/common/changes/office-ui-fabric-react/panel-custom-align_2018-08-16-17-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: remove selected media queries to ensure that custom panels are always right-aligned",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.scss
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.scss
@@ -105,12 +105,11 @@ $CommandBarHeight: 44px;
   }
 }
 
-//== Modifier: Medium, Large, Extra Large and Custom panels (anchored right, fluid width)
+//== Modifier: Medium, Large, and XLarge panels (anchored right, fluid width)
 //
 .root.rootIsMedium,
 .root.rootIsLarge,
-.root.rootIsXLarge,
-.root.rootIsCustom {
+.root.rootIsXLarge {
   .main {
     @media (min-width: $uhf-screen-min-mobile) {
       @include ms-left($Panel-margin-md);
@@ -161,14 +160,11 @@ $CommandBarHeight: 44px;
   }
 }
 
-//== Modifier: Medium panel (anchored right, fixed width)
+//== Modifier: Custom panel (anchored right, fixed width)
 //
 .root.rootIsCustom {
   .main {
     max-width: 100vw;
-    @media (min-width: $ms-screen-min-xl) {
-      @include ms-left(auto);
-    }
   }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5015 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Due to media queries, custom panels would be left-aligned for certain screen widths. This change removes those media queries so that custom panels are right-aligned regardless of screen size.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5959)

