### PR TITLE
Coachmark - fixing the beak showing up when isCollapsed=false

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-08-30-19-41.json
+++ b/common/changes/office-ui-fabric-react/master_2018-08-30-19-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Coachmark - only show beak if it is collapsed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
@@ -239,16 +239,17 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
           <div className={classNames.translateAnimationContainer} ref={this._translateAnimationContainer}>
             <div className={classNames.scaleAnimationLayer}>
               <div className={classNames.rotateAnimationLayer}>
-                {this._positioningContainer.current && (
-                  <Beak
-                    left={beakLeft}
-                    top={beakTop}
-                    right={beakRight}
-                    bottom={beakBottom}
-                    direction={this._beakDirection}
-                    color={color}
-                  />
-                )}
+                {this._positioningContainer.current &&
+                  isCollapsed && (
+                    <Beak
+                      left={beakLeft}
+                      top={beakTop}
+                      right={beakRight}
+                      bottom={beakBottom}
+                      direction={this._beakDirection}
+                      color={color}
+                    />
+                  )}
                 <FocusTrapZone
                   componentRef={this._focusTrapZone}
                   isClickableOutsideFocusTrap={true}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5822
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Coachmark - fixing the beak showing up when isCollapsed=false

When coachmark is NOT collapsed, that means it's expanded and the beak should not show up.


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6158)

