### PR TITLE
Sticky: fix an edge case when scrolling all the way down.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-StickyFix_2018-08-18-02-42.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-StickyFix_2018-08-18-02-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Sticky: Fix an edge case causing Sticky footer to wrongly re-calculate it's height.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -201,7 +201,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       // Can sticky bottom if the scrollablePane - total sticky footer height is smaller than the sticky's distance from the top of the pane
       if (this.canStickyBottom && container.clientHeight - footerStickyContainer.offsetHeight <= this.distanceFromTop) {
         isStickyBottom =
-          this.distanceFromTop - container.scrollTop >
+          this.distanceFromTop - container.scrollTop >=
           this._getStickyDistanceFromTopForFooter(container, footerStickyContainer);
       }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Fix an edge case causing Sticky footer to wrongly re-calculate it's height when no content in ScrollablePane after footer sticky.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5984)

