### PR TITLE
Change bodyDivider value from neutralTertiaryAlt back to neutralLight

### DIFF
--- a/common/changes/@uifabric/styling/bodyDividerSlotValue_2018-08-31-23-45.json
+++ b/common/changes/@uifabric/styling/bodyDividerSlotValue_2018-08-31-23-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Change bodyDivider value from neutralTertiaryAlt back to neutralLight",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "v-jescla@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/bodyDividerSlotValue_2018-08-31-23-45.json
+++ b/common/changes/office-ui-fabric-react/bodyDividerSlotValue_2018-08-31-23-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Change bodyDivider value from neutralTertiaryAlt back to neutralLight",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jescla@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -7,7 +7,7 @@ $bodyFrameDividerColor: '[theme:bodyFrameDivider, default: #eaeaea]';
 $bodyTextColor: '[theme:bodyText, default: #333333]';
 $bodyTextCheckedColor: '[theme:bodyTextChecked, default: #000000]';
 $bodySubtextColor: '[theme:bodySubtext, default: #666666]';
-$bodyDividerColor: '[theme:bodyDivider, default: #c8c8c8]';
+$bodyDividerColor: '[theme:bodyDivider, default: #eaeaea]';
 
 $actionLinkColor: '[theme:actionLink, default: #333333]';
 $actionLinkHoveredColor: '[theme:actionLinkHovered, default: #212121]';

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`DetailsHeader can render 1`] = `
       ms-DetailsHeader
       {
         background: #ffffff;
-        border-bottom: 1px solid #c8c8c8;
+        border-bottom: 1px solid #eaeaea;
         box-sizing: content-box;
         cursor: default;
         display: inline-block;
@@ -888,7 +888,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
       ms-DetailsHeader
       {
         background: #ffffff;
-        border-bottom: 1px solid #c8c8c8;
+        border-bottom: 1px solid #eaeaea;
         box-sizing: content-box;
         cursor: default;
         display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`DetailsList renders List correctly 1`] = `
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;
@@ -628,7 +628,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;
@@ -1205,7 +1205,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;
@@ -2165,7 +2165,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;
@@ -863,7 +863,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;
@@ -2199,7 +2199,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;
@@ -3011,7 +3011,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
               ms-DetailsHeader
               {
                 background: #ffffff;
-                border-bottom: 1px solid #c8c8c8;
+                border-bottom: 1px solid #eaeaea;
                 box-sizing: content-box;
                 cursor: default;
                 display: inline-block;

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -168,7 +168,7 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean, depCom
     bodyText: p.neutralPrimary,
     bodyTextChecked: p.black,
     bodySubtext: p.neutralSecondary,
-    bodyDivider: p.neutralTertiaryAlt,
+    bodyDivider: p.neutralLight,
 
     disabledBackground: p.neutralLighter,
     disabledText: p.neutralTertiary,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Per approval from designers, including @betrue-final-final who had previously made this color change, we're now changing the bodyDivider semantic slot value from neutralTertiaryAlt back to neutralLight
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6194)

