### PR TITLE
ComboBox: Update ComboBox to allow for empty string to be submitted

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxEmptyStringFix_2018-08-29-22-13.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxEmptyStringFix_2018-08-29-22-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Update ComboBox to allow for empty string to be submitted",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -235,6 +235,156 @@ describe('ComboBox', () => {
     expect(wrapper.find('input').props().value).toEqual('One');
   });
 
+  it('Can insert an empty string in uncontrolled case with autoComplete and allowFreeform on', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS2}
+        autoComplete="on"
+        allowFreeform={true}
+      />
+    );
+    (wrapper.find('input').instance() as any).value = '';
+    wrapper.find('input').simulate('input', { target: { value: '' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('');
+  });
+
+  it('Cannot insert an empty string in uncontrolled case with autoComplete on and allowFreeform off', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS2}
+        autoComplete="on"
+        allowFreeform={false}
+      />
+    );
+
+    (wrapper.find('input').instance() as any).value = '';
+    wrapper.find('input').simulate('input', { target: { value: '' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
+  it('Can insert an empty string in uncontrolled case with autoComplete off and allowFreeform on', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS2}
+        autoComplete="off"
+        allowFreeform={true}
+      />
+    );
+    (wrapper.find('input').instance() as any).value = '';
+    wrapper.find('input').simulate('input', { target: { value: '' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('');
+  });
+
+  it('Cannot insert an empty string in uncontrolled case with autoComplete and allowFreeform off', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS2}
+        autoComplete="off"
+        allowFreeform={false}
+      />
+    );
+    (wrapper.find('input').instance() as any).value = '';
+    wrapper.find('input').simulate('input', { target: { value: '' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
+  // jeremy
+
+  it('Can insert an empty string after removing a pending value in uncontrolled case with autoComplete and allowFreeform on', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS2}
+        autoComplete="on"
+        allowFreeform={true}
+      />
+    );
+
+    (wrapper.find('input').instance() as any).value = 'f';
+    wrapper.find('input').simulate('input', { target: { value: 'f' } });
+    (wrapper.find('input').instance() as any).value = '';
+    wrapper.find('input').simulate('input', { target: { value: '' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('');
+  });
+
+  it('Cannot insert an empty string after removing a pending value in uncontrolled case with autoComplete on and allowFreeform off', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS2}
+        autoComplete="on"
+        allowFreeform={false}
+      />
+    );
+
+    (wrapper.find('input').instance() as any).value = 'f';
+    wrapper.find('input').simulate('input', { target: { value: 'f' } });
+    (wrapper.find('input').instance() as any).value = '';
+    wrapper.find('input').simulate('input', { target: { value: '' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Foo');
+  });
+
+  it('Can insert an empty string after removing a pending value in uncontrolled case with autoComplete off and allowFreeform on', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS2}
+        autoComplete="off"
+        allowFreeform={true}
+      />
+    );
+
+    (wrapper.find('input').instance() as any).value = 'f';
+    wrapper.find('input').simulate('input', { target: { value: 'f' } });
+    (wrapper.find('input').instance() as any).value = '';
+    wrapper.find('input').simulate('input', { target: { value: '' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('');
+  });
+
+  it('Cannot insert an empty string after removing a pending value in uncontrolled case with autoComplete and allowFreeform off', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS2}
+        autoComplete="off"
+        allowFreeform={false}
+      />
+    );
+    (wrapper.find('input').instance() as any).value = 'f';
+    wrapper.find('input').simulate('input', { target: { value: 'f' } });
+    (wrapper.find('input').instance() as any).value = '';
+    wrapper.find('input').simulate('input', { target: { value: '' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('One');
+  });
+
   it('Can change selected option with keyboard', () => {
     const wrapper = mount(<ComboBox label="testgroup" defaultSelectedKey="1" options={DEFAULT_OPTIONS2} />);
     wrapper.find('input').simulate('keydown', { which: KeyCodes.down });

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -640,11 +640,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   private _processInputChangeWithFreeform(updatedValue: string): void {
     const { currentOptions } = this.state;
     updatedValue = this._removeZeroWidthSpaces(updatedValue);
+    let newCurrentPendingValueValidIndex = -1;
 
     // if the new value is empty, see if we have an exact match
     // and then set the pending info
     if (updatedValue === '') {
-      let newCurrentPendingValueValidIndex = -1;
       const items = currentOptions
         .map((item, index) => {
           return { ...item, index };
@@ -671,7 +671,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     updatedValue = updatedValue.toLocaleLowerCase();
 
     let newSuggestedDisplayValue = '';
-    let newCurrentPendingValueValidIndex = -1;
 
     // If autoComplete is on, attempt to find a match from the available options
     if (this.props.autoComplete === 'on') {
@@ -1009,7 +1008,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     if (allowFreeform) {
       // if currentPendingValue is null or undefined the user did not submit anything
       // (not even empty because we would have stored that as the pending value)
-      if (currentPendingValue == null || currentPendingValue == undefined) {
+      if (currentPendingValue === null || currentPendingValue === undefined) {
         return;
       }
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -51,7 +51,7 @@ export interface IComboBoxState {
 
   // when taking input, this will store
   // the actual text that is being entered
-  currentPendingValue: string;
+  currentPendingValue?: string;
 }
 
 enum SearchDirection {
@@ -185,10 +185,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       isOpen: false,
       selectedIndices: initialSelectedIndices,
       focused: false,
-      suggestedDisplayValue: '',
+      suggestedDisplayValue: undefined,
       currentOptions: this.props.options,
       currentPendingValueValidIndex: -1,
-      currentPendingValue: '',
+      currentPendingValue: undefined,
       currentPendingValueValidIndexOnHover: HoverStatus.default
     };
   }
@@ -473,8 +473,12 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       return null;
     }
 
-    if (this._currentVisibleValue && this._currentVisibleValue !== '' && comboBox.value !== this._currentVisibleValue) {
-      return this._currentVisibleValue;
+    const visibleValue = this._normalizeToString(this._currentVisibleValue);
+    if (comboBox.value !== visibleValue) {
+      // If visibleValue is empty, make it a zero width space.
+      // If we did not do that, the empty string would not get used
+      // potentially resulting in an unexpected value being used
+      return visibleValue || '​';
     }
 
     return comboBox.value;
@@ -525,14 +529,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     const displayValues = [];
 
     if (this.props.multiSelect) {
-      // MUlti-select
+      // Multi-select
       if (focused) {
         let index = -1;
         if (autoComplete === 'on' && currentPendingIndexValid) {
           index = currentPendingValueValidIndex;
         }
         displayValues.push(
-          currentPendingValue !== ''
+          currentPendingValue !== null && currentPendingValue !== undefined
             ? currentPendingValue
             : this._indexWithinBounds(currentOptions, index)
               ? currentOptions[index].text
@@ -542,7 +546,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         for (let idx = 0; selectedIndices && idx < selectedIndices.length; idx++) {
           const index: number = selectedIndices[idx];
           displayValues.push(
-            this._indexWithinBounds(currentOptions, index) ? currentOptions[index].text : suggestedDisplayValue
+            this._indexWithinBounds(currentOptions, index)
+              ? currentOptions[index].text
+              : this._normalizeToString(suggestedDisplayValue)
           );
         }
       }
@@ -557,10 +563,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           index = currentPendingValueValidIndex;
         }
 
-        // Since we are allowing freeform, if there is currently a nonempty pending value, use that
+        // Since we are allowing freeform, if there is currently a pending value, use that
         // otherwise use the index determined above (falling back to '' if we did not get a valid index)
         displayValues.push(
-          currentPendingValue !== ''
+          currentPendingValue !== null && currentPendingValue !== undefined
             ? currentPendingValue
             : this._indexWithinBounds(currentOptions, index)
               ? currentOptions[index].text
@@ -575,10 +581,12 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           // raw pending value, otherwise remember
           // the matched option's index
           index = currentPendingValueValidIndex;
-          displayValues.push(currentPendingValue);
+          displayValues.push(this._normalizeToString(currentPendingValue));
         } else {
           displayValues.push(
-            this._indexWithinBounds(currentOptions, index) ? currentOptions[index].text : suggestedDisplayValue
+            this._indexWithinBounds(currentOptions, index)
+              ? currentOptions[index].text
+              : this._normalizeToString(suggestedDisplayValue)
           );
         }
       }
@@ -631,9 +639,29 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    */
   private _processInputChangeWithFreeform(updatedValue: string): void {
     const { currentOptions } = this.state;
+    updatedValue = this._removeZeroWidthSpaces(updatedValue);
 
-    // if the new value is empty, nothing needs to be done
+    // if the new value is empty, see if we have an exact match
+    // and then set the pending info
     if (updatedValue === '') {
+      let newCurrentPendingValueValidIndex = -1;
+      const items = currentOptions
+        .map((item, index) => {
+          return { ...item, index };
+        })
+        .filter(
+          option =>
+            option.itemType !== SelectableOptionMenuItemType.Header &&
+            option.itemType !== SelectableOptionMenuItemType.Divider
+        )
+        .filter(option => this._getPreviewText(option) === updatedValue);
+
+      // if we found a match remember the index
+      if (items.length === 1) {
+        newCurrentPendingValueValidIndex = items[0].index;
+      }
+
+      this._setPendingInfo(updatedValue, newCurrentPendingValueValidIndex, updatedValue);
       return;
     }
 
@@ -686,7 +714,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         )
         .filter(option => this._getPreviewText(option).toLocaleLowerCase() === updatedValue);
 
-      // if we fould a match remember the index
+      // if we found a match remember the index
       if (items.length === 1) {
         newCurrentPendingValueValidIndex = items[0].index;
       }
@@ -704,6 +732,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   private _processInputChangeWithoutFreeform(updatedValue: string): void {
     const { currentPendingValue, currentPendingValueValidIndex, currentOptions } = this.state;
 
+    updatedValue = this._removeZeroWidthSpaces(updatedValue);
     if (this.props.autoComplete === 'on') {
       // If autoComplete is on while allow freeform is off,
       // we will remember the keypresses and build up a string to attempt to match
@@ -718,7 +747,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         if (this._lastReadOnlyAutoCompleteChangeTimeoutId !== undefined) {
           this._async.clearTimeout(this._lastReadOnlyAutoCompleteChangeTimeoutId);
           this._lastReadOnlyAutoCompleteChangeTimeoutId = undefined;
-          updatedValue = currentPendingValue + updatedValue;
+          updatedValue = this._normalizeToString(currentPendingValue) + updatedValue;
         }
 
         const originalUpdatedValue: string = updatedValue;
@@ -976,9 +1005,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     } = this.state;
     let { selectedIndices } = this.state;
 
-    // If we allow freeform and we have a pending value, we
-    // need to handle that
-    if (allowFreeform && currentPendingValue !== '') {
+    // If we allow freeform we need to handle that
+    if (allowFreeform) {
+      // if currentPendingValue is null or undefined the user did not submit anything
+      // (not even empty because we would have stored that as the pending value)
+      if (currentPendingValue == null || currentPendingValue == undefined) {
+        return;
+      }
+
       // Check to see if the user typed an exact match
       if (this._indexWithinBounds(currentOptions, currentPendingValueValidIndex)) {
         const pendingOptionText: string = this._getPreviewText(
@@ -1019,7 +1053,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         }
       } else {
         // If we are not controlled, create a new option
-        const newOption: IComboBoxOption = { key: currentPendingValue, text: currentPendingValue };
+        const newOption: IComboBoxOption = {
+          key: currentPendingValue || getId(),
+          text: this._normalizeToString(currentPendingValue)
+        };
         const newOptions: IComboBoxOption[] = [...currentOptions, newOption];
         if (selectedIndices) {
           if (!this.props.multiSelect) {
@@ -1031,15 +1068,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           currentOptions: newOptions,
           selectedIndices: selectedIndices
         });
-      }
-    } else if (allowFreeform && currentPendingValue === '' && (onChange || onChanged)) {
-      if (onChange) {
-        // trigger onChange to clear value
-        onChange(submitPendingValueEvent, undefined, undefined, currentPendingValue);
-      }
-      if (onChanged) {
-        // trigger onChanged to clear value
-        onChanged(undefined, undefined, currentPendingValue, submitPendingValueEvent);
       }
     } else if (currentPendingValueValidIndex >= 0) {
       // Since we are not allowing freeform, we must have a matching
@@ -1434,11 +1462,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * Clears the pending info state
    */
   private _clearPendingInfo(): void {
-    this._setPendingInfo(
-      '' /* suggestedDisplayValue */,
-      -1 /* currentPendingValueValidIndex */,
-      '' /* currentPendingValue */
-    );
+    this._setPendingInfo();
   }
 
   /**
@@ -1448,12 +1472,12 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * @param suggestedDisplayValue - new suggest display value to set
    */
   private _setPendingInfo(
-    currentPendingValue: string,
-    currentPendingValueValidIndex: number,
-    suggestedDisplayValue: string
+    currentPendingValue?: string,
+    currentPendingValueValidIndex: number = -1,
+    suggestedDisplayValue?: string
   ): void {
     this.setState({
-      currentPendingValue: currentPendingValue,
+      currentPendingValue: currentPendingValue && this._removeZeroWidthSpaces(currentPendingValue),
       currentPendingValueValidIndex: currentPendingValueValidIndex,
       suggestedDisplayValue: suggestedDisplayValue,
       currentPendingValueValidIndexOnHover: HoverStatus.default
@@ -1995,5 +2019,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   // when the useAriaLabelAsText prop is set to true
   private _getPreviewText(item: IComboBoxOption): string {
     return item.useAriaLabelAsText && item.ariaLabel ? item.ariaLabel : item.text;
+  }
+
+  private _normalizeToString(value?: string): string {
+    return value || '';
+  }
+
+  private _removeZeroWidthSpaces(value: string): string {
+    // remove any zero width space characters
+    return value.replace(RegExp('​', 'g'), '');
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #3055 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
ComboBoxes used to not allow for empty value to be submitted and there was a bug where it would incorrectly say report  the final character that was deleted prior to submit

This fixes up the last character bug as well as generally adding support for allowing comboBoxes to accept an empty string as a "valid" submit-able value.

The main issue stemmed from the fact that currentPendingValue could not be undefined and an undefined value is different than an empty value (and should be handled differently). That's the core motivation of this fix and there's some logic added to allow for empty strings to be rendered as expected in the input (Autofill)

#### Focus areas to test
Verified that the values get reported correctly on submit, an empty string can be submitted (and will only be added to the options once for an uncontrolled comboBox), and no other behavior has changed. This was tested for both single and multi select comboBoxes

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6142)

