### PR TITLE
ChoiceGroupOption: use new ms-Fabric--isFocusVisible classname

### DIFF
--- a/common/changes/@uifabric/utilities/choiceGroupIsFocusVisible_2018-08-27-20-39.json
+++ b/common/changes/@uifabric/utilities/choiceGroupIsFocusVisible_2018-08-27-20-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Replace comment reference to old ms-Fabric is-focusVisible with ms-Fabric--isFocusVisible",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "naethell@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/choiceGroupIsFocusVisible_2018-08-27-20-39.json
+++ b/common/changes/office-ui-fabric-react/choiceGroupIsFocusVisible_2018-08-27-20-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: have ChoiceGroupOption style use new ms-Fabric--isFocusVisible class",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -25,7 +25,7 @@ function getChoiceGroupFocusStyle(palette: Partial<IPalette>, hasIconOrImage?: b
     'is-inFocus',
     {
       selectors: {
-        '.ms-Fabric.is-focusVisible &': {
+        '.ms-Fabric--isFocusVisible &': {
           position: 'relative',
           outline: 'transparent',
           selectors: {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -1,4 +1,5 @@
 import { FontSizes, FontWeights, HighContrastSelector, IStyle, IPalette, getGlobalClassNames } from '../../../Styling';
+import { IsFocusVisibleClassName } from '../../../Utilities';
 import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from './ChoiceGroupOption.types';
 
 const GlobalClassNames = {
@@ -25,7 +26,7 @@ function getChoiceGroupFocusStyle(palette: Partial<IPalette>, hasIconOrImage?: b
     'is-inFocus',
     {
       selectors: {
-        '.ms-Fabric--isFocusVisible &': {
+        [`.${IsFocusVisibleClassName} &`]: {
           position: 'relative',
           outline: 'transparent',
           selectors: {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -138,14 +138,14 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       className=
           ms-ChoiceField-wrapper
           is-inFocus
-          .ms-Fabric.is-focusVisible & {
+          .ms-Fabric--isFocusVisible & {
             outline: transparent;
             position: relative;
           }
-          .ms-Fabric.is-focusVisible &::-moz-focus-inner {
+          .ms-Fabric--isFocusVisible &::-moz-focus-inner {
             border: 0px;
           }
-          .ms-Fabric.is-focusVisible &:after {
+          .ms-Fabric--isFocusVisible &:after {
             border: 1px solid #333333;
             bottom: -2px;
             content: "";
@@ -155,7 +155,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          @media screen and (-ms-high-contrast: active){.ms-Fabric.is-focusVisible &:after {
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:after {
             border-color: WindowText;
             border-width: 2px;
           }
@@ -270,14 +270,14 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       className=
           ms-ChoiceField-wrapper
           is-inFocus
-          .ms-Fabric.is-focusVisible & {
+          .ms-Fabric--isFocusVisible & {
             outline: transparent;
             position: relative;
           }
-          .ms-Fabric.is-focusVisible &::-moz-focus-inner {
+          .ms-Fabric--isFocusVisible &::-moz-focus-inner {
             border: 0px;
           }
-          .ms-Fabric.is-focusVisible &:after {
+          .ms-Fabric--isFocusVisible &:after {
             border: 1px solid #333333;
             bottom: -2px;
             content: "";
@@ -287,7 +287,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          @media screen and (-ms-high-contrast: active){.ms-Fabric.is-focusVisible &:after {
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:after {
             border-color: WindowText;
             border-width: 2px;
           }
@@ -856,14 +856,14 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       className=
           ms-ChoiceField-wrapper
           is-inFocus
-          .ms-Fabric.is-focusVisible & {
+          .ms-Fabric--isFocusVisible & {
             outline: transparent;
             position: relative;
           }
-          .ms-Fabric.is-focusVisible &::-moz-focus-inner {
+          .ms-Fabric--isFocusVisible &::-moz-focus-inner {
             border: 0px;
           }
-          .ms-Fabric.is-focusVisible &:after {
+          .ms-Fabric--isFocusVisible &:after {
             border: 1px solid #666666;
             bottom: -2px;
             content: "";
@@ -873,7 +873,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
             right: -2px;
             top: -2px;
           }
-          @media screen and (-ms-high-contrast: active){.ms-Fabric.is-focusVisible &:after {
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:after {
             border-color: WindowText;
             border-width: 1px;
           }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -2,7 +2,7 @@ import { getDividerClassNames } from '../Divider/VerticalDivider.classNames';
 import { getMenuItemStyles, getStyles as getContextualMenuStyles } from './ContextualMenu.cnstyles';
 import { ITheme, mergeStyleSets } from '../../Styling';
 import { IVerticalDividerClassNames } from '../Divider/VerticalDivider.types';
-import { memoizeFunction } from '../../Utilities';
+import { memoizeFunction, IsFocusVisibleClassName } from '../../Utilities';
 
 export interface IContextualMenuClassNames {
   container: string;
@@ -96,8 +96,8 @@ export const getItemClassNames = memoizeFunction(
               selectors: {
                 ':hover': styles.rootHovered,
                 ':active': styles.rootPressed,
-                '.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover': styles.rootFocused,
-                '.ms-Fabric--isFocusVisible &:hover': { background: 'inherit;' }
+                [`.${IsFocusVisibleClassName} &:focus, .${IsFocusVisibleClassName} &:focus:hover`]: styles.rootFocused,
+                [`.${IsFocusVisibleClassName} &:hover`]: { background: 'inherit;' }
               }
             }
           ]
@@ -112,8 +112,8 @@ export const getItemClassNames = memoizeFunction(
               selectors: {
                 ':hover': styles.rootHovered,
                 ':active': styles.rootPressed,
-                '.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover': styles.rootFocused,
-                '.ms-Fabric--isFocusVisible &:hover': { background: 'inherit;' }
+                [`.${IsFocusVisibleClassName} &:focus, .${IsFocusVisibleClassName} &:focus:hover`]: styles.rootFocused,
+                [`.${IsFocusVisibleClassName} &:hover`]: { background: 'inherit;' }
               }
             }
           ]
@@ -131,8 +131,8 @@ export const getItemClassNames = memoizeFunction(
               selectors: {
                 ':hover': styles.rootHovered,
                 ':active': styles.rootPressed,
-                '.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover': styles.rootFocused,
-                '.ms-Fabric--isFocusVisible &:hover': { background: 'inherit;' }
+                [`.${IsFocusVisibleClassName} &:focus, .${IsFocusVisibleClassName} &:focus:hover`]: styles.rootFocused,
+                [`.${IsFocusVisibleClassName} &:hover`]: { background: 'inherit;' }
               }
             }
           ]
@@ -167,7 +167,7 @@ export const getItemClassNames = memoizeFunction(
           !checked && [
             {
               selectors: {
-                '.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover': styles.rootFocused
+                [`.${IsFocusVisibleClassName} &:focus, .${IsFocusVisibleClassName} &:focus:hover`]: styles.rootFocused
               }
             }
           ]

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -9,6 +9,7 @@ import {
   FontSizes,
   FontWeights
 } from '../../Styling';
+import { IsFocusVisibleClassName } from '../../Utilities';
 
 const globalClassNames = {
   count: 'ms-Pivot-count',
@@ -65,7 +66,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
         ':focus': {
           outline: 'none'
         },
-        '.ms-Fabric--isFocusVisible &:focus': {
+        [`.${IsFocusVisibleClassName} &:focus`]: {
           outline: `1px solid ${palette.neutralSecondaryAlt}`
         }
       }
@@ -86,7 +87,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
           ':focus': {
             outlineOffset: '-1px'
           },
-          '.ms-Fabric--isFocusVisible &:focus::before': {
+          [`.${IsFocusVisibleClassName} &:focus::before`]: {
             height: 'auto',
             background: 'transparent',
             transition: 'none'

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -1,4 +1,5 @@
 import { IRawStyle, HighContrastSelector } from '../../Styling';
+import { IsFocusVisibleClassName } from '../../Utilities';
 import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from './ColorPickerGridCell.types';
 
 const ACTIVE_BORDER_COLOR = '#969696';
@@ -37,8 +38,8 @@ export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGr
         height: 40,
         selectors: {
           [HighContrastSelector]: { border: 'none' },
-          '.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after': { border: 'none' },
-          '.ms-Fabric--isFocusVisible &:focus $svg': getSvgSelectorStyles(theme.palette.neutralQuaternaryAlt, false),
+          [`.${IsFocusVisibleClassName} &:focus, .${IsFocusVisibleClassName} &:focus::after`]: { border: 'none' },
+          [`.${IsFocusVisibleClassName} &:focus $svg`]: getSvgSelectorStyles(theme.palette.neutralQuaternaryAlt, false),
           ':hover $svg': getSvgSelectorStyles(theme.palette.neutralQuaternaryAlt, true),
           ':focus $svg': getSvgSelectorStyles(theme.palette.neutralQuaternaryAlt, false),
           ':active $svg': getSvgSelectorStyles(ACTIVE_BORDER_COLOR, false)

--- a/packages/utilities/src/initializeFocusRects.ts
+++ b/packages/utilities/src/initializeFocusRects.ts
@@ -8,7 +8,7 @@ export const IsFocusVisibleClassName = 'ms-Fabric--isFocusVisible';
  *
  * 1. Subscribes keydown and mousedown events. (It will only do it once per window,
  *    so it's safe to call this method multiple times.)
- * 2. When the user presses directional keyboard keys, adds the 'is-focusVisible' classname
+ * 2. When the user presses directional keyboard keys, adds the 'ms-Fabric--isFocusVisible' classname
  *    to the document body.
  * 3. When the user clicks a mouse button, we remove the classname if it exists.
  *


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6080 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes replace the old "ms-Fabric is-focusVisible" classname with the new "ms-Fabric--isFocusVisible" classname (this transition was made in this PR: https://github.com/OfficeDev/office-ui-fabric-react/pull/4628).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6097)

