### PR TITLE
Fix inability to focus on inputs when Coachmark is mounted

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-fixCoachmarkFocus_2018-08-16-19-09.json
+++ b/common/changes/office-ui-fabric-react/edwl-fixCoachmarkFocus_2018-08-16-19-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Coachmark: Fix inability to focus on inputs when Coachmark is active",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
@@ -28,7 +28,7 @@ import {
   ICoachmarkStyles,
   ICoachmarkStyleProps
 } from './Coachmark.styles';
-import { FocusZone } from '../../FocusZone';
+import { FocusTrapZone } from '../../FocusTrapZone';
 
 const getClassNames = classNamesFunction<ICoachmarkStyleProps, ICoachmarkStyles>();
 
@@ -132,7 +132,7 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
   private _translateAnimationContainer = createRef<HTMLDivElement>();
   private _ariaAlertContainer = createRef<HTMLDivElement>();
   private _positioningContainer = createRef<IPositioningContainer>();
-  private _focusZone = createRef<FocusZone>();
+  private _focusTrapZone = createRef<FocusTrapZone>();
 
   /**
    * The target element the mouse would be in
@@ -249,7 +249,11 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
                     color={color}
                   />
                 )}
-                <FocusZone componentRef={this._focusZone} isCircularNavigation={true}>
+                <FocusTrapZone
+                  componentRef={this._focusTrapZone}
+                  isClickableOutsideFocusTrap={true}
+                  forceFocusInsideTrap={false}
+                >
                   <div
                     className={classNames.entityHost}
                     tabIndex={-1}
@@ -278,7 +282,7 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
                       {children}
                     </div>
                   </div>
-                </FocusZone>
+                </FocusTrapZone>
               </div>
             </div>
           </div>
@@ -346,8 +350,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
           }, 0);
         }
         this._async.setTimeout(() => {
-          if (this._focusZone.current) {
-            this._focusZone.current.focus();
+          if (this._focusTrapZone.current) {
+            this._focusTrapZone.current.focus();
           }
         }, 1000);
       }

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
@@ -5,6 +5,7 @@ import {
   classNamesFunction,
   createRef,
   elementContains,
+  focusFirstChild,
   getDocument,
   IRectangle,
   KeyCodes,
@@ -27,7 +28,7 @@ import {
   ICoachmarkStyles,
   ICoachmarkStyleProps
 } from './Coachmark.styles';
-import { FocusTrapZone } from '../../FocusTrapZone';
+import { FocusZone } from '../../FocusZone';
 
 const getClassNames = classNamesFunction<ICoachmarkStyleProps, ICoachmarkStyles>();
 
@@ -131,6 +132,7 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
   private _translateAnimationContainer = createRef<HTMLDivElement>();
   private _ariaAlertContainer = createRef<HTMLDivElement>();
   private _positioningContainer = createRef<IPositioningContainer>();
+  private _focusZone = createRef<FocusZone>();
 
   /**
    * The target element the mouse would be in
@@ -238,7 +240,7 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
                     color={color}
                   />
                 )}
-                <FocusTrapZone isClickableOutsideFocusTrap={true}>
+                <FocusZone componentRef={this._focusZone} isCircularNavigation={true}>
                   <div
                     className={classNames.entityHost}
                     tabIndex={-1}
@@ -267,7 +269,7 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
                       {children}
                     </div>
                   </div>
-                </FocusTrapZone>
+                </FocusZone>
               </div>
             </div>
           </div>
@@ -319,7 +321,7 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
 
         this._addListeners();
 
-        // We dont want to the user to immediatley trigger the coachmark when it's opened
+        // We don't want to the user to immediately trigger the Coachmark when it's opened
         this._async.setTimeout(() => {
           this._addProximityHandler(this.props.mouseProximityOffset);
         }, this.props.delayBeforeMouseOpen!);
@@ -334,6 +336,11 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
             }
           }, 0);
         }
+        this._async.setTimeout(() => {
+          if (this._focusZone.current) {
+            this._focusZone.current.focus();
+          }
+        }, 1000);
       }
     );
   }
@@ -528,10 +535,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
         (): void => {
           // Need setTimeout to trigger narrator
           this._async.setTimeout(() => {
-            if (this.props.teachingBubbleRef) {
-              this.props.teachingBubbleRef.focus();
-            }
-          }, 500);
+            focusFirstChild(this._entityInnerHostElement.current!);
+          }, 1000);
 
           if (this.props.onAnimationOpenEnd) {
             this.props.onAnimationOpenEnd();

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
@@ -143,6 +143,15 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
   constructor(props: ICoachmarkProps) {
     super(props);
 
+    this._warnDeprecations({
+      teachingBubbleRef: undefined,
+      collapsed: 'isCollapsed',
+      beakWidth: undefined,
+      beakHeight: undefined,
+      width: undefined,
+      height: undefined
+    });
+
     // Set defaults for state
     this.state = {
       isCollapsed: props.isCollapsed!,
@@ -535,7 +544,9 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
         (): void => {
           // Need setTimeout to trigger narrator
           this._async.setTimeout(() => {
-            focusFirstChild(this._entityInnerHostElement.current!);
+            if (this._entityInnerHostElement.current) {
+              focusFirstChild(this._entityInnerHostElement.current);
+            }
           }, 1000);
 
           if (this.props.onAnimationOpenEnd) {

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
@@ -128,6 +128,7 @@ export interface ICoachmarkProps extends React.Props<Coachmark> {
 
   /**
    * Ref for TeachingBubble
+   * @deprecated Coachmark uses focusFirstChild utility instead to focus on TeachingBubbleContent
    */
   teachingBubbleRef?: ITeachingBubble;
 

