### PR TITLE
Improve a DX issue with IProcessedStyleSet typings. (issue #6124)

### DIFF
--- a/common/changes/@uifabric/merge-styles/issue6124_2018-08-30-00-55.json
+++ b/common/changes/@uifabric/merge-styles/issue6124_2018-08-30-00-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Improve a DX issue with IProcessedStyleSet typings. (issue #6124)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -15,7 +15,7 @@ export type __ReduceToFunction<T> = T extends (...args: any[]) => any ? T : neve
  * Note: the commmented segment is the right expression but it is buggy in 2.8.2. Once Fabric upgrades to Typescript 3,
  *  we should uncomment the commented segmment below as well as uncomment the test in mergeStyleSets.test.ts.
  */
-export type __MapToFunctionType<T> = [T] extends [IStyleSet<any>] ? (...args: any[]) => T : __ReduceToFunction<T>;
+export type __MapToFunctionType<T> = /*[T] extends [IStyleSet<any>] ? (...args: any[]) => T :*/ __ReduceToFunction<T>;
 
 /**
  * A style set is a dictionary of display areas to IStyle objects.

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -14,6 +14,8 @@ export type __ReduceToFunction<T> = T extends (...args: any[]) => any ? T : neve
  *
  * Note: the commmented segment is the right expression but it is buggy in 2.8.2. Once Fabric upgrades to Typescript 3,
  *  we should uncomment the commented segmment below as well as uncomment the test in mergeStyleSets.test.ts.
+ *
+ * See https://github.com/OfficeDev/office-ui-fabric-react/issues/6124.
  */
 export type __MapToFunctionType<T> = /*[T] extends [IStyleSet<any>] ? (...args: any[]) => T :*/ __ReduceToFunction<T>;
 

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -6,7 +6,16 @@ export type Diff<T extends keyof any, U extends keyof any> = ({ [P in T]: P } &
 
 export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 
-export type TrimToFunction<T> = T extends (...args: any[]) => any ? T : () => T;
+export type __ReduceToFunction<T> = T extends (...args: any[]) => any ? T : never;
+
+/**
+ * Helper function whose role is supposed to express that regardless if T is a style object or style function,
+ * it will always map to a style function.
+ *
+ * Note: the commmented segment is the right expression but it is buggy in 2.8.2. Once Fabric upgrades to Typescript 3,
+ *  we should uncomment the commented segmment below as well as uncomment the test in mergeStyleSets.test.ts.
+ */
+export type __MapToFunctionType<T> = [T] extends [IStyleSet<any>] ? (...args: any[]) => T : __ReduceToFunction<T>;
 
 /**
  * A style set is a dictionary of display areas to IStyle objects.
@@ -36,6 +45,6 @@ export type IProcessedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string
 } & {
   subComponentStyles: {
-    [P in keyof TStyleSet['subComponentStyles']]: TrimToFunction<TStyleSet['subComponentStyles'][P]>
+    [P in keyof TStyleSet['subComponentStyles']]: __MapToFunctionType<TStyleSet['subComponentStyles'][P]>
   };
 };

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -1,11 +1,8 @@
 import { mergeStyleSets } from './mergeStyleSets';
 import { Stylesheet, InjectionMode } from './Stylesheet';
+import { IStyle, IStyleSet, IStyleFunctionOrObject } from '.';
 
 const _stylesheet: Stylesheet = Stylesheet.getInstance();
-
-interface ITestClasses {
-  root: string;
-}
 
 _stylesheet.setConfig({ injectionMode: InjectionMode.none });
 
@@ -168,8 +165,8 @@ describe('mergeStyleSets', () => {
   });
 
   it('can auto expand a previously registered style', () => {
-    const styles: ITestClasses = mergeStyleSets({ root: { background: 'red' } });
-    const styles2: ITestClasses = mergeStyleSets({ root: [{ background: 'purple' }, styles.root] });
+    const styles = mergeStyleSets({ root: { background: 'red' } });
+    const styles2 = mergeStyleSets({ root: [{ background: 'purple' }, styles.root] });
 
     expect(styles.root).toEqual(styles2.root);
 
@@ -177,17 +174,17 @@ describe('mergeStyleSets', () => {
   });
 
   it('can normalize duplicate static class names', () => {
-    const styles: ITestClasses = mergeStyleSets({ root: ['a', { background: 'red' }] });
-    const styles1: ITestClasses = mergeStyleSets(styles, styles);
+    const styles = mergeStyleSets({ root: ['a', { background: 'red' }] });
+    const styles1 = mergeStyleSets(styles, styles);
 
     expect(styles1).toEqual({ root: 'a root-0', subComponentStyles: {} });
   });
 
   it('can auto expand a previously registered style embedded in static classname', () => {
-    const styles: ITestClasses = mergeStyleSets({ root: ['a', { background: 'red' }] });
-    const styles2: ITestClasses = mergeStyleSets({ root: ['b', { background: 'purple' }] }, styles);
-    const styles3: ITestClasses = mergeStyleSets(styles, { root: ['b', { background: 'purple' }] });
-    const styles4: ITestClasses = mergeStyleSets(styles, styles2, styles3, { root: 'c' });
+    const styles = mergeStyleSets({ root: ['a', { background: 'red' }] });
+    const styles2 = mergeStyleSets({ root: ['b', { background: 'purple' }] }, styles);
+    const styles3 = mergeStyleSets(styles, { root: ['b', { background: 'purple' }] });
+    const styles4 = mergeStyleSets(styles, styles2, styles3, { root: 'c' });
 
     expect(styles).toEqual({ root: 'a root-0', subComponentStyles: {} });
     expect(styles2).toEqual({ root: 'b a root-0', subComponentStyles: {} });
@@ -196,14 +193,118 @@ describe('mergeStyleSets', () => {
   });
 
   it('can merge two sets with class names', () => {
-    const styleSet1: ITestClasses = mergeStyleSets({
+    const styleSet1 = mergeStyleSets({
       root: ['ms-Foo', { background: 'red' }]
     });
-    const styleSet2: ITestClasses = mergeStyleSets(styleSet1, {
+    const styleSet2 = mergeStyleSets(styleSet1, {
       root: ['ms-Bar', { background: 'green' }]
     });
 
     expect(styleSet2).toEqual({ root: 'ms-Foo ms-Bar root-1', subComponentStyles: {} });
     expect(_stylesheet.getRules()).toEqual('.root-0{background:red;}' + '.root-1{background:green;}');
+  });
+
+  describe('typings tests', () => {
+    interface ISubComponentStyles extends IStyleSet<ISubComponentStyles> {
+      root: IStyle;
+    }
+
+    interface ISubComponentStyleProps {
+      isCollapsed: boolean;
+    }
+
+    interface IStyles extends IStyleSet<IStyles> {
+      root: IStyle;
+      subComponentStyles: {
+        button: IStyleFunctionOrObject<ISubComponentStyleProps, IStyleSet<ISubComponentStyles>>;
+      };
+    }
+
+    interface IStylesWithStyleObjectAsSubCommponent extends IStyleSet<IStyles> {
+      root: IStyle;
+      subComponentStyles: {
+        button: Partial<IStyleSet<ISubComponentStyles>>;
+      };
+    }
+
+    /** Button component as of test writing has this interface. */
+    const LegacySubComponent: (props: { styles: Partial<ISubComponentStyles> }) => any = (props: {
+      styles: Partial<ISubComponentStyles>;
+    }) => {
+      return;
+    };
+
+    const SubComponent: (
+      props: { styles: IStyleFunctionOrObject<ISubComponentStyleProps, ISubComponentStyles> }
+    ) => any = (props: { styles: IStyleFunctionOrObject<ISubComponentStyleProps, ISubComponentStyles> }) => {
+      return;
+    };
+
+    const getStyles = (): IStyles => ({
+      root: {
+        background: 'red'
+      },
+      subComponentStyles: {
+        button: {
+          root: {
+            background: 'green'
+          }
+        }
+      }
+    });
+
+    it('IStyleSet/IProcessedStyleSet should work with standard sub components', () => {
+      const classNames = mergeStyleSets<IStyles>(getStyles());
+
+      SubComponent({ styles: classNames.subComponentStyles.button });
+
+      // this test primarily tests that the lines above do not result in a Typescript error.
+      expect.assertions(0);
+    });
+
+    it('IStyleSet/IProcessedStyleSet should work with legacy sub components that only take IStyleFunctions', () => {
+      const classNames = mergeStyleSets<IStyles>(getStyles());
+
+      LegacySubComponent({ styles: classNames.subComponentStyles.button({ isCollapsed: false }) });
+
+      // this test primarily tests that the lines above do not result in a Typescript error.
+      expect.assertions(0);
+    });
+
+    describe('IStylesWithStyleObjectAsSubCommponent', () => {
+      const getStyles2 = (): IStylesWithStyleObjectAsSubCommponent => ({
+        root: {
+          background: 'red'
+        },
+        subComponentStyles: {
+          button: {
+            root: {
+              background: 'green'
+            }
+          }
+        }
+      });
+
+      it('IStyleSet/IProcessedStyleSet should work with standard sub components', () => {
+        const classNames = mergeStyleSets<IStyles>(getStyles2());
+
+        // this test primarily
+        SubComponent({ styles: classNames.subComponentStyles.button });
+
+        // this test primarily tests that the lines above do not result in a Typescript error.
+        expect.assertions(0);
+      });
+
+      // NOTE: The following test should be enabled when Fabric is upgraded to Typescript 3.
+      it.skip('IStyleSet/IProcessedStyleSet should work with legacy sub components that only take IStyleFunctions', () => {
+        const classNames = mergeStyleSets<IStylesWithStyleObjectAsSubCommponent>(getStyles2());
+
+        // NOTE: The following line should be uncommented when Fabric is upgraded to Typescript 3.
+        // LegacySubComponent({ styles: classNames.subComponentStyles.button({ isCollapsed: false }) });
+
+        // this test primarily tests that the lines above do not result in a Typescript error.
+        expect.assertions(0);
+      });
+    });
   });
 });

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -1,6 +1,8 @@
 import { mergeStyleSets } from './mergeStyleSets';
 import { Stylesheet, InjectionMode } from './Stylesheet';
-import { IStyle, IStyleSet, IStyleFunctionOrObject } from '.';
+import { IStyleSet } from './IStyleSet';
+import { IStyleFunctionOrObject } from './IStyleFunction';
+import { IStyle } from './IStyle';
 
 const _stylesheet: Stylesheet = Stylesheet.getInstance();
 
@@ -245,11 +247,11 @@ describe('mergeStyleSets', () => {
         background: 'red'
       },
       subComponentStyles: {
-        button: {
+        button: () => ({
           root: {
             background: 'green'
           }
-        }
+        })
       }
     });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6124
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Addresses the main problem in #6124. This is not a perfect fix - the perfect fix would require consumers be on Typescript 3. For that matter, it requires OUFR itself to be on Typescript 3 so that our test cases pass.

This however will work for what is likely to be the far more common pattern (the first two test cases). For the edge cases (the last 2 cases), it should be fortunately relatively easy to workaround the problem.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6146)

