### PR TITLE
Allow MaskedTextField to backspace to the beginning when the mask is all numbers

### DIFF
--- a/common/changes/office-ui-fabric-react/mask_2018-08-29-18-34.json
+++ b/common/changes/office-ui-fabric-react/mask_2018-08-29-18-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow MaskedTextField to backspace to the beginning when the mask is all numbers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -106,7 +106,7 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
 
   public componentDidUpdate() {
     // Move the cursor to the start of the mask format on update
-    if (this.state.maskCursorPosition) {
+    if (this.state.maskCursorPosition !== undefined) {
       this._textField.setSelectionRange(this.state.maskCursorPosition, this.state.maskCursorPosition);
     }
   }

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/inputMask.test.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/inputMask.test.ts
@@ -165,8 +165,8 @@ describe('inputMask', () => {
       { value: '3', format: /[0-9]/, displayIndex: 2 }
     ];
 
-    const result = insertString(maskedValues, 2, '1');
+    const result = insertString(maskedValues, 3, '1');
 
-    expect(result).toEqual(2);
+    expect(result).toEqual(3);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/inputMask.test.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/inputMask.test.ts
@@ -157,4 +157,16 @@ describe('inputMask', () => {
     expect(values[7].value).toEqual('8');
     expect(result).toEqual(33);
   });
+
+  it('insertString will keep index at the end even if the value is entered passed the end', () => {
+    const maskedValues = [
+      { value: '1', format: /[0-9]/, displayIndex: 0 },
+      { value: '2', format: /[0-9]/, displayIndex: 1 },
+      { value: '3', format: /[0-9]/, displayIndex: 2 }
+    ];
+
+    const result = insertString(maskedValues, 2, '1');
+
+    expect(result).toEqual(2);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/inputMask.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/inputMask.ts
@@ -220,11 +220,14 @@ export function clearPrev(maskCharData: IMaskValue[], selectionStart: number): I
  * @return The displayIndex of the next format character
  */
 export function insertString(maskCharData: IMaskValue[], selectionStart: number, newString: string): number {
-  let stringIndex = 0,
-    nextIndex = 0;
+  let stringIndex = 0;
+  let nextIndex = 0;
+  let isStringInserted = false;
+
   // Iterate through _maskCharData finding values with a displayIndex after the specified range start
   for (let i = 0; i < maskCharData.length && stringIndex < newString.length; i++) {
     if (maskCharData[i].displayIndex >= selectionStart) {
+      isStringInserted = true;
       nextIndex = maskCharData[i].displayIndex;
       // Find the next character in the newString that matches the format
       while (stringIndex < newString.length) {
@@ -243,5 +246,6 @@ export function insertString(maskCharData: IMaskValue[], selectionStart: number,
       }
     }
   }
-  return nextIndex;
+
+  return isStringInserted ? nextIndex : selectionStart;
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Basic.Example.tsx
@@ -12,6 +12,7 @@ export class TextFieldBasicExample extends React.Component<any, any> {
         <TextField label="Read Only" readOnly={true} />
         <TextField label="Required " required={true} />
         <TextField label="With error message" errorMessage="Error message" />
+        <MaskedTextField label="With number mask" mask="99999" />
         <MaskedTextField label="With input mask" mask="m\ask: (999) 999 - 9999" />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -736,7 +736,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
         htmlFor="TextField10"
         required={undefined}
       >
-        With input mask
+        With number mask
       </label>
       <div
         className=
@@ -810,6 +810,142 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 opacity: 1;
               }
           id="TextField10"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onPaste={[Function]}
+          readOnly={undefined}
+          type="text"
+          value="_____"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-TextField
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border-width: 2px;
+        }
+  >
+    <div
+      className=
+          ms-TextField-wrapper
+
+    >
+      <label
+        className=
+            ms-Label
+            {
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        htmlFor="TextField12"
+        required={undefined}
+      >
+        With input mask
+      </label>
+      <div
+        className=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border: 1px solid #a6a6a6;
+              box-shadow: none;
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              height: 32px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            &:hover {
+              border-color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
+      >
+        <input
+          aria-describedby={undefined}
+          aria-invalid={false}
+          aria-label={undefined}
+          className=
+              ms-TextField-field
+              {
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 0px;
+                outline: 0px;
+                padding-bottom: 0;
+                padding-left: 12px;
+                padding-right: 12px;
+                padding-top: 0;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              &::placeholder {
+                color: #666666;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #666666;
+                opacity: 1;
+              }
+          id="TextField12"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6092
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Allow MaskedTextField to backspace to the beginning when the mask is all numbers:
- also added a check for when the "insertString" function to account for when things are entered past the end
- let selection change even when the value is "0" 
- added a test for insertString checks

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6135)

