### PR TITLE
DetailsList: "select all" checkbox aria hidden attribute in single selection mode

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListCheckboxAriaHidden_2018-08-16-21-18.json
+++ b/common/changes/office-ui-fabric-react/detailsListCheckboxAriaHidden_2018-08-16-21-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: add aria-hidden to select all checkbox in single selectionmode",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -238,6 +238,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
                 onClick={!isCheckboxHidden ? this._onSelectAllClicked : undefined}
                 aria-colindex={1}
                 role={'columnheader'}
+                aria-hidden={isCheckboxHidden ? true : undefined}
               >
                 {onRenderColumnHeaderTooltip(
                   {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`DetailsHeader can render 1`] = `
 >
   <div
     aria-colindex={1}
+    aria-hidden={undefined}
     aria-labelledby="header0-check"
     className=
         ms-DetailsHeader-cell
@@ -921,6 +922,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
 >
   <div
     aria-colindex={1}
+    aria-hidden={undefined}
     aria-labelledby="header4-check"
     className=
         ms-DetailsHeader-cell

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`DetailsList renders List correctly 1`] = `
         >
           <div
             aria-colindex={1}
+            aria-hidden={undefined}
             aria-labelledby="header0-check"
             className=
                 ms-DetailsHeader-cell
@@ -661,6 +662,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
         >
           <div
             aria-colindex={1}
+            aria-hidden={undefined}
             aria-labelledby="header6-check"
             className=
                 ms-DetailsHeader-cell
@@ -1237,6 +1239,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
         >
           <div
             aria-colindex={1}
+            aria-hidden={undefined}
             aria-labelledby="header3-check"
             className=
                 ms-DetailsHeader-cell

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
         >
           <div
             aria-colindex={1}
+            aria-hidden={undefined}
             aria-labelledby="header0-check"
             className=
                 ms-DetailsHeader-cell
@@ -896,6 +897,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
         >
           <div
             aria-colindex={1}
+            aria-hidden={undefined}
             aria-labelledby="header9-check"
             className=
                 ms-DetailsHeader-cell
@@ -2231,6 +2233,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
         >
           <div
             aria-colindex={1}
+            aria-hidden={undefined}
             aria-labelledby="header3-check"
             className=
                 ms-DetailsHeader-cell
@@ -3042,6 +3045,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
         >
           <div
             aria-colindex={1}
+            aria-hidden={undefined}
             aria-labelledby="header6-check"
             className=
                 ms-DetailsHeader-cell

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
         >
           <div
             aria-colindex={1}
+            aria-hidden={undefined}
             aria-labelledby="header0-check"
             className=
                 ms-DetailsHeader-cell

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -130,6 +130,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           checkboxVisibility={checkboxVisibility}
           layoutMode={layoutMode}
           isHeaderVisible={isHeaderVisible}
+          selectionMode={selectionMode}
           constrainMode={constrainMode}
           groupProps={groupProps}
           enterModalSelectionOnTouch={true}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes add an `aria-hidden` attribute to the "select all" checkbox when in a DetailsList is in single selection mode, as it only serves as a column header in that case and is not focusable. 

I've also added a fix for the DetailsList advanced example.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5963)

