### PR TITLE
Form: Adding TagPicker as an input component.

### DIFF
--- a/common/changes/@uifabric/experiments/master_2018-08-27-21-39.json
+++ b/common/changes/@uifabric/experiments/master_2018-08-27-21-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "TagPicker added as a Form input component.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "nerios@microsoft.com"
+}

--- a/packages/experiments/src/components/Form/inputs/tagPicker/FormTagPicker.test.tsx
+++ b/packages/experiments/src/components/Form/inputs/tagPicker/FormTagPicker.test.tsx
@@ -1,0 +1,136 @@
+/* tslint:disable:no-any jsx-no-lambda no-string-literal */
+
+import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
+import * as sinon from 'sinon';
+
+import { Form } from '../../Form';
+import { DEFAULT_DEBOUNCE } from '../../FormBaseInput';
+import { FormTagPicker } from './FormTagPicker';
+import { ITag } from 'office-ui-fabric-react/lib/components/pickers/TagPicker/TagPicker';
+
+describe('FormTagPicker Unit Tests', () => {
+  describe('Renders for all combinations of props', () => {
+    let renderedForm: Form;
+    let renderedInput: HTMLElement;
+
+    beforeEach(() => {
+      (renderedForm as any) = undefined;
+      (renderedInput as any) = undefined;
+    });
+
+    afterEach(() => {
+      expect(renderedForm).toBeTruthy();
+      expect(renderedInput).toBeTruthy();
+    });
+
+    it('Null name throws error', () => {
+      const consoleMock = jest.spyOn(console, 'error');
+      consoleMock.mockImplementation(() => undefined);
+
+      const errorFunction = () => {
+        ReactTestUtils.renderIntoDocument(
+          <Form onSubmit={undefined}>
+            <FormTagPicker
+              inputKey={null as any}
+              value={undefined}
+              tagPickerProps={{ onResolveSuggestions: () => [] }}
+            />
+          </Form>
+        );
+      };
+
+      expect(errorFunction).toThrow();
+      expect(console.error).toHaveBeenCalledTimes(2);
+      expect((consoleMock as jest.MockInstance<{}>).mock.calls[0][0]).toMatch(
+        'Uncaught [Error: FormBaseInput: name must defined on all form inputs]'
+      );
+
+      consoleMock.mockRestore();
+
+      (renderedForm as any) = {};
+      (renderedInput as any) = {};
+    });
+
+    it('Null props still render', () => {
+      renderedForm = ReactTestUtils.renderIntoDocument(
+        <Form onSubmit={undefined}>
+          <FormTagPicker inputKey="tag" value={undefined} tagPickerProps={{ onResolveSuggestions: () => [] }} />
+        </Form>
+      ) as Form;
+
+      renderedInput = ReactTestUtils.findRenderedDOMComponentWithClass(renderedForm, 'ms-BasePicker') as HTMLElement;
+    });
+
+    it('With initial value', () => {
+      let result: any;
+
+      const option1: ITag = { key: '1', name: 'Tag 1' };
+      const option2: ITag = { key: '2', name: 'Tag 2' };
+
+      renderedForm = ReactTestUtils.renderIntoDocument(
+        <Form
+          onSubmit={(value: any) => {
+            result = value;
+          }}
+        >
+          <FormTagPicker
+            inputKey="tag"
+            tagPickerProps={{ onResolveSuggestions: () => [option1, option2] }}
+            value={[option2]}
+          />
+        </Form>
+      ) as Form;
+
+      renderedInput = ReactTestUtils.findRenderedDOMComponentWithClass(renderedForm, 'ms-BasePicker') as HTMLElement;
+      const form: HTMLFormElement = ReactTestUtils.findRenderedDOMComponentWithTag(
+        renderedForm,
+        'form'
+      ) as HTMLFormElement;
+      ReactTestUtils.Simulate.submit(form);
+
+      expect(result['tag']).toEqual([option2]);
+    });
+  });
+
+  describe('TagPicker update tests', () => {
+    class ExtendsTagPicker extends FormTagPicker {
+      public setValue(value: Array<ITag>): void {
+        super.setValue(value);
+      }
+    }
+
+    let clock: sinon.SinonFakeTimers;
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(Date.now());
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('TagPicker is leading and trailing debounced', () => {
+      const option1: ITag = { key: '1', name: 'Tag 1' };
+      const option2: ITag = { key: '2', name: 'Tag 2' };
+
+      const updateStub: sinon.SinonStub = sinon.stub();
+      const renderedForm = ReactTestUtils.renderIntoDocument(
+        <Form onUpdated={updateStub}>
+          <ExtendsTagPicker
+            inputKey="tag"
+            value={[option1]}
+            tagPickerProps={{ onResolveSuggestions: () => [option1, option2] }}
+          />
+        </Form>
+      ) as Form;
+
+      const datePicker: ExtendsTagPicker = ReactTestUtils.findRenderedComponentWithType(renderedForm, ExtendsTagPicker);
+      datePicker.setValue([option2]);
+      expect(updateStub.callCount).toEqual(1);
+      datePicker.setValue([option1, option2]);
+      expect(updateStub.callCount).toEqual(1);
+      clock.tick(DEFAULT_DEBOUNCE);
+      expect(updateStub.callCount).toEqual(2);
+    });
+  });
+});

