### PR TITLE
Fix Coachmark focus when tabbing

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-09-2018-CoachmarkFocusTab_2018-09-05-19-35.json
+++ b/common/changes/office-ui-fabric-react/edwl-09-2018-CoachmarkFocusTab_2018-09-05-19-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Coachmark: Fix tabbing when Coachmark is mounted",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -26,6 +26,11 @@ export interface ICoachmarkStyleProps {
   isMeasuring: boolean;
 
   /**
+   * Is the Coachmark finished measuring the dimensions of innerHostElement
+   */
+  isMeasured: boolean;
+
+  /**
    * The height measured before the component has been mounted
    * in pixels
    */
@@ -74,8 +79,7 @@ export interface ICoachmarkStyles {
   root?: IStyle;
 
   /**
-   * The pulsing beacon that animates when the coachmark
-   * is collapsed.
+   * The pulsing beacon that animates when the Coachmark is collapsed.
    */
   pulsingBeacon?: IStyle;
 
@@ -107,7 +111,12 @@ export interface ICoachmarkStyles {
   entityInnerHost: IStyle;
 
   /**
-   * The styles applied when the coachmark has collapsed.
+   * The layer that directly contains the TeachingBubbleContent
+   */
+  childrenContainer: IStyle;
+
+  /**
+   * The styles applied when the Coachmark has collapsed.
    */
   collapsed?: IStyle;
 
@@ -357,6 +366,11 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
       },
       !props.isMeasuring && {
         visibility: 'visible'
+      }
+    ],
+    childrenContainer: [
+      {
+        display: props.isMeasured && props.isCollapsed ? 'none' : 'block'
       }
     ],
     ariaContainer: {

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
@@ -556,7 +556,6 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
       this._entityInnerHostElement.current.addEventListener(
         'transitionend',
         (): void => {
-          console.log('testing here');
           // Need setTimeout to trigger narrator
           this._async.setTimeout(() => {
             if (this._entityInnerHostElement.current) {

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
@@ -62,6 +62,11 @@ export interface ICoachmarkState {
   isMeasuring: boolean;
 
   /**
+   * Is the Coachmark done measuring the hosted entity
+   */
+  isMeasured: boolean;
+
+  /**
    * Cached width and height of _entityInnerHostElement
    */
   entityInnerHostRect: IEntityRect;
@@ -128,11 +133,12 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
    * The cached HTMLElement reference to the Entity Inner Host
    * element.
    */
+  private _entityHost = createRef<HTMLDivElement>();
   private _entityInnerHostElement = createRef<HTMLDivElement>();
   private _translateAnimationContainer = createRef<HTMLDivElement>();
   private _ariaAlertContainer = createRef<HTMLDivElement>();
+  private _childrenContainer = createRef<HTMLDivElement>();
   private _positioningContainer = createRef<IPositioningContainer>();
-  private _focusTrapZone = createRef<FocusTrapZone>();
 
   /**
    * The target element the mouse would be in
@@ -161,7 +167,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
         width: 0,
         height: 0
       },
-      isMouseInProximity: false
+      isMouseInProximity: false,
+      isMeasured: false
     };
   }
 
@@ -197,7 +204,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
       isMeasuring,
       entityInnerHostRect,
       transformOrigin,
-      alertText
+      alertText,
+      isMeasured
     } = this.state;
 
     const classNames = getClassNames(getStyles, {
@@ -209,7 +217,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
       width: `${COACHMARK_WIDTH}px`,
       height: `${COACHMARK_HEIGHT}px`,
       color: color,
-      transformOrigin: transformOrigin
+      transformOrigin: transformOrigin,
+      isMeasured: isMeasured
     });
 
     const finalHeight: number = isCollapsed ? COACHMARK_HEIGHT : entityInnerHostRect.height;
@@ -250,40 +259,39 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
                       color={color}
                     />
                   )}
-                <FocusTrapZone
-                  componentRef={this._focusTrapZone}
-                  isClickableOutsideFocusTrap={true}
-                  forceFocusInsideTrap={false}
+                <div
+                  className={classNames.entityHost}
+                  ref={this._entityHost}
+                  tabIndex={-1}
+                  data-is-focusable={true}
+                  role="dialog"
+                  aria-labelledby={ariaLabelledBy}
+                  aria-describedby={ariaDescribedBy}
                 >
-                  <div
-                    className={classNames.entityHost}
-                    tabIndex={-1}
-                    data-is-focusable={true}
-                    role="dialog"
-                    aria-labelledby={ariaLabelledBy}
-                    aria-describedby={ariaDescribedBy}
-                  >
-                    {isCollapsed && [
-                      ariaLabelledBy && (
-                        <p id={ariaLabelledBy} key={0} className={classNames.ariaContainer}>
-                          {ariaLabelledByText}
-                        </p>
-                      ),
-                      ariaDescribedBy && (
-                        <p id={ariaDescribedBy} key={1} className={classNames.ariaContainer}>
-                          {ariaDescribedByText}
-                        </p>
-                      )
-                    ]}
-                    <div
-                      className={classNames.entityInnerHost}
-                      ref={this._entityInnerHostElement}
-                      aria-hidden={isCollapsed}
-                    >
-                      {children}
+                  {isCollapsed && [
+                    ariaLabelledBy && (
+                      <p id={ariaLabelledBy} key={0} className={classNames.ariaContainer}>
+                        {ariaLabelledByText}
+                      </p>
+                    ),
+                    ariaDescribedBy && (
+                      <p id={ariaDescribedBy} key={1} className={classNames.ariaContainer}>
+                        {ariaDescribedByText}
+                      </p>
+                    )
+                  ]}
+                  <FocusTrapZone isClickableOutsideFocusTrap={true} forceFocusInsideTrap={false}>
+                    <div className={classNames.entityInnerHost} ref={this._entityInnerHostElement}>
+                      <div
+                        className={classNames.childrenContainer}
+                        ref={this._childrenContainer}
+                        aria-hidden={isCollapsed}
+                      >
+                        {children}
+                      </div>
                     </div>
-                  </div>
-                </FocusTrapZone>
+                  </FocusTrapZone>
+                </div>
               </div>
             </div>
           </div>
@@ -327,7 +335,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
             entityInnerHostRect: {
               width: this._entityInnerHostElement.current.offsetWidth,
               height: this._entityInnerHostElement.current.offsetHeight
-            }
+            },
+            isMeasured: true
           });
           this._setBeakPosition();
           this.forceUpdate();
@@ -351,8 +360,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
           }, 0);
         }
         this._async.setTimeout(() => {
-          if (this._focusTrapZone.current) {
-            this._focusTrapZone.current.focus();
+          if (this._entityHost.current) {
+            this._entityHost.current.focus();
           }
         }, 1000);
       }
@@ -547,6 +556,7 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
       this._entityInnerHostElement.current.addEventListener(
         'transitionend',
         (): void => {
+          console.log('testing here');
           // Need setTimeout to trigger narrator
           this._async.setTimeout(() => {
             if (this._entityInnerHostElement.current) {


### PR DESCRIPTION

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5960
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds another container to Coachmark and sets its `display` to `block` or `none` depending on the Coachmark state.  Setting to `none` will prevent focus to the Primary/Secondary buttons inside of TeachingBubbleContent, so tabbing will not be trapped inside of TeachingBubbleContent.  

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6240)

