### PR TITLE
Fix meta keyboard key state not checked during selection

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-09-10-17-10.json
+++ b/common/changes/office-ui-fabric-react/master_2018-09-10-17-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Check whether meta key is pressed during selection",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aharper@altair.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -195,7 +195,8 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
         } else if (
           (target === itemRoot || this._shouldAutoSelect(target)) &&
           !this._isShiftPressed &&
-          !this._isCtrlPressed
+          !this._isCtrlPressed &&
+          !this._isMetaPressed
         ) {
           this._onInvokeMouseDown(ev, this._getItemIndex(itemRoot));
           break;
@@ -310,10 +311,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
       const index = this._getItemIndex(itemRoot);
 
       while (target !== this._root.current) {
-        if (
-          this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME) ||
-          this._hasAttribute(target, SELECTION_INVOKE_ATTRIBUTE_NAME)
-        ) {
+        if (this._hasAttribute(target, SELECTION_TOGGLE_ATTRIBUTE_NAME) || this._hasAttribute(target, SELECTION_INVOKE_ATTRIBUTE_NAME)) {
           break;
         } else if (target === itemRoot) {
           this._onInvokeClick(ev, index);
@@ -481,10 +479,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     }
   }
 
-  private _onInvokeMouseDown(
-    ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-    index: number
-  ): void {
+  private _onInvokeMouseDown(ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, index: number): void {
     const { selection } = this.props;
 
     // Only do work if item is not selected.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5994
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Check the meta keyboard key state during selection. This fixes a bug where Mac users cannot command-select multiple items.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6301)

