### PR TITLE
ContextualMenu: remove line-height 0 style for lists

### DIFF
--- a/common/changes/office-ui-fabric-react/contextualMenuItem_2018-08-23-19-02.json
+++ b/common/changes/office-ui-fabric-react/contextualMenuItem_2018-08-23-19-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: remove line-height 0 styling for lists",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -42,8 +42,7 @@ export const getStyles = (props: IContextualMenuStyleProps): IContextualMenuStyl
       {
         listStyleType: 'none',
         margin: '0',
-        padding: '0',
-        lineHeight: '0'
+        padding: '0'
       }
     ],
     header: [


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6022 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

With the line-height: 0 style on lists, certain ContextualMenu items had their heights restricted, even if there was enough space. Below you can see the before and after of rendering Personas with details inside a ContextualMenu.

Before:
![image](https://user-images.githubusercontent.com/14134000/44547163-09f08980-a6cf-11e8-8de7-585716044f53.png)


After:
![image](https://user-images.githubusercontent.com/14134000/44547125-efb6ab80-a6ce-11e8-8e71-5809db7867e7.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6053)

