### PR TITLE
Fix DatePicker re-rendering due to focus behavior change

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-datepicker-focus_2018-09-10-22-02.json
+++ b/common/changes/office-ui-fabric-react/keco-datepicker-focus_2018-09-10-22-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Revert removal of should render DatePicker guard given focus changes with Layer changes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -93,10 +93,13 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   private _calendar = createRef<ICalendar>();
   private _datePickerDiv = createRef<HTMLDivElement>();
   private _textField = createRef<ITextField>();
+  private _preventFocusOpeningPicker: boolean;
 
   constructor(props: IDatePickerProps) {
     super(props);
     this.state = this._getDefaultState();
+
+    this._preventFocusOpeningPicker = false;
   }
 
   public componentWillReceiveProps(nextProps: IDatePickerProps): void {
@@ -291,7 +294,11 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     }
 
     if (!this.props.allowTextInput) {
-      this._showDatePickerPopup();
+      if (!this._preventFocusOpeningPicker) {
+        this._showDatePickerPopup();
+      } else {
+        this._preventFocusOpeningPicker = false;
+      }
     }
   };
 
@@ -361,6 +368,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
   private _showDatePickerPopup(): void {
     if (!this.state.isDatePickerShown) {
+      this._preventFocusOpeningPicker = true;
       this.setState({
         isDatePickerShown: true,
         errorMessage: ''
@@ -382,6 +390,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
    * Callback for closing the calendar callout
    */
   private _calendarDismissed = (): void => {
+    this._preventFocusOpeningPicker = true;
     this._dismissDatePickerPopup();
     // don't need to focus the text box, if necessary the focusTrapZone will do it
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6297 & #5583 (?)
- [x] Include a change request file using `$ npm run change`

#### Description of changes

It appears that `focus` is behaving differently perhaps due to our `<Layer>` improvements in #6211. There was a `<DatePicker/>` focus change made in #5583 that assumed certain focus behavior that no longer applies (I think). Therefore to fix #6297 I reverted that commit.

I'd like to confirm that the issue from #5583 is also fixed even with the revert cc: @kisiebel please. It appears to be from my testing, but I don't have much context.

#### Focus areas to test

1. Open the DatePicker in `master` and select dates.. it will aggressively re-render and maintain focus.
1. Clone this branch
1. Open the DatePicker and it will close on click-outside or selection of a date.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6308)

