### PR TITLE
Spinbutton: allow classname to be passed through

### DIFF
--- a/common/changes/office-ui-fabric-react/spinbutton_2018-09-06-17-08.json
+++ b/common/changes/office-ui-fabric-react/spinbutton_2018-09-06-17-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "allow custom classnames to be passed thru to spinbutton",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.classNames.ts
@@ -20,10 +20,11 @@ export const getClassNames = memoizeFunction(
     disabled: boolean,
     isFocused: boolean,
     keyboardSpinDirection: KeyboardSpinDirection,
-    labelPosition: Position = Position.start
+    labelPosition: Position = Position.start,
+    className: string | undefined = undefined
   ): ISpinButtonClassNames => {
     return {
-      root: mergeStyles(styles.root),
+      root: mergeStyles(styles.root, className),
       labelWrapper: mergeStyles(styles.labelWrapper, _getStyleForLabelBasedOnPosition(labelPosition, styles)),
       icon: mergeStyles(styles.icon, disabled && styles.iconDisabled),
       label: mergeStyles(styles.label, disabled && styles.labelDisabled),

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -135,14 +135,22 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
       ariaSetSize,
       ariaValueNow,
       ariaValueText,
-      keytipProps
+      keytipProps,
+      className
     } = this.props;
 
     const { isFocused, value, keyboardSpinDirection } = this.state;
 
     const classNames = this.props.getClassNames
-      ? this.props.getClassNames(theme!, !!disabled, !!isFocused, keyboardSpinDirection, labelPosition)
-      : getClassNames(getStyles(theme!, customStyles), !!disabled, !!isFocused, keyboardSpinDirection, labelPosition);
+      ? this.props.getClassNames(theme!, !!disabled, !!isFocused, keyboardSpinDirection, labelPosition, className)
+      : getClassNames(
+          getStyles(theme!, customStyles),
+          !!disabled,
+          !!isFocused,
+          keyboardSpinDirection,
+          labelPosition,
+          className
+        );
 
     return (
       <div className={classNames.root}>

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -149,7 +149,8 @@ export interface ISpinButtonProps {
     disabled: boolean,
     isFocused: boolean,
     keyboardSpinDirection: KeyboardSpinDirection,
-    labelPosition?: Position
+    labelPosition?: Position,
+    className?: string
   ) => ISpinButtonClassNames;
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5327
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Spinbutton: allow classname to be passed through
- the styles and classnames structure of spinbutton is not using the standard `styled` mechanism
- placed a new getClassName prop param to make it consistent; but we really should refactor this spinbutton to be standard way in Fabric later 

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6254)

