### PR TITLE
[Commandbar] Fixes the chevron to make it the same size as a menuIcon inside commandbar

### DIFF
--- a/common/changes/office-ui-fabric-react/commandbar_2018-08-27-21-41.json
+++ b/common/changes/office-ui-fabric-react/commandbar_2018-08-27-21-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding a missing passthrough of the menuicon style from base button to split menu icon",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -581,7 +581,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       allowDisabledFocus: allowDisabledFocus,
       onClick: this._onMenuClick,
       menuProps: undefined,
-      iconProps: menuIconProps,
+      iconProps: { ...menuIconProps, className: this._classNames.menuIcon },
       ariaLabel: splitButtonAriaLabel,
       'aria-haspopup': true,
       'aria-expanded': this._isExpanded,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
@@ -464,15 +464,26 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
               aria-hidden={true}
               className=
                   ms-Button-icon
+                  ms-Button-menuIcon
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     color: #333333;
                     display: inline-block;
+                    flex-shrink: 0;
                     font-family: "FabricMDL2Icons";
+                    font-size: 12px;
                     font-style: normal;
                     font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
                     speak: none;
+                    text-align: center;
+                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -286,15 +286,26 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               aria-hidden={true}
               className=
                   ms-Button-icon
+                  ms-Button-menuIcon
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     color: #333333;
                     display: inline-block;
+                    flex-shrink: 0;
                     font-family: "FabricMDL2Icons";
+                    font-size: 12px;
                     font-style: normal;
                     font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
                     speak: none;
+                    text-align: center;
+                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -600,15 +611,26 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               aria-hidden={true}
               className=
                   ms-Button-icon
+                  ms-Button-menuIcon
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     color: #ffffff;
                     display: inline-block;
+                    flex-shrink: 0;
                     font-family: "FabricMDL2Icons";
+                    font-size: 12px;
                     font-style: normal;
                     font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
                     speak: none;
+                    text-align: center;
+                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -907,15 +929,26 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               aria-hidden={true}
               className=
                   ms-Button-icon
+                  ms-Button-menuIcon
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     color: #ffffff;
                     display: inline-block;
+                    flex-shrink: 0;
                     font-family: "FabricMDL2Icons";
+                    font-size: 12px;
                     font-style: normal;
                     font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
                     speak: none;
+                    text-align: center;
+                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -1215,15 +1248,26 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               aria-hidden={true}
               className=
                   ms-Button-icon
+                  ms-Button-menuIcon
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     color: #a6a6a6;
                     display: inline-block;
+                    flex-shrink: 0;
                     font-family: "FabricMDL2Icons";
+                    font-size: 12px;
                     font-style: normal;
                     font-weight: normal;
+                    height: 16px;
+                    line-height: 16px;
+                    margin-bottom: 0;
+                    margin-left: 4px;
+                    margin-right: 4px;
+                    margin-top: 0;
                     speak: none;
+                    text-align: center;
+                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -1520,15 +1564,25 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
             aria-hidden={true}
             className=
                 ms-Button-icon
+                ms-Button-menuIcon
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   display: inline-block;
+                  flex-shrink: 0;
                   font-family: "FabricMDL2Icons";
                   font-size: 7px;
                   font-style: normal;
                   font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
                   speak: none;
+                  text-align: center;
+                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -717,15 +717,26 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 aria-hidden={true}
                 className=
                     ms-Button-icon
+                    ms-Button-menuIcon
                     {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
                       color: #333333;
                       display: inline-block;
+                      flex-shrink: 0;
                       font-family: "FabricMDL2Icons";
+                      font-size: 12px;
                       font-style: normal;
                       font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
                       speak: none;
+                      text-align: center;
+                      vertical-align: middle;
                     }
                 data-icon-name="ChevronDown"
                 role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -657,15 +657,26 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
             aria-hidden={true}
             className=
                 ms-Button-icon
+                ms-Button-menuIcon
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #333333;
                   display: inline-block;
+                  flex-shrink: 0;
                   font-family: "FabricMDL2Icons";
+                  font-size: 12px;
                   font-style: normal;
                   font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
                   speak: none;
+                  text-align: center;
+                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6018
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes the chevron to make it the same size as a menuIcon inside commandbar

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6098)

