### PR TITLE
Donut chart changes

### DIFF
--- a/common/changes/@uifabric/charting/donutChartChanges_2018-09-10-21-27.json
+++ b/common/changes/@uifabric/charting/donutChartChanges_2018-09-10-21-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Centering legends component for Donut chart. Introducing prop for legends component that helps users align the component center",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "nulikarthik@gmail.com"
+}

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -113,9 +113,7 @@ export class DonutChartBase extends React.Component<
     const widthVal = node.parentElement ? node.parentElement.clientWidth : this.state._width;
 
     const heightVal =
-      node.parentElement && node.parentElement.offsetHeight > this.state._height!
-        ? node.parentElement.offsetHeight
-        : this.state._height;
+      node.parentElement && node.parentElement.offsetHeight > this.state._height! ? node.parentElement.offsetHeight : this.state._height;
     const viewbox = `0 0 ${widthVal!} ${heightVal!}`;
     node.setAttribute('viewBox', viewbox);
   }
@@ -151,7 +149,7 @@ export class DonutChartBase extends React.Component<
         };
         return legend;
       });
-    const legends = <Legends legends={legendDataItems} />;
+    const legends = <Legends legends={legendDataItems} centerLegends={true} />;
     return legends;
   }
 

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -149,7 +149,7 @@ export class DonutChartBase extends React.Component<
         };
         return legend;
       });
-    const legends = <Legends legends={legendDataItems} centerLegends={true} />;
+    const legends = <Legends legends={legendDataItems} centerLegends />;
     return legends;
   }
 

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -29,6 +29,7 @@ export interface ILegendState {
 }
 export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   private _classNames: IProcessedStyleSet<ILegendsStyles>;
+  private centerLegends: boolean;
 
   public constructor(props: ILegendsProps) {
     super(props);
@@ -42,6 +43,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
 
   public render(): JSX.Element {
     const { theme, className, styles } = this.props;
+    this.centerLegends = this.props.centerLegends ? this.props.centerLegends : false;
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className
@@ -86,6 +88,11 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         overflowItems={data.overflow}
         onRenderItem={this._renderButton}
         onRenderOverflowButton={this._renderOverflowItems}
+        styles={{
+          root: {
+            justifyContent: this.centerLegends ? 'center' : 'unset'
+          }
+        }}
       />
     );
   };

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -29,7 +29,6 @@ export interface ILegendState {
 }
 export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   private _classNames: IProcessedStyleSet<ILegendsStyles>;
-  private centerLegends: boolean;
 
   public constructor(props: ILegendsProps) {
     super(props);
@@ -43,7 +42,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
 
   public render(): JSX.Element {
     const { theme, className, styles } = this.props;
-    this.centerLegends = this.props.centerLegends ? this.props.centerLegends : false;
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className
@@ -90,7 +88,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         onRenderOverflowButton={this._renderOverflowItems}
         styles={{
           root: {
-            justifyContent: this.centerLegends ? 'center' : 'unset'
+            justifyContent: this.props.centerLegends ? 'center' : 'unset'
           }
         }}
       />

--- a/packages/charting/src/components/Legends/Legends.types.ts
+++ b/packages/charting/src/components/Legends/Legends.types.ts
@@ -94,4 +94,9 @@ export interface ILegendsProps {
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<ILegendStyleProps, ILegendsStyles>;
+
+  /**
+   * This prop makes the legends component align itself to the center in the container it is sitting in
+   */
+  centerLegends?: boolean;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Introducing a prop for legends component that will center the legends in the container it is sitting in. Making this prop true for Donut chart.
Added border for the screenshot below to see the centering
![image](https://user-images.githubusercontent.com/22408128/45325531-fda96080-b505-11e8-82ea-93268092d248.png)


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6307)

