### PR TITLE
Commandbar: remove invalid aria attributes

### DIFF
--- a/common/changes/office-ui-fabric-react/commandbar_2018-09-05-21-38.json
+++ b/common/changes/office-ui-fabric-react/commandbar_2018-09-05-21-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: get rid of invalid aria attributes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -46,7 +46,6 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     overflowItems: []
   };
 
-  private _setSize: number;
   private _overflowSet = createRef<IOverflowSet>();
   private _resizeGroup = createRef<IResizeGroup>();
   private _classNames: { [key in keyof ICommandBarStyles]: string };
@@ -71,7 +70,6 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       cacheKey: ''
     };
 
-    this._setAriaPosinset(commandBarData);
     this._classNames = getClassNames(styles!, { theme: theme!, className });
 
     return (
@@ -94,26 +92,6 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   public remeasure(): void {
     this._resizeGroup.current && this._resizeGroup.current.remeasure();
-  }
-
-  private _setAriaPosinset(data: ICommandBarData): ICommandBarData {
-    this._setSize = data.primaryItems.length + (data.overflowItems.length > 0 ? 1 : 0);
-
-    data.primaryItems = data.primaryItems.map((item, i, array) => {
-      item['aria-posinset'] = i + 1;
-      item['aria-setsize'] = this._setSize;
-      return item;
-    });
-
-    if (data.farItems) {
-      data.farItems = data.farItems.map((item, i, array) => {
-        item['aria-posinset'] = i + 1;
-        item['aria-setsize'] = array.length;
-        return item;
-      });
-    }
-
-    return data;
   }
 
   private _onRenderData = (data: ICommandBarData): JSX.Element => {
@@ -213,13 +191,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       menuIconProps: { iconName: 'More', ...overflowButtonProps.menuIconProps }
     };
 
-    return (
-      <OverflowButtonType
-        aria-posinset={this._setSize}
-        aria-setsize={this._setSize}
-        {...overflowProps as IButtonProps}
-      />
-    );
+    return <OverflowButtonType {...overflowProps as IButtonProps} />;
   };
 
   private _computeCacheKey(data: ICommandBarData): string {
@@ -249,15 +221,15 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       overflowItems = [movedItem, ...overflowItems];
       primaryItems = shiftOnReduce ? primaryItems.slice(1) : primaryItems.slice(0, -1);
 
-      const newData = this._setAriaPosinset({ ...data, primaryItems, overflowItems });
-
-      cacheKey = this._computeCacheKey(newData);
+      data.primaryItems = primaryItems;
+      data.overflowItems = overflowItems;
+      cacheKey = this._computeCacheKey(data);
 
       if (onDataReduced) {
         onDataReduced(movedItem);
       }
 
-      return { ...newData, cacheKey };
+      return { ...data, cacheKey };
     }
 
     return undefined;
@@ -277,14 +249,15 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       // if shiftOnReduce, movedItem goes first, otherwise, last.
       primaryItems = shiftOnReduce ? [movedItem, ...primaryItems] : [...primaryItems, movedItem];
 
-      const newData = this._setAriaPosinset({ ...data, primaryItems, overflowItems });
-      cacheKey = this._computeCacheKey(newData);
+      data.primaryItems = primaryItems;
+      data.overflowItems = overflowItems;
+      cacheKey = this._computeCacheKey(data);
 
       if (onDataGrown) {
         onDataGrown(movedItem);
       }
 
-      return { ...newData, cacheKey };
+      return { ...data, cacheKey };
     }
 
     return undefined;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.styles.ts
@@ -1,9 +1,8 @@
 import { IGroupFooterStyleProps, IGroupFooterStyles } from './GroupFooter.types';
-import { getGlobalClassNames, FontSizes } from '../../Styling';
+import { getGlobalClassNames } from '../../Styling';
 
 const GlobalClassNames = {
-  root: 'ms-groupFooter',
-  link: 'ms-Link'
+  root: 'ms-groupFooter'
 };
 
 export const getStyles = (props: IGroupFooterStyleProps): IGroupFooterStyles => {
@@ -15,12 +14,7 @@ export const getStyles = (props: IGroupFooterStyleProps): IGroupFooterStyles => 
       classNames.root,
       {
         position: 'relative',
-        padding: '5px 38px',
-        selectors: {
-          [`:global(.${classNames.link}`]: {
-            fontSize: FontSizes.small
-          }
-        }
+        padding: '5px 38px'
       },
       className
     ]

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.styles.ts
@@ -1,8 +1,9 @@
 import { IGroupFooterStyleProps, IGroupFooterStyles } from './GroupFooter.types';
-import { getGlobalClassNames } from '../../Styling';
+import { getGlobalClassNames, FontSizes } from '../../Styling';
 
 const GlobalClassNames = {
-  root: 'ms-groupFooter'
+  root: 'ms-groupFooter',
+  link: 'ms-Link'
 };
 
 export const getStyles = (props: IGroupFooterStyleProps): IGroupFooterStyles => {
@@ -14,7 +15,12 @@ export const getStyles = (props: IGroupFooterStyleProps): IGroupFooterStyles => 
       classNames.root,
       {
         position: 'relative',
-        padding: '5px 38px'
+        padding: '5px 38px',
+        selectors: {
+          [`:global(.${classNames.link}`]: {
+            fontSize: FontSizes.small
+          }
+        }
       },
       className
     ]


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6232 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Commandbar: remove invalid aria attributes
- removed function that modifies the aria attribs
- kept the cacheKey calculation
- adding back the clone array functionality of set aria function

#### Focus areas to test

(optional)
