### PR TITLE
DetailsList: Column header should only have role button when oncolumnclick prop is defined

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListHeaderRoleButton_2018-08-30-20-00.json
+++ b/common/changes/office-ui-fabric-react/detailsListHeaderRoleButton_2018-08-30-20-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: only use role button when onColumnClick prop is defined",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -96,7 +96,12 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                   aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name `}
                   className={classNames.cellTitle}
                   data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
-                  role={column.columnActionsMode !== ColumnActionsMode.disabled ? 'button' : undefined}
+                  role={
+                    column.columnActionsMode !== ColumnActionsMode.disabled &&
+                    (column.onColumnClick !== undefined || this.props.onColumnClick !== undefined)
+                      ? 'button'
+                      : undefined
+                  }
                   aria-describedby={
                     this.props.onRenderColumnHeaderTooltip || this._hasAccessibleLabel()
                       ? `${parentId}-${column.key}-tooltip`

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -373,7 +373,7 @@ exports[`DetailsHeader can render 1`] = `
         id="header0-a"
         onClick={[Function]}
         onContextMenu={[Function]}
-        role="button"
+        role={undefined}
       >
         <span
           className=
@@ -566,7 +566,7 @@ exports[`DetailsHeader can render 1`] = `
         id="header0-b"
         onClick={[Function]}
         onContextMenu={[Function]}
-        role="button"
+        role={undefined}
       >
         <span
           className=
@@ -781,7 +781,7 @@ exports[`DetailsHeader can render 1`] = `
         id="header0-c"
         onClick={[Function]}
         onContextMenu={[Function]}
-        role="button"
+        role={undefined}
       >
         <span
           className=
@@ -1251,7 +1251,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         id="header4-a"
         onClick={[Function]}
         onContextMenu={[Function]}
-        role="button"
+        role={undefined}
       >
         <span
           className=
@@ -1444,7 +1444,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         id="header4-b"
         onClick={[Function]}
         onContextMenu={[Function]}
-        role="button"
+        role={undefined}
       >
         <span
           className=
@@ -1683,7 +1683,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         id="header4-c"
         onClick={[Function]}
         onContextMenu={[Function]}
-        role="button"
+        role={undefined}
       >
         <span
           className=

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -414,7 +414,7 @@ exports[`DetailsList renders List correctly 1`] = `
                 id="header0-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -991,7 +991,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 id="header6-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -1568,7 +1568,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 id="header3-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -1760,7 +1760,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 id="header3-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -1952,7 +1952,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 id="header3-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -2390,7 +2390,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 id="header9-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -414,7 +414,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 id="header0-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -550,7 +550,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 id="header0-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -686,7 +686,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 id="header0-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -1226,7 +1226,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 id="header9-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -1362,7 +1362,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 id="header9-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -1498,7 +1498,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 id="header9-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -2562,7 +2562,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 id="header3-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -2698,7 +2698,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 id="header3-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -2834,7 +2834,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 id="header3-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -3374,7 +3374,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 id="header6-key"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -3510,7 +3510,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 id="header6-name"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=
@@ -3646,7 +3646,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 id="header6-value"
                 onClick={[Function]}
                 onContextMenu={[Function]}
-                role="button"
+                role={undefined}
               >
                 <span
                   className=


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6145 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adds a check for onColumnClick and column.onColumnClick before setting role="button" on the span in the column header. The column header should only have this role if one of these is defined. Otherwise, the button has no use.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6160)

