### PR TITLE
Semantic colors: menu slots and filling in gaps in variant logic 5.0

### DIFF
--- a/common/changes/@uifabric/styling/semanticColorDefinitions_2018-09-11-19-34.json
+++ b/common/changes/@uifabric/styling/semanticColorDefinitions_2018-09-11-19-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Adds new semantic slots per design direction",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "v-jescla@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/semanticColorDefinitions_2018-09-11-19-34.json
+++ b/common/changes/@uifabric/variants/semanticColorDefinitions_2018-09-11-19-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/variants",
+      "comment": "Adds new semantic slots per design direction",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "v-jescla@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/semanticColorDefinitions_2018-09-11-19-34.json
+++ b/common/changes/office-ui-fabric-react/semanticColorDefinitions_2018-09-11-19-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds new semantic slots per design direction",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jescla@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
+++ b/packages/office-ui-fabric-react/src/common/_semanticSlots.scss
@@ -67,9 +67,14 @@ $primarybuttonTextHoveredColor: "[theme:primaryButtonTextHovered, default: #ffff
 $primaryButtonTextPressedColor: "[theme:primaryButtonTextPressed, default: #ffffff]";
 
 /* Menus */
-$menuItemBackgroundHoveredColor: "[theme:menuItemBackgroundHovered, default: #f8f8f8]";
+$menuBackgroundColor: "[theme:menuBackground, default: #ffffff]";
+$menuDividerColor: "[theme:menuDivider, default: #c8c8c8]";
 $menuIconColor: "[theme:menuIcon, default: #0078d4]";
 $menuHeaderColor: "[theme:menuHeader, default: #0078d4]";
