### PR TITLE
 add support for commandBarButtonAs to ICommandBarItemProps

### DIFF
--- a/common/changes/office-ui-fabric-react/nidurak-contextualMenuAsV2_2018-09-12-19-09.json
+++ b/common/changes/office-ui-fabric-react/nidurak-contextualMenuAsV2_2018-09-12-19-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add support for commandBarButtonAs to ICommandBarItemProps, and contextualMenuItemAs to IContextualMenuItem",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nidurak@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/nidurak-contextualMenuAsV2_2018-09-12-22-36.json
+++ b/common/changes/office-ui-fabric-react/nidurak-contextualMenuAsV2_2018-09-12-22-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add support for commandBarButtonAs to ICommandBarItemProps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nidurak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -147,12 +147,12 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     if (item.iconOnly && itemText !== undefined) {
       return (
         <TooltipHost content={itemText} {...item.tooltipHostProps}>
-          <ItemCommandButtonType {...commandButtonProps as IButtonProps} />
+          <ItemCommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />
         </TooltipHost>
       );
     }
 
-    return <ItemCommandButtonType {...commandButtonProps as IButtonProps} />;
+    return <ItemCommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />;
   };
 
   private _onButtonClick(item: ICommandBarItemProps): (ev: React.MouseEvent<HTMLButtonElement>) => void {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 
 import { BaseComponent, css, nullRender } from '../../Utilities';
-import {
-  ICommandBar,
-  ICommandBarItemProps,
-  ICommandBarProps,
-  ICommandBarStyleProps,
-  ICommandBarStyles
-} from './CommandBar.types';
+import { ICommandBar, ICommandBarItemProps, ICommandBarProps, ICommandBarStyleProps, ICommandBarStyles } from './CommandBar.types';
 import { IOverflowSet, OverflowSet } from '../../OverflowSet';
 import { IResizeGroup, ResizeGroup } from '../../ResizeGroup';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
@@ -131,6 +125,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   private _onRenderItem = (item: ICommandBarItemProps): JSX.Element | React.ReactNode => {
     const { buttonAs: CommandButtonType = CommandBarButton } = this.props;
+    const { commandBarButtonAs: ItemCommandButtonType = CommandButtonType } = item;
 
     const itemText = item.text || item.name;
 
@@ -152,12 +147,12 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     if (item.iconOnly && itemText !== undefined) {
       return (
         <TooltipHost content={itemText} {...item.tooltipHostProps}>
-          <CommandButtonType {...commandButtonProps as IButtonProps} />
+          <ItemCommandButtonType {...commandButtonProps as IButtonProps} />
         </TooltipHost>
       );
     }
 
-    return <CommandButtonType {...commandButtonProps as IButtonProps} />;
+    return <ItemCommandButtonType {...commandButtonProps as IButtonProps} />;
   };
 
   private _onButtonClick(item: ICommandBarItemProps): (ev: React.MouseEvent<HTMLButtonElement>) => void {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -136,6 +136,12 @@ export interface ICommandBarItemProps extends IContextualMenuItem {
    * This value is controlled by the component and useful for adjusting onRender function
    */
   renderedInOverflow?: boolean;
+
+  /**
+   * Method to override the render of the individual command bar button. Note, is not used when rendered in overflow
+   * @default CommandBarButton
+   */
+  commandBarButtonAs?: React.ComponentClass<ICommandBarItemProps> | React.StatelessComponent<ICommandBarItemProps>;
 }
 
 export interface ICommandBarStyleProps {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -141,7 +141,7 @@ export interface ICommandBarItemProps extends IContextualMenuItem {
    * Method to override the render of the individual command bar button. Note, is not used when rendered in overflow
    * @default CommandBarButton
    */
-  commandBarButtonAs?: React.ComponentClass<ICommandBarItemProps> | React.StatelessComponent<ICommandBarItemProps>;
+  commandBarButtonAs?: IComponentAs<ICommandBarItemProps>;
 }
 
 export interface ICommandBarStyleProps {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -144,10 +144,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
    * menu item.
    * Returning true will dismiss the menu even if ev.preventDefault() was called.
    */
-  onItemClick?: (
-    ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-    item?: IContextualMenuItem
-  ) => boolean | void;
+  onItemClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
 
   /**
    * Whether this menu is a submenu of another menu or not.
@@ -223,9 +220,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
    * Method to override the render of the individual menu items
    * @default ContextualMenuItem
    */
-  contextualMenuItemAs?:
-    | React.ComponentClass<IContextualMenuItemProps>
-    | React.StatelessComponent<IContextualMenuItemProps>;
+  contextualMenuItemAs?: React.ComponentClass<IContextualMenuItemProps> | React.StatelessComponent<IContextualMenuItemProps>;
 
   /**
    * Props to pass down to the FocusZone.
@@ -342,10 +337,7 @@ export interface IContextualMenuItem {
    * Callback issued when the menu item is invoked. If ev.preventDefault() is called in onClick, click will not close menu.
    * Returning true will dismiss the menu even if ev.preventDefault() was called.
    */
-  onClick?: (
-    ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
-    item?: IContextualMenuItem
-  ) => boolean | void;
+  onClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
 
   /**
    * An optional URL to navigate to upon selection
@@ -481,6 +473,12 @@ export interface IContextualMenuItem {
    * @deprecated Use `text` instead.
    */
   name?: string;
+
+  /**
+   * Method to override the render of the individual menu items
+   * @default ContextualMenuItem
+   */
+  contextualMenuItemAs?: React.ComponentClass<IContextualMenuItemProps> | React.StatelessComponent<IContextualMenuItemProps>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -473,12 +473,6 @@ export interface IContextualMenuItem {
    * @deprecated Use `text` instead.
    */
   name?: string;
-
-  /**
-   * Method to override the render of the individual menu items
-   * @default ContextualMenuItem
-   */
-  contextualMenuItemAs?: React.ComponentClass<IContextualMenuItemProps> | React.StatelessComponent<IContextualMenuItemProps>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -26,7 +26,6 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       dismissMenu
     } = this.props;
 
-    const { contextualMenuItemAs: ItemChildrenRenderer = ChildrenRenderer } = item;
     const subMenuId = this._getSubMenuId(item);
     const ariaLabel = item.ariaLabel || item.text || item.name || '';
 
@@ -83,7 +82,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
             {...itemButtonProperties as React.ButtonHTMLAttributes<HTMLButtonElement>}
             {...keytipAttributes}
           >
-            <ItemChildrenRenderer
+            <ChildrenRenderer
               componentRef={item.componentRef}
               item={item}
               classNames={classNames}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -26,6 +26,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       dismissMenu
     } = this.props;
 
+    const { contextualMenuItemAs: ItemChildrenRenderer = ChildrenRenderer } = item;
     const subMenuId = this._getSubMenuId(item);
     const ariaLabel = item.ariaLabel || item.text || item.name || '';
 
@@ -82,7 +83,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
             {...itemButtonProperties as React.ButtonHTMLAttributes<HTMLButtonElement>}
             {...keytipAttributes}
           >
-            <ChildrenRenderer
+            <ItemChildrenRenderer
               componentRef={item.componentRef}
               item={item}
               classNames={classNames}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

add support for commandBarButtonAs to ICommandBarItemProps, and contextualMenuItemAs to IContextualMenuItem

#### Focus areas to test

CommandBar and ContextualMenuButton

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6344)

