### PR TITLE
update leftNav fix

### DIFF
--- a/common/changes/@uifabric/dashboard/NAVfix_2018-08-21-02-30.json
+++ b/common/changes/@uifabric/dashboard/NAVfix_2018-08-21-02-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "fix leftNav styles per PM feedback",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "yuz@microsoft.com"
+}

--- a/packages/dashboard/src/components/Nav/Nav.styles.ts
+++ b/packages/dashboard/src/components/Nav/Nav.styles.ts
@@ -17,7 +17,7 @@ const navFontSize = 14;
 const navTextColor = '#FFF';
 const navWidth = 280;
 const navCollapsedWidth = 48;
-const shortenedIconWidth = 38;
+const shortenedIconWidth = 32;
 const navFloatingWidth = 230;
 const navItemHeight = 48;
 const navChildItemHeight = 32;
@@ -28,6 +28,7 @@ const navGroupSeparatorWithGroupNameHeight = 70;
 const navItemWithChildBgColor = '#CCCCCC';
 const navItemSelectedColor = '#B7B7B7';
 const navItemIndentSize = 50;
+const navFloatingItemIndentSize = 20;
 
 export const getStyles = (props: INavStyleProps): INavStyles => {
   const { isSelected, hasChildren, nestingLevel, isCollapsed, scrollTop, isChildLinkSelected, hasGroupName } = props;
@@ -68,6 +69,9 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
       selectors: {
         ':hover': {
           backgroundColor: hasChildren ? navItemWithChildBgColor : navItemHoverColor
+        },
+        ':active': {
+          backgroundColor: navItemSelectedColor
         }
       }
     },
@@ -91,6 +95,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
     },
     navItemNameColumn: {
       width: '100%',
+      marginLeft: isChildLinkSelected ? '8px' : '0px',
       lineHeight: !!nestingLevel && nestingLevel > 0 ? navChildItemHeight : navItemHeight,
       verticalAlign: 'top',
       display: 'inline-block',
@@ -114,7 +119,6 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
         marginTop: -navItemHeight - (!!scrollTop && scrollTop > 0 ? scrollTop : 0),
         width: navFloatingWidth,
         color: navTextColor,
-        backgroundColor: hasChildren ? navItemWithChildBgColor : navItemHoverColor,
         selectors: {
           a: {
             width: '100%',
@@ -127,11 +131,14 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
     navFloatingItemRoot: {
       height: !!nestingLevel && nestingLevel > 0 ? navChildItemHeight : navItemHeight,
       cursor: 'pointer',
-      backgroundColor: navBackgroundColor,
-      paddingLeft: !!nestingLevel && nestingLevel > 0 ? nestingLevel * navItemIndentSize : 'inherit',
+      backgroundColor: !(nestingLevel && nestingLevel > 0) ? navItemHoverColor : navBackgroundColor,
+      paddingLeft: navFloatingItemIndentSize,
       selectors: {
         ':hover': {
-          backgroundColor: !!nestingLevel && nestingLevel > 0 ? navItemHoverColor : 'unset'
+          backgroundColor: !!nestingLevel && nestingLevel > 0 ? navItemHoverColor : 'navItemHoverColor'
+        },
+        ':active': {
+          backgroundColor: navItemSelectedColor
         }
       }
     },

--- a/packages/dashboard/src/components/Nav/Nav.tsx
+++ b/packages/dashboard/src/components/Nav/Nav.tsx
@@ -134,10 +134,11 @@ class NavComponent extends NavBase {
     }
 
     const linkText = this.getLinkText(link, this.props.showMore);
-    const isChildLinkSelected = this.isChildLinkSelected(link);
 
     // if allowed, auto expand if the child is selected
-    link.isExpanded = link.disableAutoExpand ? link.isExpanded : isChildLinkSelected;
+    // per PM/Dsigner feedback, let user to control expand/collapse state, so comment out next line.
+    // const isChildLinkSelected = this.isChildLinkSelected(link);
+    // link.isExpanded = link.disableAutoExpand ? link.isExpanded : isChildLinkSelected;
 
     // enable auto expand until the next manual expand disables the auto expand
     link.disableAutoExpand = true;

--- a/packages/dashboard/src/components/Nav/NavLink.tsx
+++ b/packages/dashboard/src/components/Nav/NavLink.tsx
@@ -24,6 +24,11 @@ export const NavLink: React.SFC<INavLinkProps> = (props: INavLinkProps) => {
     computedTextWidth.width = 'calc(100% - 48px)';
   }
 
+  const fixedIconWidth: IStyle = {
+    width: '48px',
+    display: props.rightIconName === 'OpenInNewWindow' ? 'none' : 'inline-block'
+  };
+
   return (
     <a
       id={props.id}
@@ -42,7 +47,9 @@ export const NavLink: React.SFC<INavLinkProps> = (props: INavLinkProps) => {
         {props.content ? (
           <div className={mergeStyles(props.textClassName, computedTextWidth)}>{props.content}</div>
         ) : null}
-        {props.rightIconName ? <Icon iconName={props.rightIconName} className={props.iconClassName} /> : null}
+        {props.rightIconName ? (
+          <Icon iconName={props.rightIconName} className={mergeStyles(props.iconClassName, fixedIconWidth)} />
+        ) : null}
       </div>
     </a>
   );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)

2503089 | Nav: Click State   of darker grey is not implemented per Figma | New | Ignite2018
-- | -- | -- | --
2503090 | Nav: Hover text   should be a full grey bar when in collapsed nav | New | Ignite2018
2503092 | Nav: When Nav is   collapsed and the item is highlighted, there should be a shadow on the   container (per figma) | New | Ignite2018
2503093 | Nav: Edit your   navigation list for admin centers, the alignment of the checkboxes is off | New | Ignite2018
2503094 | Nav: Remove the   external site icon on then external admin centers in nav | New | Ignite2018
2503102 | Nav: Auto-Hide   the scroll bar if they are not engaged (Brandon has some mocks) | New | Ignite2018
2503104 | Nav: Chevron on   the parent node has the carrot misaligned when a child is selected | New | Ignite2018


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6004)

