### PR TITLE
add onBlur prop on Slider (#6108)

### DIFF
--- a/common/changes/office-ui-fabric-react/slider-onBlur_2018-08-29-14-33.json
+++ b/common/changes/office-ui-fabric-react/slider-onBlur_2018-08-29-14-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add onBlur on Slider",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "blandine.descamps@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -252,11 +252,15 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
     );
   }
 
-  private _onMouseUpOrTouchEnd = (): void => {
+  private _onMouseUpOrTouchEnd = (event: MouseEvent | TouchEvent): void => {
     // Synchronize the renderedValue to the actual value.
     this.setState({
       renderedValue: this.state.value
     });
+
+    if (this.props.onChanged) {
+      this.props.onChanged(event, this.state.value as number);
+    }
 
     this._events.off();
   };

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
@@ -73,6 +73,11 @@ export interface ISliderProps extends React.Props<SliderBase> {
   onChange?: (value: number) => void;
 
   /**
+   * Callback on mouse up or touch end
+   */
+  onChanged?: (event: MouseEvent | TouchEvent, value: number) => void;
+
+  /**
    * A description of the Slider for the benefit of screen readers.
    */
   ariaLabel?: string;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6108 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In Slider component, there is a new prop 'onBlur' which is called on mouseUp or touchEnd

#### Focus areas to test
I tried to add test in the .spec file but I don't know how to simulate the mouseUp event since it's a listener on the window object. I'm open to suggestions :)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6127)

