### PR TITLE
Final semantic colors for news webpart

### DIFF
--- a/common/changes/@uifabric/styling/finalSemanticColorsForNews_2018-08-20-17-52.json
+++ b/common/changes/@uifabric/styling/finalSemanticColorsForNews_2018-08-20-17-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "adds variantBorderHovered and emptyStateBackground semantic slots to theme and variants logic",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "v-jescla@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/finalSemanticColorsForNews_2018-08-20-17-52.json
+++ b/common/changes/@uifabric/variants/finalSemanticColorsForNews_2018-08-20-17-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/variants",
+      "comment": "adds variantBorderHovered and emptyStateBackground semantic slots to theme and variants logic",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "v-jescla@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/finalSemanticColorsForNews_2018-08-20-17-52.json
+++ b/common/changes/office-ui-fabric-react/finalSemanticColorsForNews_2018-08-20-17-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "adds variantBorderHovered and emptyStateBackground semantic slots to theme and variants logic",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jescla@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -21,6 +21,8 @@ $disabledSubtextColor: '[theme:disabledSubtext, default: #dadada]';
 
 $focusBorderColor: '[theme:focusBorder, default: #000000]';
 $variantBorderColor: '[theme:variantBorder, default: #eaeaea]';
+$variantBorderHoveredColor: '[theme:variantBorderHovered, default: #a6a6a6]';
+$emptyStateBackgroundColor: '[theme:emptyStateBackground, default: #eaeaea]';
 
 $errorTextColor: '[theme:errorText, default: #a80000]';
 $warningTextColor: '[theme:warningText, default: #333333]';

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -22,7 +22,7 @@ $disabledSubtextColor: '[theme:disabledSubtext, default: #dadada]';
 $focusBorderColor: '[theme:focusBorder, default: #000000]';
 $variantBorderColor: '[theme:variantBorder, default: #eaeaea]';
 $variantBorderHoveredColor: '[theme:variantBorderHovered, default: #a6a6a6]';
