### PR TITLE
Fix alignment of DetailsList header icons

### DIFF
--- a/common/changes/office-ui-fabric-react/details-icon_2018-08-17-15-43.json
+++ b/common/changes/office-ui-fabric-react/details-icon_2018-08-17-15-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Don't left-pad DetailsColumn header icons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -120,7 +120,13 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
       }
     ],
 
-    iconClassName: [nearIconStyle, iconClassName],
+    iconClassName: [
+      {
+        color: colors.iconForegroundColor,
+        opacity: 1
+      },
+      iconClassName
+    ],
 
     filterChevron: [
       classNames.filterChevron,


### PR DESCRIPTION
An incorrect `8px` left-padding was added to column headers which use only icons. This change removes it, since header cells already have `8px` of left padding.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5973)

