### PR TITLE
Adds missing property values for 'alignSelf' (Fixes #6068)

### DIFF
--- a/common/changes/@uifabric/merge-styles/Issue-6068_2018-08-24-17-17.json
+++ b/common/changes/@uifabric/merge-styles/Issue-6068_2018-08-24-17-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/merge-styles",
-      "comment": "Adds missing CSS property values for 'align-self' in merge-styles",
+      "comment": "Adds missing CSS property values for 'align-self' in `IRawStyle` type definition.",
       "type": "patch"
     }
   ],

--- a/common/changes/@uifabric/merge-styles/Issue-6068_2018-08-24-17-17.json
+++ b/common/changes/@uifabric/merge-styles/Issue-6068_2018-08-24-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Adds missing CSS property values for 'align-self' in merge-styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "patrik@themediaexchange.nl"
+}

--- a/common/changes/@uifabric/merge-styles/Issue-6068_2018-08-27-14-30.json
+++ b/common/changes/@uifabric/merge-styles/Issue-6068_2018-08-27-14-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Adds missing CSS property values for 'align-self' in `IRawStyle` type definition and corrects CSS property values for 'justify-self' in 'IRawStyle'",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "patrik@themediaexchange.nl"
+}

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -212,9 +212,20 @@ export interface IRawStyleBase extends IRawFontStyle {
   alignItems?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch';
 
   /**
-   * Allows the default alignment to be overridden for individual flex items.
+   * Aligns the box (as the alignment subject) within its containing block (as the alignment container)
+   * along the block/column/cross axis of the alignment container.
+   *
+   * See CSS align-self property
+   * https://www.w3.org/TR/css-align-3/#propdef-align-self
    */
-  alignSelf?: ICSSRule | 'auto' | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch';
+  alignSelf?:
+    | ICSSRule
+    | 'auto'
+    | 'normal'
+    | 'stretch'
+    | ICSSBaselinePositionRule
+    | ICSSOverflowPositionRule
+    | ICSSSelfPositionRule;
 
   /**
    * This property allows precise alignment of elements, such as graphics, that do not

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -13,10 +13,32 @@ export type ICSSPixelUnitRule = string | number;
 export type ICSSBaselinePositionRule = 'baseline' | 'last baseline' | 'first baseline';
 
 // See CSS <overflow-position> type https://www.w3.org/TR/css-align-3/#typedef-overflow-position
-export type ICSSOverflowPositionRule = 'safe' | 'unsafe';
-
 // See CSS <self-position> type https://www.w3.org/TR/css-align-3/#typedef-self-position
-export type ICSSSelfPositionRule = 'center' | 'start' | 'end' | 'self-start' | 'self-end' | 'flex-start' | 'flex-end';
+export type ICSSOverflowAndSelfPositionRule =
+  // <self-position>
+  | 'center'
+  | 'start'
+  | 'end'
+  | 'self-start'
+  | 'self-end'
+  | 'flex-start'
+  | 'flex-end'
+  // <self-position> prefixed with <overflow-position> value 'safe'
+  | 'safe center'
+  | 'safe start'
+  | 'safe end'
+  | 'safe self-start'
+  | 'safe self-end'
+  | 'safe flex-start'
+  | 'safe flex-end'
+  // <self-position> prefixed with <overflow-position> value 'unsafe'
+  | 'unsafe center'
+  | 'unsafe start'
+  | 'unsafe end'
+  | 'unsafe self-start'
+  | 'unsafe self-end'
+  | 'unsafe flex-start'
+  | 'unsafe flex-end';
 
 export type IFontWeight =
   | ICSSRule
@@ -218,14 +240,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * See CSS align-self property
    * https://www.w3.org/TR/css-align-3/#propdef-align-self
    */
-  alignSelf?:
-    | ICSSRule
-    | 'auto'
-    | 'normal'
-    | 'stretch'
-    | ICSSBaselinePositionRule
-    | ICSSOverflowPositionRule
-    | ICSSSelfPositionRule;
+  alignSelf?: ICSSRule | 'auto' | 'normal' | 'stretch' | ICSSBaselinePositionRule | ICSSOverflowAndSelfPositionRule;
 
   /**
    * This property allows precise alignment of elements, such as graphics, that do not
@@ -981,10 +996,15 @@ export interface IRawStyleBase extends IRawFontStyle {
     | 'normal'
     | 'stretch'
     | ICSSBaselinePositionRule
-    | ICSSOverflowPositionRule
-    | ICSSSelfPositionRule
+    | ICSSOverflowAndSelfPositionRule
     | 'left'
-    | 'right';
+    | 'right'
+    // prefixed with <overflow-position> value 'safe'
+    | 'safe left'
+    | 'safe right'
+    // prefixed with <overflow-position> value 'unsafe'
+    | 'unsafe left'
+    | 'unsafe right';
 
   /**
    * Sets the left position of an element relative to the nearest anscestor that is set


### PR DESCRIPTION
Adds missing property values for "align-self" css property.

#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6068
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adds missing property values to 'self-align' per https://www.w3.org/TR/css-align-3/#propdef-align-self

#### Focus areas to test

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6071)