-$emptyStateBackgroundColor: '[theme:emptyStateBackground, default: #eaeaea]';
+$defaultStateBackgroundColor: '[theme:defaultStateBackground, default: #eaeaea]';
 
 $errorTextColor: '[theme:errorText, default: #a80000]';
 $warningTextColor: '[theme:warningText, default: #333333]';

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -156,7 +156,8 @@ export interface ISemanticColors {
   variantBorderHovered: string;
 
   /**
-   * Background color for default/empty state graphical elements, eg icons, placeholder graphics, etc.
+   * Background color for default/empty state graphical elements; eg default icons, empty section that
+   * needs user to fill in content, placeholder graphics, empty seats, etc.
    */
   defaultStateBackground: string;
 

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -158,7 +158,7 @@ export interface ISemanticColors {
   /**
    * Background color for default/empty state graphical elements, eg icons, placeholder graphics, etc.
    */
-  emptyStateBackground: string;
+  defaultStateBackground: string;
 
   //// Invariants - slots that rarely change color theme-to-theme because the color has meaning
 

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -150,6 +150,16 @@ export interface ISemanticColors {
    */
   variantBorder: string;
 
+  /**
+   * Hover color of border that provides contrast between an element, such as a card, and an emphasized background.
+   */
+  variantBorderHovered: string;
+
+  /**
+   * Background color for default/empty state graphical elements, eg icons, placeholder graphics, etc.
+   */
+  emptyStateBackground: string;
+
   //// Invariants - slots that rarely change color theme-to-theme because the color has meaning
 
   /**

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -160,6 +160,8 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean, depCom
 
     focusBorder: p.black,
     variantBorder: p.neutralLight,
+    variantBorderHovered: p.neutralTertiary,
+    emptyStateBackground: p.neutralLight,
 
     errorText: !isInverted ? p.redDark : '#ff5f5f',
     warningText: !isInverted ? '#333333' : '#ffffff',

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -161,7 +161,7 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean, depCom
     focusBorder: p.black,
     variantBorder: p.neutralLight,
     variantBorderHovered: p.neutralTertiary,
-    emptyStateBackground: p.neutralLight,
+    defaultStateBackground: p.neutralLight,
 
     errorText: !isInverted ? p.redDark : '#ff5f5f',
     warningText: !isInverted ? '#333333' : '#ffffff',

--- a/packages/variants/src/variants.ts
+++ b/packages/variants/src/variants.ts
@@ -86,6 +86,8 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
     bodyFrameBackground: !fullTheme.isInverted ? p.neutralLight : p.neutralLighter,
     bodyFrameDivider: !fullTheme.isInverted ? p.neutralLight : p.neutralQuaternary,
     variantBorder: !fullTheme.isInverted ? p.neutralQuaternaryAlt : p.neutralLighterAlt,
+    variantBorderHovered: p.neutralTertiary,
+    emptyStateBackground: p.neutralQuaternaryAlt,
 
     buttonBackground: p.neutralLighter,
     buttonBackgroundHovered: p.neutralLight,
@@ -166,6 +168,8 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     inputForegroundChecked: p.themeLighter,
     // inputFocusBorderAlt: p.themePrimary,
     variantBorder: !fullTheme.isInverted ? p.neutralLight : p.neutralLighterAlt,
+    variantBorderHovered: p.neutralTertiary,
+    emptyStateBackground: !fullTheme.isInverted ? p.themeLight : p.themeTertiary,
 
     buttonBackground: !fullTheme.isInverted ? p.themeLighterAlt : p.themeLight,
     buttonBackgroundHovered: !fullTheme.isInverted ? p.themeLighter : p.themeTertiary,
@@ -257,6 +261,8 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
     inputForegroundChecked: p.themeDark,
     // inputFocusBorderAlt: p.themePrimary,
     variantBorder: p.themeDark,
+    variantBorderHovered: p.themeDarker,
+    emptyStateBackground: p.themeDark,
 
     buttonBackground: p.white,
     buttonBackgroundHovered: !fullTheme.isInverted ? p.themeLighter : p.themeLight,

--- a/packages/variants/src/variants.ts
+++ b/packages/variants/src/variants.ts
@@ -87,7 +87,7 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
     bodyFrameDivider: !fullTheme.isInverted ? p.neutralLight : p.neutralQuaternary,
     variantBorder: !fullTheme.isInverted ? p.neutralQuaternaryAlt : p.neutralLighterAlt,
     variantBorderHovered: p.neutralTertiary,
-    emptyStateBackground: p.neutralQuaternaryAlt,
+    defaultStateBackground: p.neutralQuaternaryAlt,
 
     buttonBackground: p.neutralLighter,
     buttonBackgroundHovered: p.neutralLight,
@@ -169,7 +169,7 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     // inputFocusBorderAlt: p.themePrimary,
     variantBorder: !fullTheme.isInverted ? p.neutralLight : p.neutralLighterAlt,
     variantBorderHovered: p.neutralTertiary,
-    emptyStateBackground: !fullTheme.isInverted ? p.themeLight : p.themeTertiary,
+    defaultStateBackground: !fullTheme.isInverted ? p.themeLight : p.themeTertiary,
 
     buttonBackground: !fullTheme.isInverted ? p.themeLighterAlt : p.themeLight,
     buttonBackgroundHovered: !fullTheme.isInverted ? p.themeLighter : p.themeTertiary,
@@ -262,7 +262,7 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
     // inputFocusBorderAlt: p.themePrimary,
     variantBorder: p.themeDark,
     variantBorderHovered: p.themeDarker,
-    emptyStateBackground: p.themeDark,
+    defaultStateBackground: p.themeDark,
 
     buttonBackground: p.white,
     buttonBackgroundHovered: !fullTheme.isInverted ? p.themeLighter : p.themeLight,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adds variantBorderHovered and emptyStateBackground semantic slots to theme and variants logic
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5993)

