### PR TITLE
Optional allFocusable prop

### DIFF
--- a/common/changes/office-ui-fabric-react/kisiebel-calendar-ios-accessibility_2018-09-13-20-05.json
+++ b/common/changes/office-ui-fabric-react/kisiebel-calendar-ios-accessibility_2018-09-13-20-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds an optional prop to the DatePicker that allows disabled elements to be focused (although not pressed)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kisiebel@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -78,7 +78,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
     dateTimeFormatter: dateTimeFormatterCallbacks,
     showSixWeeksByDefault: false,
     workWeekDays: defaultWorkWeekDays,
-    showCloseButton: false
+    showCloseButton: false,
+    allFocusable: false
   };
 
   private _dayPicker = createRef<ICalendarDay>();
@@ -143,7 +144,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
       minDate,
       maxDate,
       className,
-      showCloseButton
+      showCloseButton,
+      allFocusable
     } = this.props;
     const { selectedDate, navigatedDayDate, navigatedMonthDate, isMonthPickerVisible, isDayPickerVisible } = this.state;
     const onHeaderSelect = showMonthPickerAsOverlay ? this._onHeaderSelect : undefined;
@@ -197,6 +199,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
                     workWeekDays={this.props.workWeekDays}
                     componentRef={this._dayPicker}
                     showCloseButton={showCloseButton}
+                    allFocusable={allFocusable}
                   />
                 )}
                 {isDayPickerVisible && isMonthPickerVisible && <div className={styles.divider} />}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -162,8 +162,15 @@ export interface ICalendarProps extends IBaseProps<ICalendar> {
 
   /**
    * Whether the close button should be shown or not
+   * @defaultvalue false
    */
   showCloseButton?: boolean;
+
+  /**
+   * Allows all dates and buttons to be focused, including disabled ones
+   * @defaultvalue false
+   */
+  allFocusable?: boolean;
 }
 
 export interface ICalendarStrings {

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -60,6 +60,7 @@ export interface ICalendarDayProps extends React.Props<CalendarDay> {
   maxDate?: Date;
   workWeekDays?: DayOfWeek[];
   showCloseButton?: boolean;
+  allFocusable?: boolean;
 }
 
 export interface ICalendarDayState {
@@ -108,7 +109,8 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       dateTimeFormatter,
       minDate,
       maxDate,
-      showCloseButton
+      showCloseButton,
+      allFocusable
     } = this.props;
     const dayPickerId = getId('DatePickerDay-dayPicker');
     const monthAndYearId = getId('DatePickerDay-monthAndYear');
@@ -135,8 +137,8 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
           'ms-DatePicker-dayPicker',
           styles.dayPicker,
           showWeekNumbers &&
-            'ms-DatePicker-showWeekNumbers' &&
-            (getRTL() ? styles.showWeekNumbersRTL : styles.showWeekNumbers)
+          'ms-DatePicker-showWeekNumbers' &&
+          (getRTL() ? styles.showWeekNumbersRTL : styles.showWeekNumbers)
         )}
         id={dayPickerId}
       >
@@ -156,15 +158,14 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 aria-label={dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
                 role="button"
                 tabIndex={0}
-                data-is-focusable={true}
               >
                 {dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
               </div>
             ) : (
-              <div className={css('ms-DatePicker-monthAndYear', styles.monthAndYear)}>
-                {dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
-              </div>
-            )}
+                <div className={css('ms-DatePicker-monthAndYear', styles.monthAndYear)}>
+                  {dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
+                </div>
+              )}
           </div>
           <div className={css('ms-DatePicker-monthComponents', styles.monthComponents)}>
             <div className={css('ms-DatePicker-navContainer', styles.navContainer)}>
@@ -172,7 +173,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 className={css('ms-DatePicker-prevMonth js-prevMonth', styles.prevMonth, {
                   ['ms-DatePicker-prevMonth--disabled ' + styles.prevMonthIsDisabled]: !prevMonthInBounds
                 })}
-                disabled={false} // !prevMonthInBounds}
+                disabled={!allFocusable && !prevMonthInBounds}
                 aria-disabled={!prevMonthInBounds}
                 onClick={prevMonthInBounds ? this._onSelectPrevMonth : undefined}
                 onKeyDown={prevMonthInBounds ? this._onPrevMonthKeyDown : undefined}
