### PR TITLE
DetailsList: give isMultiline className precedence

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListIsMultiline_2018-08-30-21-54.json
+++ b/common/changes/office-ui-fabric-react/detailsListIsMultiline_2018-08-30-21-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: isMultiline className takes precedence",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -42,12 +42,12 @@ export class DetailsRowFields extends BaseComponent<IDetailsRowFieldsProps, IDet
               aria-colindex={columnIndex + columnStartIndex + 1}
               className={css(
                 column.className,
-                column.isMultiline && rowClassNames.isMultiline,
                 column.isRowHeader && rowClassNames.isRowHeader,
                 column.isIconOnly && shimmer && rowClassNames.shimmerIconPlaceholder,
                 shimmer && rowClassNames.shimmer,
                 rowClassNames.cell,
-                column.isPadded ? rowClassNames.cellPadded : rowClassNames.cellUnpadded
+                column.isPadded ? rowClassNames.cellPadded : rowClassNames.cellUnpadded,
+                column.isMultiline && rowClassNames.isMultiline
               )}
               style={{ width }}
               data-automationid="DetailsRowCell"


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5814 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

By changing the ordering in which classNames are applied to DetailsList, the isMultiline className now has precedence, and the rows will not shrink when selected.

Before:
![detailslist ismultiline collapses on select](https://user-images.githubusercontent.com/14134000/44881980-522b2100-ac66-11e8-8977-9241b64e0d68.gif)

After:
![detailslist ismultiline does not collapse on select](https://user-images.githubusercontent.com/14134000/44882050-9a4a4380-ac66-11e8-88c5-dffbf5c8d755.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6166)