--- a/packages/experiments/src/components/Form/inputs/tagPicker/FormTagPicker.tsx
+++ b/packages/experiments/src/components/Form/inputs/tagPicker/FormTagPicker.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+// Components
+import { IFormTagPickerProps } from './FormTagPicker.types';
+import { TagPicker, ITag, ITagPickerProps } from 'office-ui-fabric-react/lib/components/pickers/TagPicker/TagPicker';
+import { FormBaseInput, IFormBaseInputState } from '../../FormBaseInput';
+import { IFormContext } from '../../Form';
+
+/**
+ * TagPicker input for Form
+ */
+export class FormTagPicker extends FormBaseInput<Array<ITag>, IFormTagPickerProps, IFormBaseInputState<Array<ITag>>> {
+  constructor(props: IFormTagPickerProps, context: IFormContext) {
+    super(props, context);
+
+    this.state = {
+      isValid: true,
+      currentValue: props.value,
+      currentError: undefined
+    };
+
+    this._validateTagPickerProps(this.props.tagPickerProps);
+  }
+
+  /**
+   * Render a Fabric TagPicker
+   */
+  public render(): JSX.Element {
+    const { currentValue } = this.state;
+
+    return (
+      <TagPicker
+        {...this.props.tagPickerProps}
+        // These props cannot be overridden
+        key={this.props.inputKey}
+        onChange={this._onChange}
+        selectedItems={currentValue}
+      />
+    );
+  }
+
+  private _onChange = (items: ITag[]): void => {
+    this.setValue(items);
+  };
+
+  private _validateTagPickerProps(props?: ITagPickerProps): void {
+    if (!props) {
+      return;
+    }
+
+    if (props.selectedItems !== null && props.selectedItems !== undefined) {
+      console.warn(`FormTagPicker: 'selectedItems' prop was specified and will be ignored`);
+    }
+
+    if (props.onChange) {
+      console.warn(`FormTagPicker: 'onChange' prop was specified and will be ignored`);
+    }
+  }
+}

--- a/packages/experiments/src/components/Form/inputs/tagPicker/FormTagPicker.types.ts
+++ b/packages/experiments/src/components/Form/inputs/tagPicker/FormTagPicker.types.ts
@@ -1,0 +1,8 @@
+import { ITagPickerProps, ITag } from 'office-ui-fabric-react/lib/components/pickers/TagPicker/TagPicker';
+import { IFormBaseInputProps } from '../../FormBaseInput';
+export { ITagPickerProps };
+
+export interface IFormTagPickerProps extends IFormBaseInputProps<Array<ITag>> {
+  /** Props for the TagPicker component */
+  tagPickerProps: ITagPickerProps;
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adding TagPicker as a new Form input component.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6099)

