### PR TITLE
Fix scroll syncing in ScrollablePane and fix alignment of Sticky headers/footers

### DIFF
--- a/apps/fabric-website-resources/src/components/DemoPage.tsx
+++ b/apps/fabric-website-resources/src/components/DemoPage.tsx
@@ -28,7 +28,13 @@ export const DemoPage: React.StatelessComponent<IDemoPageProps> = componentPageP
           {componentPageProps.exampleKnobs}
           {componentPageProps.examples &&
             componentPageProps.examples.map(example => (
-              <ExampleCard title={example.title} code={example.code} key={example.title} codepenJS={example.codepenJS}>
+              <ExampleCard
+                title={example.title}
+                code={example.code}
+                key={example.title}
+                codepenJS={example.codepenJS}
+                isScrollable={example.isScrollable}
+              >
                 {example.view}
               </ExampleCard>
             ))}

--- a/common/changes/@uifabric/fabric-website-resources/scrollable-pane_2018-08-20-19-13.json
+++ b/common/changes/@uifabric/fabric-website-resources/scrollable-pane_2018-08-20-19-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website-resources",
+      "comment": "Allow examples to provide their own scroll mechanic",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "tmichon@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/scrollable-pane_2018-08-20-19-13.json
+++ b/common/changes/office-ui-fabric-react/scrollable-pane_2018-08-20-19-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Scrollable scroll syncing and header/footer alignment",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/DocPage.types.ts
+++ b/packages/office-ui-fabric-react/src/common/DocPage.types.ts
@@ -71,6 +71,8 @@ export interface IDocPageProps {
     /** Working example of the example */
     view: JSX.Element;
 
+    isScrollable?: boolean;
+
     /** JS String for codepen of the example */
     codepenJS?: string;
   }[];

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsFooter.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsFooter.types.ts
@@ -1,7 +1,3 @@
-import { IColumn } from './DetailsList.types';
-import { ISelection } from '../../utilities/selection/index';
-export interface IDetailsFooterProps {
-  columns: IColumn[];
-  groupNestingDepth?: number;
-  selection?: ISelection;
-}
+import { IDetailsItemProps } from './DetailsRow.types';
+
+export interface IDetailsFooterProps extends IDetailsItemProps {}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsFooter.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsFooter.types.ts
@@ -1,7 +1,7 @@
 import { IColumn } from './DetailsList.types';
 import { ISelection } from '../../utilities/selection/index';
 export interface IDetailsFooterProps {
-  columns?: IColumn[];
+  columns: IColumn[];
   groupNestingDepth?: number;
   selection?: ISelection;
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -652,7 +652,9 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
   private _onSelectAllClicked = (): void => {
     const { selection } = this.props;
 
-    selection.toggleAllSelected();
+    if (selection) {
+      selection.toggleAllSelected();
+    }
   };
 
   private _onRootMouseDown = (ev: MouseEvent): void => {
@@ -833,7 +835,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
   };
 
   private _onSelectionChanged(): void {
-    const isAllSelected = this.props.selection.isAllSelected();
+    const isAllSelected = !!this.props.selection && this.props.selection.isAllSelected();
 
     if (this.state.isAllSelected !== isAllSelected) {
       this.setState({

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -2,19 +2,17 @@ import * as React from 'react';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { CollapseAllVisibility } from '../../GroupedList';
 import { ITooltipHostProps } from '../../Tooltip';
-import { IViewport } from '../../utilities/decorators/withViewport';
-import { ISelection, SelectionMode } from '../../utilities/selection/interfaces';
 import { ITheme, IStyle } from '../../Styling';
 import { DetailsHeaderBase } from './DetailsHeader.base';
 import { IColumn, DetailsListLayoutMode, IColumnReorderOptions, ColumnDragEndLocation } from './DetailsList.types';
-import { ICellStyleProps } from './DetailsRow.types';
+import { ICellStyleProps, IDetailsItemProps } from './DetailsRow.types';
 
 export interface IDetailsHeader {
   /** sets focus into the header */
   focus: () => boolean;
 }
 
-export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase> {
+export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase>, IDetailsItemProps {
   /** Theme from the Higher Order Component */
   theme?: ITheme;
 
@@ -23,15 +21,6 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase> {
 
   /** Ref to the component itself */
   componentRef?: IRefObject<IDetailsHeader>;
-
-  /** Column definitions */
-  columns: IColumn[];
-
-  /** Selection utility */
-  selection: ISelection;
-
-  /** Selection mode used for this component */
-  selectionMode: SelectionMode;
 
   /** Layout mode - fixedColumns or justified */
   layoutMode: DetailsListLayoutMode;
@@ -54,12 +43,6 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase> {
   /** Callback to render a tooltip for the column header */
   onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
 
-  /** Group nesting depth */
-  groupNestingDepth?: number;
-
-  /** Indent width */
-  indentWidth?: number;
-
   /** Whether to collapse for all visibility */
   collapseAllVisibility?: CollapseAllVisibility;
 
@@ -81,9 +64,6 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase> {
   /** Select all button visibility */
   selectAllVisibility?: SelectAllVisibility;
 
-  /** Viewport of the virtualized DetailsList */
-  viewport?: IViewport;
-
   /** Column reordering options */
   columnReorderOptions?: IColumnReorderOptions;
 
@@ -95,8 +75,6 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase> {
 
   /** Overriding class name */
   className?: string;
-
-  cellStyleProps?: ICellStyleProps;
 }
 
 export enum SelectAllVisibility {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -57,7 +57,7 @@ export interface IDetailsListState {
   focusedItemIndex: number;
   lastWidth?: number;
   lastSelectionMode?: SelectionMode;
-  adjustedColumns?: IColumn[];
+  adjustedColumns: IColumn[];
   isCollapsed?: boolean;
   isSizing?: boolean;
   isDropping?: boolean;
@@ -280,6 +280,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       dragDropEvents,
       groups,
       groupProps,
+      indentWidth,
       items,
       isHeaderVisible,
       layoutMode,
@@ -397,7 +398,9 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
                   viewport: viewport,
                   columnReorderProps: columnReorderProps,
                   minimumPixelsForDrag: minimumPixelsForDrag,
-                  cellStyleProps: cellStyleProps
+                  cellStyleProps: cellStyleProps,
+                  checkboxVisibility,
+                  indentWidth
                 },
                 this._onRenderDetailsHeader
               )}
@@ -512,6 +515,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       checkboxCellClassName,
       groupProps,
       useReducedRowRenderer,
+      indentWidth,
       cellStyleProps = DEFAULT_CELL_STYLE_PROPS
     } = this.props;
     const collapseAllVisibility = groupProps && groupProps.collapseAllVisibility;
@@ -541,6 +545,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       checkButtonAriaLabel: checkButtonAriaLabel,
       checkboxCellClassName: checkboxCellClassName,
       useReducedRowRenderer: useReducedRowRenderer,
+      indentWidth,
       cellStyleProps: cellStyleProps
     };
 
@@ -694,7 +699,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
     newProps: IDetailsListProps,
     forceUpdate?: boolean,
     resizingColumnIndex?: number
-  ): IColumn[] | undefined {
+  ): IColumn[] {
     const { items: newItems, layoutMode, selectionMode } = newProps;
     let { columns: newColumns } = newProps;
     let { width: viewportWidth } = newProps.viewport!;
@@ -710,7 +715,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
         lastSelectionMode === selectionMode &&
         (!columns || newColumns === columns)
       ) {
-        return undefined;
+        return [];
       }
     } else {
       viewportWidth = this.props.viewport!.width;
@@ -958,13 +963,18 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
 
   private _getDetailsFooterProps(): IDetailsFooterProps {
     const { adjustedColumns: columns } = this.state;
-    const detailsFooterProps: IDetailsFooterProps = {
-      columns: columns as IColumn[],
-      groupNestingDepth: this._getGroupNestingDepth(),
-      selection: this._selection
-    };
+
+    const { viewport, checkboxVisibility, indentWidth, cellStyleProps = DEFAULT_CELL_STYLE_PROPS } = this.props;
+
     return {
-      ...detailsFooterProps
+      columns: columns,
+      groupNestingDepth: this._getGroupNestingDepth(),
+      selection: this._selection,
+      selectionMode: this.props.selectionMode,
+      viewport: viewport,
+      checkboxVisibility,
+      indentWidth,
+      cellStyleProps
     };
   }
 
@@ -984,6 +994,13 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       onRenderHeader: onRenderDetailsGroupHeader
     } = detailsGroupProps;
     const { adjustedColumns: columns } = this.state;
+    const {
+      selectionMode,
+      viewport,
+      cellStyleProps = DEFAULT_CELL_STYLE_PROPS,
+      checkboxVisibility,
+      indentWidth
+    } = this.props;
     const groupNestingDepth = this._getGroupNestingDepth();
     const onRenderFooter = onRenderDetailsGroupFooter
       ? (props: IGroupDividerProps, defaultRender?: IRenderFunction<IGroupDividerProps>) => {
@@ -992,7 +1009,12 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
               ...props,
               columns: columns,
               groupNestingDepth: groupNestingDepth,
-              selection: this._selection
+              indentWidth,
+              selection: this._selection,
+              selectionMode: selectionMode,
+              viewport: viewport,
+              checkboxVisibility,
+              cellStyleProps
             },
             defaultRender
           );
@@ -1006,7 +1028,12 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
               ...props,
               columns: columns,
               groupNestingDepth: groupNestingDepth,
-              selection: this._selection
+              indentWidth,
+              selection: this._selection,
+              selectionMode: selectionMode,
+              viewport: viewport,
+              checkboxVisibility,
+              cellStyleProps
             },
             defaultRender
           );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -176,20 +176,8 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
   }
 
   public componentWillUnmount(): void {
-    const { onScroll } = this.props;
-    if (onScroll && this._root.current) {
-      this._root.current.removeEventListener('scroll', this._onScroll);
-    }
-
     if (this._dragDropHelper) {
       this._dragDropHelper.dispose();
-    }
-  }
-
-  public componentDidMount(): void {
-    const { onScroll } = this.props;
-    if (onScroll && this._root.current) {
-      this._root.current.addEventListener('scroll', this._onScroll);
     }
   }
 
@@ -968,14 +956,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
     return itemKey;
   }
 
