### PR TITLE
Made Datepicker not overflow when showGotoToday is false & showMonthAsOverlay is true

### DIFF
--- a/apps/vr-tests/src/stories/DatePicker.stories.tsx
+++ b/apps/vr-tests/src/stories/DatePicker.stories.tsx
@@ -10,7 +10,7 @@ storiesOf('DatePicker', module)
   .addDecorator(FabricDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
-      steps={ new Screener.Steps()
+      steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
         .hover('.ms-DatePicker')
         .snapshot('hover datepicker', { cropTo: '.testWrapper' })
@@ -21,15 +21,12 @@ storiesOf('DatePicker', module)
         .snapshot('hover day', { cropTo: '.ms-Layer' })
         .hover('.ms-DatePicker-monthOption')
         .snapshot('hover month', { cropTo: '.ms-Layer' })
-        .end()
-      }
+        .end()}
     >
-      { story() }
+      {story()}
     </Screener>
   ))
-  .add('Root', () => (
-    <DatePicker
-      value={ date }
-    />
-  ))
-  ;
+  .add('Root', () => <DatePicker value={date} />)
+  .add('Show Month as Overlay and no Go To Today', () => (
+    <DatePicker value={date} showGoToToday={false} showMonthPickerAsOverlay={true} />
+  ));

--- a/apps/vr-tests/src/stories/DatePicker.stories.tsx
+++ b/apps/vr-tests/src/stories/DatePicker.stories.tsx
@@ -26,7 +26,26 @@ storiesOf('DatePicker', module)
       {story()}
     </Screener>
   ))
-  .add('Root', () => <DatePicker value={date} />)
+  .add('Root', () => <DatePicker value={date} />);
+
+storiesOf('DatePicker - No Month Option', module)
+  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('.ms-DatePicker')
+        .snapshot('hover datepicker', { cropTo: '.testWrapper' })
+        .click('.ms-DatePicker')
+        .hover('.ms-DatePicker')
+        .snapshot('click', { cropTo: '.ms-Layer' })
+        .hover('.ms-DatePicker-day')
+        .snapshot('hover day', { cropTo: '.ms-Layer' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
   .add('Show Month as Overlay and no Go To Today', () => (
     <DatePicker value={date} showGoToToday={false} showMonthPickerAsOverlay={true} />
   ));

--- a/common/changes/office-ui-fabric-react/datepicker_2018-08-29-21-34.json
+++ b/common/changes/office-ui-fabric-react/datepicker_2018-08-29-21-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add overflow hidden to hide scroll from calendar holder",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
@@ -201,6 +201,20 @@ export const CalendarPageProps: IDocPageProps = {
           buttonString={'Click for Overlayed Day Picker and Month Picker'}
         />
       )
+    },
+    {
+      title: 'Calendar with overlayed month picker launched from a button without show go to today button',
+      code: CalendarButtonExampleCode,
+
+      view: (
+        <CalendarButtonExample
+          showMonthPickerAsOverlay={true}
+          showGoToToday={false}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          buttonString={'Click for Overlayed Day Picker and Month Picker without go to today button'}
+        />
+      )
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -4,7 +4,7 @@
 // Office UI Fabric
 // --------------------------------------------------
 // Calendar styles
-$Calendar-day:28px;
+$Calendar-day: 28px;
 $Calendar-dayPicker-margin: 10px;
 .root {
   @include ms-normalize;
@@ -88,7 +88,8 @@ $Calendar-dayPicker-margin: 10px;
   padding: 0 5px;
 }
 
-.monthAndYear:hover, .currentYear:hover {
+.monthAndYear:hover,
+.currentYear:hover {
   color: $ms-color-black;
 }
 
@@ -143,7 +144,8 @@ $Calendar-dayPicker-margin: 10px;
 }
 
 // Today.
-.dayIsToday, .dayIsToday:hover {
+.dayIsToday,
+.dayIsToday:hover {
   position: relative;
   background-color: $ms-color-themeLight;
   @include high-contrast {
@@ -199,17 +201,21 @@ $Calendar-dayPicker-margin: 10px;
 }
 
 // Highlighted date squares
-.dayBackground, .dayBackground:hover, .dayBackground:active {
+.dayBackground,
+.dayBackground:hover,
+.dayBackground:active {
   border-radius: 2px;
 }
 
-.dayHover, .dayHover:hover {
+.dayHover,
+.dayHover:hover {
   cursor: pointer;
   background: $ms-color-neutralLight;
   color: $ms-color-neutralDark;
 }
 
-.dayPress, .dayPress:hover {
+.dayPress,
+.dayPress:hover {
   cursor: pointer;
   font-weight: $ms-font-weight-semibold;
   background: $ms-color-themeLight;
@@ -221,16 +227,22 @@ $Calendar-dayPicker-margin: 10px;
 
 .dayIsUnfocused:active,
 .dayIsFocused:active,
-.dayIsHighlighted, .dayIsHighlighted:hover, .dayIsHighlighted:active,
-.weekBackground, .weekBackground:hover, .weekBackground:active {
+.dayIsHighlighted,
+.dayIsHighlighted:hover,
+.dayIsHighlighted:active,
+.weekBackground,
+.weekBackground:hover,
+.weekBackground:active {
   background: $ms-color-themeLight;
   color: $ms-color-neutralPrimary;
   font-weight: $ms-font-weight-semibold;
 }
 
 // Today.
-.dayIsToday, .dayIsToday,
-.pickerIsFocused .dayIsToday, .dayIsToday.day:active {
+.dayIsToday,
+.dayIsToday,
+.pickerIsFocused .dayIsToday,
+.dayIsToday.day:active {
   position: relative;
   color: $ms-color-white;
   font-weight: $ms-font-weight-semibold;
@@ -485,6 +497,7 @@ $Calendar-dayPicker-margin: 10px;
   .holder {
     display: inline-block;
     height: auto;
+    overflow: hidden;
   }
   .monthAndYear,
   .year {
@@ -555,7 +568,7 @@ $Calendar-dayPicker-margin: 10px;
       &:hover {
         outline: 1px solid transparent;
       }
-      &:nth-child(4n+4) {
+      &:nth-child(4n + 4) {
         @include margin(0, 0px, 16px, 0);
       }
     } // Position the "Go to today" button below the month picker.
@@ -624,8 +637,8 @@ $Calendar-dayPicker-margin: 10px;
       min-height: 240px;
     }
 
-    .holderWithButton{
-      padding-top:6px;
+    .holderWithButton {
+      padding-top: 6px;
       height: auto;
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -42,6 +42,7 @@ export interface ICalendarButtonExampleProps {
   highlightSelectedMonth?: boolean;
   buttonString?: string;
   showMonthPickerAsOverlay?: boolean;
+  showGoToToday?: boolean;
 }
 
 export class CalendarButtonExample extends React.Component<ICalendarButtonExampleProps, ICalendarButtonExampleState> {
@@ -49,6 +50,7 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
     showMonthPickerAsOverlay: false,
     isDayPickerVisible: true,
     isMonthPickerVisible: true,
+    showGoToToday: true,
     buttonString: 'Click for Calendar'
   };
 
@@ -99,6 +101,7 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
                 highlightCurrentMonth={this.props.highlightCurrentMonth}
                 highlightSelectedMonth={this.props.highlightSelectedMonth}
                 showMonthPickerAsOverlay={this.props.showMonthPickerAsOverlay}
+                showGoToToday={this.props.showGoToToday}
               />
             </FocusTrapZone>
           </Callout>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6131
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Made Datepicker not overflow when showGotoToday is false & showMonthAsOverlay is true

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6139)

