### PR TITLE
Donut chart arc opacity issue

### DIFF
--- a/common/changes/@uifabric/charting/donutOpacityBug_2018-09-06-07-00.json
+++ b/common/changes/@uifabric/charting/donutOpacityBug_2018-09-06-07-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "donut chart arc sectors selected arc show and remaining arcs decrease opacity",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "gorigarajesh@gmail.com"
+}

--- a/packages/charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.tsx
@@ -34,21 +34,26 @@ export class Arc extends React.Component<IArcProps, { isCalloutVisible: boolean 
     const { color, arc } = this.props;
     const getClassNames = classNamesFunction<IArcProps, IArcStyles>();
     const classNames = getClassNames(getStyles, { color });
-
+    const id = this.props.uniqText! + this.props.data!.data.legend!.replace(/\s+/, '') + this.props.data!.data.data;
+    const opacity: number =
+      this.props.activeArc === this.props.data!.data.legend || this.props.activeArc === '' ? 1 : 0.1;
     return (
       <g>
         <path
-          id={this.props.uniqText! + this.props.data!.data.legend!.replace(/\s+/, '') + this.props.data!.data.data}
+          id={id}
           d={arc(this.props.data)}
           className={classNames.root}
-          onMouseOver={this._hoverOn.bind(this, this.props.data!.data)}
+          onMouseOver={this._hoverOn.bind(this, this.props.data!.data, id)}
           onMouseLeave={this._hoverOff}
+          opacity={opacity}
         />
       </g>
     );
   }
