### PR TITLE
Fix issue where deleting all selected items wouldn't update selection

### DIFF
--- a/common/changes/office-ui-fabric-react/select-all-delete_2018-08-31-16-11.json
+++ b/common/changes/office-ui-fabric-react/select-all-delete_2018-08-31-16-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix issue where deleting all selected items wouldn't update selection",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -45,6 +45,7 @@ export interface IDetailsListAdvancedExampleState {
   layoutMode?: LayoutMode;
   selectionMode?: SelectionMode;
   sortedColumnKey?: string;
+  selectionCount: number;
 }
 
 export class DetailsListAdvancedExample extends React.Component<{}, IDetailsListAdvancedExampleState> {
@@ -58,11 +59,14 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       _items = createListItems(ITEMS_COUNT);
     }
 
-    this._selection = new Selection();
+    this._selection = new Selection({
+      onSelectionChanged: this._onItemsSelectionChanged
+    });
     this._selection.setItems(_items, false);
 
     this.state = {
       items: _items,
+      selectionCount: 0,
       groups: undefined,
       groupItemLimit: DEFAULT_ITEM_LIMIT,
       layoutMode: LayoutMode.justified,
@@ -117,7 +121,10 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
 
     return (
       <div className="ms-DetailsListAdvancedExample">
-        <CommandBar items={this._getCommandItems()} />
+        <CommandBar
+          items={this._getCommandItems()}
+          farItems={[{ key: 'count', text: `${this.state.selectionCount} selected` }]}
+        />
 
         {isGrouped ? <TextField label="Group Item Limit" onChange={this._onItemLimitChanged} /> : null}
 
@@ -605,8 +612,32 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
   };
 
   private _onDeleteRow = (): void => {
+    if (this._selection.getSelectedCount() > 0) {
+      this.setState((previousState: this['state']) => {
+        const items: this['state']['items'] = [];
+
+        const previousItems = previousState.items!;
+
+        for (let i = 0; i < previousItems.length; i++) {
+          if (!this._selection.isIndexSelected(i)) {
+            items.push(previousItems[i]);
+          }
+        }
+
+        return {
+          items
+        };
+      });
+    } else {
+      this.setState({
+        items: this.state.items!.slice(1)
+      });
+    }
+  };
+
+  private _onItemsSelectionChanged = () => {
     this.setState({
-      items: this.state.items!.slice(1)
+      selectionCount: this._selection.getSelectedCount()
     });
   };
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -557,6 +557,147 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
             </button>
           </div>
         </div>
+        <div
+          className=
+              ms-OverflowSet
+              ms-CommandBar-secondaryCommand
+              {
+                align-items: stretch;
+                display: flex;
+                flex-shrink: 0;
+                flex-wrap: nowrap;
+                position: relative;
+              }
+          role="presentation"
+        >
+          <div
+            className=
+                ms-OverflowSet-item
+                {
+                  display: inherit;
+                  flex-shrink: 0;
+                }
+          >
+            <button
+              aria-describedby={undefined}
+              aria-disabled={undefined}
+              aria-label={undefined}
+              aria-labelledby={undefined}
+              aria-pressed={undefined}
+              className=
+                  ms-Button
+                  ms-Button--commandBar
+                  ms-CommandBarItem-link
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #f4f4f4;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 100%;
+                    min-width: 40px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: 4px;
+                    left: 4px;
+                    outline-color: ButtonText;
+                    right: 4px;
+                    top: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
+                  &:hover {
+                    background-color: #eaeaea;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #dadada;
+                    color: #000000;
+                  }
+              data-is-focusable={true}
+              disabled={undefined}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: normal;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
+                    id="id__10"
+                  >
+                    0 selected
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.test.ts
@@ -84,4 +84,26 @@ describe('Selection', () => {
     selection.setAllSelected(true);
     expect(selection.isAllSelected()).toEqual(true);
   });
+
+  it('notifies consumers when all items are selected and some are removed', () => {
+    let changeCount = 0;
+    const selection = new Selection({ onSelectionChanged: () => changeCount++ });
+
+    selection.setItems(setA);
+
+    selection.setAllSelected(true);
+
+    expect(changeCount).toEqual(1);
+    expect(selection.getSelectedCount()).toEqual(3);
+
+    selection.setItems([{ key: 'a' }, { key: 'b' }], false);
+
+    expect(changeCount).toEqual(2);
+    expect(selection.getSelectedCount()).toEqual(2);
+
+    selection.setItems([], false);
+
+    expect(changeCount).toEqual(3);
+    expect(selection.getSelectedCount()).toEqual(0);
+  });
 });

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -135,12 +135,13 @@ export class Selection implements ISelection {
       }
     }
 
-    if (shouldClear) {
+    if (shouldClear || items.length === 0) {
       this.setAllSelected(false);
     }
 
     // Check the exemption list for discrepencies.
     const newExemptedIndicies: { [key: string]: boolean } = {};
+    let newExemptedCount = 0;
 
     for (const indexProperty in this._exemptedIndices) {
       if (this._exemptedIndices.hasOwnProperty(indexProperty)) {
@@ -150,22 +151,27 @@ export class Selection implements ISelection {
         const newIndex = exemptKey ? newKeyToIndexMap[exemptKey] : index;
 
         if (newIndex === undefined) {
-          // We don't know the index of the item any more so it's either moved or removed.
-          // In this case we reset the entire selection.
-          this.setAllSelected(false);
-          break;
+          // The item has likely been replaced or removed.
+          hasSelectionChanged = true;
         } else {
           // We know the new index of the item. update the existing exemption table.
           newExemptedIndicies[newIndex] = true;
+          newExemptedCount++;
           hasSelectionChanged = hasSelectionChanged || newIndex !== index;
         }
       }
     }
 
+    if (this._items && this._exemptedCount === 0 && items.length !== this._items.length && this._isAllSelected) {
+      // If everything was selected but the number of items has changed, selection has changed.
+      hasSelectionChanged = true;
+    }
+
     this._exemptedIndices = newExemptedIndicies;
+    this._exemptedCount = newExemptedCount;
     this._keyToIndexMap = newKeyToIndexMap;
     this._unselectableIndices = newUnselectableIndices;
-    this._items = items || [];
+    this._items = items;
     this._selectedItems = null;
 
     if (hasSelectionChanged) {


### PR DESCRIPTION
# Overview

This change fixes an issue where, if 'select all' had been used, deleting any (or all) items in a set would not trigger a selection update, resulting in the UX getting out of sync, and in the Selection getting 'stuck' in 'select all' mode.

To fix this, the `Selection` model now ensures that it tracks the update to `exemptedCount` (so 'is all selected' can be recalculated), detects a change in item count (going to 0 should reset selection), and handles the 'all selected' case (if everything is selected, changing the item count at all changes selection).

A demonstration has been added to the `DetailsList.Advanced.Example`.

This change should be cherry-picked to Fabric 5.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6184)

