### PR TITLE
Dropdown margin

### DIFF
--- a/common/changes/office-ui-fabric-react/DropdownMargin_2018-08-29-17-40.json
+++ b/common/changes/office-ui-fabric-react/DropdownMargin_2018-08-29-17-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove unnecessary margin on dropdown",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "savannahkbourgeois@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -298,6 +298,6 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         textAlign: 'left'
       }
     ],
-    subComponentStyles: { label: { root: { display: 'inline-block', marginBottom: 8 } } }
+    subComponentStyles: { label: { root: { display: 'inline-block' } } }
   };
 };

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -21,7 +21,7 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
               box-sizing: border-box;
               color: #333333;
               display: inline-block;
-              margin-bottom: 8px;
+              margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -655,7 +655,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
               box-sizing: border-box;
               color: #333333;
               display: inline-block;
-              margin-bottom: 8px;
+              margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -25,7 +25,7 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
               box-sizing: border-box;
               color: #333333;
               display: inline-block;
-              margin-bottom: 8px;
+              margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -185,7 +185,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
               box-sizing: border-box;
               color: #333333;
               display: inline-block;
-              margin-bottom: 8px;
+              margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -184,7 +184,7 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -184,7 +184,7 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -18,7 +18,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
@@ -351,7 +351,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
@@ -555,7 +555,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
@@ -764,7 +764,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
@@ -970,7 +970,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
@@ -1179,7 +1179,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -18,7 +18,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -18,7 +18,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             box-sizing: border-box;
             color: #333333;
             display: inline-block;
-            margin-bottom: 8px;
+            margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -731,7 +731,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               box-sizing: border-box;
               color: #333333;
               display: inline-block;
-              margin-bottom: 8px;
+              margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -941,7 +941,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               box-sizing: border-box;
               color: #333333;
               display: inline-block;
-              margin-bottom: 8px;
+              margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -81,7 +81,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
               box-sizing: border-box;
               color: #333333;
               display: inline-block;
-              margin-bottom: 8px;
+              margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3615,7 +3615,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 box-sizing: border-box;
                 color: #333333;
                 display: inline-block;
-                margin-bottom: 8px;
+                margin-bottom: 0px;
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6082
- [x] Include a change request file using `$ npm run change`

#### Description of changes
There was an extra 8px margin between the dropdown label and container. This caused the dropdown container to be lower than a textfield with a label so they did not properly align. This change removes the bottom 8px from the dropdown and design has approved removing this.

#### Focus areas to test
Verify the dropdown examples look as expected.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6133)

Below are some before and after screenshots of the dropdown and label. I added the codepen example included in the bug locally to verify the change which you can see at the bottom of each screenshot.
Before:
![dropdownbottommarginbefore](https://user-images.githubusercontent.com/42548121/44807269-f71dff00-ab7d-11e8-8390-49bde40f12b8.JPG)
After:
![dropdownafter](https://user-images.githubusercontent.com/42548121/44807274-fa18ef80-ab7d-11e8-93f2-ffe6eb7e5538.JPG)
