### PR TITLE
DetailsList: select first row on down arrow key event

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListSelectFirstRow_2018-08-16-22-20.json
+++ b/common/changes/office-ui-fabric-react/detailsListSelectFirstRow_2018-08-16-22-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: select first row on down arrow key event",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -575,6 +575,8 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
   private _onHeaderKeyDown(ev: React.KeyboardEvent<HTMLElement>): void {
     if (ev.which === KeyCodes.down) {
       if (this._focusZone.current && this._focusZone.current.focus()) {
+        // select the first item in list after down arrow key event
+        this._selection.setIndexSelected(0, true, false);
         ev.preventDefault();
         ev.stopPropagation();
       }
@@ -912,7 +914,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
   }
 
   /**
-   * Call back function when an element in FocusZone becomes active. It will transalate it into item
+   * Call back function when an element in FocusZone becomes active. It will translate it into item
    * and call onActiveItemChanged callback if specified.
    *
    * @private

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -66,7 +66,6 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   private _isShiftPressed: boolean;
   private _isMetaPressed: boolean;
   private _isTabPressed: boolean;
-  private _isDownArrowPressed: boolean;
   private _shouldHandleFocus: boolean;
   private _shouldHandleFocusTimeoutId: number | undefined;
   private _isTouch: boolean;
@@ -146,12 +145,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     const target = ev.target as HTMLElement;
     const { selection } = this.props;
     const isToggleModifierPressed = this._isCtrlPressed || this._isMetaPressed;
-    // we should select an item if the focus originates from an arrow down keyboard event
-    const isDownArrowPressed = this._isDownArrowPressed;
 
     const selectionMode = this._getSelectionMode();
 
-    if ((this._shouldHandleFocus || isDownArrowPressed) && selectionMode !== SelectionMode.none) {
+    if (this._shouldHandleFocus && selectionMode !== SelectionMode.none) {
       const isToggle = this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME);
       const itemRoot = this._findItemRoot(target);
 
@@ -528,7 +525,6 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
 
     const keyCode = (ev as React.KeyboardEvent<HTMLElement>).keyCode;
     this._isTabPressed = keyCode ? keyCode === KeyCodes.tab : false;
-    this._isDownArrowPressed = keyCode ? keyCode === KeyCodes.down : false;
   }
 
   private _findItemRoot(target: HTMLElement): HTMLElement | undefined {

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -66,6 +66,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   private _isShiftPressed: boolean;
   private _isMetaPressed: boolean;
   private _isTabPressed: boolean;
+  private _isDownArrowPressed: boolean;
   private _shouldHandleFocus: boolean;
   private _shouldHandleFocusTimeoutId: number | undefined;
   private _isTouch: boolean;
@@ -145,10 +146,12 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     const target = ev.target as HTMLElement;
     const { selection } = this.props;
     const isToggleModifierPressed = this._isCtrlPressed || this._isMetaPressed;
+    // we should select an item if the focus originates from an arrow down keyboard event
+    const isDownArrowPressed = this._isDownArrowPressed;
 
     const selectionMode = this._getSelectionMode();
 
-    if (this._shouldHandleFocus && selectionMode !== SelectionMode.none) {
+    if ((this._shouldHandleFocus || isDownArrowPressed) && selectionMode !== SelectionMode.none) {
       const isToggle = this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME);
       const itemRoot = this._findItemRoot(target);
 
@@ -525,6 +528,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
 
     const keyCode = (ev as React.KeyboardEvent<HTMLElement>).keyCode;
     this._isTabPressed = keyCode ? keyCode === KeyCodes.tab : false;
+    this._isDownArrowPressed = keyCode ? keyCode === KeyCodes.down : false;
   }
 
   private _findItemRoot(target: HTMLElement): HTMLElement | undefined {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

With these changes, the first row of a DetailsList is selected when navigating from the DetailsList "select all" using a down arrow key. This makes sense given the behavior of arrow keys once in the DetailsList.

Before:

![detailslist select first row on down arrow not working](https://user-images.githubusercontent.com/14134000/44239453-3572f180-a16e-11e8-95d2-b3d6e6abed06.gif)

After:

![detailslist select first row on down arrow working](https://user-images.githubusercontent.com/14134000/44239454-373cb500-a16e-11e8-9286-e63dbed2c9d5.gif)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5966)

