### PR TITLE
Spin button/expose key press event to on validate

### DIFF
--- a/common/changes/office-ui-fabric-react/SpinButton-ExposeKeyPressEventToOnValidate_2018-08-24-02-22.json
+++ b/common/changes/office-ui-fabric-react/SpinButton-ExposeKeyPressEventToOnValidate_2018-08-24-02-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Expose keyPress event used to commit manually entered value to OnValidate callback so consumers can handle focus in an accessible way",
+      "comment": "Expose the event that triggers the commit of a manually entered value to OnValidate callback so consumers can handle focus transitions in an accessible way",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/SpinButton-ExposeKeyPressEventToOnValidate_2018-08-24-02-22.json
+++ b/common/changes/office-ui-fabric-react/SpinButton-ExposeKeyPressEventToOnValidate_2018-08-24-02-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Expose keyPress event used to commit manually entered value to OnValidate callback so consumers can handle focus in an accessible way",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rpsenski@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -664,4 +664,44 @@ describe('SpinButton', () => {
 
     expect(onValidate).toBeCalled();
   });
+
+  it(`should pass KeyCode ${KeyCodes.enter} to onValidate handler`, () => {
+    let keyCode;
+    const onValidate: jest.Mock = jest.fn((value, event) => {
+      keyCode = event.which;
+      return value;
+    });
+    const exampleNewValue = '99';
+
+    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onValidate={onValidate} />);
+
+    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    ReactTestUtils.Simulate.focus(inputDOM);
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
+    expect(keyCode).toEqual(KeyCodes.enter);
+    expect(onValidate).toBeCalled();
+    ReactTestUtils.Simulate.blur(inputDOM);
+    expect(onValidate).toHaveBeenCalledTimes(1);
+  });
+
+  it('onValidate is not called again on enter key press until the input changes', () => {
+    const onValidate: jest.Mock = jest.fn((value, event) => {
+      return value;
+    });
+    const exampleNewValue = '99';
+    const exampleChangedValue = '10';
+
+    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onValidate={onValidate} />);
+
+    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
+    expect(onValidate).toHaveBeenCalledTimes(1);
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
+    expect(onValidate).toHaveBeenCalledTimes(1);
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleChangedValue)));
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
+    expect(onValidate).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -97,9 +97,11 @@ export interface ISpinButtonProps {
 
   /**
    * This callback is triggered when the value inside the SpinButton should be validated.
+   * @param value: The value entered in the SpinButton to validate
+   * @param keyboardEvent: The keyboard event that triggered this validate, if any. (For accessibility)
    * @return {string | void} If a string is returned, it will be used as the value of the SpinButton.
    */
-  onValidate?: (value: string) => string | void;
+  onValidate?: (value: string, keyboardEvent?: React.KeyboardEvent<HTMLElement>) => string | void;
 
   /**
    * This callback is triggered when the increment button is pressed or if the user presses up arrow with focus on the input of the spinButton

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -98,10 +98,10 @@ export interface ISpinButtonProps {
   /**
    * This callback is triggered when the value inside the SpinButton should be validated.
    * @param value: The value entered in the SpinButton to validate
-   * @param keyboardEvent: The keyboard event that triggered this validate, if any. (For accessibility)
+   * @param event: The event that triggered this validate, if any. (For accessibility)
    * @return {string | void} If a string is returned, it will be used as the value of the SpinButton.
    */
-  onValidate?: (value: string, keyboardEvent?: React.KeyboardEvent<HTMLElement>) => string | void;
+  onValidate?: (value: string, event?: React.SyntheticEvent<HTMLElement>) => string | void;
 
   /**
    * This callback is triggered when the increment button is pressed or if the user presses up arrow with focus on the input of the spinButton


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Applications using the spin button control need to know how the value was committed. If a value is manually entered, the user can commit it by hitting enter or hitting tab. An application may want to take different action based on the user action.

The hook exposed to consumers tied to the manual input is the onValidate prop, so this change adds an optional React.KeyboardEvent<HtmlElement> parameter that may be supplied to the onValidate callback. The caller can confirm that it's defined and check if the which parameter is defined and test its value to do the right thing for accessibility. 

SpinButton used to validate via the onBlur handler. On enter key press, it internally fired the blur event on the input to trigger validation, but that obscured which key (if any) was pressed. Having the keyboard event handler trigger validation allows us to pass the keyboard event to the callback, but has a bad side-effect: if the key press is the tab key, that should commit the value, but it also triggers an onBlur event (which submits again). With enter key press followed by an onBlur, again there would be two commits. So I've added state to track that we've submitted already, and it will be cleared onBlur, or on any edit that changes the value (newly entered text or spinning).

#### Focus areas to test
Keyboard event gets passed
- Only tab and enter commit. I tested these manually and unit tests use enter.

onValidate is only called once on commit via tab
- tested manually and wrote a unit test for this

onValidate can be called multiple times if blurred, or updated and re-committed 
- tested manually and wrote a unit test that tests the "commit, update, commit again" scenario

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6058)

