### PR TITLE
Sticky: Fix an edge case for correct sticky sort.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-StickyEdgeCaseFix_2018-08-21-01-46.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-StickyEdgeCaseFix_2018-08-21-01-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Sticky: Fix logic when Sticky on first render is at most top position to get it sorted properly.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -195,7 +195,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
       if (this.canStickyTop) {
         const distanceToStickTop = this.distanceFromTop - this._getStickyDistanceFromTop();
-        isStickyTop = distanceToStickTop < container.scrollTop;
+        isStickyTop = distanceToStickTop <= container.scrollTop;
       }
 
       // Can sticky bottom if the scrollablePane - total sticky footer height is smaller than the sticky's distance from the top of the pane


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

When Sticky at it's first render is at most top position he needs to be sorted as already sticked.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6003)

