### PR TITLE
Polyfill Promise for local dev site IE compatibility

### DIFF
--- a/apps/fabric-website-resources/src/index.tsx
+++ b/apps/fabric-website-resources/src/index.tsx
@@ -1,3 +1,5 @@
+require('es6-promise/auto');
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { App, AppDefinition } from './AppDefinition';

--- a/common/changes/@uifabric/fabric-website-resources/keco-ie-promise-polyfill-local-site_2018-08-31-18-54.json
+++ b/common/changes/@uifabric/fabric-website-resources/keco-ie-promise-polyfill-local-site_2018-08-31-18-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website-resources",
+      "comment": "Invoke ES6 Promise polyfill in local dev site root for IE compat",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "keco@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes local dev site breaking in IE due to ES6 Promise not being polyfilled. We currently only polyfill in the demo website root which isn't hit when local dev'ing. See:

https://github.com/OfficeDev/office-ui-fabric-react/blob/master/apps/fabric-website/src/root.tsx

I'm using https://github.com/stefanpenner/es6-promise/blob/master/lib/es6-promise.auto.js which is just a convenience wrapper of how we invoke it above.

@micahgodbolt lmk if you can think of a better place to put this polyfill.

#### Focus areas to test

1. `npm start` to launch the local dev site
1. Open the local dev site in IE
1. Navigate to a component and on `master` you'll see a `Promise` is `undefined` error. That's fixed in this branch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6188)

