### PR TITLE
Zhiliu/viewport

### DIFF
--- a/common/changes/office-ui-fabric-react/zhiliu-viewport_2018-08-31-06-59.json
+++ b/common/changes/office-ui-fabric-react/zhiliu-viewport_2018-08-31-06-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fix re-render caused by view port resize observer",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "zhiliu@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
ResizeObserver seems always fire even window is not resized. This is particularly bad when skipViewportMeasures is set to optimize fixed layout lists. It will do measurement and update and re-render the entire list after list is fully rendered. So we should fallback to listen to resize event when skipViewportMeasures is set.

(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6175)

