### PR TITLE
Fluent: Fix background color of Primary Buttons

### DIFF
--- a/common/changes/@uifabric/experiments/jahnp-fluent-fixes_2018-09-13-21-30.json
+++ b/common/changes/@uifabric/experiments/jahnp-fluent-fixes_2018-09-13-21-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fluent: Fix issue with background color on primary buttons using the wrong values",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "pejahn@microsoft.com"
+}

--- a/packages/experiments/src/components/fluent/FluentStyles.ts
+++ b/packages/experiments/src/components/fluent/FluentStyles.ts
@@ -1,6 +1,7 @@
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { NeutralColors } from './FluentColors';
 import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { FontSizes } from './FluentType';
 import { Depths } from './FluentDepths';
 
@@ -31,16 +32,22 @@ const CompoundButtonStyles = {
   }
 };
 
-const DefaultButtonStyles = {
-  root: {
-    borderRadius: fluentBorderRadius,
-    backgroundColor: '#fff',
-    border: `1px solid ${NeutralColors.gray110}`
-  },
-  rootHovered: {
-    backgroundColor: '#f3f2f1',
-    border: `1px solid ${NeutralColors.gray110}`
-  }
+const DefaultButtonStyles = (props: IButtonProps) => {
+  const { primary, theme } = props;
+  const { palette, semanticColors } = theme!;
+
+  return {
+    root: {
+      borderRadius: fluentBorderRadius,
+      backgroundColor: primary ? semanticColors.primaryButtonBackground : palette.white,
+      border: primary ? '' : `1px solid ${NeutralColors.gray110}`,
+      color: primary ? semanticColors.buttonText : palette.white
+    },
+    rootHovered: {
+      backgroundColor: primary ? palette.themeDarkAlt : NeutralColors.gray20,
+      border: primary ? '' : `1px solid ${NeutralColors.gray110}`
+    }
+  };
 };
 
 const CheckboxStyles = {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #6117
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Fix an issue with the background color of Primary Buttons when using `FluentCustomizations`. 

Here is what they look like now:
![image](https://user-images.githubusercontent.com/307118/45519001-46f8ea80-b768-11e8-9ca4-99c1748f29e6.png)

Here is what they look like with this PR:
![image](https://user-images.githubusercontent.com/307118/45519012-50825280-b768-11e8-9243-b444e58bd7a8.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6361)

