### PR TITLE
Mark setPortalAttribute as public to fix LayerBase runtime error

### DIFF
--- a/common/changes/@uifabric/utilities/keco-mark-setPortalAttribute-public_2018-09-10-21-17.json
+++ b/common/changes/@uifabric/utilities/keco-mark-setPortalAttribute-public_2018-09-10-21-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Mark setPortalAttribute dom utility function as public to fix undefined runtime error.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "keco@microsoft.com"
+}

--- a/packages/utilities/src/dom.ts
+++ b/packages/utilities/src/dom.ts
@@ -76,10 +76,7 @@ export function getVirtualParent(child: HTMLElement): HTMLElement | undefined {
  * @public
  */
 export function getParent(child: HTMLElement, allowVirtualParents: boolean = true): HTMLElement | null {
-  return (
-    child &&
-    ((allowVirtualParents && getVirtualParent(child)) || (child.parentNode && (child.parentNode as HTMLElement)))
-  );
+  return child && ((allowVirtualParents && getVirtualParent(child)) || (child.parentNode && (child.parentNode as HTMLElement)));
 }
 
 /**
@@ -112,11 +109,7 @@ export function getChildren(parent: HTMLElement, allowVirtualChildren: boolean =
  *
  * @public
  */
-export function elementContains(
-  parent: HTMLElement | null,
-  child: HTMLElement | null,
-  allowVirtualParents: boolean = true
-): boolean {
+export function elementContains(parent: HTMLElement | null, child: HTMLElement | null, allowVirtualParents: boolean = true): boolean {
   let isContained = false;
 
   if (parent && child) {
@@ -209,6 +202,7 @@ export function getRect(element: HTMLElement | Window | null): IRectangle | unde
 /**
  * Identify element as a portal by setting an attribute.
  * @param element Element to mark as a portal.
+ * @public
  */
 export function setPortalAttribute(element: HTMLElement): void {
   element.setAttribute(DATA_PORTAL_ATTRIBUTE, 'true');
@@ -235,10 +229,7 @@ export function portalContainsElement(target: HTMLElement, parent?: HTMLElement)
  * @param matchFunction the function that determines if the element is a match
  * @returns the matched element or null no match was found
  */
-export function findElementRecursive(
-  element: HTMLElement | null,
-  matchFunction: (element: HTMLElement) => boolean
-): HTMLElement | null {
+export function findElementRecursive(element: HTMLElement | null, matchFunction: (element: HTMLElement) => boolean): HTMLElement | null {
   if (!element || element === document.body) {
     return null;
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There's currently a runtime error thrown in `<LayerBase>` due to a missing import `setPortalAttribute`

![image](https://user-images.githubusercontent.com/706967/45324753-ee291800-b503-11e8-9c97-8ae5cebced3a.png)

It looks like the fix is to mark it `@public` so it can be properly imported?

#### Focus areas to test

1. Run `npm start` in this branch
1. Navigate to something using `<LayerBase/>` such as `<DatePicker/>`.
1. The page shouldn't crash as it does when you try to open the DatePicker on the examples site.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6306)

