### PR TITLE
Legends hover card scaling as per content for all data viz

### DIFF
--- a/common/changes/@uifabric/charting/legendHoverCardScaling_2018-09-06-23-01.json
+++ b/common/changes/@uifabric/charting/legendHoverCardScaling_2018-09-06-23-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Adding temporary fix for hovercard. This fix scales the hover card size based upon the content inside it",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "nulikarthik@gmail.com"
+}

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -25,6 +25,7 @@ export interface ILegendState {
   selectedLegend: string;
   selectedState: boolean;
   hoverState: boolean;
+  hoverCardHeight: number;
 }
 export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   private _classNames: IProcessedStyleSet<ILegendsStyles>;
@@ -34,7 +35,8 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     this.state = {
       selectedLegend: 'none',
       selectedState: false,
-      hoverState: false
+      hoverState: false,
+      hoverCardHeight: 0
     };
   }
 
@@ -123,7 +125,8 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       const hoverCardElement = this._renderButton(legend, index, true);
       overflowHoverCardLegends.push(hoverCardElement);
     });
-    return <div>{overflowHoverCardLegends}</div>;
+    const hoverCardData = <div className="hoverCardRoot">{overflowHoverCardLegends}</div>;
+    return hoverCardData;
   };
 
   private _renderOverflowItems = (legends: ILegend[]) => {
@@ -133,9 +136,23 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     });
     const renderOverflowData: IExpandingCardProps = { renderData: legends };
     const expandingCardProps: IExpandingCardProps = {
+      compactCardHeight: this.state.hoverCardHeight + 16,
       onRenderCompactCard: this._onRenderCompactCard,
       renderData: renderOverflowData,
-      mode: 0
+      mode: 0,
+      styles: {
+        root: {
+          width: 'auto',
+          height: 'auto'
+        },
+        compactCard: {
+          width: 'auto',
+          height: 'auto'
+        },
+        expandedCard: {
+          width: 0
+        }
+      }
     };
     const { theme, className, styles } = this.props;
     const classNames = getClassNames(styles!, {
@@ -143,10 +160,20 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       className
     });
     return (
-      <HoverCard expandingCardProps={expandingCardProps}>
-        <div className={classNames.overflowIndicationTextStyle}>{items.length} more</div>
+      <HoverCard expandingCardProps={expandingCardProps} cardOpenDelay={10}>
+        <div className={classNames.overflowIndicationTextStyle} onMouseOver={this._calculateHoverCardLength}>
+          {items.length} more
+        </div>
       </HoverCard>
     );
+  };
+
+  private _calculateHoverCardLength = () => {
+    setTimeout(() => {
+      if (document.getElementsByClassName('hoverCardRoot')[0]) {
+        this.setState({ hoverCardHeight: document.getElementsByClassName('hoverCardRoot')[0].clientHeight });
+      }
+    }, 20);
   };
 
   private _onHoverOverLegend = (legend: ILegend) => {
@@ -195,13 +222,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       this._onLeave(legend);
     };
     return (
-      <div
-        key={index}
-        className={classNames.legend}
-        onClick={onClickHandler}
-        onMouseOver={onHoverHandler}
-        onMouseOut={onMouseOut}
-      >
+      <div key={index} className={classNames.legend} onClick={onClickHandler} onMouseOver={onHoverHandler} onMouseOut={onMouseOut}>
         <div className={classNames.rect} />
         <div className={classNames.text}>{legend.title}</div>
       </div>

--- a/packages/charting/src/components/Legends/Legends.styles.ts
+++ b/packages/charting/src/components/Legends/Legends.styles.ts
@@ -16,8 +16,7 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
       display: 'flex',
       alignItems: 'center',
       cursor: 'pointer',
-      marginTop: props.overflow ? '8px' : '',
-      marginLeft: props.overflow ? '8px' : ''
+      margin: props.overflow ? '16px 0px 16px 16px' : ''
     },
     rect: {
       width: '12px',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Adding temporary fix for legend's hover card for all DataViz. This fix will scale the size of the hovercard based upon the content it.
![image](https://user-images.githubusercontent.com/22408128/45189438-e446a280-b1ed-11e8-8f05-668117d6f5c7.png)


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6266)