--- a/packages/office-ui-fabric-react/src/components/Coachmark/examples/Coachmark.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/examples/Coachmark.Basic.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Coachmark } from '../Coachmark';
-import { ITeachingBubble, TeachingBubbleContent } from 'office-ui-fabric-react/lib/TeachingBubble';
+import { TeachingBubbleContent } from 'office-ui-fabric-react/lib/TeachingBubble';
 import { DefaultButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
 import { IStyle } from 'office-ui-fabric-react/lib/Styling';

--- a/packages/office-ui-fabric-react/src/components/Coachmark/examples/Coachmark.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/examples/Coachmark.Basic.Example.tsx
@@ -31,7 +31,6 @@ export interface ICoachmarkBasicExampleStyles {
 
 export class CoachmarkBasicExample extends BaseComponent<{}, ICoachmarkBasicExampleState> {
   private _targetButton = createRef<HTMLDivElement>();
-  private _teachingBubbleContent: ITeachingBubble;
 
   public constructor(props: {}) {
     super(props);
@@ -106,15 +105,12 @@ export class CoachmarkBasicExample extends BaseComponent<{}, ICoachmarkBasicExam
               directionalHint: this.state.coachmarkPosition
             }}
             ariaAlertText="A Coachmark has appeared"
-            teachingBubbleRef={this._teachingBubbleContent}
             ariaDescribedBy={'coachmark-desc1'}
             ariaLabelledBy={'coachmark-label1'}
             ariaDescribedByText={'Press enter or alt + C to open the Coachmark notification'}
             ariaLabelledByText={'Coachmark notification'}
-            onDismiss={this._onDismiss}
           >
             <TeachingBubbleContent
-              componentRef={this._teachingBubbleRef}
               headline="Example Title"
               hasCloseIcon={true}
               closeButtonAriaLabel="Close"
@@ -148,9 +144,5 @@ export class CoachmarkBasicExample extends BaseComponent<{}, ICoachmarkBasicExam
     this.setState({
       isCoachmarkVisible: !this.state.isCoachmarkVisible
     });
-  };
-
-  private _teachingBubbleRef = (component: ITeachingBubble): void => {
-    this._teachingBubbleContent = component;
   };
 }

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -22,7 +22,7 @@ export interface ITeachingBubbleProps
   extends React.Props<TeachingBubbleBase | TeachingBubbleContentBase>,
     IAccessiblePopupProps {
   /**
-   * Optional callback to access the ISlider interface. Use this instead of ref for accessing
+   * Optional callback to access the ITeachingBubble interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
   componentRef?: IRefObject<ITeachingBubble>;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5960
- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Change Coachmark to use FocusZone instead of FocusTrapZone to fix inability to use inputs when Coachmark is active.
- Deprecate teachingBubbleRef prop for Coachmark; Use focusFirstChild utility instead

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5961)

