### PR TITLE
Update Codepen code gen to handle multiple exports

### DIFF
--- a/scripts/tasks/build-codepen-examples.js
+++ b/scripts/tasks/build-codepen-examples.js
@@ -1,10 +1,9 @@
-module.exports = function(filter) {
+module.exports = function() {
   const path = require('path');
   const transformer = require('./codepen-examples-transform');
   const glob = require('glob');
-  const files = glob
-    .sync(path.resolve(__dirname, '../../packages/*/src/components/**/examples/*Example*.tsx'))
-    .filter(name => (filter ? name.indexOf(filter) > -1 : name));
+  const files = glob.sync(path.resolve(__dirname, '../../packages/*/src/components/**/examples/*Example*.tsx'));
+
   const jscodeshift = require('jscodeshift');
   const fs = require('fs');
   const async = require('async');
@@ -48,10 +47,6 @@ module.exports = function(filter) {
 };
 
 // This is run as a CLI when we do 'npm start' - otherwise, it is simply a module to be run by build.js as a task
-//
-// You can also test out a transform by running ./scripts/build-codepen-examples.js Chedckbox
-// This will run the CLI tool in a one off basis on the examples that match a certain pattern
 if (require.main == module) {
-  const args = process.argv.slice(2);
-  module.exports(args ? args[0] : null);
+  module.exports();
 }

--- a/scripts/tasks/build-codepen-examples.js
+++ b/scripts/tasks/build-codepen-examples.js
@@ -1,8 +1,10 @@
-module.exports = function() {
+module.exports = function(filter) {
   const path = require('path');
   const transformer = require('./codepen-examples-transform');
   const glob = require('glob');
-  const files = glob.sync(path.resolve(__dirname, '../../packages/*/src/components/**/examples/*Example*.tsx'));
+  const files = glob
+    .sync(path.resolve(__dirname, '../../packages/*/src/components/**/examples/*Example*.tsx'))
+    .filter(name => (filter ? name.indexOf(filter) > -1 : name));
   const jscodeshift = require('jscodeshift');
   const fs = require('fs');
   const async = require('async');
@@ -46,6 +48,10 @@ module.exports = function() {
 };
 
 // This is run as a CLI when we do 'npm start' - otherwise, it is simply a module to be run by build.js as a task
+//
+// You can also test out a transform by running ./scripts/build-codepen-examples.js Chedckbox
+// This will run the CLI tool in a one off basis on the examples that match a certain pattern
 if (require.main == module) {
-  module.exports();
+  const args = process.argv.slice(2);
+  module.exports(args ? args[0] : null);
 }

--- a/scripts/tests/__snapshots__/codepen-transform.test.js.snap
+++ b/scripts/tests/__snapshots__/codepen-transform.test.js.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Codepen Transform correctly transforms code examples with class exports 1`] = `
-"let {
-	TextField,
-	MaskedTextField,
-	Fabric } = window.Fabric;
+"let { TextField, MaskedTextField, Fabric } = window.Fabric;
 
 class TextFieldBasicExample extends React.Component<any, any> {
   public render(): JSX.Element {
@@ -21,21 +18,13 @@ class TextFieldBasicExample extends React.Component<any, any> {
   }
 }
 
-ReactDOM.render(<TextFieldBasicExample/>,document.getElementById(\\"content\\"));"
+ReactDOM.render(<TextFieldBasicExample />, document.getElementById('content'));
+"
 `;
 
 exports[`Codepen Transform correctly transforms code examples with variable exports 1`] = `
-"let {
-	Label,
-	Fabric } = window.Fabric;
+"let { Label, Fabric } = window.Fabric;
 
-const LabelBasicExample = () => (
-  <div>
-    <Label>I'm a Label</Label>
-    <Label disabled={true}>I'm a disabled Label</Label>
-    <Label required={true}>I'm a required Label</Label>
-  </div>
-);
-
-ReactDOM.render(<LabelBasicExample/>,document.getElementById(\\"content\\"));"
+ReactDOM.render(<LabelBasicExample />, document.getElementById('content'));
+"
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6103

#### Description of changes

Update Codepen code gen to handle multiple exports:
- we now also run our example codegen through prettier 👍 
- get rid  extra forEach to do replace

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6123)

