### PR TITLE
Remove ShimmeredDetailsList from DetailsList's bundle root

### DIFF
--- a/common/changes/office-ui-fabric-react/shimmer-bundle_2018-08-17-06-02.json
+++ b/common/changes/office-ui-fabric-react/shimmer-bundle_2018-08-17-06-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Decouple ShimmeredDetailsList from DetailsList",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/ShimmeredDetailsList.ts
+++ b/packages/office-ui-fabric-react/src/ShimmeredDetailsList.ts
@@ -1,1 +1,2 @@
 export * from './components/DetailsList/ShimmeredDetailsList';
+export * from './components/DetailsList/ShimmeredDetailsList.base';

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -8,6 +8,4 @@ export * from './DetailsRow.base';
 export * from './DetailsRow.types';
 export * from './DetailsRowCheck';
 export * from './DetailsRowCheck.types';
-export * from './ShimmeredDetailsList';
-export * from './ShimmeredDetailsList.base';
 export * from './DetailsFooter.types';


### PR DESCRIPTION
To avoid causing grief for non-shaking bundlers, this change removes `ShimmeredDetailsList` from `DetailsList`'s inner-most export...again.