### PR TITLE
Contextualmenu: prevent setState call while unmounted

### DIFF
--- a/common/changes/office-ui-fabric-react/contextualmenu_2018-09-06-22-01.json
+++ b/common/changes/office-ui-fabric-react/contextualmenu_2018-09-06-22-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add safeguard in contextualmenu against doing setstate while unmounted",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -104,6 +104,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   private _processingExpandCollapseKeyOnly: boolean;
   private _shouldUpdateFocusOnMouseEvent: boolean;
   private _gotMouseMove: boolean;
+  private _mounted = false;
 
   private _adjustedFocusZoneProps: IFocusZoneProps;
 
@@ -176,6 +177,8 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     if (!this.props.hidden) {
       this._onMenuOpened();
     }
+
+    this._mounted = true;
   }
 
   // Invoked immediately before a component is unmounted from the DOM.
@@ -196,6 +199,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
 
     this._events.dispose();
     this._async.dispose();
+    this._mounted = false;
   }
 
   public render(): JSX.Element | null {
@@ -1148,10 +1152,16 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     }
   }
 
+  /**
+   * This function is called ASYNCHRONOUSLY, and so there is a chance it is called
+   * after the component is unmounted. The _mounted property is added to prevent
+   * from calling setState() after unmount. Do NOT copy this pattern in synchronous
+   * code.
+   */
   private _onSubMenuDismiss = (ev?: any, dismissAll?: boolean): void => {
     if (dismissAll) {
       this.dismiss(ev, dismissAll);
-    } else {
+    } else if (this._mounted) {
       this.setState({
         dismissedMenuItemKey: this.state.expandedMenuItemKey,
         expandedMenuItemKey: undefined,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5433
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Contextualmenu: prevent setState call while unmounted

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6261)

