### PR TITLE
add support for commandBarButtonAs to ICommandBarItemProps

### DIFF
--- a/common/changes/@uifabric/utilities/nidurak-contextualMenuAsV2_2018-09-13-17-44.json
+++ b/common/changes/@uifabric/utilities/nidurak-contextualMenuAsV2_2018-09-13-17-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "add optional defaultRender to IComponentAs",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "nidurak@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/nidurak-contextualMenuAsV2_2018-09-13-17-44.json
+++ b/common/changes/office-ui-fabric-react/nidurak-contextualMenuAsV2_2018-09-13-17-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add support for commandBarButtonAs to ICommandBarItemProps along with passing the defaultRender to the commandBarButtonAs",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nidurak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 
 import { BaseComponent, css, nullRender } from '../../Utilities';
-import {
-  ICommandBar,
-  ICommandBarItemProps,
-  ICommandBarProps,
-  ICommandBarStyleProps,
-  ICommandBarStyles
-} from './CommandBar.types';
+import { ICommandBar, ICommandBarItemProps, ICommandBarProps, ICommandBarStyleProps, ICommandBarStyles } from './CommandBar.types';
 import { IOverflowSet, OverflowSet } from '../../OverflowSet';
 import { IResizeGroup, ResizeGroup } from '../../ResizeGroup';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
@@ -131,6 +125,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   private _onRenderItem = (item: ICommandBarItemProps): JSX.Element | React.ReactNode => {
     const { buttonAs: CommandButtonType = CommandBarButton } = this.props;
+    const { commandBarButtonAs: ItemCommandButtonType = CommandButtonType } = item;
 
     const itemText = item.text || item.name;
 
@@ -152,12 +147,12 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     if (item.iconOnly && itemText !== undefined) {
       return (
         <TooltipHost content={itemText} {...item.tooltipHostProps}>
-          <CommandButtonType {...commandButtonProps as IButtonProps} />
+          <ItemCommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />
         </TooltipHost>
       );
     }
 
-    return <CommandButtonType {...commandButtonProps as IButtonProps} />;
+    return <ItemCommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />;
   };
 
   private _onButtonClick(item: ICommandBarItemProps): (ev: React.MouseEvent<HTMLButtonElement>) => void {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -146,12 +146,12 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     if (item.iconOnly && itemText !== undefined) {
       return (
         <TooltipHost content={itemText} {...item.tooltipHostProps}>
-          <CommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />
+          <CommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandBarButton} />
         </TooltipHost>
       );
     }
 
-    return <CommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />;
+    return <CommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandBarButton} />;
   };
 
   private _onButtonClick(item: ICommandBarItemProps): (ev: React.MouseEvent<HTMLButtonElement>) => void {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -124,8 +124,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   };
 
   private _onRenderItem = (item: ICommandBarItemProps): JSX.Element | React.ReactNode => {
-    const { buttonAs: CommandButtonType = CommandBarButton } = this.props;
-    const { commandBarButtonAs: ItemCommandButtonType = CommandButtonType } = item;
+    const CommandButtonType = this.props.buttonAs || item.commandBarButtonAs || CommandBarButton;
 
     const itemText = item.text || item.name;
 
@@ -147,12 +146,12 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     if (item.iconOnly && itemText !== undefined) {
       return (
         <TooltipHost content={itemText} {...item.tooltipHostProps}>
-          <ItemCommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />
+          <CommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />
         </TooltipHost>
       );
     }
 
-    return <ItemCommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />;
+    return <CommandButtonType {...commandButtonProps as IButtonProps} defaultRender={CommandButtonType} />;
   };
 
   private _onButtonClick(item: ICommandBarItemProps): (ev: React.MouseEvent<HTMLButtonElement>) => void {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -136,6 +136,12 @@ export interface ICommandBarItemProps extends IContextualMenuItem {
    * This value is controlled by the component and useful for adjusting onRender function
    */
   renderedInOverflow?: boolean;
+
+  /**
+   * Method to override the render of the individual command bar button. Note, is not used when rendered in overflow
+   * @default CommandBarButton
+   */
+  commandBarButtonAs?: IComponentAs<ICommandBarItemProps>;
 }
 
 export interface ICommandBarStyleProps {

--- a/packages/utilities/src/IComponentAs.ts
+++ b/packages/utilities/src/IComponentAs.ts
@@ -4,4 +4,6 @@
  * @public
  */
 // export type IComponentAs<P> = string | ((props?: P) => JSX.Element);
-export type IComponentAs<T> = React.StatelessComponent<T> | React.ComponentClass<T>;
+export type IComponentAs<T> =
+  | React.StatelessComponent<T & { defaultRender?: React.StatelessComponent<T> }>
+  | React.ComponentClass<T & { defaultRender?: React.ComponentClass<T> }>;

--- a/packages/utilities/src/IComponentAs.ts
+++ b/packages/utilities/src/IComponentAs.ts
@@ -4,6 +4,4 @@
  * @public
  */
 // export type IComponentAs<P> = string | ((props?: P) => JSX.Element);
-export type IComponentAs<T> =
-  | React.StatelessComponent<T & { defaultRender?: React.StatelessComponent<T> }>
-  | React.ComponentClass<T & { defaultRender?: React.ComponentClass<T> }>;
+export type IComponentAs<T> = React.ComponentType<T & { defaultRender?: React.ComponentType<T> }>;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Continuation of the following PR: https://github.com/OfficeDev/office-ui-fabric-react/pull/6344

Add support for commandBarButtonAs to ICommandBarItemProps, and allow for passing the default render logic to commandBarButtonAs.

#### Focus areas to test

CommandBar and IComponentAs


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6354)

