### PR TITLE
Scrollablecontent fix

### DIFF
--- a/common/changes/@uifabric/utilities/scrollablecontent-fix_2018-08-31-17-44.json
+++ b/common/changes/@uifabric/utilities/scrollablecontent-fix_2018-08-31-17-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Scroll: add flex-grow: 1 to scrollable content elements",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "kakje@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/scrollablecontent-fix_2018-08-31-23-28.json
+++ b/common/changes/@uifabric/utilities/scrollablecontent-fix_2018-08-31-23-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Scroll: remove inline styles from scrollable content elements",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "kakje@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/scrollablecontent-fix_2018-08-31-23-28.json
+++ b/common/changes/office-ui-fabric-react/scrollablecontent-fix_2018-08-31-23-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Modal, Panel: make scrollable content styles customizable via className or styles props",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -81,6 +81,7 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
     const {
       className,
       containerClassName,
+      scrollableContentClassName,
       elementToFocusOnDismiss,
       firstFocusableSelector,
       forceFocusInsideTrap,
@@ -106,6 +107,7 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
       theme: theme!,
       className,
       containerClassName,
+      scrollableContentClassName,
       isOpen,
       isVisible
     });
@@ -135,7 +137,9 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
                 forceFocusInsideTrap={forceFocusInsideTrap}
                 firstFocusableSelector={firstFocusableSelector}
               >
-                <div ref={this._allowScrollOnModal}>{this.props.children}</div>
+                <div ref={this._allowScrollOnModal} className={classNames.scrollableContent}>
+                  {this.props.children}
+                </div>
               </FocusTrapZone>
             </div>
           </Popup>

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
@@ -17,11 +17,12 @@ export const getOverlayStyles: IOverlayStyles = {
 const globalClassNames = {
   root: 'ms-Modal',
   main: 'ms-Dialog-main',
+  scrollableContent: 'ms-Modal-scrollableContent',
   isOpen: 'is-open'
 };
 
 export const getStyles = (props: IModalStyleProps): IModalStyles => {
-  const { className, containerClassName, isOpen, isVisible, theme } = props;
+  const { className, containerClassName, scrollableContentClassName, isOpen, isVisible, theme } = props;
   const { palette } = theme;
 
   const classNames = getGlobalClassNames(globalClassNames, theme);
@@ -61,6 +62,14 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
         overflowY: 'auto'
       },
       containerClassName
+    ],
+    scrollableContent: [
+      classNames.scrollableContent,
+      {
+        overflowY: 'auto',
+        flexGrow: 1
+      },
+      scrollableContentClassName
     ]
   };
 };

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.types.ts
@@ -68,6 +68,11 @@ export interface IModalProps extends React.Props<ModalBase>, IWithResponsiveMode
   containerClassName?: string;
 
   /**
+   * Optional override for scrollable content class
+   */
+  scrollableContentClassName?: string;
+
+  /**
    * A callback function for when the Modal content is mounted on the overlay layer
    */
   onLayerDidMount?: () => void;
@@ -84,7 +89,7 @@ export interface IModalProps extends React.Props<ModalBase>, IWithResponsiveMode
 }
 
 export type IModalStyleProps = Required<Pick<IModalProps, 'theme'>> &
-  Pick<IModalProps, 'className' | 'containerClassName'> & {
+  Pick<IModalProps, 'className' | 'containerClassName' | 'scrollableContentClassName'> & {
     /** Modal open state. */
     isOpen?: boolean;
     /** Modal visible state. */
@@ -94,4 +99,5 @@ export type IModalStyleProps = Required<Pick<IModalProps, 'theme'>> &
 export interface IModalStyles {
   root: IStyle;
   main: IStyle;
+  scrollableContent: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -68,7 +68,14 @@ exports[`Modal renders Modal correctly 1`] = `
       onFocusCapture={[Function]}
       onKeyDown={[Function]}
     >
-      <div>
+      <div
+        className=
+            ms-Modal-scrollableContent
+            {
+              flex-grow: 1;
+              overflow-y: auto;
+            }
+      >
         Test Content
       </div>
     </div>

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -260,7 +260,9 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     scrollableContent: [
       classNames.scrollableContent,
       {
-        height: '100%'
+        height: '100%',
+        overflowY: 'auto',
+        flexGrow: 1
       }
     ],
     navigation: [

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -97,7 +97,9 @@ exports[`Panel renders Panel correctly 1`] = `
         className=
             ms-Panel-scrollableContent
             {
+              flex-grow: 1;
               height: 100%;
+              overflow-y: auto;
             }
       >
         <div

--- a/packages/utilities/src/scroll.ts
+++ b/packages/utilities/src/scroll.ts
@@ -65,8 +65,6 @@ const _makeElementScrollAllower = () => {
       return;
     }
 
-    element.style.overflowY = 'auto';
-    element.style.flexGrow = '1';
     events.on(element, 'touchstart', _saveClientY);
     events.on(element, 'touchmove', _preventOverscrolling);
 

--- a/packages/utilities/src/scroll.ts
+++ b/packages/utilities/src/scroll.ts
@@ -66,6 +66,7 @@ const _makeElementScrollAllower = () => {
     }
 
     element.style.overflowY = 'auto';
+    element.style.flexGrow = '1';
     events.on(element, 'touchstart', _saveClientY);
     events.on(element, 'touchmove', _preventOverscrolling);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6180 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add `flex-grow: 1` to the style of any element created for scrolling purposes, so that components that use scrollable content (e.g. Dialog) are styled correctly.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6186)

