### PR TITLE
DatePicker close button

### DIFF
--- a/common/changes/office-ui-fabric-react/kisiebel-calendar-close-button_2018-08-22-21-56.json
+++ b/common/changes/office-ui-fabric-react/kisiebel-calendar-close-button_2018-08-22-21-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds an optional close button to the DatePicker",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kisiebel@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -290,6 +290,7 @@ $Calendar-dayPicker-margin: 10px;
   align-self: flex-end;
 }
 
+.closeButton,
 .prevMonth,
 .nextMonth,
 .prevYear,
@@ -469,6 +470,7 @@ $Calendar-dayPicker-margin: 10px;
     line-height: $Calendar-day;
     font-size: $ms-font-size-s;
   } // Reduce the size of arrows to change month/year.
+  .closeButton,
   .prevMonth,
   .nextMonth,
   .prevYear,
@@ -647,6 +649,7 @@ $Calendar-dayPicker-margin: 10px;
   width: auto;
 }
 
+.closeButton,
 .nextMonth,
 .prevMonth,
 .nextYear,

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -16,9 +16,11 @@ const styles: any = stylesImport;
 
 const leftArrow = 'Up';
 const rightArrow = 'Down';
+const closeIcon = 'ChromeClose';
 const iconStrings: ICalendarIconStrings = {
   leftNavigation: leftArrow,
-  rightNavigation: rightArrow
+  rightNavigation: rightArrow,
+  closeIcon: closeIcon
 };
 const defaultWorkWeekDays: DayOfWeek[] = [
   DayOfWeek.Monday,
@@ -75,7 +77,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
     firstWeekOfYear: FirstWeekOfYear.FirstDay,
     dateTimeFormatter: dateTimeFormatterCallbacks,
     showSixWeeksByDefault: false,
-    workWeekDays: defaultWorkWeekDays
+    workWeekDays: defaultWorkWeekDays,
+    showCloseButton: false
   };
 
   private _dayPicker = createRef<ICalendarDay>();
@@ -139,7 +142,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
       navigationIcons,
       minDate,
       maxDate,
-      className
+      className,
+      showCloseButton
     } = this.props;
     const { selectedDate, navigatedDayDate, navigatedMonthDate, isMonthPickerVisible, isDayPickerVisible } = this.state;
     const onHeaderSelect = showMonthPickerAsOverlay ? this._onHeaderSelect : undefined;
@@ -192,6 +196,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
                     maxDate={maxDate}
                     workWeekDays={this.props.workWeekDays}
                     componentRef={this._dayPicker}
+                    showCloseButton={showCloseButton}
                   />
                 )}
                 {isDayPickerVisible && isMonthPickerVisible && <div className={styles.divider} />}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -16,7 +16,7 @@ const styles: any = stylesImport;
 
 const leftArrow = 'Up';
 const rightArrow = 'Down';
