### PR TITLE
Fix handling of status indicators on icon-only DetailsList column headers

### DIFF
--- a/common/changes/office-ui-fabric-react/details-header-icon_2018-08-28-15-42.json
+++ b/common/changes/office-ui-fabric-react/details-header-icon_2018-08-28-15-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix status indicators on icon-only column headers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -147,7 +147,14 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
         alignItems: 'stretch',
         boxSizing: 'border-box',
         overflow: 'hidden',
-        padding: `0 ${cellStyleProps.cellRightPadding}px 0 ${cellStyleProps.cellLeftPadding}px`
+        padding: `0 ${cellStyleProps.cellRightPadding}px 0 ${cellStyleProps.cellLeftPadding}px`,
+        ...(isIconOnly
+          ? {
+              alignContent: 'flex-end',
+              maxHeight: '100%',
+              flexWrap: 'wrap-reverse'
+            }
+          : {})
       }
     ],
 


### PR DESCRIPTION
# Overview

This change fixes a visual issue when there is not enough space horizontal space to show the icon for a column header and its status indicators. This usually happens when filtering or sorting an 'icon only' header.  In such a case, the proper thing to do is to hide the main icon completely, showing only the status indicator. This can be accomplished using the `wrap-reverse` flex behavior, which causes the status indicator to push off the preceding elements onto a newline, which can then be hidden.