### PR TITLE
Prevent breaking change in DetailsList render typings

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-details-types_2018-08-24-13-23.json
+++ b/common/changes/office-ui-fabric-react/fix-details-types_2018-08-24-13-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Prevent breaking change in DetailsItemProps",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsFooter.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsFooter.types.ts
@@ -1,3 +1,22 @@
 import { IDetailsItemProps } from './DetailsRow.types';
+import { IColumn } from './DetailsList.types';
+import { ISelection, SelectionMode } from '../../utilities/selection/index';
 
-export interface IDetailsFooterProps extends IDetailsItemProps {}
+export interface IDetailsFooterBaseProps extends IDetailsItemProps {}
+
+export interface IDetailsFooterProps extends IDetailsFooterBaseProps {
+  /**
+   * Column metadata
+   */
+  columns: IColumn[];
+
+  /**
+   * Selection from utilities
+   */
+  selection: ISelection;
+
+  /**
+   * Selection mode
+   */
+  selectionMode: SelectionMode;
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -3,7 +3,7 @@ import { findDOMNode } from 'react-dom';
 import { BaseComponent, css, getRTL, getId, KeyCodes, IRenderFunction, createRef, IClassNames } from '../../Utilities';
 import {
   IColumn,
-  IDetailsHeaderProps,
+  IDetailsHeaderBaseProps,
   IColumnDragDropDetails,
   ColumnDragEndLocation,
   IColumnReorderOptions
@@ -32,6 +32,8 @@ const getClassNames = classNamesFunction<IDetailsHeaderStyleProps, IDetailsHeade
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 const MOUSEMOVE_PRIMARY_BUTTON = 1; // for mouse move event we are using ev.buttons property, 1 means left button
 
+const NO_COLUMNS: IColumn[] = [];
+
 export interface IDetailsHeader {
   focus: () => boolean;
 }
@@ -44,7 +46,7 @@ export interface IDetailsHeaderState {
   isAllCollapsed?: boolean;
 }
 
-export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetailsHeaderState>
+export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, IDetailsHeaderState>
   implements IDetailsHeader {
   public static defaultProps = {
     selectAllVisibility: SelectAllVisibility.visible,
@@ -67,7 +69,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
     sourceIndex: number;
     targetIndex: number;
   };
-  constructor(props: IDetailsHeaderProps) {
+  constructor(props: IDetailsHeaderBaseProps) {
     super(props);
     this._columnReorderProps =
       props.columnReorderProps ||
@@ -120,7 +122,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
     }
   }
 
-  public componentDidUpdate(prevProps: IDetailsHeaderProps): void {
+  public componentDidUpdate(prevProps: IDetailsHeaderBaseProps): void {
     this._columnReorderProps =
       this.props.columnReorderProps ||
       (this.props.columnReorderOptions && getLegacyColumnReorderProps(this.props.columnReorderOptions));
@@ -139,10 +141,9 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
     }
 
     if (this.props !== prevProps && this._onDropIndexInfo.sourceIndex >= 0 && this._onDropIndexInfo.targetIndex >= 0) {
-      if (
-        prevProps.columns[this._onDropIndexInfo.sourceIndex].key ===
-        this.props.columns[this._onDropIndexInfo.targetIndex].key
-      ) {
+      const { columns: previousColumns = NO_COLUMNS } = prevProps;
+      const { columns = NO_COLUMNS } = this.props;
+      if (previousColumns[this._onDropIndexInfo.sourceIndex].key === columns[this._onDropIndexInfo.targetIndex].key) {
         this._onDropIndexInfo = {
           sourceIndex: Number.MIN_SAFE_INTEGER,
           targetIndex: Number.MIN_SAFE_INTEGER
@@ -151,7 +152,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
     }
   }
 
-  public componentWillReceiveProps(newProps: IDetailsHeaderProps): void {
+  public componentWillReceiveProps(newProps: IDetailsHeaderBaseProps): void {
     const { groupNestingDepth } = this.state;
 
     if (newProps.groupNestingDepth !== groupNestingDepth) {
@@ -168,7 +169,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
 
   public render(): JSX.Element {
     const {
-      columns,
+      columns = NO_COLUMNS,
       ariaLabel,
       ariaLabelForSelectAllCheckbox,
       selectAllVisibility,
@@ -432,7 +433,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
   }
 
   private _getDropHintPositions = (): void => {
-    const { columns } = this.props;
+    const { columns = NO_COLUMNS } = this.props;
     const columnReorderProps = this._columnReorderProps;
     let prevX = 0;
     let prevMid = 0;
@@ -497,7 +498,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
           return;
         }
       }
-      const { columns } = this.props;
+      const { columns = NO_COLUMNS } = this.props;
       const columnReorderProps = this._columnReorderProps;
       const frozenColumnCountFromStart =
         columnReorderProps && columnReorderProps.frozenColumnCountFromStart
@@ -576,8 +577,8 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
   }
 
   private _renderColumnSizer(columnIndex: number): JSX.Element {
-    const { columns } = this.props;
-    const column = this.props.columns[columnIndex];
+    const { columns = NO_COLUMNS } = this.props;
+    const column = columns[columnIndex];
     const { columnResizeDetails } = this.state;
     const classNames = this._classNames;
 
@@ -640,7 +641,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
    * @param {React.MouseEvent} ev (mouse double click event)
    */
   private _onSizerDoubleClick(columnIndex: number, ev: React.MouseEvent<HTMLElement>): void {
-    const { onColumnAutoResized, columns } = this.props;
+    const { onColumnAutoResized, columns = NO_COLUMNS } = this.props;
     if (onColumnAutoResized) {
       onColumnAutoResized(columns[columnIndex], columnIndex);
     }
@@ -660,7 +661,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
   private _onRootMouseDown = (ev: MouseEvent): void => {
     const columnIndexAttr = (ev.target as HTMLElement).getAttribute('data-sizer-index');
     const columnIndex = Number(columnIndexAttr);
-    const { columns } = this.props;
+    const { columns = NO_COLUMNS } = this.props;
 
     if (columnIndexAttr === null || ev.button !== MOUSEDOWN_PRIMARY_BUTTON) {
       // Ignore anything except the primary button.
@@ -698,7 +699,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
 
   private _onRootKeyDown = (ev: KeyboardEvent): void => {
     const { columnResizeDetails, isSizing } = this.state;
-    const { columns, onColumnResized } = this.props;
+    const { columns = NO_COLUMNS, onColumnResized } = this.props;
 
     const columnIndexAttr = (ev.target as HTMLElement).getAttribute('data-sizer-index');
 
@@ -771,7 +772,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
       // but firefox doesn't support it, so we set the default value when it is not defined.
       buttons
     } = ev;
-    const { onColumnIsSizingChanged, onColumnResized, columns } = this.props;
+    const { onColumnIsSizingChanged, onColumnResized, columns = NO_COLUMNS } = this.props;
     const { columnResizeDetails } = this.state;
 
     if (buttons !== undefined && buttons !== MOUSEMOVE_PRIMARY_BUTTON) {
@@ -821,7 +822,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderProps, IDetai
    * @param {React.MouseEvent} ev (mouse up event)
    */
   private _onSizerMouseUp = (ev: React.MouseEvent<HTMLElement>): void => {
-    const { columns, onColumnIsSizingChanged } = this.props;
+    const { columns = NO_COLUMNS, onColumnIsSizingChanged } = this.props;
     const { columnResizeDetails } = this.state;
 
     this.setState({

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.ts
@@ -1,11 +1,16 @@
 import { styled } from '../../Utilities';
-import { IDetailsHeaderProps, IDetailsHeaderStyleProps, IDetailsHeaderStyles } from './DetailsHeader.types';
+import {
+  IDetailsHeaderProps,
+  IDetailsHeaderBaseProps,
+  IDetailsHeaderStyleProps,
+  IDetailsHeaderStyles
+} from './DetailsHeader.types';
 import { DetailsHeaderBase } from './DetailsHeader.base';
 import { getStyles } from './DetailsHeader.styles';
 
-export { IDetailsHeaderProps };
+export { IDetailsHeaderProps, IDetailsHeaderBaseProps };
 
-export const DetailsHeader = styled<IDetailsHeaderProps, IDetailsHeaderStyleProps, IDetailsHeaderStyles>(
+export const DetailsHeader = styled<IDetailsHeaderBaseProps, IDetailsHeaderStyleProps, IDetailsHeaderStyles>(
   DetailsHeaderBase,
   getStyles,
   undefined,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -6,13 +6,14 @@ import { ITheme, IStyle } from '../../Styling';
 import { DetailsHeaderBase } from './DetailsHeader.base';
 import { IColumn, DetailsListLayoutMode, IColumnReorderOptions, ColumnDragEndLocation } from './DetailsList.types';
 import { ICellStyleProps, IDetailsItemProps } from './DetailsRow.types';
+import { ISelection, SelectionMode } from '../../utilities/selection/index';
 
 export interface IDetailsHeader {
   /** sets focus into the header */
   focus: () => boolean;
 }
 
-export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase>, IDetailsItemProps {
+export interface IDetailsHeaderBaseProps extends React.Props<DetailsHeaderBase>, IDetailsItemProps {
   /** Theme from the Higher Order Component */
   theme?: ITheme;
 
@@ -75,6 +76,23 @@ export interface IDetailsHeaderProps extends React.Props<DetailsHeaderBase>, IDe
 
   /** Overriding class name */
   className?: string;
+}
+
+export interface IDetailsHeaderProps extends IDetailsHeaderBaseProps {
+  /**
+   * Column metadata
+   */
+  columns: IColumn[];
+
+  /**
+   * Selection from utilities
+   */
+  selection: ISelection;
+
+  /**
+   * Selection mode
+   */
+  selectionMode: SelectionMode;
 }
 
 export enum SelectAllVisibility {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -288,7 +288,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       onItemContextMenu,
       onColumnHeaderClick,
       onColumnHeaderContextMenu,
-      selectionMode,
+      selectionMode = this._selection.mode,
       selectionPreservedOnEmptyClick,
       selectionZoneProps,
       ariaLabel,
@@ -378,10 +378,10 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
               onRenderDetailsHeader(
                 {
                   componentRef: this._header,
-                  selectionMode: selectionMode!,
+                  selectionMode: selectionMode,
                   layoutMode: layoutMode!,
                   selection: selection,
-                  columns: adjustedColumns as IColumn[],
+                  columns: adjustedColumns,
                   onColumnClick: onColumnHeaderClick,
                   onColumnContextMenu: onColumnHeaderContextMenu,
                   onColumnResized: this._onColumnResized,
@@ -966,13 +966,19 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
   private _getDetailsFooterProps(): IDetailsFooterProps {
     const { adjustedColumns: columns } = this.state;
 
-    const { viewport, checkboxVisibility, indentWidth, cellStyleProps = DEFAULT_CELL_STYLE_PROPS } = this.props;
+    const {
+      viewport,
+      checkboxVisibility,
+      indentWidth,
+      cellStyleProps = DEFAULT_CELL_STYLE_PROPS,
+      selectionMode = this._selection.mode
+    } = this.props;
 
     return {
       columns: columns,
       groupNestingDepth: this._getGroupNestingDepth(),
       selection: this._selection,
-      selectionMode: this.props.selectionMode,
+      selectionMode: selectionMode,
       viewport: viewport,
       checkboxVisibility,
       indentWidth,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -4,15 +4,15 @@ import { ISelection, SelectionMode, ISelectionZoneProps } from '../../utilities/
 import { IRefObject, IBaseProps, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IDragDropEvents, IDragDropContext } from './../../utilities/dragdrop/index';
 import { IGroup, IGroupRenderProps, IGroupDividerProps } from '../GroupedList/index';
-import { IDetailsRowProps } from '../DetailsList/DetailsRow';
-import { IDetailsHeaderProps } from './DetailsHeader';
-import { IDetailsFooterProps } from './DetailsFooter.types';
+import { IDetailsRowProps, IDetailsRowBaseProps } from '../DetailsList/DetailsRow';
+import { IDetailsHeaderProps, IDetailsHeaderBaseProps } from './DetailsHeader';
+import { IDetailsFooterProps, IDetailsFooterBaseProps } from './DetailsFooter.types';
 import { IWithViewportProps, IViewport } from '../../utilities/decorators/withViewport';
 import { IList, IListProps, ScrollToMode } from '../List/index';
 import { ITheme, IStyle } from '../../Styling';
 import { ICellStyleProps, IDetailsItemProps } from './DetailsRow.types';
 
-export { IDetailsHeaderProps };
+export { IDetailsHeaderProps, IDetailsRowBaseProps, IDetailsHeaderBaseProps, IDetailsFooterBaseProps };
 
 export interface IDetailsList extends IList {
   /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -18,7 +18,7 @@ import { FocusZone, FocusZoneDirection, IFocusZone } from '../../FocusZone';
 import { SelectionMode, SELECTION_CHANGE } from '../../utilities/selection/interfaces';
 import { CollapseAllVisibility } from '../../GroupedList';
 import { IDragDropOptions } from './../../utilities/dragdrop/interfaces';
-import { IDetailsRowProps } from './DetailsRow.types';
+import { IDetailsRowBaseProps } from './DetailsRow.types';
 import { IDetailsRowCheckProps } from './DetailsRowCheck.types';
 import { IDetailsRowStyleProps, IDetailsRowStyles } from './DetailsRow.types';
 import { classNamesFunction } from '../../Utilities';
@@ -43,7 +43,9 @@ export interface IDetailsRowState {
 
 const DEFAULT_DROPPING_CSS_CLASS = 'is-dropping';
 
-export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowState> {
+const NO_COLUMNS: IColumn[] = [];
+
+export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetailsRowState> {
   private _root: HTMLElement | undefined;
   private _cellMeasurer = createRef<HTMLSpanElement>();
   private _focusZone = createRef<IFocusZone>();
@@ -51,7 +53,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
   private _hasMounted: boolean;
   private _dragDropSubscription: IDisposable;
 
-  constructor(props: IDetailsRowProps) {
+  constructor(props: IDetailsRowBaseProps) {
     super(props);
 
     this.state = {
@@ -87,7 +89,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
     }
   }
 
-  public componentDidUpdate(previousProps: IDetailsRowProps) {
+  public componentDidUpdate(previousProps: IDetailsRowBaseProps) {
     const state = this.state;
     const { item, onDidMount } = this.props;
     const { columnMeasureInfo } = state;
@@ -141,14 +143,14 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
     }
   }
 
-  public componentWillReceiveProps(newProps: IDetailsRowProps): void {
+  public componentWillReceiveProps(newProps: IDetailsRowBaseProps): void {
     this.setState({
       selectionState: this._getSelectionState(newProps),
       groupNestingDepth: newProps.groupNestingDepth
     });
   }
 
-  public shouldComponentUpdate(nextProps: IDetailsRowProps, nextState: IDetailsRowState): boolean {
+  public shouldComponentUpdate(nextProps: IDetailsRowBaseProps, nextState: IDetailsRowState): boolean {
     if (this.props.useReducedRowRenderer) {
       if (this.state.selectionState) {
         const newSelectionState = this._getSelectionState(nextProps);
@@ -165,7 +167,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
   public render(): JSX.Element {
     const {
       className,
-      columns,
+      columns = NO_COLUMNS,
       dragDropEvents,
       item,
       itemIndex,
@@ -305,7 +307,8 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
    * @param {(width: number) => void} onMeasureDone (the call back function when finish measure)
    */
   public measureCell(index: number, onMeasureDone: (width: number) => void): void {
-    const column = assign({}, this.props.columns[index]) as IColumn;
+    const { columns = NO_COLUMNS } = this.props;
+    const column = assign({}, columns[index]) as IColumn;
 
     column.minWidth = 0;
     column.maxWidth = 999999;
@@ -329,7 +332,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowProps, IDetailsRowS
     return <DetailsRowCheck {...props} />;
   }
 
-  private _getSelectionState(props: IDetailsRowProps): IDetailsRowSelectionState {
+  private _getSelectionState(props: IDetailsRowBaseProps): IDetailsRowSelectionState {
     const { itemIndex, selection } = props;
 
     return {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.ts
@@ -1,11 +1,11 @@
 import { styled } from '../../Utilities';
-import { IDetailsRowProps, IDetailsRowStyleProps, IDetailsRowStyles } from './DetailsRow.types';
+import { IDetailsRowProps, IDetailsRowBaseProps, IDetailsRowStyleProps, IDetailsRowStyles } from './DetailsRow.types';
 import { DetailsRowBase } from './DetailsRow.base';
 import { getStyles } from './DetailsRow.styles';
 
-export { IDetailsRowProps };
+export { IDetailsRowProps, IDetailsRowBaseProps };
 
-export const DetailsRow = styled<IDetailsRowProps, IDetailsRowStyleProps, IDetailsRowStyles>(
+export const DetailsRow = styled<IDetailsRowBaseProps, IDetailsRowStyleProps, IDetailsRowStyles>(
   DetailsRowBase,
   getStyles,
   undefined,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -16,7 +16,7 @@ export interface IDetailsItemProps {
   /**
    * Column metadata
    */
-  columns: IColumn[];
+  columns?: IColumn[];
 
   /**
    * Nesting depth of a grouping
@@ -54,7 +54,7 @@ export interface IDetailsItemProps {
   cellStyleProps?: ICellStyleProps;
 }
 
-export interface IDetailsRowProps extends IBaseProps<IDetailsRow>, IDetailsItemProps {
+export interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsItemProps {
   /**
    * Theme provided by styled() function
    */
@@ -165,6 +165,23 @@ export interface IDetailsRowProps extends IBaseProps<IDetailsRow>, IDetailsItemP
    * @default false
    */
   useReducedRowRenderer?: boolean;
+}
+
+export interface IDetailsRowProps extends IDetailsRowBaseProps {
+  /**
+   * Column metadata
+   */
+  columns: IColumn[];
+
+  /**
+   * Selection from utilities
+   */
+  selection: ISelection;
+
+  /**
+   * Selection mode
+   */
+  selectionMode: SelectionMode;
 }
 
 export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme'>> & {


### PR DESCRIPTION
# Overview

A previous change, #5997, accidentally introduced a breaking change in `onRender` overrides by requiring `columns` to be passed to the `onRender___` overrides for `groupProps`. This was breaking because it required implementors to forward that interface along, which required diligent use of `...` to avoid TypeScript catching the deficiency.
This change makes `columns` optional in `IDetailsItemProps`, but to maintain the point of the original change, `DetailsRow`, `DetailsHeader`, and `DetailsFooter` now treat `columns` as optional, but the `onRender` functions still mandate the props correctly. This avoids a breaking change to downstream consumers.

The gist is that this is now allowed:
```tsx
<DetailsRow
    columns={undefined}
    selection={undefined}
    selectionMode={undefined}
/>
```

While this still ensures those fields are present:
```tsx
function onRenderRow(props: IDetailsRowProps, defaultRender?: IRenderFunction<IDetailsRowProps>) {
    expect(props.selection).notToBeUndefined();
    expect(props.columns).notToBeUndefined();
    expect(props.selectionMode).notToBeUndefined();

    return (
        <MyDetailsRow
            { ...props }
        />
    );
}
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6065)

