### PR TITLE
ChoiceGroup: focus() should focus on selected option

### DIFF
--- a/common/changes/office-ui-fabric-react/choiceGroupFocus_2018-09-05-00-24.json
+++ b/common/changes/office-ui-fabric-react/choiceGroupFocus_2018-09-05-00-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: have focus method take into account selectedKey",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Label } from '../../Label';
 import { ChoiceGroupOption, OnFocusCallback, OnChangeCallback } from './ChoiceGroupOption/index';
 import { IChoiceGroupOption, IChoiceGroupProps, IChoiceGroupStyleProps, IChoiceGroupStyles } from './ChoiceGroup.types';
-import { BaseComponent, classNamesFunction, createRef, getId, find } from '../../Utilities';
+import { BaseComponent, classNamesFunction, getId, find } from '../../Utilities';
 
 const getClassNames = classNamesFunction<IChoiceGroupStyleProps, IChoiceGroupStyles>();
 
@@ -20,7 +20,6 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
 
   private _id: string;
   private _labelId: string;
-  private _inputElement = createRef<HTMLInputElement>();
   private focusedVars: { [key: string]: OnFocusCallback } = {};
   private changedVars: { [key: string]: OnChangeCallback } = {};
 
@@ -43,9 +42,9 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
 
   public componentWillReceiveProps(newProps: IChoiceGroupProps): void {
     const newKeyChecked = this._getKeyChecked(newProps);
-    const oldKeyCheched = this._getKeyChecked(this.props);
+    const oldKeyChecked = this._getKeyChecked(this.props);
 
-    if (newKeyChecked !== oldKeyCheched) {
+    if (newKeyChecked !== oldKeyChecked) {
       this.setState({
         keyChecked: newKeyChecked!
       });
@@ -110,8 +109,14 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
   }
 
   public focus() {
-    if (this._inputElement.current) {
-      this._inputElement.current.focus();
+    if (this.props.options) {
+      for (const option of this.props.options) {
+        const myElement = document.getElementById(`${this._id}-${option.key}`);
+        if (myElement && myElement.getAttribute('data-is-focusable') === 'true') {
+          myElement.focus();
+          break;
+        }
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Label } from '../../Label';
 import { ChoiceGroupOption, OnFocusCallback, OnChangeCallback } from './ChoiceGroupOption/index';
 import { IChoiceGroupOption, IChoiceGroupProps, IChoiceGroupStyleProps, IChoiceGroupStyles } from './ChoiceGroup.types';
-import { BaseComponent, classNamesFunction, getId, find } from '../../Utilities';
+import { BaseComponent, classNamesFunction, createRef, getId, find } from '../../Utilities';
 
 const getClassNames = classNamesFunction<IChoiceGroupStyleProps, IChoiceGroupStyles>();
 
@@ -20,6 +20,7 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
 
   private _id: string;
   private _labelId: string;
+  private _inputElement = createRef<HTMLInputElement>();
   private focusedVars: { [key: string]: OnFocusCallback } = {};
   private changedVars: { [key: string]: OnChangeCallback } = {};
 
@@ -109,14 +110,25 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
   }
 
   public focus() {
-    if (this.props.options) {
-      for (const option of this.props.options) {
+    const { options } = this.props;
+    if (options) {
+      for (const option of options) {
         const myElement = document.getElementById(`${this._id}-${option.key}`);
         if (myElement && myElement.getAttribute('data-is-focusable') === 'true') {
-          myElement.focus();
-          break;
+          myElement.focus(); // focus on checked or default focusable key
+          return;
         }
       }
+      const firstOption = options[0];
+      const firstElement = document.getElementById(`${this._id}-${firstOption.key}`);
+      if (firstElement) {
+        // focus on first option if there is no checked key
+        firstElement.focus();
+        return;
+      }
+    }
+    if (this._inputElement.current) {
+      this._inputElement.current.focus();
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -113,17 +113,16 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
     const { options } = this.props;
     if (options) {
       for (const option of options) {
-        const myElement = document.getElementById(`${this._id}-${option.key}`);
-        if (myElement && myElement.getAttribute('data-is-focusable') === 'true') {
-          myElement.focus(); // focus on checked or default focusable key
+        const elementToFocus = document.getElementById(`${this._id}-${option.key}`);
+        if (elementToFocus && elementToFocus.getAttribute('data-is-focusable') === 'true') {
+          elementToFocus.focus(); // focus on checked or default focusable key
           return;
         }
       }
       const firstOption = options[0];
       const firstElement = document.getElementById(`${this._id}-${firstOption.key}`);
       if (firstElement) {
-        // focus on first option if there is no checked key
-        firstElement.focus();
+        firstElement.focus(); // focus on first option if there is no checked key
         return;
       }
     }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -119,12 +119,6 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
           return;
         }
       }
-      const firstOption = options[0];
-      const firstElement = document.getElementById(`${this._id}-${firstOption.key}`);
-      if (firstElement) {
-        firstElement.focus(); // focus on first option if there is no checked key
-        return;
-      }
     }
     if (this._inputElement.current) {
       this._inputElement.current.focus();


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6025
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Before these changes, the ChoiceGroup focus method was always focusing on the last choice group option, even if there was an option selected. `this._inputElement.current` is always the last option due to, I believe, the order of the rendering.

To fix this, I took a different route, checking the `data-is-focusable` attributes, which signifies either a checked key or a default focusable key.

In these examples below, you can see that now focus() will focus on the correct option (the button's onClick method calls ChoiceGroup's focus()).

Before:
![choicegroup focus with selectedkey not working](https://user-images.githubusercontent.com/14134000/45064409-6311d300-b068-11e8-93dd-0e48f3787f80.gif)
![choicegroup focus without selectedkey not working](https://user-images.githubusercontent.com/14134000/45064413-660cc380-b068-11e8-9804-e3c1bc3edcf3.gif)

After:
![choicegroup focus with selectedkey working](https://user-images.githubusercontent.com/14134000/45064415-6907b400-b068-11e8-84a5-dbd793b099dd.gif)
![choicegroup focus without selectedkey working](https://user-images.githubusercontent.com/14134000/45064417-6ad17780-b068-11e8-83e1-8b0b5fa7655b.gif)

I'll note that I left in the original logic just in case we'd like to keep it, but if we think it's unnecessary I can remove it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6224)

