### PR TITLE
Teachingbubble: use div and instead of p if teachingbubble content isn't a string

### DIFF
--- a/common/changes/office-ui-fabric-react/teachingbubble_2018-09-04-18-29.json
+++ b/common/changes/office-ui-fabric-react/teachingbubble_2018-09-04-18-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "use div and instead of p if teachingbubble content isn't a string",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.test.tsx
@@ -4,8 +4,37 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 import { TeachingBubble } from './TeachingBubble';
 import { TeachingBubbleContent } from './TeachingBubbleContent';
+import { mount } from 'enzyme';
 
 describe('TeachingBubble', () => {
+  it('renders TeachingBubble using a <div> for the child content if the child is not a string', () => {
+    const component = mount(
+      <TeachingBubble
+        isWide={true}
+        calloutProps={{ doNotLayer: true, className: 'specialClassName' }}
+        ariaDescribedBy="content"
+      >
+        <div>Not a string child</div>
+      </TeachingBubble>
+    );
+
+    expect(component.find(TeachingBubbleContent).find('div#content').length).toBe(1);
+  });
+
+  it('renders TeachingBubble using a <p> for the child content if the child is a string', () => {
+    const component = mount(
+      <TeachingBubble
+        isWide={true}
+        calloutProps={{ doNotLayer: true, className: 'specialClassName' }}
+        ariaDescribedBy="content"
+      >
+        Not a string child
+      </TeachingBubble>
+    );
+
+    expect(component.find(TeachingBubbleContent).find('p#content').length).toBe(1);
+  });
+
   it('renders TeachingBubble correctly', () => {
     const component = renderer.create(
       <TeachingBubble isWide={true} calloutProps={{ doNotLayer: true, className: 'specialClassName' }}>

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -89,9 +89,15 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
     if (headline) {
       headerContent = (
         <div className={classNames.header}>
-          <p className={classNames.headline} id={ariaLabelledBy}>
-            {headline}
-          </p>
+          {typeof children === 'string' ? (
+            <p className={classNames.headline} id={ariaLabelledBy}>
+              {headline}
+            </p>
+          ) : (
+            <div className={classNames.headline} id={ariaLabelledBy}>
+              {headline}
+            </div>
+          )}
         </div>
       );
     }
@@ -99,9 +105,15 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
     if (children) {
       bodyContent = (
         <div className={classNames.body}>
-          <p className={classNames.subText} id={ariaDescribedBy}>
-            {children}
-          </p>
+          {typeof children === 'string' ? (
+            <p className={classNames.subText} id={ariaDescribedBy}>
+              {children}
+            </p>
+          ) : (
+            <div className={classNames.subText} id={ariaDescribedBy}>
+              {children}
+            </div>
+          )}
         </div>
       );
     }

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -87,33 +87,25 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
     }
 
     if (headline) {
+      const HeaderWrapperAs = typeof headline === 'string' ? 'p' : 'div';
+
       headerContent = (
         <div className={classNames.header}>
-          {typeof children === 'string' ? (
-            <p className={classNames.headline} id={ariaLabelledBy}>
-              {headline}
-            </p>
-          ) : (
-            <div className={classNames.headline} id={ariaLabelledBy}>
-              {headline}
-            </div>
-          )}
+          <HeaderWrapperAs className={classNames.headline} id={ariaLabelledBy}>
+            {headline}
+          </HeaderWrapperAs>
         </div>
       );
     }
 
     if (children) {
+      const BodyContentWrapperAs = typeof children === 'string' ? 'p' : 'div';
+
       bodyContent = (
         <div className={classNames.body}>
-          {typeof children === 'string' ? (
-            <p className={classNames.subText} id={ariaDescribedBy}>
-              {children}
-            </p>
-          ) : (
-            <div className={classNames.subText} id={ariaDescribedBy}>
-              {children}
-            </div>
-          )}
+          <BodyContentWrapperAs className={classNames.subText} id={ariaDescribedBy}>
+            {children}
+          </BodyContentWrapperAs>
         </div>
       );
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6190
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Teachingbubble: use div and instead of p if teachingbubble content isn't a string 
- checks for types for string or not
- added test to re-enforce behavior 

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6215)

