### PR TITLE
Button: Fix splitButton focus issue with Portals

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-SplitButtonPortalFocusFix_2018-09-12-00-52.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-SplitButtonPortalFocusFix_2018-09-12-00-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button: Fix splitButton focus issue with Portals",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -10,7 +10,8 @@ import {
   KeyCodes,
   createRef,
   css,
-  mergeAriaAttributeValues
+  mergeAriaAttributeValues,
+  portalContainsElement
 } from '../../Utilities';
 import { Icon } from '../../Icon';
 import { DirectionalHint } from '../../common/DirectionalHint';
@@ -516,9 +517,16 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   }
 
   private _onSplitContainerFocusCapture = (ev: React.FocusEvent<HTMLDivElement>) => {
+    const container = this._splitButtonContainer.current;
+
+    // If the target is coming from the portal we do not need to set focus on the container.
+    if (!container || (ev.target && portalContainsElement(ev.target, container))) {
+      return;
+    }
+
     // We should never be able to focus the individual buttons in a split button. Focus
     // should always remain on the container.
-    this._splitButtonContainer.current && this._splitButtonContainer.current.focus();
+    container.focus();
   };
 
   private _onSplitButtonPrimaryClick = (ev: React.MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes
With the introduction of Portals in Layers, capture events now leak outside if Layers. The splitButton regressed since it has a onFocusCapture handler which is now getting called when focus fires inside of the Layer. This results in the splitButton setting focus on the container since it did not hit this code prior to the Portal change.

Here simple repro steps for splitButtons (codepen: https://codepen.io/jspurlin/pen/eLMLYm):

Open the ContextualMenu of the splitButton (via mouse or keyboard)
Attempt to arrow around controls

#### Focus areas to test
Verified that focus is being set correctly with splitButtons now
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6330)

