### PR TITLE
Jspurlin/combo box fix hover to select

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ComboBoxFixHoverToSelect_2018-09-06-22-40.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ComboBoxFixHoverToSelect_2018-09-06-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: Fix pressing ENTER after just hovering over item when freeform (and there's no pending value)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1024,6 +1024,12 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       // if currentPendingValue is null or undefined the user did not submit anything
       // (not even empty because we would have stored that as the pending value)
       if (currentPendingValue === null || currentPendingValue === undefined) {
+        // if a user did not type anything they may just hovered over an item
+        if (currentPendingValueValidIndexOnHover >= 0) {
+          this._setSelectedIndex(currentPendingValueValidIndexOnHover, submitPendingValueEvent);
+          this._clearPendingInfo();
+        }
+
         return;
       }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Prior to this change, hovering over an item in an expanded comboBox and then pressing ENTER never worked for freeform comboBoxes, this fixes that

#### Focus areas to test
Verified that hovering over an item and pressing ENTER selects the hovered item unless there is a pending value (or a different item was selected via keyboarding)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6265)