+$menuItemBackgroundHoveredColor: "[theme:menuItemBackgroundHovered, default: #f4f4f4]";
+$menuItemBackgroundPressedColor: "[theme:menuItemBackgroundPressed, default: #eaeaea]";
+$menuItemTextColor: "[theme:menuItemText, default: #333333]";
+$menuItemTextHoveredColor: "[theme:menuItemTextHovered, default: #212121]";
 
 /* Lists */
 $listBackgroundColor: "[theme:listBackground, default: #ffffff]";

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -336,9 +336,14 @@ export interface ISemanticColors {
   //// Menus, popups, etc
 
   /**
-   * The background of a hovered menu item.
+   * The background of a menu.
    */
-  menuItemBackgroundHovered: string;
+  menuBackground: string;
+
+  /**
+   * The divider between menu items.
+   */
+  menuDivider: string;
 
   /**
    * The default colors of icons in menus.
@@ -349,6 +354,26 @@ export interface ISemanticColors {
    * The headers in menus that denote title of a section.
    */
   menuHeader: string;
+
+  /**
+   * The background of a hovered menu item.
+   */
+  menuItemBackgroundHovered: string;
+
+  /**
+   * The background of a pressed menu item.
+   */
+  menuItemBackgroundPressed: string;
+
+  /**
+   * The text color of a menu item.
+   */
+  menuItemText: string;
+
+  /**
+   * The text color of a hovered menu item.
+   */
+  menuItemTextHovered: string;
 
   //// Lists
 

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -215,9 +215,14 @@ function _makeSemanticColorsFromPalette(
     primaryButtonTextHovered: p.white,
     primaryButtonTextPressed: p.white,
 
-    menuItemBackgroundHovered: p.neutralLighter,
+    menuBackground: p.white,
+    menuDivider: p.neutralTertiaryAlt,
     menuIcon: p.themePrimary,
     menuHeader: p.themePrimary,
+    menuItemBackgroundHovered: p.neutralLighter,
+    menuItemBackgroundPressed: p.neutralLight,
+    menuItemText: p.neutralPrimary,
+    menuItemTextHovered: p.neutralDark,
 
     listBackground: p.white,
     listText: p.neutralPrimary,

--- a/packages/variants/src/variants.ts
+++ b/packages/variants/src/variants.ts
@@ -83,10 +83,19 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
     bodyBackground: p.neutralLighter,
     bodyStandoutBackground: p.neutralLight,
     bodyFrameBackground: !fullTheme.isInverted ? p.neutralLight : p.neutralLighter,
-    bodyFrameDivider: !fullTheme.isInverted ? p.neutralLight : p.neutralQuaternary,
+    bodyFrameDivider: !fullTheme.isInverted ? p.neutralLight : p.neutralQuaternaryAlt,
+    bodyText: p.neutralPrimary,
+    bodySubtext: p.neutralSecondary,
+    bodyDivider: p.neutralQuaternaryAlt,
     variantBorder: !fullTheme.isInverted ? p.neutralQuaternaryAlt : p.neutralLighterAlt,
     variantBorderHovered: p.neutralTertiary,
-    defaultStateBackground: p.neutralQuaternaryAlt,
+    defaultStateBackground: !fullTheme.isInverted ? p.neutralLight : p.neutralQuaternaryAlt,
+
+    actionLink: p.neutralPrimary,
+    actionLinkHovered: !fullTheme.isInverted ? p.neutralDark : p.neutralPrimary,
+    link: p.themeDarkAlt,
+    linkHovered: p.themeDarker,
+    disabledText: p.neutralTertiary,
 
     buttonBackground: p.neutralQuaternaryAlt,
     buttonBackgroundHovered: p.neutralQuaternary,
@@ -104,7 +113,14 @@ export function getNeutralVariant(theme: IPartialTheme): ITheme {
     primaryButtonBorder: 'transparent',
     primaryButtonText: p.white,
     primaryButtonTextHovered: p.white,
-    primaryButtonTextPressed: p.white
+    primaryButtonTextPressed: p.white,
+
+    menuBackground: p.white,
+    menuDivider: p.neutralTertiaryAlt,
+    menuItemBackgroundHovered: p.neutralLighter,
+    menuItemBackgroundPressed: p.neutralLight,
+    menuItemText: p.neutralPrimary,
+    menuItemTextHovered: !fullTheme.isInverted ? p.neutralDark : p.neutralPrimary
   };
 
   return makeThemeFromPartials(fullTheme, partialPalette, partialSemantic);
@@ -157,8 +173,10 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     bodyBackground: !fullTheme.isInverted ? p.themeLighterAlt : p.themeLight,
     bodyStandoutBackground: !fullTheme.isInverted ? p.themeLighter : p.themeTertiary,
     bodyFrameBackground: !fullTheme.isInverted ? p.themeLighter : p.themeLight,
-    bodyFrameDivider: !fullTheme.isInverted ? p.themeLighter : p.themeTertiary,
-
+    bodyFrameDivider: !fullTheme.isInverted ? p.themeLighter : p.neutralQuaternary,
+    bodyText: p.neutralPrimary,
+    bodySubtext: p.neutralSecondary,
+    bodyDivider: !fullTheme.isInverted ? p.neutralLight : p.neutralQuaternary,
     inputBorder: p.themeLighter,
     // inputBorderHovered: p.neutralPrimary,
     inputBackground: p.themeLighter,
@@ -168,7 +186,13 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     // inputFocusBorderAlt: p.themePrimary,
     variantBorder: !fullTheme.isInverted ? p.neutralLight : p.neutralLighterAlt,
     variantBorderHovered: p.neutralTertiary,
-    defaultStateBackground: !fullTheme.isInverted ? p.themeLight : p.themeTertiary,
+    defaultStateBackground: !fullTheme.isInverted ? p.neutralLight : p.neutralQuaternaryAlt,
+
+    actionLink: p.neutralPrimary,
+    actionLinkHovered: !fullTheme.isInverted ? p.neutralDark : p.neutralPrimary,
+    link: p.themeDarkAlt,
+    linkHovered: p.themeDarker,
+    disabledText: p.neutralTertiary,
 
     buttonBackground: p.neutralQuaternaryAlt,
     buttonBackgroundHovered: p.neutralQuaternary,
@@ -186,7 +210,14 @@ export function getSoftVariant(theme: IPartialTheme): ITheme {
     primaryButtonBorder: 'transparent',
     primaryButtonText: p.white,
     primaryButtonTextHovered: p.white,
-    primaryButtonTextPressed: p.white
+    primaryButtonTextPressed: p.white,
+
+    menuBackground: p.white,
+    menuDivider: p.neutralTertiaryAlt,
+    menuItemBackgroundHovered: p.neutralLighter,
+    menuItemBackgroundPressed: p.neutralLight,
+    menuItemText: p.neutralPrimary,
+    menuItemTextHovered: !fullTheme.isInverted ? p.neutralDark : p.neutralPrimary
   };
 
   return makeThemeFromPartials(fullTheme, partialPalette, partialSemantic);
@@ -246,10 +277,9 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
     bodyStandoutBackground: p.themeDarkAlt,
     bodyFrameBackground: !fullTheme.isInverted ? p.themeDarkAlt : p.themePrimary,
     bodyFrameDivider: !fullTheme.isInverted ? p.themeDarkAlt : p.themeTertiary,
-
     bodyText: p.white,
     bodySubtext: p.white,
-
+    bodyDivider: p.themeTertiary,
     inputBorder: p.themeDark,
     // inputBorderHovered: p.neutralPrimary,
     inputBackground: p.themeDark,
@@ -259,7 +289,13 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
     // inputFocusBorderAlt: p.themePrimary,
     variantBorder: p.themeDark,
     variantBorderHovered: p.themeDarker,
-    defaultStateBackground: p.themeDark,
+    defaultStateBackground: p.neutralLighterAlt,
+
+    actionLink: p.white,
+    actionLinkHovered: p.white,
+    link: p.white,
+    linkHovered: p.white,
+    disabledText: p.neutralQuaternary,
 
     buttonBackground: p.themePrimary,
     buttonBackgroundHovered: p.themeDarkAlt,
@@ -277,7 +313,14 @@ export function getStrongVariant(theme: IPartialTheme): ITheme {
     primaryButtonBorder: 'transparent',
     primaryButtonText: !fullTheme.isInverted ? p.themePrimary : p.neutralPrimary,
     primaryButtonTextHovered: !fullTheme.isInverted ? p.themeDark : p.neutralPrimary,
-    primaryButtonTextPressed: !fullTheme.isInverted ? p.themeDark : p.neutralPrimary
+    primaryButtonTextPressed: !fullTheme.isInverted ? p.themeDark : p.neutralPrimary,
+
+    menuBackground: p.white,
+    menuDivider: p.neutralTertiaryAlt,
+    menuItemBackgroundHovered: p.neutralLighter,
+    menuItemBackgroundPressed: p.neutralLight,
+    menuItemText: p.neutralPrimary,
+    menuItemTextHovered: !fullTheme.isInverted ? p.neutralDark : p.neutralPrimary
   };
 
   // Strong variant is unique here, we've redefined the entire palette and are


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Cherry pick from https://github.com/OfficeDev/office-ui-fabric-react/pull/6322


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6346)