-  private _hoverOn(data: IChartDataPoint): void {
-    this.props.hoverOnCallback!(data);
+  private _hoverOn(data: IChartDataPoint, id: string): void {
+    if (this.props.activeArc === this.props.data!.data.legend || this.props.activeArc === '') {
+      this.props.hoverOnCallback!(data);
+    }
   }
   private _hoverOff(): void {
     this.props.hoverLeaveCallback!();

--- a/packages/charting/src/components/DonutChart/Arc/Arc.types.ts
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.types.ts
@@ -41,6 +41,10 @@ export interface IArcProps {
    * Uniq string for chart
    */
   uniqText?: string;
+  /**
+   * Active Arc for chart
+   */
+  activeArc?: string;
 }
 
 export interface IArcData {

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -93,10 +93,10 @@ export class DonutChartBase extends React.Component<
             isBeakVisible={false}
             directionalHint={DirectionalHint.bottomRightEdge}
             gapSpace={5}
-            className={this._classNames.callOut}
           >
-            <div className="ms-CalloutExample-content">
-              <span>{this.state.value}</span>
+            <div className={this._classNames.hoverCardRoot}>
+              <div className={this._classNames.hoverCardTextStyles}>{this.state.legend}</div>
+              <div className={this._classNames.hoverCardDataStyles}>{this.state.value}</div>
             </div>
           </Callout>
         ) : null}

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -18,6 +18,7 @@ export class DonutChartBase extends React.Component<
     legend: string | undefined;
     _width: number | undefined;
     _height: number | undefined;
+    activeLegend: string;
   }
 > {
   public static defaultProps: Partial<IDonutChartProps> = {
@@ -34,7 +35,8 @@ export class DonutChartBase extends React.Component<
       value: '',
       legend: '',
       _width: this.props.width || 200,
-      _height: this.props.height || 200
+      _height: this.props.height || 200,
+      activeLegend: ''
     };
     this._hoverCallback = this._hoverCallback.bind(this);
     this._hoverLeave = this._hoverLeave.bind(this);
@@ -78,6 +80,7 @@ export class DonutChartBase extends React.Component<
             hoverOnCallback={this._hoverCallback}
             hoverLeaveCallback={this._hoverLeave}
             uniqText={this._uniqText}
+            activeArc={this.state.activeLegend}
           />
         </svg>
         {this.state.showHover ? (
@@ -110,7 +113,7 @@ export class DonutChartBase extends React.Component<
       node.parentElement && node.parentElement.offsetHeight > this.state._height!
         ? node.parentElement.offsetHeight
         : this.state._height;
-    const viewbox = `0 0 ${widthVal!} ${heightVal!}`;
+    const viewbox = `0 0 ${widthVal!} ${heightVal!}`;
     node.setAttribute('viewBox', viewbox);
   }
   private _createLegends(data: IChartProps, palette: IPalette): JSX.Element {
@@ -124,6 +127,11 @@ export class DonutChartBase extends React.Component<
           title: point.legend!,
           color: color,
           hoverAction: () => {
+            if (this.state.activeLegend !== point.legend || this.state.activeLegend === '') {
+              this.setState({ activeLegend: point.legend! });
+            } else {
+              this.setState({ activeLegend: point.legend });
+            }
             this.setState({
               showHover: true,
               value: point.data!.toString(),
@@ -132,7 +140,8 @@ export class DonutChartBase extends React.Component<
           },
           onMouseOutAction: () => {
             this.setState({
-              showHover: false
+              showHover: false,
+              activeLegend: ''
             });
           }
         };

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -19,6 +19,7 @@ export class DonutChartBase extends React.Component<
     _width: number | undefined;
     _height: number | undefined;
     activeLegend: string;
+    color: string | undefined;
   }
 > {
   public static defaultProps: Partial<IDonutChartProps> = {
@@ -36,7 +37,8 @@ export class DonutChartBase extends React.Component<
       legend: '',
       _width: this.props.width || 200,
       _height: this.props.height || 200,
-      activeLegend: ''
+      activeLegend: '',
+      color: ''
     };
     this._hoverCallback = this._hoverCallback.bind(this);
     this._hoverLeave = this._hoverLeave.bind(this);
@@ -62,6 +64,7 @@ export class DonutChartBase extends React.Component<
       theme: theme!,
       width: _width!,
       height: _height!,
+      color: this.state.color!,
       className
     });
     const legendBars = this._createLegends(data!, palette);
@@ -135,7 +138,8 @@ export class DonutChartBase extends React.Component<
             this.setState({
               showHover: true,
               value: point.data!.toString(),
-              legend: point.legend!
+              legend: point.legend!,
+              color: point.color!
             });
           },
           onMouseOutAction: () => {
@@ -155,7 +159,8 @@ export class DonutChartBase extends React.Component<
     this.setState({
       showHover: true,
       value: data.data!.toString(),
-      legend: data.legend
+      legend: data.legend,
+      color: data.color!
     });
   }
 

--- a/packages/charting/src/components/DonutChart/DonutChart.styles.ts
+++ b/packages/charting/src/components/DonutChart/DonutChart.styles.ts
@@ -1,7 +1,7 @@
 import { IDonutChartStyleProps, IDonutChartStyles } from './DonutChart.types';
 
 export const getStyles = (props: IDonutChartStyleProps): IDonutChartStyles => {
-  const { className, width, height, theme } = props;
+  const { className, width, height, theme, color } = props;
   const { palette } = theme;
   return {
     root: [
@@ -29,7 +29,7 @@ export const getStyles = (props: IDonutChartStyleProps): IDonutChartStyles => {
     callOut: {
       padding: '10px 16px 10px 16px',
       fontSize: '12px',
-      color: palette.blue,
+      color: color ? color : palette.blue,
       fontFamily: 'Segoe UI',
       fontWeight: 'bold',
       backgroundColor: 'white'

--- a/packages/charting/src/components/DonutChart/DonutChart.styles.ts
+++ b/packages/charting/src/components/DonutChart/DonutChart.styles.ts
@@ -2,7 +2,6 @@ import { IDonutChartStyleProps, IDonutChartStyles } from './DonutChart.types';
 
 export const getStyles = (props: IDonutChartStyleProps): IDonutChartStyles => {
   const { className, width, height, theme, color } = props;
-  const { palette } = theme;
   return {
     root: [
       'ms-DonutChart',
@@ -26,13 +25,22 @@ export const getStyles = (props: IDonutChartStyleProps): IDonutChartStyles => {
       paddingTop: '16px',
       width: `${width}px`
     },
-    callOut: {
-      padding: '10px 16px 10px 16px',
-      fontSize: '12px',
-      color: color ? color : palette.blue,
+    hoverCardTextStyles: {
+      ...theme.fonts.medium,
+      lineHeight: '14px'
+    },
+    hoverCardDataStyles: {
+      color: color === '' ? theme.palette.black : color,
+      fontSize: '28px',
       fontFamily: 'Segoe UI',
       fontWeight: 'bold',
-      backgroundColor: 'white'
+      lineHeight: '31px'
+    },
+    hoverCardRoot: {
+      paddingLeft: '16px',
+      paddingRight: '22px',
+      paddingTop: '15px',
+      paddingBottom: '8px'
     }
   };
 };

--- a/packages/charting/src/components/DonutChart/DonutChart.types.ts
+++ b/packages/charting/src/components/DonutChart/DonutChart.types.ts
@@ -36,6 +36,11 @@ export interface IDonutChartProps {
   theme?: ITheme;
 
   /**
+   * color for hover font color
+   */
+  color?: string;
+
+  /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IDonutChartStyleProps, IDonutChartStyles>;
@@ -46,7 +51,7 @@ export interface IDonutChartProps {
   strokeWidth?: number;
 }
 
-export type IDonutChartStyleProps = Required<Pick<IDonutChartProps, 'theme' | 'width' | 'height'>> &
+export type IDonutChartStyleProps = Required<Pick<IDonutChartProps, 'theme' | 'width' | 'height' | 'color'>> &
   Pick<IDonutChartProps, 'className'>;
 
 export interface IDonutChartStyles {

--- a/packages/charting/src/components/DonutChart/DonutChart.types.ts
+++ b/packages/charting/src/components/DonutChart/DonutChart.types.ts
@@ -36,11 +36,6 @@ export interface IDonutChartProps {
   theme?: ITheme;
 
   /**
-   * color for hover font color
-   */
-  color?: string;
-
-  /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IDonutChartStyleProps, IDonutChartStyles>;
@@ -51,8 +46,32 @@ export interface IDonutChartProps {
   strokeWidth?: number;
 }
 
-export type IDonutChartStyleProps = Required<Pick<IDonutChartProps, 'theme' | 'width' | 'height' | 'color'>> &
-  Pick<IDonutChartProps, 'className'>;
+export interface IDonutChartStyleProps {
+  /**
+   * Theme (provided through customization.)
+   */
+  theme: ITheme;
+
+  /**
+   * Additional CSS class(es) to apply to the Donut chart.
+   */
+  className?: string;
+
+  /**
+   * Height of the donut.
+   */
+  height?: number;
+
+  /**
+   * Width of the donut.
+   */
+  width: number;
+
+  /**
+   * color for hover font color
+   */
+  color?: string;
+}
 
 export interface IDonutChartStyles {
   /**

--- a/packages/charting/src/components/DonutChart/DonutChart.types.ts
+++ b/packages/charting/src/components/DonutChart/DonutChart.types.ts
@@ -87,8 +87,19 @@ export interface IDonutChartStyles {
    * Style for the legend container.
    */
   legendContainer: IStyle;
+
   /**
-   * Style for the callout.
+   * Style for the legend card title displayed in the hover card
    */
-  callOut: IStyle;
+  hoverCardTextStyles: IStyle;
+
+  /**
+   * Style for the data displayed in the hover card
+   */
+  hoverCardDataStyles: IStyle;
+
+  /**
+   * Style for the root of the hover card
+   */
+  hoverCardRoot: IStyle;
 }

--- a/packages/charting/src/components/DonutChart/Pie/Pie.tsx
+++ b/packages/charting/src/components/DonutChart/Pie/Pie.tsx
@@ -32,6 +32,7 @@ export class Pie extends React.Component<IPieProps, {}> {
         hoverOnCallback={this._hoverCallback}
         hoverLeaveCallback={this.props.hoverLeaveCallback}
         uniqText={this.props.uniqText}
+        activeArc={this.props.activeArc}
       />
     );
   };

--- a/packages/charting/src/components/DonutChart/Pie/Pie.types.ts
+++ b/packages/charting/src/components/DonutChart/Pie/Pie.types.ts
@@ -39,6 +39,10 @@ export interface IPieProps {
    * Uniq string for chart
    */
   uniqText?: string;
+  /**
+   * Active Arc for chart
+   */
+  activeArc?: string;
 }
 
 export interface IPieStyles {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
 -donut chart when one sector is selected from legends remaining sectors opacity decreases
-update snapshot to solve build issues
#### screenshot
<img width="950" alt="donuthoveropacity" src="https://user-images.githubusercontent.com/13463251/45094951-6c6b7000-b13a-11e8-955f-88f61e5b22a0.PNG">

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6229)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6248)

