### PR TITLE
Layout edge issue

### DIFF
--- a/common/changes/@uifabric/dashboard/LayoutEdgeIssue_2018-09-07-10-39.json
+++ b/common/changes/@uifabric/dashboard/LayoutEdgeIssue_2018-09-07-10-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "ContentArea is croped in Edge browser",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "polu.balakrishna96@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/Layout/Layout.styles.ts
+++ b/packages/dashboard/src/components/Card/Layout/Layout.styles.ts
@@ -19,7 +19,6 @@ export const getStyles = (props: ILayoutProps): ILayoutStyles => {
     },
     contentAreaLayout: {
       display: 'flex',
-      paddingBottom: '16px',
       marginTop: isHeaderPresent ? '30px' : '32px',
       overflow: 'hidden',
       flex: 1


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Content area layout is cropped in Edge browser

#### Screen shots
![actionsbarcropissueinedge](https://user-images.githubusercontent.com/21668111/45214713-d4e05b80-b2b8-11e8-8c7a-a3a109a1adde.png)


(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6275)

