### PR TITLE
Teachingbubble: make teachingbuble props doc show up

### DIFF
--- a/common/changes/office-ui-fabric-react/teachingbubble_2018-09-05-22-39.json
+++ b/common/changes/office-ui-fabric-react/teachingbubble_2018-09-05-22-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react-tslint/prettier.config.js
+++ b/packages/office-ui-fabric-react-tslint/prettier.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  printWidth: 120,
+  printWidth: 140,
   tabWidth: 2,
   singleQuote: true
 };

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -17,10 +17,7 @@ export interface ITeachingBubble {
 /**
  * TeachingBubble component props.
  */
-
-export interface ITeachingBubbleProps
-  extends React.Props<TeachingBubbleBase | TeachingBubbleContentBase>,
-    IAccessiblePopupProps {
+export interface ITeachingBubbleProps extends React.Props<TeachingBubbleBase | TeachingBubbleContentBase>, IAccessiblePopupProps {
   /**
    * Optional callback to access the ITeachingBubble interface. Use this instead of ref for accessing
    * the public methods and properties of the component.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6219
- [x] Include a change request file using `$ npm run change`

#### Description of changes

We already allow for 140 characters on the workspace prettier settings. Made the config the same in prettier.config.js.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6246)

