### PR TITLE
Update count when selection is removed

### DIFF
--- a/common/changes/office-ui-fabric-react/select-count_2018-09-11-23-23.json
+++ b/common/changes/office-ui-fabric-react/select-count_2018-09-11-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Selection count not updating when items are removed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.test.ts
@@ -106,4 +106,21 @@ describe('Selection', () => {
     expect(changeCount).toEqual(3);
     expect(selection.getSelectedCount()).toEqual(0);
   });
+
+  it('notifies consumers when some items are selected and some are removed', () => {
+    let changeCount = 0;
+    const selection = new Selection({ onSelectionChanged: () => changeCount++ });
+
+    selection.setItems(setA);
+
+    selection.setIndexSelected(2, true, false);
+
+    expect(changeCount).toEqual(1);
+    expect(selection.count).toEqual(1);
+
+    selection.setItems([{ key: 'a' }, { key: 'b' }], false);
+
+    expect(changeCount).toEqual(2);
+    expect(selection.count).toEqual(0);
+  });
 });

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -31,12 +31,7 @@ export class Selection implements ISelection {
   private _isModal: boolean;
 
   constructor(options: ISelectionOptions = {}) {
-    const {
-      onSelectionChanged,
-      getKey,
-      canSelectItem = (item: IObjectWithKey) => true,
-      selectionMode = SelectionMode.multiple
-    } = options;
+    const { onSelectionChanged, getKey, canSelectItem = (item: IObjectWithKey) => true, selectionMode = SelectionMode.multiple } = options;
 
     this.mode = selectionMode;
 
@@ -175,6 +170,7 @@ export class Selection implements ISelection {
     this._selectedItems = null;
 
     if (hasSelectionChanged) {
+      this._updateCount();
       this._change();
     }
 
@@ -204,9 +200,7 @@ export class Selection implements ISelection {
   }
 
   public getSelectedCount(): number {
-    return this._isAllSelected
-      ? this._items.length - this._exemptedCount - this._unselectableCount
-      : this._exemptedCount;
+    return this._isAllSelected ? this._items.length - this._exemptedCount - this._unselectableCount : this._exemptedCount;
   }
 
   public getSelectedIndices(): number[] {


### PR DESCRIPTION
Fixed a bug where the `Selection` would not fire a change event if some items had been removed while items were selected.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6325)

