### PR TITLE
Mark unused IButtonProps' toggled prop as deprecated

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-btn-toggle-depr_2018-09-04-21-03.json
+++ b/common/changes/office-ui-fabric-react/keco-btn-toggle-depr_2018-09-04-21-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Mark unused \"toggled\" prop of IButtonProps as deprecated.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -68,7 +68,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     this._warnDeprecations({
       rootProps: undefined,
-      description: 'secondaryText'
+      description: 'secondaryText',
+      toggled: 'checked'
     });
     this._labelId = getId();
     this._descriptionId = getId();

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -218,6 +218,8 @@ export interface IButtonProps
 
   /**
    * Any custom data the developer wishes to associate with the menu item.
+   *
+   * @deprecated unused, use `checked` if setting state.
    */
   toggled?: boolean;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6199
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Marks the unused `toggled?` property of `IButtonProps` as `@deprecated` and advises users to use `checked` for state which is used when a button is toggleable.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6217)

