### PR TITLE
Add the ability to disable the built-in SelectionZone in DetailsList

### DIFF
--- a/common/changes/office-ui-fabric-react/details-selection_2018-08-29-21-46.json
+++ b/common/changes/office-ui-fabric-react/details-selection_2018-08-29-21-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add the ability to disable the built-in SelectionMode in DetailsList",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -285,6 +285,11 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    * handled separately from normal theme styling, but they are passed to the styling system.
    */
   cellStyleProps?: ICellStyleProps;
+
+  /**
+   * Whether or not to disable the built-in SelectionZone, so the host component can provide its own.
+   */
+  disableSelectionZone?: boolean;
 }
 
 export interface IColumn {


### PR DESCRIPTION
# Overview

`DetailsList` provides its own `SelectionZone`, which has an unfortunate effect of making it difficult to have `DetailsList` share the selection with other components on a page. This change provides a `disableSelectionZone` prop which makes the caller completely responsible for `SelectionZone` management. The `DetailsList` components still react to selection, but don't attempt to control it.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6140)