@@ -190,7 +191,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 className={css('ms-DatePicker-nextMonth js-nextMonth', styles.nextMonth, {
                   ['ms-DatePicker-nextMonth--disabled ' + styles.nextMonthIsDisabled]: !nextMonthInBounds
                 })}
-                disabled={false} // !nextMonthInBounds}
+                disabled={!allFocusable && !nextMonthInBounds}
                 aria-disabled={!nextMonthInBounds}
                 onClick={nextMonthInBounds ? this._onSelectNextMonth : undefined}
                 onKeyDown={nextMonthInBounds ? this._onNextMonthKeyDown : undefined}
@@ -238,7 +239,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                     key={index}
                     title={strings.days[(index + firstDayOfWeek) % DAYS_IN_WEEK]}
                     aria-label={strings.days[(index + firstDayOfWeek) % DAYS_IN_WEEK]}
-                    data-is-focusable={true}
+                    data-is-focusable={allFocusable ? true : undefined}
                   >
                     {strings.shortDays[(index + firstDayOfWeek) % DAYS_IN_WEEK]}
                   </th>
@@ -339,9 +340,9 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                           aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
                           id={isNavigatedDate ? activeDescendantId : undefined}
                           aria-selected={day.isInBounds ? day.isSelected : undefined}
-                          data-is-focusable={day.isInBounds ? true : undefined}
+                          data-is-focusable={allFocusable || (day.isInBounds ? true : undefined)}
                           ref={element => this._setDayRef(element, day, isNavigatedDate)}
-                          disabled={false} // !day.isInBounds}
+                          disabled={!allFocusable && !day.isInBounds}
                           aria-disabled={!day.isInBounds}
                         >
                           <span aria-hidden="true">{dateTimeFormatter.formatDay(day.originalDate)}</span>
@@ -401,20 +402,20 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
               weeks[weekIndex - 1] &&
               weeks[weekIndex - 1][dayIndex] &&
               weeks[weekIndex - 1][dayIndex].originalDate.getMonth() ===
-                weeks[weekIndex][dayIndex].originalDate.getMonth();
+              weeks[weekIndex][dayIndex].originalDate.getMonth();
             const below =
               weeks[weekIndex + 1] &&
               weeks[weekIndex + 1][dayIndex] &&
               weeks[weekIndex + 1][dayIndex].originalDate.getMonth() ===
-                weeks[weekIndex][dayIndex].originalDate.getMonth();
+              weeks[weekIndex][dayIndex].originalDate.getMonth();
             const left =
               weeks[weekIndex][dayIndex - 1] &&
               weeks[weekIndex][dayIndex - 1].originalDate.getMonth() ===
-                weeks[weekIndex][dayIndex].originalDate.getMonth();
+              weeks[weekIndex][dayIndex].originalDate.getMonth();
             const right =
               weeks[weekIndex][dayIndex + 1] &&
               weeks[weekIndex][dayIndex + 1].originalDate.getMonth() ===
