### PR TITLE
Masked text field on change

### DIFF
--- a/common/changes/office-ui-fabric-react/maskedTextField-onChange_2018-08-20-19-23.json
+++ b/common/changes/office-ui-fabric-react/maskedTextField-onChange_2018-08-20-19-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MaskedTextField: onChange now returns the displayed value vs the entered value",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.test.tsx
@@ -252,8 +252,15 @@ describe('MaskedTextField', () => {
   });
 
   it('should ignore overflowed characters', () => {
+    let onChangeValue;
     const component = mount(
-      <MaskedTextField label="With input mask" mask="m\ask: (999) 999 - 9999" value="123-456-7890" />
+      <MaskedTextField
+        // tslint:disable-next-line jsx-no-lambda
+        onChange={(ev, newValue) => (onChangeValue = newValue)}
+        label="With input mask"
+        mask="m\ask: (999) 999 - 9999"
+        value="123-456-7890"
+      />
     );
 
     const input = component.find('input'),
@@ -266,5 +273,6 @@ describe('MaskedTextField', () => {
     inputDOM.setSelectionRange(23, 23);
     input.simulate('change', mockEvent('mask: (123) 456 - 78901'));
     expect(inputDOM.value).toEqual('mask: (123) 456 - 7890');
+    expect(onChangeValue).toEqual('mask: (123) 456 - 7890');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -333,18 +333,20 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
 
     this._changeSelectionData = null;
 
+    const newValue = getMaskDisplay(this.props.mask, this._maskCharData, this.props.maskChar);
+
     this.setState({
-      displayValue: getMaskDisplay(this.props.mask, this._maskCharData, this.props.maskChar),
+      displayValue: newValue,
       maskCursorPosition: cursorPos
     });
 
     // Perform onChange/d after input has been processed. Return value is expected to be the displayed text
     if (this.props.onChange) {
-      this.props.onChange(ev, displayValue);
+      this.props.onChange(ev, newValue);
     }
 
     if (this.props.onChanged) {
-      this.props.onChanged(displayValue);
+      this.props.onChanged(newValue);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -268,14 +268,6 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
 
   @autobind
   private _onInputChange(ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) {
-    if (this.props.onChange) {
-      this.props.onChange(ev, value);
-    }
-
-    if (this.props.onChanged) {
-      this.props.onChanged(value);
-    }
-
     if (!this._changeSelectionData) {
       return;
     }
@@ -345,6 +337,15 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
       displayValue: getMaskDisplay(this.props.mask, this._maskCharData, this.props.maskChar),
       maskCursorPosition: cursorPos
     });
+
+    // Perform onChange/d after input has been processed. Return value is expected to be the displayed text
+    if (this.props.onChange) {
+      this.props.onChange(ev, displayValue);
+    }
+
+    if (this.props.onChanged) {
+      this.props.onChanged(displayValue);
+    }
   }
 
   @autobind


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #5989
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Moved onChange functions until after input was handled, and passed through displayed value

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5996)