-  private _onScroll = (e: Event): void => {
-    const { onScroll } = this.props;
-    if (onScroll) {
-      onScroll(e);
-    }
-  };
-
-  private _getDetailsFooterProps(): IDetailsFooterProps | undefined {
+  private _getDetailsFooterProps(): IDetailsFooterProps {
     const { adjustedColumns: columns } = this.state;
     const detailsFooterProps: IDetailsFooterProps = {
       columns: columns as IColumn[],

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -10,7 +10,7 @@ import { IDetailsFooterProps } from './DetailsFooter.types';
 import { IWithViewportProps, IViewport } from '../../utilities/decorators/withViewport';
 import { IList, IListProps, ScrollToMode } from '../List/index';
 import { ITheme, IStyle } from '../../Styling';
-import { ICellStyleProps } from './DetailsRow.types';
+import { ICellStyleProps, IDetailsItemProps } from './DetailsRow.types';
 
 export { IDetailsHeaderProps };
 
@@ -83,6 +83,9 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
 
   /** Optional override properties to render groups. The definition for IGroupRenderProps can be found under the GroupedList component. */
   groupProps?: IDetailsGroupRenderProps;
+
+  /** Optional override for the indent width used for group nesting. */
+  indentWidth?: number;
 
   /** Optional selection model to track selection state.  */
   selection?: ISelection;
@@ -602,8 +605,4 @@ export interface IDetailsGroupRenderProps extends IGroupRenderProps {
   onRenderHeader?: IRenderFunction<IDetailsGroupDividerProps>;
 }
 
-export interface IDetailsGroupDividerProps extends IGroupDividerProps {
-  columns?: IColumn[];
-  groupNestingDepth?: number;
-  selection?: ISelection;
-}
+export interface IDetailsGroupDividerProps extends IGroupDividerProps, IDetailsItemProps {}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -256,11 +256,6 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   enterModalSelectionOnTouch?: boolean;
 
   /**
-   * On horizontal scroll event listener
-   */
-  onScroll?: (e?: Event) => void;
-
-  /**
    * Options for column re-order using drag and drop
    */
   columnReorderOptions?: IColumnReorderOptions;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -197,7 +197,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
       : '';
     const ariaLabel = getRowAriaLabel ? getRowAriaLabel(item) : undefined;
     const ariaDescribedBy = getRowAriaDescribedBy ? getRowAriaDescribedBy(item) : undefined;
-    const canSelect = selection.canSelectItem!(item);
+    const canSelect = !!selection && selection.canSelectItem!(item, itemIndex);
     const isContentUnselectable = selectionMode === SelectionMode.multiple;
     const showCheckbox = selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden;
     const ariaSelected = selectionMode === SelectionMode.none ? undefined : isSelected;
@@ -333,8 +333,8 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
     const { itemIndex, selection } = props;
 
     return {
-      isSelected: selection.isIndexSelected(itemIndex),
-      isSelectionModal: !!selection.isModal && selection.isModal()
+      isSelected: !!selection && selection.isIndexSelected(itemIndex),
+      isSelectionModal: !!selection && !!selection.isModal && selection.isModal()
     };
   }
 
@@ -351,7 +351,9 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
   private _onToggleSelection(): void {
     const { selection } = this.props;
 
-    selection.toggleIndexSelected(this.props.itemIndex);
+    if (selection && this.props.itemIndex > -1) {
+      selection.toggleIndexSelected(this.props.itemIndex);
+    }
   }
 
   private _onRootRef = (focusZone: FocusZone): void => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -313,7 +313,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
         borderBottom: `1px solid ${neutralLighter}`,
         background: colors.defaultBackgroundColor,
         color: colors.defaultMetaTextColor,
-        display: 'flex',
+        display: 'inline-flex', // This ensures that the row always tries to consume is minimum width and does not compress.
         minWidth: '100%',
         minHeight: values.rowHeight,
         whiteSpace: 'nowrap',

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -12,7 +12,49 @@ import { IDetailsRowFieldsProps } from './DetailsRowFields.types';
 
 export interface IDetailsRow {}
 
-export interface IDetailsRowProps extends IBaseProps<IDetailsRow> {
+export interface IDetailsItemProps {
+  /**
+   * Column metadata
+   */
+  columns: IColumn[];
+
+  /**
+   * Nesting depth of a grouping
+   */
+  groupNestingDepth?: number;
+
+  /**
+   * How much to indent
+   */
+  indentWidth?: number | undefined;
+
+  /**
+   * Selection from utilities
+   */
+  selection?: ISelection | undefined;
+
+  /**
+   * Selection mode
+   */
+  selectionMode?: SelectionMode | undefined;
+
+  /**
+   * View port of the virtualized list
+   */
+  viewport?: IViewport | undefined;
+
+  /**
+   * Checkbox visibility
+   */
+  checkboxVisibility?: CheckboxVisibility | undefined;
+
+  /**
+   * Rules for rendering column cells.
+   */
+  cellStyleProps?: ICellStyleProps;
+}
+
+export interface IDetailsRowProps extends IBaseProps<IDetailsRow>, IDetailsItemProps {
   /**
    * Theme provided by styled() function
    */
@@ -39,24 +81,9 @@ export interface IDetailsRowProps extends IBaseProps<IDetailsRow> {
   itemIndex: number;
 
   /**
-   * Column metadata
-   */
-  columns: IColumn[];
-
-  /**
    * Whether to render in compact mode
    */
   compact?: boolean;
-
-  /**
-   * Selection mode
-   */
-  selectionMode?: SelectionMode;
-
-  /**
-   * Selection from utilities
-   */
-  selection?: ISelection;
 
   /**
    * A list of events to register
@@ -92,26 +119,6 @@ export interface IDetailsRowProps extends IBaseProps<IDetailsRow> {
    * Helper for the drag and drop
    */
   dragDropHelper?: IDragDropHelper;
-
-  /**
-   * Nesting depth of a grouping
-   */
-  groupNestingDepth?: number;
-
-  /**
-   * How much to indent
-   */
-  indentWidth?: number;
-
-  /**
-   * View port of the virtualized list
-   */
-  viewport?: IViewport;
-
-  /**
-   * Checkbox visibility
-   */
-  checkboxVisibility?: CheckboxVisibility;
 
   /**
    * Collapse all visibility
@@ -158,8 +165,6 @@ export interface IDetailsRowProps extends IBaseProps<IDetailsRow> {
    * @default false
    */
   useReducedRowRenderer?: boolean;
-
-  cellStyleProps?: ICellStyleProps;
 }
 
 export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme'>> & {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -51,12 +51,12 @@ export interface IDetailsRowProps extends IBaseProps<IDetailsRow> {
   /**
    * Selection mode
    */
-  selectionMode: SelectionMode;
+  selectionMode?: SelectionMode;
 
   /**
    * Selection from utilities
    */
-  selection: ISelection;
+  selection?: ISelection;
 
   /**
    * A list of events to register

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -2762,7 +2762,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         box-sizing: border-box;
                                         color: #767676;
                                         cursor: default;
-                                        display: flex;
+                                        display: inline-flex;
                                         min-height: 42px;
                                         min-width: 100%;
                                         outline: transparent;
@@ -2954,7 +2954,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         box-sizing: border-box;
                                         color: #767676;
                                         cursor: default;
-                                        display: flex;
+                                        display: inline-flex;
                                         min-height: 42px;
                                         min-width: 100%;
                                         outline: transparent;
@@ -3368,7 +3368,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         box-sizing: border-box;
                                         color: #767676;
                                         cursor: default;
-                                        display: flex;
+                                        display: inline-flex;
                                         min-height: 42px;
                                         min-width: 100%;
                                         outline: transparent;
@@ -3560,7 +3560,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         box-sizing: border-box;
                                         color: #767676;
                                         cursor: default;
-                                        display: flex;
+                                        display: inline-flex;
                                         min-height: 42px;
                                         min-width: 100%;
                                         outline: transparent;
@@ -3752,7 +3752,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         box-sizing: border-box;
                                         color: #767676;
                                         cursor: default;
-                                        display: flex;
+                                        display: inline-flex;
                                         min-height: 42px;
                                         min-width: 100%;
                                         outline: transparent;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1643,7 +1643,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         border-bottom: 1px solid #f4f4f4;
         box-sizing: border-box;
         color: #767676;
-        display: flex;
+        display: inline-flex;
         min-height: 42px;
         min-width: 100%;
         outline: transparent;

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.doc.tsx
@@ -19,12 +19,14 @@ export const ScrollablePanePageProps: IDocPageProps = {
     {
       title: 'Default',
       code: ScrollablePaneDefaultExampleCode,
-      view: <ScrollablePaneDefaultExample />
+      view: <ScrollablePaneDefaultExample />,
+      isScrollable: false
     },
     {
       title: 'DetailsList Locked Header',
       code: ScrollablePaneDetailsListExampleCode,
-      view: <ScrollablePaneDetailsListExample />
+      view: <ScrollablePaneDetailsListExample />,
+      isScrollable: false
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
@@ -14,7 +14,6 @@ export const getStyles = (props: IScrollablePaneStyleProps): IScrollablePaneStyl
   const AboveAndBelowStyles: IStyle = {
     position: 'absolute',
     pointerEvents: 'auto',
-    width: '100%',
     zIndex: ZIndexes.ScrollablePane
   };
 
@@ -33,7 +32,7 @@ export const getStyles = (props: IScrollablePaneStyleProps): IScrollablePaneStyl
     contentContainer: [
       classNames.contentContainer,
       {
-        overflowY: 'auto'
+        overflowY: props.scrollbarVisibility === 'always' ? 'scroll' : 'auto'
       },
       positioningStyle
     ],
@@ -63,7 +62,10 @@ export const getStyles = (props: IScrollablePaneStyleProps): IScrollablePaneStyl
       {
         bottom: 0
       },
-      AboveAndBelowStyles
+      AboveAndBelowStyles,
+      {
+        width: '100%'
+      }
     ]
   };
 };

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -38,6 +38,8 @@ export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement |
    * Sets the initial scroll position of the ScrollablePane
    */
   initialScrollPosition?: number;
+
+  scrollbarVisibility?: ScrollbarVisibility;
 }
 
 export interface IScrollablePaneStyleProps {
@@ -50,6 +52,8 @@ export interface IScrollablePaneStyleProps {
    * Accept custom classNames
    */
   className?: string;
+
+  scrollbarVisibility?: IScrollablePaneProps['scrollbarVisibility'];
 
   // Insert ScrollablePane style props below
 }
@@ -75,4 +79,9 @@ export interface IScrollablePaneStyles {
    * Style set for the contentContainer element.
    */
   contentContainer: IStyle;
+}
+
+export const enum ScrollbarVisibility {
+  auto = 'auto',
+  always = 'always'
 }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -16,7 +16,7 @@ import { ScrollablePane, IScrollablePane, ScrollbarVisibility } from 'office-ui-
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
-import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection';
+import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection/index';
 
 const _columns: IColumn[] = [
   {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -5,25 +5,24 @@ import {
   DetailsListLayoutMode,
   IDetailsHeaderProps,
   Selection,
-  IColumn
+  IColumn,
+  ConstrainMode,
+  IDetailsFooterProps,
+  DetailsRow
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { IRenderFunction, createRef } from 'office-ui-fabric-react/lib/Utilities';
 import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Tooltip';
-import { ScrollablePane, IScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { ScrollablePane, IScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-
-const _items: {
-  key: number;
-  name: string;
-  value: number;
-}[] = [];
+import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
+import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection';
 
 const _columns: IColumn[] = [
   {
     key: 'column1',
-    name: 'Name',
-    fieldName: 'name',
+    name: 'Test 1',
+    fieldName: 'test1',
     minWidth: 100,
     maxWidth: 200,
     isResizable: true,
@@ -31,14 +30,60 @@ const _columns: IColumn[] = [
   },
   {
     key: 'column2',
-    name: 'Value',
-    fieldName: 'value',
+    name: 'Test 2',
+    fieldName: 'test2',
+    minWidth: 100,
+    maxWidth: 200,
+    isResizable: true,
+    ariaLabel: 'Operations for value'
+  },
+  {
+    key: 'column3',
+    name: 'Test 3',
+    fieldName: 'test3',
+    minWidth: 100,
+    maxWidth: 200,
+    isResizable: true,
+    ariaLabel: 'Operations for value'
+  },
+  {
+    key: 'column4',
+    name: 'Test 4',
+    fieldName: 'test4',
+    minWidth: 100,
+    maxWidth: 200,
+    isResizable: true,
+    ariaLabel: 'Operations for value'
+  },
+  {
+    key: 'column5',
+    name: 'Test 4',
+    fieldName: 'test5',
+    minWidth: 100,
+    maxWidth: 200,
+    isResizable: true,
+    ariaLabel: 'Operations for value'
+  },
+  {
+    key: 'column6',
+    name: 'Test 6',
+    fieldName: 'test6',
     minWidth: 100,
     maxWidth: 200,
     isResizable: true,
     ariaLabel: 'Operations for value'
   }
 ];
+
+interface IItem {
+  key: number;
+  test1: string;
+  test2: string;
+  test3: string;
+  test4: string;
+  test5: string;
+  test6: string;
+}
 
 export class ScrollablePaneDetailsListExample extends React.Component<
   {},
@@ -49,27 +94,34 @@ export class ScrollablePaneDetailsListExample extends React.Component<
 > {
   private _scrollablePane = createRef<IScrollablePane>();
   private _selection: Selection;
+  private readonly _items: IItem[];
 
   constructor(props: {}) {
     super(props);
 
+    const items: IItem[] = [];
+
     // Populate with items for demos.
-    if (_items.length === 0) {
-      for (let i = 0; i < 200; i++) {
-        _items.push({
-          key: i,
-          name: 'Item ' + i,
-          value: i
-        });
-      }
+    for (let i = 0; i < 200; i++) {
+      items.push({
+        key: i,
+        test1: lorem(2),
+        test2: lorem(2),
+        test3: lorem(2),
+        test4: lorem(2),
+        test5: lorem(2),
+        test6: lorem(2)
+      });
     }
+
+    this._items = items;
 
     this._selection = new Selection({
       onSelectionChanged: () => this.setState({ selectionDetails: this._getSelectionDetails() })
     });
 
     this.state = {
-      items: _items,
+      items: items,
       selectionDetails: this._getSelectionDetails()
     };
   }
@@ -80,18 +132,19 @@ export class ScrollablePaneDetailsListExample extends React.Component<
     return (
       <div
         style={{
-          height: '10000px',
-          position: 'relative',
-          maxHeight: 'inherit'
+          height: '80vh',
+          position: 'relative'
         }}
       >
-        <ScrollablePane componentRef={this._scrollablePane}>
+        <ScrollablePane componentRef={this._scrollablePane} scrollbarVisibility={ScrollbarVisibility.always}>
           <Sticky stickyPosition={StickyPositionType.Header}>{selectionDetails}</Sticky>
           <TextField
             label="Filter by name:"
             // tslint:disable-next-line:jsx-no-lambda
             onChange={(ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string) =>
-              this.setState({ items: text ? _items.filter(i => i.name.toLowerCase().indexOf(text) > -1) : _items })
+              this.setState({
+                items: text ? this._items.filter((item: IItem) => hasText(item, text)) : this._items
+              })
             }
           />
           <Sticky stickyPosition={StickyPositionType.Header}>
@@ -103,20 +156,9 @@ export class ScrollablePaneDetailsListExample extends React.Component<
               columns={_columns}
               setKey="set"
               layoutMode={DetailsListLayoutMode.fixedColumns}
-              onScroll={this._onScroll}
-              onRenderDetailsHeader={
-                // tslint:disable-next-line:jsx-no-lambda
-                (detailsHeaderProps: IDetailsHeaderProps, defaultRender: IRenderFunction<IDetailsHeaderProps>) => (
-                  <Sticky stickyPosition={StickyPositionType.Header}>
-                    {defaultRender({
-                      ...detailsHeaderProps,
-                      onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => (
-                        <TooltipHost {...tooltipHostProps} />
-                      )
-                    })}
-                  </Sticky>
-                )
-              }
+              constrainMode={ConstrainMode.unconstrained}
+              onRenderDetailsHeader={onRenderDetailsHeader}
+              onRenderDetailsFooter={onRenderDetailsFooter}
               selection={this._selection}
               selectionPreservedOnEmptyClick={true}
               ariaLabelForSelectionColumn="Toggle selection"
@@ -130,12 +172,6 @@ export class ScrollablePaneDetailsListExample extends React.Component<
     );
   }
 
-  private _onScroll = (e: Event): void => {
-    if (this._scrollablePane.current) {
-      this._scrollablePane.current.forceLayoutUpdate();
-    }
-  };
-
   private _getSelectionDetails(): string {
     const selectionCount = this._selection.getSelectedCount();
 
@@ -148,4 +184,47 @@ export class ScrollablePaneDetailsListExample extends React.Component<
         return `${selectionCount} items selected`;
     }
   }
+}
+
+function onRenderDetailsHeader(
+  props: IDetailsHeaderProps,
+  defaultRender?: IRenderFunction<IDetailsHeaderProps>
+): JSX.Element {
+  return (
+    <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true}>
+      {defaultRender!({
+        ...props,
+        onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => <TooltipHost {...tooltipHostProps} />
+      })}
+    </Sticky>
+  );
+}
+
+function onRenderDetailsFooter(
+  props: IDetailsFooterProps,
+  defaultRender?: IRenderFunction<IDetailsFooterProps>
+): JSX.Element {
+  return (
+    <Sticky stickyPosition={StickyPositionType.Footer} isScrollSynced={true}>
+      <DetailsRow
+        columns={props.columns}
+        item={{
+          key: 'footer',
+          test1: 'Total 1',
+          test2: 'Total 2',
+          test3: 'Total 3',
+          test4: 'Total 4',
+          test5: 'Total 5',
+          test6: 'Total 6'
+        }}
+        itemIndex={-1}
+        selection={props.selection}
+        selectionMode={(props.selection && props.selection.mode) || SelectionMode.none}
+      />
+    </Sticky>
+  );
+}
+
+function hasText(item: IItem, text: string): boolean {
+  return `${item.test1}|${item.test2}|${item.test3}|${item.test4}|${item.test5}|${item.test6}`.indexOf(text) > -1;
 }

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { BaseComponent, createRef } from '../../Utilities';
 import { IStickyProps, StickyPositionType } from './Sticky.types';
+import { IScrollablePaneContext } from '../ScrollablePane/ScrollablePane.base';
 
 export interface IStickyState {
   isStickyTop: boolean;
@@ -22,19 +23,10 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     scrollablePane: PropTypes.object
   };
 
-  public context: {
-    scrollablePane: {
-      subscribe: (handler: Function) => void;
-      unsubscribe: (handler: Function) => void;
-      addSticky: (sticky: Sticky) => void;
-      removeSticky: (sticky: Sticky) => void;
-      updateStickyRefHeights: () => void;
-      sortSticky: (sticky: Sticky) => void;
-      notifySubscribers: (sort?: boolean) => void;
-    };
-  };
+  public context: IScrollablePaneContext;
 
   public distanceFromTop: number;
+
   private _root = createRef<HTMLDivElement>();
   private _stickyContentTop = createRef<HTMLDivElement>();
   private _stickyContentBottom = createRef<HTMLDivElement>();
@@ -77,29 +69,53 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     );
   }
 
-  public componentDidMount(): void {
-    if (!this.context.scrollablePane) {
-      throw new TypeError('Expected Sticky to be mounted within ScrollablePane');
+  public syncScroll = (container: HTMLElement): void => {
+    const { nonStickyContent } = this;
+
+    if (nonStickyContent && this.props.isScrollSynced) {
+      nonStickyContent.scrollLeft = container.scrollLeft;
     }
+  };
+
+  public componentDidMount(): void {
     const { scrollablePane } = this.context;
+
+    if (!scrollablePane) {
+      return;
+    }
+
     scrollablePane.subscribe(this._onScrollEvent);
     scrollablePane.addSticky(this);
   }
 
   public componentWillUnmount(): void {
     const { scrollablePane } = this.context;
+
+    if (!scrollablePane) {
+      return;
+    }
+
     scrollablePane.unsubscribe(this._onScrollEvent);
     scrollablePane.removeSticky(this);
   }
 
   public componentDidUpdate(prevProps: IStickyProps, prevState: IStickyState): void {
     const { scrollablePane } = this.context;
+
+    if (!scrollablePane) {
+      return;
+    }
+
     if (prevState.isStickyTop !== this.state.isStickyTop || prevState.isStickyBottom !== this.state.isStickyBottom) {
       scrollablePane.updateStickyRefHeights();
     }
   }
 
   public shouldComponentUpdate(nextProps: IStickyProps, nextState: IStickyState): boolean {
+    if (!this.context.scrollablePane) {
+      return true;
+    }
+
     const { isStickyTop, isStickyBottom } = this.state;
     return (
       isStickyTop !== nextState.isStickyTop ||
@@ -113,6 +129,10 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     const { isStickyTop, isStickyBottom } = this.state;
     const { stickyClassName, children } = this.props;
 
+    if (!this.context.scrollablePane) {
+      return <div>{this.props.children}</div>;
+    }
+
     return (
       <div ref={this._root}>
         {this.canStickyTop && (
@@ -125,13 +145,14 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
-        <div style={this._getNonStickyPlaceholderHeight()} />
-        <div
-          ref={this._nonStickyContent}
-          className={isStickyTop || isStickyBottom ? stickyClassName : undefined}
-          style={this._getContentStyles(isStickyTop || isStickyBottom)}
-        >
-          {children}
+        <div style={this._getNonStickyPlaceholderHeight()} ref={this._root}>
+          <div
+            ref={this._nonStickyContent}
+            className={isStickyTop || isStickyBottom ? stickyClassName : undefined}
+            style={this._getContentStyles(isStickyTop || isStickyBottom)}
+          >
+            {children}
+          </div>
         </div>
       </div>
     );
@@ -177,9 +198,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         height: height
       };
     } else {
-      return {
-        position: 'absolute'
-      };
+      return {};
     }
   }
 
@@ -188,10 +207,6 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       this.distanceFromTop = this._getNonStickyDistanceFromTop(container);
       let isStickyTop = false;
       let isStickyBottom = false;
-
-      if (this.props.isScrollSynced) {
-        this._syncScroll(container);
-      }
 
       if (this.canStickyTop) {
         const distanceToStickTop = this.distanceFromTop - this._getStickyDistanceFromTop();
@@ -209,24 +224,6 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         isStickyTop: this.canStickyTop && isStickyTop,
         isStickyBottom: isStickyBottom
       });
-    }
-  };
-
-  private _syncScroll = (container: HTMLElement): void => {
-    if (this.root) {
-      let scrollLeft = 0;
-      let scrollTop = 0;
-      let curr = this.root as HTMLElement;
-      while (curr !== container) {
-        scrollLeft += curr.scrollLeft;
-        scrollTop += curr.scrollTop;
-        curr = curr.parentElement as HTMLElement;
-      }
-
-      if (this.nonStickyContent) {
-        this.nonStickyContent.scrollLeft = scrollLeft;
-        this.nonStickyContent.scrollTop = scrollTop;
-      }
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -29,7 +29,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -702,7 +702,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -1375,7 +1375,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -2048,7 +2048,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -2721,7 +2721,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -3394,7 +3394,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -4067,7 +4067,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -4740,7 +4740,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -5413,7 +5413,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;
@@ -6086,7 +6086,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
           color: #767676;
-          display: flex;
+          display: inline-flex;
           min-height: 42px;
           min-width: 100%;
           outline: transparent;

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -4,7 +4,7 @@ import { EventGroup } from '../../Utilities';
 export interface ISelectionOptions {
   onSelectionChanged?: () => void;
   getKey?: (item: IObjectWithKey, index?: number) => string | number;
-  canSelectItem?: (item: IObjectWithKey) => boolean;
+  canSelectItem?: (item: IObjectWithKey, index?: number) => boolean;
   selectionMode?: SelectionMode;
 }
 
@@ -13,7 +13,7 @@ export class Selection implements ISelection {
   public readonly mode: SelectionMode;
 
   private _getKey: (item: IObjectWithKey, index?: number) => string | number;
-  private _canSelectItem: (item: IObjectWithKey) => boolean;
+  private _canSelectItem: (item: IObjectWithKey, index?: number) => boolean;
 
   private _changeEventSuppressionCount: number;
   private _items: IObjectWithKey[];
@@ -55,8 +55,12 @@ export class Selection implements ISelection {
     this.setItems([], true);
   }
 
-  public canSelectItem(item: IObjectWithKey): boolean {
-    return this._canSelectItem(item);
+  public canSelectItem(item: IObjectWithKey, index?: number): boolean {
+    if (typeof index === 'number' && index < 0) {
+      return false;
+    }
+
+    return this._canSelectItem(item, index);
   }
 
   public getKey(item: IObjectWithKey, index?: number): string {

--- a/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/interfaces.ts
@@ -14,7 +14,7 @@ export interface ISelection {
   count: number;
   mode: SelectionMode;
 
-  canSelectItem: (item: IObjectWithKey) => boolean;
+  canSelectItem: (item: IObjectWithKey, index?: number) => boolean;
 
   // Obesrvable methods.
   setChangeEvents(isEnabled: boolean, suppressChange?: boolean): void;


### PR DESCRIPTION
# Overview

Fixed the behavior of `isScrollSynced` so it tracks the horizontal scroll position of its parent `ScrollablePane`.
Fixed a layout issue when scrolling to the bottom of a `ScrollablePane` which uses a sticky footer at the very bottom.
Fixed calculation of the scrollbar width and height, so sticky elements are auto-sized more easily.
Added a `scrollbarVisibility` option so the vertical scrollbar may be forced to always show.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/5997)