-                weeks[weekIndex][dayIndex].originalDate.getMonth();
+              weeks[weekIndex][dayIndex].originalDate.getMonth();
 
             const roundedTopLeft = !above && !left;
             const roundedTopRight = !above && !right;

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -156,6 +156,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 aria-label={dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
                 role="button"
                 tabIndex={0}
+                data-is-focusable={true}
               >
                 {dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
               </div>
@@ -171,7 +172,8 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 className={css('ms-DatePicker-prevMonth js-prevMonth', styles.prevMonth, {
                   ['ms-DatePicker-prevMonth--disabled ' + styles.prevMonthIsDisabled]: !prevMonthInBounds
                 })}
-                disabled={!prevMonthInBounds}
+                disabled={false} // !prevMonthInBounds}
+                aria-disabled={!prevMonthInBounds}
                 onClick={prevMonthInBounds ? this._onSelectPrevMonth : undefined}
                 onKeyDown={prevMonthInBounds ? this._onPrevMonthKeyDown : undefined}
                 aria-controls={dayPickerId}
@@ -188,7 +190,8 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 className={css('ms-DatePicker-nextMonth js-nextMonth', styles.nextMonth, {
                   ['ms-DatePicker-nextMonth--disabled ' + styles.nextMonthIsDisabled]: !nextMonthInBounds
                 })}
-                disabled={!nextMonthInBounds}
+                disabled={false} // !nextMonthInBounds}
+                aria-disabled={!nextMonthInBounds}
                 onClick={nextMonthInBounds ? this._onSelectNextMonth : undefined}
                 onKeyDown={nextMonthInBounds ? this._onNextMonthKeyDown : undefined}
                 aria-controls={dayPickerId}
@@ -230,11 +233,12 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 {strings.shortDays.map((val, index) => (
                   <th
                     className={css('ms-DatePicker-weekday', styles.weekday)}
-                    role="grid"
+                    role="gridcell"
                     scope="col"
                     key={index}
                     title={strings.days[(index + firstDayOfWeek) % DAYS_IN_WEEK]}
                     aria-label={strings.days[(index + firstDayOfWeek) % DAYS_IN_WEEK]}
+                    data-is-focusable={true}
                   >
                     {strings.shortDays[(index + firstDayOfWeek) % DAYS_IN_WEEK]}
                   </th>
@@ -246,7 +250,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
               onMouseUp={dateRangeType !== DateRangeType.Day ? this._onTableMouseUp : undefined}
             >
               {weeks!.map((week, weekIndex) => (
-                <tr key={weekNumbers ? weekNumbers[weekIndex] : weekIndex} role="row">
+                <tr key={weekNumbers ? weekNumbers[weekIndex] : weekIndex}>
                   {showWeekNumbers &&
                     weekNumbers && (
                       <th
@@ -337,7 +341,8 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                           aria-selected={day.isInBounds ? day.isSelected : undefined}
                           data-is-focusable={day.isInBounds ? true : undefined}
                           ref={element => this._setDayRef(element, day, isNavigatedDate)}
-                          disabled={!day.isInBounds}
+                          disabled={false} // !day.isInBounds}
+                          aria-disabled={!day.isInBounds}
                         >
                           <span aria-hidden="true">{dateTimeFormatter.formatDay(day.originalDate)}</span>
                         </button>

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                 >
                   <button
                     aria-controls="DatePickerDay-dayPicker10"
+                    aria-disabled={false}
                     className="ms-DatePicker-prevMonth js-prevMonth"
                     disabled={false}
                     onClick={[Function]}
@@ -72,6 +73,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                   </button>
                   <button
                     aria-controls="DatePickerDay-dayPicker10"
+                    aria-disabled={false}
                     className="ms-DatePicker-nextMonth js-nextMonth"
                     disabled={false}
                     onClick={[Function]}
@@ -121,7 +123,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Sunday"
                       className="ms-DatePicker-weekday"
-                      role="grid"
+                      role="gridcell"
                       scope="col"
                       title="Sunday"
                     >
@@ -130,7 +132,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Monday"
                       className="ms-DatePicker-weekday"
-                      role="grid"
+                      role="gridcell"
                       scope="col"
                       title="Monday"
                     >
@@ -139,7 +141,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Tuesday"
                       className="ms-DatePicker-weekday"
-                      role="grid"
+                      role="gridcell"
                       scope="col"
                       title="Tuesday"
                     >
@@ -148,7 +150,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Wednesday"
                       className="ms-DatePicker-weekday"
-                      role="grid"
+                      role="gridcell"
                       scope="col"
                       title="Wednesday"
                     >
@@ -157,7 +159,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Thursday"
                       className="ms-DatePicker-weekday"
-                      role="grid"
+                      role="gridcell"
                       scope="col"
                       title="Thursday"
                     >
@@ -166,7 +168,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Friday"
                       className="ms-DatePicker-weekday"
-                      role="grid"
+                      role="gridcell"
                       scope="col"
                       title="Friday"
                     >
@@ -175,7 +177,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Saturday"
                       className="ms-DatePicker-weekday"
-                      role="grid"
+                      role="gridcell"
                       scope="col"
                       title="Saturday"
                     >
@@ -184,14 +186,13 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                   </tr>
                 </thead>
                 <tbody>
-                  <tr
-                    role="row"
-                  >
+                  <tr>
                     <td
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--outfocus undefined"
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="January 30, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -213,6 +214,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="January 31, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -234,6 +236,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 1, 2000"
                         aria-selected={true}
                         className="ms-DatePicker-day-button"
@@ -256,6 +259,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 2, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -277,6 +281,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 3, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -298,6 +303,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 4, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -319,6 +325,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 5, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -336,14 +343,13 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                   </tr>
-                  <tr
-                    role="row"
-                  >
+                  <tr>
                     <td
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 6, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -365,6 +371,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 7, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -386,6 +393,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 8, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -407,6 +415,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 9, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -428,6 +437,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 10, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -449,6 +459,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 11, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -470,6 +481,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 12, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -487,14 +499,13 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                   </tr>
-                  <tr
-                    role="row"
-                  >
+                  <tr>
                     <td
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 13, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -516,6 +527,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 14, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -537,6 +549,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 15, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -558,6 +571,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 16, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -579,6 +593,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 17, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -600,6 +615,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 18, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -621,6 +637,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 19, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -638,14 +655,13 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                   </tr>
-                  <tr
-                    role="row"
-                  >
+                  <tr>
                     <td
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 20, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -667,6 +683,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 21, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -688,6 +705,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 22, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -709,6 +727,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 23, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -730,6 +749,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 24, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -751,6 +771,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 25, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -772,6 +793,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 26, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -789,14 +811,13 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       </button>
                     </td>
                   </tr>
-                  <tr
-                    role="row"
-                  >
+                  <tr>
                     <td
                       className="ms-DatePicker-day ms-DatePicker-dayBackground undefined ms-DatePicker-day--infocus undefined"
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 27, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -818,6 +839,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 28, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -839,6 +861,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="February 29, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -860,6 +883,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="March 1, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -881,6 +905,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="March 2, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -902,6 +927,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="March 3, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
@@ -923,6 +949,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       role="gridcell"
                     >
                       <button
+                        aria-disabled={false}
                         aria-label="March 4, 2000"
                         aria-selected={false}
                         className="ms-DatePicker-day-button"

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -68,7 +68,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     showGoToToday: true,
     dateTimeFormatter: undefined,
     showCloseButton: false,
-    underlined: false
+    underlined: false,
+    allFocusable: false
   };
 
   private _calendar = createRef<ICalendar>();
@@ -155,7 +156,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       maxDate,
       showCloseButton,
       calendarProps,
-      underlined
+      underlined,
+      allFocusable
     } = this.props;
     const { isDatePickerShown, formattedDate, selectedDate, errorMessage } = this.state;
 
@@ -232,6 +234,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
                 maxDate={maxDate}
                 componentRef={this._calendar}
                 showCloseButton={showCloseButton}
+                allFocusable={allFocusable}
               />
             </FocusTrapZone>
           </Callout>

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -197,6 +197,12 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker> {
   initialPickerDate?: Date;
 
   /**
+   * Allows all elements to be focused, including disabled ones
+   * @defaultvalue false
+   */
+  allFocusable?: boolean;
+
+  /**
    * Callback that runs after DatePicker's menu (Calendar) is closed
    */
   onAfterMenuDismiss?: () => void;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -9,20 +9,7 @@ const maxDate: Date = addYears(today, 1);
 const description = `When date boundaries are set (via minDate and maxDate props) the DatePicker will not allow out-of-bounds dates to be picked or entered. In this example, the allowed dates are ${minDate.toLocaleDateString()}-${maxDate.toLocaleDateString()}`;
 
 const DayPickerStrings: IDatePickerStrings = {
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
-  ],
+  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
 
   shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
 
@@ -71,7 +58,6 @@ export class DatePickerBoundedExample extends React.Component<{}, IDatePickerReq
           minDate={minDate}
           maxDate={maxDate}
           allowTextInput={true}
-          allFocusable={true}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -71,6 +71,7 @@ export class DatePickerBoundedExample extends React.Component<{}, IDatePickerReq
           minDate={minDate}
           maxDate={maxDate}
           allowTextInput={true}
+          allFocusable={true}
         />
       </div>
     );

--- a/scripts/tasks/webpack-resources.js
+++ b/scripts/tasks/webpack-resources.js
@@ -78,7 +78,6 @@ module.exports = {
       {
         devServer: {
           inline: true,
-          host: '10.106.133.215',
           port: 4322
         },
 

--- a/scripts/tasks/webpack-resources.js
+++ b/scripts/tasks/webpack-resources.js
@@ -78,6 +78,7 @@ module.exports = {
       {
         devServer: {
           inline: true,
+          host: '10.106.133.215',
           port: 4322
         },
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds an optional prop to the DatePicker that allows disabled elements to be focused (although still not pressed). Due to an interaction between disabled elements and FocusTrapZone, this behavior is useful for accessibility on iOS.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6357)

