### PR TITLE
Choicegroupoption styles

### DIFF
--- a/common/changes/office-ui-fabric-react/choicegroupoption-styles_2018-08-16-22-33.json
+++ b/common/changes/office-ui-fabric-react/choicegroupoption-styles_2018-08-16-22-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: change styles so that label styles do not apply to Label components in onRenderField",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -133,7 +133,7 @@ export class ChoiceGroupOptionBase extends BaseComponent<IChoiceGroupOptionProps
 
   private _onRenderLabel = (props: IChoiceGroupOptionProps): JSX.Element => {
     return (
-      <span id={props.labelId} className="ms-Label">
+      <span id={props.labelId} className="ms-ChoiceFieldLabel">
         {props.text}
       </span>
     );

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -93,7 +93,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
 
   const fieldHoverOrFocusProperties = {
     selectors: {
-      '.ms-Label': {
+      '.ms-ChoiceFieldLabel': {
         color: semanticColors.bodyTextChecked
       },
       ':before': {
@@ -210,7 +210,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         position: 'relative',
         marginTop: 8,
         selectors: {
-          '.ms-Label': {
+          '.ms-ChoiceFieldLabel': {
             fontSize: FontSizes.medium,
             display: 'inline-block'
           }
@@ -219,7 +219,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       !hasIcon &&
         !hasImage && {
           selectors: {
-            '.ms-Label': {
+            '.ms-ChoiceFieldLabel': {
               paddingLeft: '26px'
             }
           }
@@ -307,7 +307,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       disabled && {
         cursor: 'default',
         selectors: {
-          '.ms-Label': {
+          '.ms-ChoiceFieldLabel': {
             color: semanticColors.disabledBodyText
           },
           [HighContrastSelector]: {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           min-height: 26px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
           padding-left: 26px;
@@ -59,13 +59,13 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               user-select: none;
               vertical-align: top;
             }
-            &:hover .ms-Label {
+            &:hover .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:hover:before {
               border-color: #212121;
             }
-            &:focus .ms-Label {
+            &:focus .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:focus:before {
@@ -106,7 +106,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         htmlFor={undefined}
       >
         <span
-          className="ms-Label"
+          className="ms-ChoiceFieldLabel"
           id={undefined}
         >
           Option A
@@ -129,7 +129,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           min-height: 26px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
           padding-left: 26px;
@@ -192,13 +192,13 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               user-select: none;
               vertical-align: top;
             }
-            &:hover .ms-Label {
+            &:hover .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:hover:before {
               border-color: #212121;
             }
-            &:focus .ms-Label {
+            &:focus .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:focus:before {
@@ -239,7 +239,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         htmlFor={undefined}
       >
         <span
-          className="ms-Label"
+          className="ms-ChoiceFieldLabel"
           id={undefined}
         >
           Option B
@@ -262,7 +262,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           min-height: 26px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
           padding-left: 26px;
@@ -326,13 +326,13 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               user-select: none;
               vertical-align: top;
             }
-            &:hover .ms-Label {
+            &:hover .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:hover:before {
               border-color: #106ebe;
             }
-            &:focus .ms-Label {
+            &:focus .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:focus:before {
@@ -383,7 +383,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         htmlFor={undefined}
       >
         <span
-          className="ms-Label"
+          className="ms-ChoiceFieldLabel"
           id={undefined}
         >
           Option C
@@ -406,7 +406,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           min-height: 26px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
           padding-left: 26px;
@@ -483,7 +483,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 0px;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               color: #c8c8c8;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -492,7 +492,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         htmlFor={undefined}
       >
         <span
-          className="ms-Label"
+          className="ms-ChoiceFieldLabel"
           id={undefined}
         >
           Option D
@@ -515,7 +515,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           min-height: 26px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
           padding-left: 26px;
@@ -601,7 +601,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:after {
               border-color: Highlight;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               color: #c8c8c8;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -610,7 +610,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         htmlFor={undefined}
       >
         <span
-          className="ms-Label"
+          className="ms-ChoiceFieldLabel"
           id={undefined}
         >
           Option E
@@ -640,7 +640,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           padding-left: 0px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
         }
@@ -705,7 +705,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:hover {
               border-color: #c8c8c8;
             }
-            &:hover .ms-Label {
+            &:hover .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:hover:before {
@@ -715,7 +715,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:focus {
               border-color: #c8c8c8;
             }
-            &:focus .ms-Label {
+            &:focus .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:focus:before {
@@ -822,7 +822,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           }
         >
           <span
-            className="ms-Label"
+            className="ms-ChoiceFieldLabel"
             id={undefined}
           >
             Option F
@@ -853,7 +853,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           padding-left: 0px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
         }
@@ -939,7 +939,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:hover {
               border-color: #c8c8c8;
             }
-            &:hover .ms-Label {
+            &:hover .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:hover:before {
@@ -949,7 +949,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:focus {
               border-color: #c8c8c8;
             }
-            &:focus .ms-Label {
+            &:focus .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:focus:before {
@@ -1056,7 +1056,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           }
         >
           <span
-            className="ms-Label"
+            className="ms-ChoiceFieldLabel"
             id={undefined}
           >
             Option G
@@ -1087,7 +1087,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           padding-left: 0px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
         }
@@ -1153,7 +1153,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:hover {
               border-color: #005a9e;
             }
-            &:hover .ms-Label {
+            &:hover .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:hover:before {
@@ -1163,7 +1163,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             &:focus {
               border-color: #005a9e;
             }
-            &:focus .ms-Label {
+            &:focus .ms-ChoiceFieldLabel {
               color: #000000;
             }
             &:focus:before {
@@ -1280,7 +1280,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           }
         >
           <span
-            className="ms-Label"
+            className="ms-ChoiceFieldLabel"
             id={undefined}
           >
             Option H
@@ -1311,7 +1311,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           padding-left: 0px;
           position: relative;
         }
-        & .ms-Label {
+        & .ms-ChoiceFieldLabel {
           display: inline-block;
           font-size: 14px;
         }
@@ -1410,7 +1410,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 0px;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               color: #c8c8c8;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -1487,7 +1487,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           }
         >
           <span
-            className="ms-Label"
+            className="ms-ChoiceFieldLabel"
             id={undefined}
           >
             Option I

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
               min-height: 26px;
               position: relative;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               display: inline-block;
               font-size: 14px;
               padding-left: 26px;
@@ -84,13 +84,13 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   user-select: none;
                   vertical-align: top;
                 }
-                &:hover .ms-Label {
+                &:hover .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:hover:before {
                   border-color: #212121;
                 }
-                &:focus .ms-Label {
+                &:focus .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:focus:before {
@@ -131,7 +131,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             htmlFor="ChoiceGroup0-1"
           >
             <span
-              className="ms-Label"
+              className="ms-ChoiceFieldLabel"
               id="ChoiceGroupLabel1-1"
             >
               1
@@ -154,7 +154,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
               min-height: 26px;
               position: relative;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               display: inline-block;
               font-size: 14px;
               padding-left: 26px;
@@ -197,13 +197,13 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   user-select: none;
                   vertical-align: top;
                 }
-                &:hover .ms-Label {
+                &:hover .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:hover:before {
                   border-color: #212121;
                 }
-                &:focus .ms-Label {
+                &:focus .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:focus:before {
@@ -244,7 +244,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             htmlFor="ChoiceGroup0-2"
           >
             <span
-              className="ms-Label"
+              className="ms-ChoiceFieldLabel"
               id="ChoiceGroupLabel1-2"
             >
               2
@@ -267,7 +267,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
               min-height: 26px;
               position: relative;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               display: inline-block;
               font-size: 14px;
               padding-left: 26px;
@@ -310,13 +310,13 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
                   user-select: none;
                   vertical-align: top;
                 }
-                &:hover .ms-Label {
+                &:hover .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:hover:before {
                   border-color: #212121;
                 }
-                &:focus .ms-Label {
+                &:focus .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:focus:before {
@@ -357,7 +357,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             htmlFor="ChoiceGroup0-3"
           >
             <span
-              className="ms-Label"
+              className="ms-ChoiceFieldLabel"
               id="ChoiceGroupLabel1-3"
             >
               3

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -71,7 +71,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                 min-height: 26px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
                 padding-left: 26px;
@@ -115,13 +115,13 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                     user-select: none;
                     vertical-align: top;
                   }
-                  &:hover .ms-Label {
+                  &:hover .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:hover:before {
                     border-color: #212121;
                   }
-                  &:focus .ms-Label {
+                  &:focus .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:focus:before {
@@ -162,7 +162,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               htmlFor="ChoiceGroup0-A"
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-A"
               >
                 Option A
@@ -185,7 +185,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                 min-height: 26px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
                 padding-left: 26px;
@@ -229,13 +229,13 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                     user-select: none;
                     vertical-align: top;
                   }
-                  &:hover .ms-Label {
+                  &:hover .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:hover:before {
                     border-color: #106ebe;
                   }
-                  &:focus .ms-Label {
+                  &:focus .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:focus:before {
@@ -286,7 +286,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               htmlFor="ChoiceGroup0-B"
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-B"
               >
                 Option B
@@ -309,7 +309,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                 min-height: 26px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
                 padding-left: 26px;
@@ -387,7 +387,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 0px;
                   }
-                  & .ms-Label {
+                  & .ms-ChoiceFieldLabel {
                     color: #c8c8c8;
                   }
                   @media screen and (-ms-high-contrast: active){& {
@@ -396,7 +396,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               htmlFor="ChoiceGroup0-C"
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-C"
               >
                 Option C
@@ -419,7 +419,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                 min-height: 26px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
                 padding-left: 26px;
@@ -497,7 +497,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 0px;
                   }
-                  & .ms-Label {
+                  & .ms-ChoiceFieldLabel {
                     color: #c8c8c8;
                   }
                   @media screen and (-ms-high-contrast: active){& {
@@ -506,7 +506,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               htmlFor="ChoiceGroup0-D"
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-D"
               >
                 Option D

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -71,7 +71,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 min-height: 26px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
                 padding-left: 26px;
@@ -117,13 +117,13 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                       user-select: none;
                       vertical-align: top;
                     }
-                    &:hover .ms-Label {
+                    &:hover .ms-ChoiceFieldLabel {
                       color: #000000;
                     }
                     &:hover:before {
                       border-color: #212121;
                     }
-                    &:focus .ms-Label {
+                    &:focus .ms-ChoiceFieldLabel {
                       color: #000000;
                     }
                     &:focus:before {
@@ -164,7 +164,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 htmlFor="ChoiceGroup0-A"
               >
                 <span
-                  className="ms-Label"
+                  className="ms-ChoiceFieldLabel"
                   id="ChoiceGroupLabel1-A"
                 >
                   Mark displayed items as read after
@@ -368,7 +368,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 min-height: 26px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
                 padding-left: 26px;
@@ -412,13 +412,13 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                     user-select: none;
                     vertical-align: top;
                   }
-                  &:hover .ms-Label {
+                  &:hover .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:hover:before {
                     border-color: #106ebe;
                   }
-                  &:focus .ms-Label {
+                  &:focus .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:focus:before {
@@ -469,7 +469,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               htmlFor="ChoiceGroup0-B"
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-B"
               >
                 Option B
@@ -492,7 +492,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 min-height: 26px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
                 padding-left: 26px;
@@ -570,7 +570,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 0px;
                   }
-                  & .ms-Label {
+                  & .ms-ChoiceFieldLabel {
                     color: #c8c8c8;
                   }
                   @media screen and (-ms-high-contrast: active){& {
@@ -579,7 +579,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               htmlFor="ChoiceGroup0-C"
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-C"
               >
                 Option C
@@ -602,7 +602,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 min-height: 26px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
                 padding-left: 26px;
@@ -645,13 +645,13 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                     user-select: none;
                     vertical-align: top;
                   }
-                  &:hover .ms-Label {
+                  &:hover .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:hover:before {
                     border-color: #212121;
                   }
-                  &:focus .ms-Label {
+                  &:focus .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:focus:before {
@@ -692,7 +692,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               htmlFor="ChoiceGroup0-D"
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-D"
               >
                 Option D

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -76,7 +76,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               padding-left: 0px;
               position: relative;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               display: inline-block;
               font-size: 14px;
             }
@@ -142,7 +142,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                 &:hover {
                   border-color: #c8c8c8;
                 }
-                &:hover .ms-Label {
+                &:hover .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:hover:before {
@@ -152,7 +152,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                 &:focus {
                   border-color: #c8c8c8;
                 }
-                &:focus .ms-Label {
+                &:focus .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:focus:before {
@@ -259,7 +259,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               }
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-day"
               >
                 Day
@@ -290,7 +290,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               padding-left: 0px;
               position: relative;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               display: inline-block;
               font-size: 14px;
             }
@@ -356,7 +356,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                 &:hover {
                   border-color: #c8c8c8;
                 }
-                &:hover .ms-Label {
+                &:hover .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:hover:before {
@@ -366,7 +366,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                 &:focus {
                   border-color: #c8c8c8;
                 }
-                &:focus .ms-Label {
+                &:focus .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:focus:before {
@@ -473,7 +473,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               }
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-week"
               >
                 Week
@@ -504,7 +504,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               padding-left: 0px;
               position: relative;
             }
-            & .ms-Label {
+            & .ms-ChoiceFieldLabel {
               display: inline-block;
               font-size: 14px;
             }
@@ -604,7 +604,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 0px;
                 }
-                & .ms-Label {
+                & .ms-ChoiceFieldLabel {
                   color: #c8c8c8;
                 }
                 @media screen and (-ms-high-contrast: active){& {
@@ -681,7 +681,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               }
             >
               <span
-                className="ms-Label"
+                className="ms-ChoiceFieldLabel"
                 id="ChoiceGroupLabel1-month"
               >
                 Month

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -77,7 +77,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 padding-left: 0px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
               }
@@ -144,7 +144,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   &:hover {
                     border-color: #005a9e;
                   }
-                  &:hover .ms-Label {
+                  &:hover .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:hover:before {
@@ -154,7 +154,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   &:focus {
                     border-color: #005a9e;
                   }
-                  &:focus .ms-Label {
+                  &:focus .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:focus:before {
@@ -351,7 +351,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 }
               >
                 <span
-                  className="ms-Label"
+                  className="ms-ChoiceFieldLabel"
                   id="ChoiceGroupLabel1-bar"
                 >
                   Clustered bar chart
@@ -382,7 +382,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 padding-left: 0px;
                 position: relative;
               }
-              & .ms-Label {
+              & .ms-ChoiceFieldLabel {
                 display: inline-block;
                 font-size: 14px;
               }
@@ -448,7 +448,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   &:hover {
                     border-color: #c8c8c8;
                   }
-                  &:hover .ms-Label {
+                  &:hover .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:hover:before {
@@ -458,7 +458,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                   &:focus {
                     border-color: #c8c8c8;
                   }
-                  &:focus .ms-Label {
+                  &:focus .ms-ChoiceFieldLabel {
                     color: #000000;
                   }
                   &:focus:before {
@@ -645,7 +645,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 }
               >
                 <span
-                  className="ms-Label"
+                  className="ms-ChoiceFieldLabel"
                   id="ChoiceGroupLabel1-pie"
                 >
                   Pie chart


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3376 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

ChoiceGroupOption renders a span that previously had a `ms-Label` className applied. This interfered with the styles for all Label components that the user renders using the `onRenderField` prop. This change uses a new `ms-ChoiceFieldLabel` class instead to style the span without styling any Labels.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5964)

