### PR TITLE
ContextMenuItem declare font color as semanticColors.bodyText instead of 'inherit'

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-ctx-menu-root-font-color_2018-09-05-18-05.json
+++ b/common/changes/office-ui-fabric-react/keco-ctx-menu-root-font-color_2018-09-05-18-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenuItem declare font-color as semanticColors.bodyText instead of inherit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -53,7 +53,7 @@ export const getMenuItemStyles = memoizeFunction(
         getFocusStyle(theme),
         fonts.medium,
         {
-          color: 'inherit',
+          color: semanticColors.bodyText,
           backgroundColor: 'transparent',
           border: 'none',
           width: '100%',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5864
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Declares the default `color` styles property of ContextualMenuItem's `.root-` to be `semanticColors.bodyText` rather than `inherit`. This is to address the scenario where emphasized item headers are bleeding into normal item text colors (reported above).

#### Focus areas to test

ContextualMenu and their items should render as they do in `master` with their default style now being:

![image](https://user-images.githubusercontent.com/706967/45112295-1f68a900-b0fc-11e8-946e-7837d146e631.png)

@joschect see any potential issues with this change?

@phkuo do you have a snippet to test if this fixes the specific issue you were experiencing.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6235)

