### PR TITLE
Reverting customizer React 16 usage

### DIFF
--- a/apps/fabric-website-resources/webpack.serve.config.js
+++ b/apps/fabric-website-resources/webpack.serve.config.js
@@ -15,7 +15,6 @@ module.exports = resources.createServeConfig({
 
   resolve: {
     alias: {
-      'office-ui-fabric-react$': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
       'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
       'office-ui-fabric-react/lib/codepen': path.resolve(
         __dirname,

--- a/common/changes/@uifabric/experiments/revert-context-usage_2018-08-24-04-56.json
+++ b/common/changes/@uifabric/experiments/revert-context-usage_2018-08-24-04-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Reverting Customizer React 16 context change.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website-resources/revert-context-usage_2018-08-24-05-25.json
+++ b/common/changes/@uifabric/fabric-website-resources/revert-context-usage_2018-08-24-05-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website-resources",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/foundation/revert-context-usage_2018-08-24-04-56.json
+++ b/common/changes/@uifabric/foundation/revert-context-usage_2018-08-24-04-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/foundation",
+      "comment": "Reverting Customizer React 16 context change.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/revert-context-usage_2018-08-24-04-56.json
+++ b/common/changes/@uifabric/utilities/revert-context-usage_2018-08-24-04-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Reverting Customizer React 16 context change.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/revert-context-usage_2018-08-24-04-56.json
+++ b/common/changes/office-ui-fabric-react/revert-context-usage_2018-08-24-04-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Reverting Customizer React 16 context change, while we dig into the Layer portal conversion first. As it is moving to React 16 breaks layer theming, which we believe can only be fixed if we move to portals (which has other issues to investigate.)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/experiments/src/Foundation.ts
+++ b/packages/experiments/src/Foundation.ts
@@ -5,6 +5,7 @@ import {
   IComponentOptions,
   IViewComponentProps,
   IStateComponent,
+  IStyleableComponent,
   IStyleableComponentProps,
   IStylingProviders,
   IThemedComponent,
@@ -12,7 +13,7 @@ import {
 } from '@uifabric/foundation';
 export { IStateComponentProps } from '@uifabric/foundation';
 import { IProcessedStyleSet, IStyleSet } from './Styling';
-import { Customizations, CustomizerContext, ICustomizations } from './Utilities';
+import { Customizations, CustomizableContextTypes, ICustomizations } from './Utilities';
 
 // Centralize Foundation interaction for use throughout this package. These convenience types provide types
 //  that are global for all of OUFR, such as ITheme and IProcessedStyleSet.
@@ -24,12 +25,11 @@ export type IViewComponentProps<TProps, TStyleSet extends IStyleSet<TStyleSet>> 
   TProps,
   IProcessedStyleSet<TStyleSet>
 >;
-
 /**
  * Required properties for styleable components.
  */
+export type IStyleableComponent<TProps, TStyleSet> = IStyleableComponent<TProps, TStyleSet, ITheme>;
 export type IStyleableComponentProps<TProps, TStyleSet> = IStyleableComponentProps<TProps, TStyleSet, ITheme>;
-
 /**
  * Required properties for themed components.
  */
@@ -45,7 +45,7 @@ type IContextCustomization = { customizations: ICustomizations };
 const providers: IStylingProviders<any, any, any, IContextCustomization, ITheme> = {
   mergeStyleSets,
   getCustomizations,
-  CustomizerContext
+  CustomizableContextTypes
 };
 
 /**
@@ -54,7 +54,7 @@ const providers: IStylingProviders<any, any, any, IContextCustomization, ITheme>
  * @param {IComponentOptions} options
  */
 export function createStatelessComponent<
-  TComponentProps extends IStyleableComponentProps<TComponentProps, TStyleSet, ITheme>,
+  TComponentProps extends IStyleableComponent<TComponentProps, TStyleSet, ITheme>,
   TStyleSet extends IStyleSet<TStyleSet>,
   TStatics = {}
 >(
@@ -77,7 +77,7 @@ export function createStatelessComponent<
  * @param {IStateComponent} state
  */
 export function createComponent<
-  TComponentProps extends IStyleableComponentProps<TViewProps, TStyleSet, ITheme>,
+  TComponentProps extends IStyleableComponent<TViewProps, TStyleSet, ITheme>,
   TViewProps,
   TStyleSet extends IStyleSet<TStyleSet>,
   TStatics = {}

--- a/packages/experiments/src/components/Accordion/Accordion.tsx
+++ b/packages/experiments/src/components/Accordion/Accordion.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { createStatelessComponent, IViewComponentProps, IStyleableComponentProps } from '../../Foundation';
+import { createStatelessComponent, IViewComponentProps, IStyleableComponent } from '../../Foundation';
 import { CollapsibleSection, ICollapsibleSectionProps, ICollapsibleSectionStyles } from '../../CollapsibleSection';
 import { IAccordionProps, IAccordionStyles } from './Accordion.types';
 import { styles } from './Accordion.styles';
 
 const AccordionItemType = (<CollapsibleSection /> as React.ReactElement<ICollapsibleSectionProps> &
-  IStyleableComponentProps<ICollapsibleSectionProps, ICollapsibleSectionStyles>).type;
+  IStyleableComponent<ICollapsibleSectionProps, ICollapsibleSectionStyles>).type;
 
 const view = (props: IViewComponentProps<IAccordionProps, IAccordionStyles>) => {
   const { renderAs: RootType = 'div', classNames, collapseItems } = props;

--- a/packages/experiments/src/components/Accordion/Accordion.types.ts
+++ b/packages/experiments/src/components/Accordion/Accordion.types.ts
@@ -1,7 +1,7 @@
 import { IStyle } from '../../Styling';
-import { IStyleableComponentProps } from '../../Foundation';
+import { IStyleableComponent } from '../../Foundation';
 
-export interface IAccordionProps extends IStyleableComponentProps<IAccordionProps, IAccordionStyles> {
+export interface IAccordionProps extends IStyleableComponent<IAccordionProps, IAccordionStyles> {
   renderAs?: string | React.ReactType<IAccordionProps>;
   className?: string;
 

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { IStyle } from 'office-ui-fabric-react';
-import { IStyleableComponentProps, IThemedProps } from '../../Foundation';
+import { IStyleableComponent, IStyleableComponentProps, IThemedProps } from '../../Foundation';
 import { RefObject } from '../../Utilities';
 
 import { ICollapsibleSectionTitleProps } from './CollapsibleSectionTitle.types';
 
 export interface ICollapsibleSectionProps
-  extends IStyleableComponentProps<ICollapsibleSectionProps, ICollapsibleSectionStyles> {
+  extends IStyleableComponent<ICollapsibleSectionProps, ICollapsibleSectionStyles> {
   /**
    * Additional class name to provide on the root element.
    */

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
@@ -1,8 +1,8 @@
 import { IStyle, RefObject } from 'office-ui-fabric-react';
-import { IStyleableComponentProps, IThemedProps } from '../../Foundation';
+import { IStyleableComponent, IThemedProps } from '../../Foundation';
 
 export interface ICollapsibleSectionTitleProps
-  extends IStyleableComponentProps<ICollapsibleSectionTitleProps, ICollapsibleSectionTitleStyles> {
+  extends IStyleableComponent<ICollapsibleSectionTitleProps, ICollapsibleSectionTitleStyles> {
   focusElementRef?: RefObject<HTMLElement>;
   /**
    * Collapsed state of body associated with this component.

--- a/packages/experiments/src/components/Stack/Stack.tsx
+++ b/packages/experiments/src/components/Stack/Stack.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createStatelessComponent, IStyleableComponentProps, IViewComponentProps } from '../../Foundation';
+import { createStatelessComponent, IStyleableComponent, IViewComponentProps } from '../../Foundation';
 import StackItem from './StackItem/StackItem';
 import { IStackItemProps, IStackItemStyles } from './StackItem/StackItem.types';
 import { IStackProps, IStackStyles } from './Stack.types';
@@ -7,7 +7,7 @@ import { styles } from './Stack.styles';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
 const StackItemType = (<StackItem /> as React.ReactElement<IStackItemProps> &
-  IStyleableComponentProps<IStackItemProps, IStackItemStyles>).type;
+  IStyleableComponent<IStackItemProps, IStackItemStyles>).type;
 
 const view = (props: IViewComponentProps<IStackProps, IStackStyles>) => {
   const {

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -1,5 +1,5 @@
 import { IStyle } from '../../Styling';
-import { IStyleableComponentProps } from '../../Foundation';
+import { IStyleableComponent } from '../../Foundation';
 
 export type Alignment =
   | 'start'
@@ -16,7 +16,7 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 // contains the members of IStackProps that are common to both VerticalStack and HorizontalStack
 export type IPartialStackProps = Omit<IStackProps, 'verticalAlignment' | 'horizontalAlignment' | 'horizontal'>;
 
-export interface IStackProps extends IStyleableComponentProps<IStackProps, IStackStyles> {
+export interface IStackProps extends IStyleableComponent<IStackProps, IStackStyles> {
   /**
    * How to render the Stack.
    */

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -1,7 +1,7 @@
 import { IStyle } from '../../../Styling';
-import { IStyleableComponentProps } from '../../../Foundation';
+import { IStyleableComponent } from '../../../Foundation';
 
-export interface IStackItemProps extends IStyleableComponentProps<IStackItemProps, IStackItemStyles> {
+export interface IStackItemProps extends IStyleableComponent<IStackItemProps, IStackItemStyles> {
   /**
    * CSS class name used to style the StackItem.
    */

--- a/packages/experiments/src/components/Text/Text.types.tsx
+++ b/packages/experiments/src/components/Text/Text.types.tsx
@@ -50,12 +50,12 @@ export interface ITextProps extends IStyleableComponent<ITextProps, ITextStyles>
   /**
    * Optional font color for Text.
    */
-  color?: keyof IPalette | keyof ISemanticTextColors;
+  color?: keyof IPalette | keyof ISemanticColors;
 
   /**
    * Optional color for hovered text.
    */
-  hoverColor?: keyof IPalette | keyof ISemanticTextColors;
+  hoverColor?: keyof IPalette | keyof ISemanticColors;
 
   /**
    * Whether the text is displayed as an inline element.

--- a/packages/experiments/src/components/Text/Text.types.tsx
+++ b/packages/experiments/src/components/Text/Text.types.tsx
@@ -1,5 +1,5 @@
-import { IStyle, IPalette, ISemanticTextColors } from '../../Styling';
-import { IStyleableComponentProps } from '../../Foundation';
+import { IStyle, IPalette, ISemanticColors } from '../../Styling';
+import { IStyleableComponent } from '../../Foundation';
 import { IFontVariants, IFontFamilies, IFontSizes, IFontWeights } from '../../Styling';
 
 // Styles for the component
@@ -11,7 +11,7 @@ export interface ITextStyles {
 }
 
 // Inputs to the component
-export interface ITextProps extends IStyleableComponentProps<ITextProps, ITextStyles> {
+export interface ITextProps extends IStyleableComponent<ITextProps, ITextStyles> {
   /**
    * Optionaly render the component as another component type or primative.
    */

--- a/packages/experiments/src/components/Text/examples/Text.Ramp.Example.tsx
+++ b/packages/experiments/src/components/Text/examples/Text.Ramp.Example.tsx
@@ -4,7 +4,7 @@ import { IFontVariants, IFontSizes, IFontWeights, IFontFamilies, IStyle } from '
 import { ISemanticTextColors, IPalette, ITheme } from '@uifabric/experiments/lib/Styling';
 import {
   createStatelessComponent,
-  IStyleableComponentProps,
+  IStyleableComponent,
   IViewComponentProps
 } from '@uifabric/experiments/lib/Foundation';
 
@@ -64,7 +64,7 @@ interface ITableStyles {
 }
 
 // Note I intuitively tried to extend IStyleableComponentProps... this was confusing.
-interface ITableProps extends IStyleableComponentProps<ITableProps, ITableStyles> {
+interface ITableProps extends IStyleableComponent<ITableProps, ITableStyles> {
   className?: string;
   title: string;
   headers: string[];

--- a/packages/office-ui-fabric-react/jest.config.js
+++ b/packages/office-ui-fabric-react/jest.config.js
@@ -6,7 +6,6 @@ const config = createConfig({
 
   moduleNameMapper: {
     // These mappings allow Jest to run snapshot tests against Example files.
-    'office-ui-fabric-react/lib/codepen/(.*)$': '<rootDir>/lib/codepen/$1',
     'office-ui-fabric-react/lib/(.*)$': '<rootDir>/src/$1'
   },
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -4,12 +4,11 @@ import * as ReactDOM from 'react-dom';
 /* tslint:enable:no-unused-variable */
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import { KeyCodes, resetIds } from '../../Utilities';
 import { Dropdown } from './Dropdown';
-import { DropdownBase } from './Dropdown.base';
-import { DropdownMenuItemType, IDropdownOption, IDropdown } from './Dropdown.types';
+import { DropdownMenuItemType, IDropdownOption } from './Dropdown.types';
 
 const DEFAULT_OPTIONS: IDropdownOption[] = [
   { key: 'Header1', text: 'Header 1', itemType: DropdownMenuItemType.Header },
@@ -191,18 +190,24 @@ describe('Dropdown', () => {
     it('sets the selected item even when key is number 0', () => {
       const options = [{ key: 0, text: 'item1' }, { key: 1, text: 'item2' }];
       const selectedKey = 0;
-      const dropdown = React.createRef<IDropdown>();
 
-      const wrapper = mount(<Dropdown componentRef={dropdown} options={options} />);
+      const wrapper = shallow(<Dropdown options={options} />);
 
-      expect((dropdown.current as DropdownBase).state.selectedIndices).toEqual([]);
+      // Use .dive() because Dropdown is a decorated component
+      let state = wrapper
+        .dive() // styled
+        .dive() // withResponsiveMode
+        .state('selectedIndices');
+      expect(state).toEqual([]);
 
       const newProps = { options, selectedKey };
-
       wrapper.setProps(newProps);
       wrapper.update();
-
-      expect((dropdown.current as DropdownBase).state.selectedIndices).toEqual([selectedKey]);
+      state = wrapper
+        .dive()
+        .dive()
+        .state('selectedIndices');
+      expect(state).toEqual([selectedKey]);
     });
 
     it('does not issue the onChange callback when the selected item is not different', () => {
@@ -373,17 +378,23 @@ describe('Dropdown', () => {
     it('sets the selected items even when key is number 0', () => {
       const options = [{ key: 0, text: 'item1' }, { key: 1, text: 'item2' }];
       const selectedKeys = [0, 1];
-      const dropdown = React.createRef<IDropdown>();
-      const wrapper = mount(<Dropdown multiSelect componentRef={dropdown} options={options} />);
+
+      const wrapper = shallow(<Dropdown multiSelect options={options} />);
 
       // Use .dive() because Dropdown is a decorated component
-      let state = (dropdown.current as DropdownBase).state.selectedIndices;
+      let state = wrapper
+        .dive() // styled
+        .dive() // withresponsivemode
+        .state('selectedIndices');
       expect(state).toEqual([]);
 
       const newProps = { options, selectedKeys };
       wrapper.setProps(newProps);
       wrapper.update();
-      state = (dropdown.current as DropdownBase).state.selectedIndices;
+      state = wrapper
+        .dive()
+        .dive()
+        .state('selectedIndices');
       expect(state).toEqual(selectedKeys);
     });
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -14,7 +14,7 @@ export interface IDropdown {
   focus: (shouldOpenOnFocus?: boolean) => void;
 }
 
-export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown> {
+export interface IDropdownProps extends ISelectableDroppableTextProps<HTMLDivElement> {
   /**
    * Input placeholder text. Displayed until option is selected.
    */


### PR DESCRIPTION
Reverting Customizer React 16 context change, while we dig into the Layer portal conversion first. As it is moving to React 16 breaks layer theming, which we believe can only be fixed if we move to portals (which has other issues to investigate.)

Fixes #6055.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6057)