-const closeIcon = 'ChromeClose';
+const closeIcon = 'CalculatorMultiply';
 const iconStrings: ICalendarIconStrings = {
   leftNavigation: leftArrow,
   rightNavigation: rightArrow,

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -242,7 +242,7 @@ export interface ICalendarIconStrings {
 
   /**
    * Close icon
-   * @defaultvalue  'ChromeClose'
+   * @defaultvalue  'CalculatorMultiply'
    */
   closeIcon?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -159,6 +159,11 @@ export interface ICalendarProps extends IBaseProps<ICalendar> {
    * @defaultvalue false
    */
   selectDateOnClick?: boolean;
+
+  /**
+   * Whether the close button should be shown or not
+   */
+  showCloseButton?: boolean;
 }
 
 export interface ICalendarStrings {
@@ -212,6 +217,11 @@ export interface ICalendarStrings {
   nextYearAriaLabel?: string;
 
   /**
+   * Aria-label for the "close" button.
+   */
+  closeButtonAriaLabel?: string;
+
+  /**
    * Aria-label format string for the week number header. Should have 1 string param e.g. "week number {0}"
    */
   weekNumberFormatString?: string;
@@ -229,6 +239,12 @@ export interface ICalendarIconStrings {
    * @defaultvalue  'Down'
    */
   rightNavigation?: string;
+
+  /**
+   * Close icon
+   * @defaultvalue  'ChromeClose'
+   */
+  closeIcon?: string;
 }
 
 export interface ICalendarFormatDateCallbacks {

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -59,6 +59,7 @@ export interface ICalendarDayProps extends React.Props<CalendarDay> {
   minDate?: Date;
   maxDate?: Date;
   workWeekDays?: DayOfWeek[];
+  showCloseButton?: boolean;
 }
 
 export interface ICalendarDayState {
@@ -84,6 +85,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
 
     this._onSelectNextMonth = this._onSelectNextMonth.bind(this);
     this._onSelectPrevMonth = this._onSelectPrevMonth.bind(this);
+    this._onClose = this._onClose.bind(this);
   }
 
   public componentWillReceiveProps(nextProps: ICalendarDayProps): void {
@@ -105,12 +107,14 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       firstWeekOfYear,
       dateTimeFormatter,
       minDate,
-      maxDate
+      maxDate,
+      showCloseButton
     } = this.props;
     const dayPickerId = getId('DatePickerDay-dayPicker');
     const monthAndYearId = getId('DatePickerDay-monthAndYear');
     const leftNavigationIcon = navigationIcons.leftNavigation;
     const rightNavigationIcon = navigationIcons.rightNavigation;
+    const closeNavigationIcon = navigationIcons.closeIcon;
     const weekNumbers = showWeekNumbers
       ? getWeekNumbersInMonth(weeks!.length, firstDayOfWeek, firstWeekOfYear, navigatedDate)
       : null;
@@ -197,6 +201,19 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
               >
                 <Icon iconName={rightNavigationIcon} />
               </button>
+              {showCloseButton ? (
+                <button
+                  className={css('ms-DatePicker-closeButton js-closeButton', styles.closeButton)}
+                  onClick={this._onClose}
+                  onKeyDown={this._onCloseButtonKeyDown}
+                  aria-label={strings.closeButtonAriaLabel}
+                  role="button"
+                >
+                  <Icon iconName={closeNavigationIcon} />
+                </button>
+              ) : (
+                ''
+              )}
             </div>
           </div>
         </div>
@@ -684,6 +701,12 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
     this.props.onNavigateDate(addMonths(this.props.navigatedDate, -1), false);
   };
 
+  private _onClose = (): void => {
+    if (this.props.onDismiss) {
+      this.props.onDismiss();
+    }
+  };
+
   private _onHeaderSelect = (): void => {
     const { onHeaderSelect } = this.props;
     if (onHeaderSelect) {
@@ -707,6 +730,12 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
   private _onNextMonthKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
     if (ev.which === KeyCodes.enter) {
       this._onKeyDown(this._onSelectNextMonth, ev);
+    }
+  };
+
+  private _onCloseButtonKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
+    if (ev.which === KeyCodes.enter) {
+      this._onKeyDown(this._onClose, ev);
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -201,7 +201,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
               >
                 <Icon iconName={rightNavigationIcon} />
               </button>
-              {showCloseButton ? (
+              {showCloseButton && (
                 <button
                   className={css('ms-DatePicker-closeButton js-closeButton', styles.closeButton)}
                   onClick={this._onClose}
@@ -211,8 +211,6 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 >
                   <Icon iconName={closeNavigationIcon} />
                 </button>
-              ) : (
-                ''
               )}
             </div>
           </div>

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -50,7 +50,8 @@ const DEFAULT_STRINGS: IDatePickerStrings = {
   prevMonthAriaLabel: 'Go to previous month',
   nextMonthAriaLabel: 'Go to next month',
   prevYearAriaLabel: 'Go to previous year',
-  nextYearAriaLabel: 'Go to next year'
+  nextYearAriaLabel: 'Go to next year',
+  closeButtonAriaLabel: 'Close date picker'
 };
 
 export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerState> implements IDatePicker {
@@ -84,7 +85,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     showWeekNumbers: false,
     firstWeekOfYear: FirstWeekOfYear.FirstDay,
     showGoToToday: true,
-    dateTimeFormatter: undefined
+    dateTimeFormatter: undefined,
+    showCloseButton: false
   };
 
   private _calendar = createRef<ICalendar>();
@@ -161,6 +163,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       borderless,
       minDate,
       maxDate,
+      showCloseButton,
       calendarProps
     } = this.props;
     const { isDatePickerShown, formattedDate, selectedDate, errorMessage } = this.state;
@@ -235,6 +238,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
                 minDate={minDate}
                 maxDate={maxDate}
                 componentRef={this._calendar}
+                showCloseButton={showCloseButton}
               />
             </FocusTrapZone>
           </Callout>

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -194,6 +194,11 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker> {
    * Callback that runs after DatePicker's menu (Calendar) is closed
    */
   onAfterMenuDismiss?: () => void;
+
+  /**
+   * Whether the CalendarDay close button should be shown or not.
+   */
+  showCloseButton?: boolean;
 }
 
 export interface IDatePickerStrings {
@@ -260,6 +265,11 @@ export interface IDatePickerStrings {
    * Aria-label for the "next year" button.
    */
   nextYearAriaLabel?: string;
+
+  /**
+   * Aria-label for the "close" button.
+   */
+  closeButtonAriaLabel?: string;
 }
 export interface IDatePickerStyleProps {
   /**

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
@@ -30,7 +30,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevMonthAriaLabel: 'Go to previous month',
   nextMonthAriaLabel: 'Go to next month',
   prevYearAriaLabel: 'Go to previous year',
-  nextYearAriaLabel: 'Go to next year'
+  nextYearAriaLabel: 'Go to next year',
+  closeButtonAriaLabel: 'Close date picker'
 };
 
 export interface IDatePickerBasicExampleState {

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -35,6 +35,7 @@ const DayPickerStrings: IDatePickerStrings = {
   nextMonthAriaLabel: 'Go to next month',
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
+  closeButtonAriaLabel: 'Close date picker',
 
   isRequiredErrorMessage: 'Field is required.',
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
@@ -30,6 +30,7 @@ const DayPickerStrings: IDatePickerStrings = {
   nextMonthAriaLabel: 'Go to next month',
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
+  closeButtonAriaLabel: 'Close date picker',
 
   isRequiredErrorMessage: 'Start date is required.',
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
@@ -30,6 +30,7 @@ const DayPickerStrings: IDatePickerStrings = {
   nextMonthAriaLabel: 'Go to next month',
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
+  closeButtonAriaLabel: 'Close date picker',
 
   isRequiredErrorMessage: 'Start date is required.',
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -29,6 +29,7 @@ const DayPickerStrings: IDatePickerStrings = {
   nextMonthAriaLabel: 'Go to next month',
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
+  closeButtonAriaLabel: 'Close date picker',
 
   isRequiredErrorMessage: 'Field is required.',
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
@@ -29,7 +29,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevMonthAriaLabel: 'Go to previous month',
   nextMonthAriaLabel: 'Go to next month',
   prevYearAriaLabel: 'Go to previous year',
-  nextYearAriaLabel: 'Go to next year'
+  nextYearAriaLabel: 'Go to next year',
+  closeButtonAriaLabel: 'Close date picker'
 };
 
 export interface IDatePickerBasicExampleState {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adds an optional close button to the DatePicker. The button is located in the CalendarDay component. DatePicker, Calendar, and CalendarDay all take an optional prop showCloseButton that determines whether or not to render the button.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6034)

